### PR TITLE
fix(ws): 터미널 WebSocket 연결 안정화

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -1,8 +1,21 @@
 /**
  * Next.js 커스텀 서버 부트스트랩.
- * tsx를 통해 server.ts를 로드하기 전에 AsyncLocalStorage를 전역에 등록하여
- * Next.js 16의 런타임 요구사항을 충족한다.
+ * tsx를 통해 server.ts를 로드하기 전에 AsyncLocalStorage를 전역에 등록하고,
+ * .env 파일을 수동 파싱하여 Next.js prepare() 이전에 환경변수를 사용할 수 있게 한다.
  */
+const { readFileSync, existsSync } = require("node:fs");
+const { resolve } = require("node:path");
+
+const envPath = resolve(".env");
+if (existsSync(envPath)) {
+  for (const line of readFileSync(envPath, "utf-8").split("\n")) {
+    const match = line.match(/^([^#=\s]+)\s*=\s*(.*)$/);
+    if (match && !process.env[match[1]]) {
+      process.env[match[1]] = match[2].trim().replace(/^(['"])(.*)\1$/, "$2");
+    }
+  }
+}
+
 const { AsyncLocalStorage } = require("node:async_hooks");
 globalThis.AsyncLocalStorage = AsyncLocalStorage;
 require("tsx/cjs");

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "kanvibe",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
         "@xterm/addon-fit": "^0.11.0",
@@ -83,7 +84,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2628,7 +2628,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2738,7 +2737,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -3259,7 +3257,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3665,7 +3662,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4432,7 +4428,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4618,7 +4613,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6655,6 +6649,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -6969,7 +6974,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -7220,7 +7224,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7230,7 +7233,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7272,8 +7274,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
@@ -8163,7 +8164,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8480,7 +8480,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8992,7 +8991,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "node boot.js",
     "build": "next build",
     "start": "node boot.js",
-    "lint": "eslint"
+    "lint": "eslint",
+    "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null || true"
   },
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -44,7 +44,9 @@ export default function Terminal({ taskId }: TerminalProps) {
     xtermRef.current = term;
 
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const wsUrl = `${protocol}//${window.location.host}/api/terminal/${taskId}`;
+    const wsHost = window.location.hostname;
+    const wsPort = parseInt(window.location.port || "4886", 10) + 10000;
+    const wsUrl = `${protocol}//${wsHost}:${wsPort}/api/terminal/${taskId}`;
     const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
 

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -38,10 +38,10 @@ export async function getDataSource(): Promise<DataSource> {
  */
 export async function getTaskRepository(): Promise<Repository<KanbanTask>> {
   const ds = await getDataSource();
-  return ds.getRepository(KanbanTask);
+  return ds.getRepository("KanbanTask") as Repository<KanbanTask>;
 }
 
 export async function getProjectRepository(): Promise<Repository<Project>> {
   const ds = await getDataSource();
-  return ds.getRepository(Project);
+  return ds.getRepository("Project") as Repository<Project>;
 }


### PR DESCRIPTION
## Summary
- Next.js 16 Turbopack이 같은 포트의 WebSocket upgrade를 가로채는 문제 해결 (httpServer 옵션 + 별도 포트 PORT+10000)
- TypeORM 엔티티 메타데이터 미인식 500 에러를 문자열 기반 리포지토리 조회로 수정
- node-pty spawn-helper 실행 권한 누락으로 인한 posix_spawnp 크래시를 postinstall 스크립트로 해결

## Test plan
- [ ] 서버 시작 후 메인 HTTP 포트(PORT)와 WS 포트(PORT+10000) 모두 LISTEN 확인
- [ ] 터미널 페이지에서 WebSocket 연결 성공 및 tmux 세션 attach 확인
- [ ] 로그아웃/재로그인 후 터미널 인증(auth=true) 정상 동작 확인
- [ ] `npm install` 후 node-pty spawn-helper 실행 권한 자동 복구 확인