### PR TITLE
refactor: 불필요한 환경 변수 제거 및 포트 설정 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
-DATABASE_URL=postgresql://kanvibe:kanvibe@localhost:5432/kanvibe
+PORT=4885
 KANVIBE_USER=admin
 KANVIBE_PASSWORD=changeme
-KANVIBE_API_TOKEN=your-api-token-here
-KANVIBE_SESSION_SECRET=your-session-secret-here
-GIT_REPO_PATH=/path/to/your/git/repo

--- a/README.md
+++ b/README.md
@@ -22,12 +22,9 @@ cp .env.example .env
 
 | 변수 | 설명 | 기본값 |
 |------|------|--------|
-| `DATABASE_URL` | PostgreSQL 접속 URL | `postgresql://kanvibe:kanvibe@localhost:5432/kanvibe` |
+| `PORT` | 웹 서버 포트 번호 | `4885` |
 | `KANVIBE_USER` | 로그인 사용자명 | `admin` |
 | `KANVIBE_PASSWORD` | 로그인 비밀번호 | (필수 변경) |
-| `KANVIBE_API_TOKEN` | Hook API 인증 토큰 | (필수 변경) |
-| `KANVIBE_SESSION_SECRET` | 세션 암호화 시크릿 | (필수 변경) |
-| `GIT_REPO_PATH` | git 저장소 경로 (worktree 생성 기준) | `.` |
 
 ### Docker Compose 실행
 
@@ -35,7 +32,7 @@ cp .env.example .env
 docker compose up -d
 ```
 
-브라우저에서 `http://localhost:3000` 접속.
+브라우저에서 `http://localhost:4885` 접속.
 
 ### 로컬 개발
 
@@ -53,8 +50,7 @@ npm run dev
 ### 작업 시작
 
 ```bash
-curl -X POST http://localhost:3000/api/hooks/start \
-  -H "Authorization: Bearer YOUR_API_TOKEN" \
+curl -X POST http://localhost:4885/api/hooks/start \
   -H "Content-Type: application/json" \
   -d '{
     "title": "feature/user-auth 구현",
@@ -67,8 +63,7 @@ curl -X POST http://localhost:3000/api/hooks/start \
 ### 작업 업데이트
 
 ```bash
-curl -X POST http://localhost:3000/api/hooks/update \
-  -H "Authorization: Bearer YOUR_API_TOKEN" \
+curl -X POST http://localhost:4885/api/hooks/update \
   -H "Content-Type: application/json" \
   -d '{
     "id": "task-uuid",
@@ -80,8 +75,7 @@ curl -X POST http://localhost:3000/api/hooks/update \
 ### 작업 완료
 
 ```bash
-curl -X POST http://localhost:3000/api/hooks/complete \
-  -H "Authorization: Bearer YOUR_API_TOKEN" \
+curl -X POST http://localhost:4885/api/hooks/complete \
   -H "Content-Type: application/json" \
   -d '{ "id": "task-uuid" }'
 ```
@@ -96,7 +90,7 @@ curl -X POST http://localhost:3000/api/hooks/complete \
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "command": "curl -s -X POST http://YOUR_KANVIBE_HOST:3000/api/hooks/start -H 'Authorization: Bearer YOUR_TOKEN' -H 'Content-Type: application/json' -d '{\"title\": \"Claude Code 작업\", \"agentType\": \"claude\"}'"
+        "command": "curl -s -X POST http://YOUR_KANVIBE_HOST:4885/api/hooks/start -H 'Content-Type: application/json' -d '{\"title\": \"Claude Code 작업\", \"agentType\": \"claude\"}'"
       }
     ]
   }

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   serverExternalPackages: ["node-pty", "ssh2"],
-  allowedDevOrigins: ["http://192.168.36.150:3000"],
+  allowedDevOrigins: ["http://192.168.36.150:4885"],
 };
 
 export default nextConfig;

--- a/server.ts
+++ b/server.ts
@@ -10,7 +10,7 @@ import { parseSSHConfig } from "@/lib/sshConfig";
 
 const dev = process.env.NODE_ENV !== "production";
 const hostname = "0.0.0.0";
-const port = parseInt(process.env.PORT || "3000", 10);
+const port = parseInt(process.env.PORT || "4885", 10);
 
 const app = next({ dev, hostname, port });
 const handle = app.getRequestHandler();

--- a/src/app/api/hooks/complete/route.ts
+++ b/src/app/api/hooks/complete/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { validateApiToken } from "@/lib/auth";
 import { getTaskRepository } from "@/lib/database";
 import { TaskStatus } from "@/entities/KanbanTask";
 
