### PR TITLE
modify(terminal): workmux 스타일 window/tab 기반 세션 관리

### DIFF
--- a/.claude/plan/terminal/2602/12-session-to-window-tab.plan.md
+++ b/.claude/plan/terminal/2602/12-session-to-window-tab.plan.md
@@ -1,0 +1,109 @@
+# Session to Window/Tab 전환 (workmux 스타일)
+
+## Business Goal
+현재 task마다 별도 tmux 세션/zellij 세션을 생성하는 방식을 workmux처럼 하나의 메인 세션(프로젝트명) 안에서 tmux window / zellij tab으로 관리하도록 전환한다. 이를 통해 터미널 multiplexer의 세션 관리가 더 깔끔해지고, 하나의 세션 내에서 모든 작업 브랜치를 window/tab으로 전환할 수 있다.
+
+## Scope
+- **In Scope**: worktree.ts 세션→window/tab 전환, terminal.ts 연결 방식 변경, server.ts 파라미터 전달
+- **Out of Scope**: DB 스키마 변경, UI 컴포넌트 변경, 기존 task 데이터 마이그레이션
+
+## Codebase Analysis Summary
+- `src/lib/worktree.ts`: `createWorktreeWithSession()`, `removeWorktreeAndSession()`, `listActiveSessions()` — 핵심 변경 대상
+- `src/lib/terminal.ts`: `attachLocalSession()`, `attachRemoteSession()` — window/tab 타겟팅으로 변경
+- `server.ts`: terminal 함수 호출부 — branchName 파라미터 추가 전달
+- `src/entities/KanbanTask.ts`: `sessionName` 필드 의미 변경 (세션명 → 메인 세션명). 스키마 변경 불필요
+- `src/app/actions/kanban.ts`: `createTask()`, `deleteTask()`, `branchFromTask()` — worktree 함수 호출부
+- `src/app/api/hooks/start/route.ts`: hook API — worktree 함수 호출부
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/lib/worktree.ts` | worktree + 세션 생성/삭제 | Modify |
+| `src/lib/terminal.ts` | 터미널 WebSocket 연결 | Modify |
+| `server.ts` | WebSocket 핸들러 (terminal 함수 호출) | Modify |
+| `src/app/actions/kanban.ts` | task CRUD (worktree 함수 호출) | Reference (변경 불필요) |
+| `src/app/api/hooks/start/route.ts` | Hook API (worktree 함수 호출) | Reference (변경 불필요) |
+| `src/entities/KanbanTask.ts` | task 엔티티 | Reference (변경 불필요) |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 한국어 주석 | CODE_PRINCIPLES.md | 모든 주석/JSDoc은 한국어 |
+| execGit 활용 | worktree.ts | 로컬/SSH 명령은 execGit()을 통해 실행 |
+| SessionType enum | KanbanTask.ts | TMUX / ZELLIJ enum 값 사용 |
+| 함수명 네이밍 | CODE_PRINCIPLES.md | 동사 기반 명확한 이름 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 메인 세션 이름 | project.name | workmux 컨벤션, 직관적 | 별도 필드 추가 |
+| Window/tab 이름 | branchName sanitized | 기존 sanitize 로직 재활용 | 별도 naming |
+| tmux attach | `attach -t session:window` | 특정 window 직접 타겟팅 | 전체 세션 attach |
+| zellij tab 생성 | `zellij action --session new-tab` | 외부에서 tab 생성 가능 | layout 파일 |
+| zellij tab 삭제 | `go-to-tab-name` → `close-tab` | 이름으로 tab 특정 | index 기반 |
+| sessionName 의미 | 메인 세션명 저장 | 스키마 변경 불필요 | 새 필드 추가 |
+
+## Implementation Todos
+
+### Todo 1: worktree.ts — 세션 생성을 window/tab 생성으로 전환
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: `createWorktreeWithSession()`에서 tmux new-session → new-window, zellij session → tab으로 변경. 메인 세션 없으면 자동 생성.
+- **Work**:
+  - `createWorktreeWithSession()` 수정:
+    - tmux: `tmux has-session -t "projectName" || tmux new-session -d -s "projectName"` → `tmux new-window -t "projectName" -n "windowName" -c "worktreePath"`
+    - zellij: `zellij list-sessions | grep -q "projectName" || zellij --session "projectName" options --detach-on-exit false &` 후 `zellij action --session "projectName" new-tab --name "windowName" --cwd "worktreePath"`
+    - sessionName 반환값을 메인 세션명(projectName)으로 변경
+  - `removeWorktreeAndSession()` 수정:
+    - tmux: `tmux kill-session -t "sessionName"` → `tmux kill-window -t "sessionName:windowName"` (sessionName=메인세션, windowName=branchName sanitized)
+    - zellij: `zellij delete-session` → `zellij action --session "sessionName" go-to-tab-name "windowName"` + `zellij action --session "sessionName" close-tab`
+    - 함수 시그니처에 windowName(또는 branchName에서 파생) 필요 — 이미 branchName 파라미터 존재
+  - `listActiveSessions()` → `listActiveWindows()`로 리네임 및 변경:
+    - tmux: `tmux list-windows -t "mainSession" -F "#{window_name}"`
+    - zellij: 기존 session list 유지 (tab 리스트는 별도 API 없음)
+- **Convention Notes**: execGit() 사용, 한국어 JSDoc
+- **Verification**: TypeScript 컴파일 (`npx tsc --noEmit`)
+- **Exit Criteria**: worktree.ts가 window/tab 기반으로 동작하며 컴파일 에러 없음
+- **Status**: pending
+
+### Todo 2: terminal.ts — window/tab 타겟 연결로 변경
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: `attachLocalSession()`, `attachRemoteSession()`이 특정 window/tab을 타겟으로 연결하도록 변경
+- **Work**:
+  - `attachLocalSession()` 시그니처에 `windowName: string` 파라미터 추가
+    - tmux: args를 `["attach-session", "-t", `${sessionName}:${windowName}`]`로 변경
+    - zellij: attach 전에 `zellij action --session "${sessionName}" go-to-tab-name "${windowName}"` 실행 (execLocal 사용)
+  - `attachRemoteSession()` 시그니처에 `windowName: string` 파라미터 추가
+    - tmux: command를 `tmux attach-session -t "${sessionName}:${windowName}"`로 변경
+    - zellij: attach 전에 `zellij action --session "${sessionName}" go-to-tab-name "${windowName}"` 명령 전송
+- **Convention Notes**: execGit() 또는 execLocal() 사용, 기존 PTY spawn 패턴 유지
+- **Verification**: TypeScript 컴파일 (`npx tsc --noEmit`)
+- **Exit Criteria**: terminal.ts가 window/tab 타겟으로 연결하며 컴파일 에러 없음
+- **Status**: pending
+
+### Todo 3: server.ts — branchName 전달
+- **Priority**: 2
+- **Dependencies**: Todo 2
+- **Goal**: server.ts의 WebSocket 핸들러에서 terminal 함수에 windowName(branchName 파생) 전달
+- **Work**:
+  - `wss.on("connection")` 핸들러에서 task.branchName으로 windowName 계산
+    - `const windowName = task.branchName?.replace(/\//g, "-") || ""`
+  - `attachLocalSession()` 호출에 windowName 추가
+  - `attachRemoteSession()` 호출에 windowName 추가
+- **Convention Notes**: 기존 에러 처리 패턴 유지
+- **Verification**: TypeScript 컴파일 (`npx tsc --noEmit`)
+- **Exit Criteria**: server.ts가 windowName을 올바르게 전달하며 컴파일 에러 없음
+- **Status**: pending
+
+## Verification Strategy
+- TypeScript 컴파일: `npx tsc --noEmit`
+- 빌드: `npm run build` (Next.js 빌드)
+
+## Progress Tracking
+- Total Todos: 3
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-12: Plan created

--- a/messages/en.json
+++ b/messages/en.json
@@ -83,12 +83,21 @@
   },
   "taskDetail": {
     "backToBoard": "Back to Board",
-    "moveToTodo": "Move to Todo",
-    "moveToProgress": "Move to Progress",
-    "moveToReview": "Move to Review",
-    "moveToDone": "Move to Done",
+    "moveToTodo": "Todo",
+    "moveToProgress": "Progress",
+    "moveToReview": "Review",
+    "moveToDone": "Done",
     "delete": "Delete",
     "terminal": "Terminal",
-    "noTerminal": "No terminal session connected to this task."
+    "noTerminal": "No terminal session connected to this task.",
+    "info": "Task Info",
+    "branch": "Branch",
+    "agent": "Agent",
+    "session": "Session",
+    "sshHost": "SSH Host",
+    "createdAt": "Created",
+    "updatedAt": "Updated",
+    "actions": "Change Status",
+    "deleteConfirm": "Are you sure you want to delete this task?"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -31,12 +31,8 @@
     }
   },
   "task": {
-    "titleLabel": "Title",
-    "titlePlaceholder": "Task title",
-    "titleRequired": "Title *",
     "descriptionLabel": "Description",
     "descriptionPlaceholder": "Task description (optional)",
-    "createWithSession": "Create with Branch + Session",
     "project": "Project",
     "projectSelect": "Select project",
     "baseBranch": "Base branch",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -83,12 +83,21 @@
   },
   "taskDetail": {
     "backToBoard": "보드로 돌아가기",
-    "moveToTodo": "Todo로 이동",
-    "moveToProgress": "Progress로 이동",
-    "moveToReview": "Review로 이동",
-    "moveToDone": "Done으로 이동",
+    "moveToTodo": "Todo",
+    "moveToProgress": "Progress",
+    "moveToReview": "Review",
+    "moveToDone": "Done",
     "delete": "삭제",
     "terminal": "터미널",
-    "noTerminal": "이 작업에는 연결된 터미널 세션이 없습니다."
+    "noTerminal": "이 작업에는 연결된 터미널 세션이 없습니다.",
+    "info": "작업 정보",
+    "branch": "브랜치",
+    "agent": "에이전트",
+    "session": "세션",
+    "sshHost": "SSH 호스트",
+    "createdAt": "생성일",
+    "updatedAt": "수정일",
+    "actions": "상태 변경",
+    "deleteConfirm": "이 작업을 삭제하시겠습니까?"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -31,16 +31,12 @@
     }
   },
   "task": {
-    "titleLabel": "제목",
-    "titlePlaceholder": "작업 제목",
-    "titleRequired": "제목 *",
     "descriptionLabel": "설명",
     "descriptionPlaceholder": "작업 설명 (선택)",
-    "createWithSession": "Branch + 세션과 함께 생성",
     "project": "프로젝트",
     "projectSelect": "프로젝트 선택",
     "baseBranch": "베이스 브랜치",
-    "branchName": "Branch 이름",
+    "branchName": "브랜치 이름",
     "branchPlaceholder": "feat/my-feature",
     "sessionType": "세션 타입",
     "sshHost": "SSH 호스트 (선택)",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -31,12 +31,8 @@
     }
   },
   "task": {
-    "titleLabel": "标题",
-    "titlePlaceholder": "任务标题",
-    "titleRequired": "标题 *",
     "descriptionLabel": "描述",
     "descriptionPlaceholder": "任务描述（可选）",
-    "createWithSession": "同时创建 Branch + 会话",
     "project": "项目",
     "projectSelect": "选择项目",
     "baseBranch": "基础分支",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -83,12 +83,21 @@
   },
   "taskDetail": {
     "backToBoard": "返回看板",
-    "moveToTodo": "移至待办",
-    "moveToProgress": "移至进行中",
-    "moveToReview": "移至审核",
-    "moveToDone": "移至完成",
+    "moveToTodo": "待办",
+    "moveToProgress": "进行中",
+    "moveToReview": "审核",
+    "moveToDone": "完成",
     "delete": "删除",
     "terminal": "终端",
-    "noTerminal": "此任务没有关联的终端会话。"
+    "noTerminal": "此任务没有关联的终端会话。",
+    "info": "任务信息",
+    "branch": "分支",
+    "agent": "代理",
+    "session": "会话",
+    "sshHost": "SSH 主机",
+    "createdAt": "创建时间",
+    "updatedAt": "更新时间",
+    "actions": "状态变更",
+    "deleteConfirm": "确定要删除此任务吗？"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "eslint-config-next": "16.1.6",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -83,7 +83,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2628,7 +2627,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2738,7 +2736,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -3259,7 +3256,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3665,7 +3661,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4432,7 +4427,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4618,7 +4612,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6655,6 +6648,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -6969,7 +6973,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -7220,7 +7223,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7230,7 +7232,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7272,8 +7273,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
@@ -8163,7 +8163,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8480,7 +8479,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8992,7 +8990,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }

