### PR TITLE
fix(task): 태스크 삭제 후 칸반 보드로 redirect 추가

### DIFF
--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import {
   getTaskById,
@@ -13,7 +13,7 @@ import { Link } from "@/i18n/navigation";
 export const dynamicConfig = "force-dynamic";
 
 interface TaskDetailPageProps {
-  params: Promise<{ id: string }>;
+  params: Promise<{ locale: string; id: string }>;
 }
 
 const STATUS_TRANSITIONS: { status: TaskStatus; labelKey: string }[] = [
@@ -31,7 +31,7 @@ const AGENT_TAG_STYLES: Record<string, string> = {
 };
 
 export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
-  const { id } = await params;
+  const { locale, id } = await params;
   const task = await getTaskById(id);
   const t = await getTranslations("taskDetail");
 
@@ -48,6 +48,7 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
   async function handleDelete() {
     "use server";
     await deleteTask(id);
+    redirect(`/${locale}`);
   }
 
   const agentTagStyle = task.agentType


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- 태스크 상세 페이지에서 삭제 시 칸반 보드로 돌아가지 않는 버그 수정

## 어떻게 해결했나요?
**삭제 후 redirect 추가**
- `handleDelete` 서버 액션에서 `deleteTask()` 호출 후 `redirect()` 가 없어 삭제된 페이지에 머무르는 문제
- `redirect(`/${locale}`)` 를 추가하여 삭제 완료 후 해당 locale의 칸반 보드로 이동하도록 수정

## 중요한 변경 사항은 무엇인가요?
### 태스크 삭제 후 redirect 추가

**handleDelete 서버 액션에 redirect 로직 추가**
- **변경 이유**: 삭제 후 이미 존재하지 않는 상세 페이지에 머무르는 버그
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`

**params 타입에 locale 추가**
- **변경 이유**: redirect 경로에 locale 정보가 필요하여 params에서 locale도 추출하도록 변경
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`