@@ -8,14 +7,6 @@ import { TaskStatus } from "@/entities/KanbanTask";
  * AI 에이전트가 작업을 완료했을 때 호출하여 done 상태로 변경한다.
  */
 export async function POST(request: NextRequest) {
-  const authHeader = request.headers.get("authorization");
-  if (!validateApiToken(authHeader)) {
-    return NextResponse.json(
-      { success: false, error: "인증 실패" },
-      { status: 401 }
-    );
-  }
-
   try {
     const body = await request.json();
     const { id } = body;

--- a/src/app/api/hooks/start/route.ts
+++ b/src/app/api/hooks/start/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { validateApiToken } from "@/lib/auth";
 import { getTaskRepository } from "@/lib/database";
 import { KanbanTask, TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { createWorktreeWithSession } from "@/lib/worktree";
@@ -10,14 +9,6 @@ import { getProjectRepository } from "@/lib/database";
  * AI 에이전트가 작업을 시작할 때 호출하여 progress 카드를 자동 생성한다.
  */
 export async function POST(request: NextRequest) {
-  const authHeader = request.headers.get("authorization");
-  if (!validateApiToken(authHeader)) {
-    return NextResponse.json(
-      { success: false, error: "인증 실패" },
-      { status: 401 }
-    );
-  }
-
   try {
     const body = await request.json();
     const { title, branchName, agentType, sessionType, sshHost, projectId, baseBranch } = body;

--- a/src/app/api/hooks/update/route.ts
+++ b/src/app/api/hooks/update/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { validateApiToken } from "@/lib/auth";
 import { getTaskRepository } from "@/lib/database";
 import { TaskStatus } from "@/entities/KanbanTask";
 
@@ -8,14 +7,6 @@ import { TaskStatus } from "@/entities/KanbanTask";
  * AI 에이전트가 작업 상태나 정보를 업데이트할 때 호출한다.
  */
 export async function POST(request: NextRequest) {
-  const authHeader = request.headers.get("authorization");
-  if (!validateApiToken(authHeader)) {
-    return NextResponse.json(
-      { success: false, error: "인증 실패" },
-      { status: 401 }
-    );
-  }
-
   try {
     const body = await request.json();
     const { id, status, title, description } = body;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,7 +9,7 @@ const SESSION_COOKIE = "kanvibe_session";
  * Turbopack 워커와 메인 프로세스 간 상태 공유 문제를 우회한다.
  */
 function getSecret(): string {
-  return process.env.KANVIBE_SESSION_SECRET || process.env.KANVIBE_PASSWORD || "kanvibe-default-secret";
+  return process.env.KANVIBE_PASSWORD || "kanvibe-default-secret";
 }
 
 /** 토큰에 HMAC 서명을 붙여 반환한다 */
@@ -76,14 +76,6 @@ export function validateSessionFromCookie(cookieHeader: string): boolean {
   if (!match) return false;
   return verifySignedToken(decodeURIComponent(match[1])) !== null;
 }
-
-/** Hook API용 Bearer 토큰을 검증한다 */
-export function validateApiToken(authHeader: string | null): boolean {
-  if (!authHeader?.startsWith("Bearer ")) return false;
-  const token = authHeader.slice(7);
-  return token === process.env.KANVIBE_API_TOKEN;
-}
-
 /** 세션 쿠키를 제거한다 */
 export async function destroySession(): Promise<void> {
   const cookieStore = await cookies();

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -14,7 +14,7 @@ const globalForDb = globalThis as unknown as {
 function createDataSource(): DataSource {
   return new DataSource({
     type: "postgres",
-    url: process.env.DATABASE_URL,
+    url: "postgresql://kanvibe:kanvibe@localhost:5432/kanvibe",
     entities: [KanbanTask, Project],
     synchronize: true,
     logging: process.env.NODE_ENV !== "production",


### PR DESCRIPTION
## 어떤 작업인가요?
- 불필요한 환경 변수를 정리하고, 웹 서버 포트를 환경 변수로 관리할 수 있도록 변경

## 어떻게 해결했나요?
**불필요한 환경 변수 제거**
- `DATABASE_URL`, `KANVIBE_API_TOKEN`, `KANVIBE_SESSION_SECRET`, `GIT_REPO_PATH` 4개 환경 변수를 `.env`에서 제거
- `DATABASE_URL`은 docker-compose와 항상 동일하므로 코드에 하드코딩
- `KANVIBE_SESSION_SECRET`은 `KANVIBE_PASSWORD`로 대체 (기존 폴백 활용)
- `GIT_REPO_PATH`는 코드에서 미사용이므로 단순 제거

**API 토큰 인증 제거**
- `validateApiToken()` 함수 삭제
- Hook API 3개 route에서 Bearer 토큰 인증 체크 제거

**포트 설정 변경**
- 기본 포트를 3000에서 4885로 변경
- `PORT` 환경 변수로 포트 관리 가능

## 중요한 변경 사항은 무엇인가요?
### 환경 변수 정리

**DATABASE_URL 하드코딩**
- **변경 이유**: docker-compose에서 항상 동일한 값을 사용하므로 env 관리 불필요
- **수정 파일**: `src/lib/database.ts`

**API 토큰 인증 제거**
- **변경 이유**: Hook API에 별도 토큰 인증이 불필요
- **수정 파일**: `src/lib/auth.ts`, `src/app/api/hooks/{start,complete,update}/route.ts`

### 포트 설정 변경

**기본 포트 4885 및 PORT 환경 변수 추가**
- **변경 이유**: 포트를 환경 변수로 유연하게 관리
- **수정 파일**: `server.ts`, `next.config.ts`, `.env.example`, `README.md`
