### PR TITLE
fix(terminal): 이모지/유니코드 특수 문자 렌더링 깨짐 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "next": "16.1.6",
@@ -3234,6 +3235,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "next": "16.1.6",

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -22,6 +22,7 @@ export default function Terminal({ taskId }: TerminalProps) {
     const { Terminal } = await import("@xterm/xterm");
     const { FitAddon } = await import("@xterm/addon-fit");
     const { WebLinksAddon } = await import("@xterm/addon-web-links");
+    const { Unicode11Addon } = await import("@xterm/addon-unicode11");
 
     const term = new Terminal({
       cursorBlink: true,
@@ -38,6 +39,8 @@ export default function Terminal({ taskId }: TerminalProps) {
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.loadAddon(new WebLinksAddon());
+    term.loadAddon(new Unicode11Addon());
+    term.unicode.activeVersion = "11";
     term.open(terminalRef.current);
     fitAddon.fit();
 

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -53,7 +53,11 @@ export async function attachLocalSession(
     cols: 120,
     rows: 30,
     cwd: process.env.HOME || "/",
-    env: process.env as Record<string, string>,
+    env: {
+      ...process.env,
+      LANG: process.env.LANG || "en_US.UTF-8",
+      LC_ALL: process.env.LC_ALL || "en_US.UTF-8",
+    } as Record<string, string>,
   });
 
   activeTerminals.set(taskId, { pty: ptyProcess, ws });


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/terminal/2602/12-fix-unicode-rendering.plan.md)

## 어떤 작업인가요?
- 터미널에서 이모지/유니코드 특수 문자가 깨지는 현상을 수정한다.

## 어떻게 해결했나요?
**Unicode 11 애드온 적용**
- xterm.js에 `@xterm/addon-unicode11`을 추가하여 이모지 등 Unicode 11 문자의 폭을 정확히 계산하도록 함
- `term.unicode.activeVersion = "11"`로 활성화

**PTY 환경변수 UTF-8 보장**
- node-pty 프로세스의 `LANG`/`LC_ALL` 환경변수에 UTF-8 기본값을 설정하여 서버 측 인코딩 보장

## 중요한 변경 사항은 무엇인가요?
### Unicode 11 애드온 추가

**@xterm/addon-unicode11 패키지 설치 및 로드**
- **변경 이유**: xterm.js 기본값은 Unicode 6 기반 wcwidth를 사용하여 이모지 등 다중 폭 문자의 폭 계산이 부정확
- **수정 파일**: `package.json`, `src/components/Terminal.tsx`

### PTY UTF-8 환경변수 보장

**LANG/LC_ALL 기본값 설정**
- **변경 이유**: PTY 프로세스에 UTF-8 로케일이 설정되지 않으면 서버 측에서 유니코드 문자 인코딩 오류 발생 가능
- **수정 파일**: `src/lib/terminal.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