--- a/prd/design-system.json
+++ b/prd/design-system.json
@@ -83,6 +83,14 @@
         "surfaceRaised": "{white}",
         "overlay": "rgba(0, 0, 0, 0.5)"
       },
+      "terminal": {
+        "chrome": "#1e1e1e",
+        "body": "#0a0a0a",
+        "text": "#9ca3af",
+        "trafficClose": "#ff5f56",
+        "trafficMinimize": "#ffbd2e",
+        "trafficMaximize": "#27c93f"
+      },
       "text": {
         "primary": "#202124",
         "secondary": "#5F6368",
@@ -179,7 +187,8 @@
       "tag": "{full}",
       "modal": "{xl}",
       "dropdown": "{lg}",
-      "contextMenu": "{lg}"
+      "contextMenu": "{lg}",
+      "terminalWindow": "{lg}"
     }
   },
   "shadows": {
@@ -212,6 +221,11 @@
     "kanbanBoard": {
       "columnMinWidth": "280px",
       "columnMaxWidth": "350px"
+    },
+    "taskDetail": {
+      "type": "two-panel",
+      "sidebarWidth": "320px",
+      "terminalMinHeight": "400px"
     },
     "breakpoints": {
       "mobile": "640px",

--- a/server.ts
+++ b/server.ts
@@ -68,6 +68,9 @@ app.prepare().then(() => {
         return;
       }
 
+      /** branchName에서 window/tab 이름을 파생한다 */
+      const windowName = task.branchName?.replace(/\//g, "-") || "";
+
       if (task.sshHost) {
         const sshHosts = await parseSSHConfig();
         const hostConfig = sshHosts.find((h) => h.host === task.sshHost);
@@ -82,11 +85,12 @@ app.prepare().then(() => {
           task.sshHost,
           task.sessionType,
           task.sessionName,
+          windowName,
           ws,
           hostConfig
         );
       } else {
-        await attachLocalSession(taskId, task.sessionType, task.sessionName, ws);
+        await attachLocalSession(taskId, task.sessionType, task.sessionName, windowName, ws);
       }
     } catch (error) {
       console.error("터미널 연결 오류:", error);

--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -40,8 +40,8 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
   }
 
   return (
-    <div className="min-h-screen">
-      <header className="flex items-center gap-4 px-6 py-4 border-b border-border-default bg-bg-surface">
+    <div className="h-screen flex flex-col">
+      <header className="flex items-center gap-4 px-6 py-4 border-b border-border-default bg-bg-surface shrink-0">
         <Link
           href="/"
           className="text-text-secondary hover:text-text-primary transition-colors"
@@ -50,8 +50,8 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
         </Link>
       </header>
 
-      <main className="max-w-4xl mx-auto p-6">
-        <div className="flex items-start justify-between mb-6">
+      <main className="flex-1 flex flex-col min-h-0 p-4">
+        <div className="flex items-start justify-between mb-4 shrink-0">
           <div>
             <div className="flex items-center gap-3 mb-2">
               <h1 className="text-2xl font-bold text-text-primary">
@@ -110,11 +110,13 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
         </div>
 
         {hasTerminal ? (
-          <div>
-            <h2 className="text-lg font-semibold mb-3 text-text-primary">
+          <div className="flex-1 flex flex-col min-h-0">
+            <h2 className="text-lg font-semibold mb-3 text-text-primary shrink-0">
               {t("terminal")}
             </h2>
-            <TerminalLoader taskId={task.id} />
+            <div className="flex-1 min-h-0">
+              <TerminalLoader taskId={task.id} />
+            </div>
           </div>
         ) : (
           <div className="text-center py-20 text-text-muted border border-dashed border-border-default rounded-xl">

--- a/src/app/actions/kanban.ts
+++ b/src/app/actions/kanban.ts
@@ -54,7 +54,7 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
   const repo = await getTaskRepository();
 
   const task = repo.create({
-    title: input.title,
+    title: input.title || input.branchName || "Untitled",
     description: input.description || null,
     branchName: input.branchName || null,
     baseBranch: input.baseBranch || null,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -100,6 +100,14 @@
   --color-tag-neutral-bg: var(--gray-100);
   --color-tag-neutral-text: var(--gray-600);
 
+  /* Terminal Chrome */
+  --color-terminal-chrome: #1e1e1e;
+  --color-terminal-bg: #0a0a0a;
+  --color-terminal-text: #9ca3af;
+  --color-traffic-close: #ff5f56;
+  --color-traffic-minimize: #ffbd2e;
+  --color-traffic-maximize: #27c93f;
+
   /* Shadows */
   --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.05);
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
@@ -170,6 +178,14 @@
   --color-tag-branch-text: var(--color-tag-branch-text);
   --color-tag-neutral-bg: var(--color-tag-neutral-bg);
   --color-tag-neutral-text: var(--color-tag-neutral-text);
+
+  /* Terminal Chrome */
+  --color-terminal-chrome: var(--color-terminal-chrome);
+  --color-terminal-bg: var(--color-terminal-bg);
+  --color-terminal-text: var(--color-terminal-text);
+  --color-traffic-close: var(--color-traffic-close);
+  --color-traffic-minimize: var(--color-traffic-minimize);
+  --color-traffic-maximize: var(--color-traffic-maximize);
 
   /* Shadows */
   --shadow-xs: var(--shadow-xs);

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -54,6 +54,11 @@ export default function Board({ initialTasks, sshHosts, projects }: BoardProps) 
     setIsMounted(true);
   }, []);
 
+  /** 서버 revalidation 후 initialTasks가 변경되면 로컬 state에 반영한다 */
+  useEffect(() => {
+    setTasks(initialTasks);
+  }, [initialTasks]);
+
   const handleDragEnd = useCallback(
     (result: DropResult) => {
       const { source, destination, draggableId } = result;

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -106,7 +106,7 @@ export default function Terminal({ taskId }: TerminalProps) {
   return (
     <div
       ref={terminalRef}
-      className="w-full h-full rounded-lg overflow-hidden border border-gray-700 bg-[#0a0a0a]"
+      className="w-full h-full overflow-hidden bg-terminal-bg"
     />
   );
 }

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -106,7 +106,7 @@ export default function Terminal({ taskId }: TerminalProps) {
   return (
     <div
       ref={terminalRef}
-      className="w-full h-[500px] rounded-lg overflow-hidden border border-gray-700 bg-[#0a0a0a]"
+      className="w-full h-full rounded-lg overflow-hidden border border-gray-700 bg-[#0a0a0a]"
     />
   );
 }

--- a/src/components/TerminalLoader.tsx
+++ b/src/components/TerminalLoader.tsx
@@ -10,5 +10,9 @@ interface TerminalLoaderProps {
 
 /** xterm.js는 SSR 불가이므로 Client Component에서 dynamic import한다 */
 export default function TerminalLoader({ taskId }: TerminalLoaderProps) {
-  return <Terminal taskId={taskId} />;
+  return (
+    <div className="h-full">
+      <Terminal taskId={taskId} />
+    </div>
+  );
 }

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -12,11 +12,12 @@ interface TerminalEntry {
 
 const activeTerminals = new Map<string, TerminalEntry>();
 
-/** 로컬 tmux/zellij 세션에 attach하여 WebSocket과 연결한다 */
+/** 로컬 tmux window / zellij tab에 attach하여 WebSocket과 연결한다 */
 export async function attachLocalSession(
   taskId: string,
   sessionType: SessionType,
   sessionName: string,
+  windowName: string,
   ws: WebSocket
 ): Promise<void> {
   const pty = await import("node-pty");
@@ -26,10 +27,26 @@ export async function attachLocalSession(
       ? "tmux"
       : "zellij";
 
+  /** tmux는 session:window 형식으로 특정 window에 직접 연결한다 */
   const args =
     sessionType === SessionType.TMUX
-      ? ["attach-session", "-t", sessionName]
+      ? ["attach-session", "-t", `${sessionName}:${windowName}`]
       : ["attach", sessionName];
+
+  /**
+   * zellij는 attach 전에 해당 tab으로 이동해야 한다.
+   * go-to-tab-name 액션으로 대상 tab을 선택한다.
+   */
+  if (sessionType === SessionType.ZELLIJ) {
+    const { exec } = await import("child_process");
+    const { promisify } = await import("util");
+    const execAsync = promisify(exec);
+    try {
+      await execAsync(`zellij action --session "${sessionName}" go-to-tab-name "${windowName}"`);
+    } catch {
+      // tab 이동 실패 시 기본 탭으로 attach
+    }
+  }
 
   const ptyProcess = pty.spawn(shell, args, {
     name: "xterm-256color",
@@ -75,12 +92,13 @@ export async function attachLocalSession(
   });
 }
 
-/** SSH를 통해 원격 세션에 attach하여 WebSocket과 연결한다 */
+/** SSH를 통해 원격 tmux window / zellij tab에 attach하여 WebSocket과 연결한다 */
 export async function attachRemoteSession(
   taskId: string,
   sshHost: string,
   sessionType: SessionType,
   sessionName: string,
+  windowName: string,
   ws: WebSocket,
   sshConfig: { hostname: string; port: number; username: string; privateKeyPath: string }
 ): Promise<void> {
@@ -90,10 +108,11 @@ export async function attachRemoteSession(
   const conn = new Client();
 
   conn.on("ready", () => {
+    /** tmux는 session:window 타겟으로, zellij는 tab 이동 후 attach한다 */
     const command =
       sessionType === SessionType.TMUX
-        ? `tmux attach-session -t "${sessionName}"`
-        : `zellij attach "${sessionName}"`;
+        ? `tmux attach-session -t "${sessionName}:${windowName}"`
+        : `zellij action --session "${sessionName}" go-to-tab-name "${windowName}" 2>/dev/null; zellij attach "${sessionName}"`;
 
     conn.shell({ term: "xterm-256color", cols: 120, rows: 30 }, (err, stream) => {
       if (err) {

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -18,9 +18,10 @@ export async function createWorktreeWithSession(
   sessionType: SessionType,
   sshHost?: string | null
 ): Promise<WorktreeSession> {
-  const worktreeDir = `kanvibe-${branchName.replace(/\//g, "-")}`;
-  const worktreePath = path.posix.join(path.dirname(projectPath), worktreeDir);
-  const sessionName = `kanvibe-${branchName.replace(/\//g, "-")}`;
+  const projectName = path.basename(projectPath);
+  const worktreeBase = path.posix.join(path.dirname(projectPath), `${projectName}__worktrees`);
+  const worktreePath = path.posix.join(worktreeBase, branchName.replace(/\//g, "-"));
+  const sessionName = `${projectName}-${branchName.replace(/\//g, "-")}`;
 
   await execGit(
     `git -C "${projectPath}" worktree add "${worktreePath}" -b "${branchName}" "${baseBranch}"`,


### PR DESCRIPTION
## Summary
- tmux는 메인 세션(프로젝트명) 안에서 **window**로, zellij는 **tab**으로 각 작업 브랜치를 관리하도록 전환
- 개별 세션 생성/삭제 대신 메인 세션의 window/tab을 생성/삭제
- 메인 세션이 없으면 첫 task 생성 시 자동 생성
- 웹 터미널에서 특정 window/tab에 직접 연결 (`tmux attach -t session:window`)

## Changes
- `src/lib/worktree.ts`: `new-session` → `new-window`, `kill-session` → `kill-window`, zellij `new-tab`/`close-tab` 적용
- `src/lib/terminal.ts`: `attachLocalSession`, `attachRemoteSession`에 `windowName` 파라미터 추가
- `server.ts`: `branchName`에서 `windowName` 파생하여 terminal 함수에 전달

## Test plan
- [ ] tmux 환경에서 task 생성 시 메인 세션에 window가 추가되는지 확인
- [ ] task 삭제 시 해당 window만 종료되고 메인 세션은 유지되는지 확인
- [ ] 웹 터미널에서 특정 window에 연결되는지 확인
- [ ] zellij 환경에서 tab 생성/삭제/연결 동작 확인