### PR TITLE
feat(db): TypeORM migration 인프라 구축 및 EntityMetadata 조회 안정화

### DIFF
--- a/.serena/memories/project-architecture.md
+++ b/.serena/memories/project-architecture.md
@@ -29,6 +29,14 @@
 - Pages: `src/app/[locale]/page.tsx`, `src/app/[locale]/login/page.tsx`, `src/app/[locale]/task/[id]/page.tsx`
 - Components: `src/components/Board.tsx` (main), Column, TaskCard, CreateTaskModal, BranchTaskModal, ProjectSettings, TaskContextMenu, TaskStatusBadge, Terminal, TerminalLoader
 
+## Database Migration
+- TypeORM migration 기반 스키마 관리 (`synchronize: false`)
+- CLI 설정: `src/lib/typeorm-cli.config.ts` (tsx 기반, 상대 경로 사용)
+- 앱 설정: `src/lib/database.ts` (`migrationsRun: true`로 자동 실행)
+- 마이그레이션 파일: `src/migrations/*.ts`
+- 새 마이그레이션 생성 시 `database.ts`의 `migrations` 배열에 import 추가 필수
+- 스크립트: `migration:generate`, `migration:run`, `migration:revert`
+
 ## Conventions
 - Korean comments (CODE_PRINCIPLES.md)
 - UTF-8 heredoc for Korean content files (FILE_WRITE_PRINCIPLES.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,48 @@ Google 브랜드 컬러 (#4285F4, #EA4335, #FBBC05, #34A853) 기반 + 블랙&화
 2. `src/app/globals.css`의 `:root`에 CSS 변수 추가
 3. `@theme inline` 블록에 Tailwind 등록
 
+## Database Migration
+
+TypeORM migration 기반 스키마 관리. `synchronize`는 비활성화되어 있으며, 모든 스키마 변경은 migration으로 수행한다.
+
+### 파일 구조
+
+- `src/lib/typeorm-cli.config.ts` — CLI 전용 DataSource 설정 (migration generate/run/revert)
+- `src/lib/database.ts` — 앱 런타임 DataSource 설정 (`migrationsRun: true`로 자동 실행)
+- `src/migrations/*.ts` — 마이그레이션 파일 (타임스탬프 기반 정렬)
+
+### 스키마 변경 시
+
+1. `src/entities/`에서 엔티티 수정
+2. `npm run migration:generate -- src/migrations/DescriptiveName` 실행 (DB 실행 상태 필요)
+3. 생성된 마이그레이션 파일의 SQL 검토
+4. `src/lib/database.ts`의 `migrations` 배열에 새 마이그레이션 클래스 import 추가
+5. `npm run migration:run`으로 적용
+
+### 주요 명령어
+
+```bash
+# 엔티티 변경 기반 마이그레이션 생성
+npm run migration:generate -- src/migrations/AddColumnName
+
+# 마이그레이션 실행
+npm run migration:run
+
+# 마지막 마이그레이션 롤백
+npm run migration:revert
+```
+
+### 주의사항
+
+- `synchronize: true` 사용 금지 (프로덕션 데이터 손실 위험)
+- 마이그레이션 파일은 생성 후 수정하지 않는다 (이미 실행된 환경과 불일치 발생)
+- 새 마이그레이션 생성 시 반드시 `database.ts`의 `migrations` 배열에 추가한다
+- 기존 DB 전환: `migrations` 테이블에 초기 마이그레이션 레코드를 수동 삽입한다
+
+```sql
+INSERT INTO migrations (timestamp, name) VALUES (1770854400000, 'InitialSchema1770854400000');
+```
+
 ## 국제화 (i18n)
 
 next-intl 기반. 지원 언어: 한국어(ko), 영어(en), 중국어(zh). 기본 언어: ko.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "build": "next build",
     "start": "node boot.js",
     "lint": "eslint",
+    "typeorm": "tsx node_modules/typeorm/cli.js -d src/lib/typeorm-cli.config.ts",
+    "migration:generate": "npm run typeorm migration:generate",
+    "migration:run": "npm run typeorm migration:run",
+    "migration:revert": "npm run typeorm migration:revert",
     "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null || true"
   },
   "dependencies": {

--- a/src/lib/typeorm-cli.config.ts
+++ b/src/lib/typeorm-cli.config.ts
@@ -1,0 +1,18 @@
+import "reflect-metadata";
+import { DataSource } from "typeorm";
+import { KanbanTask } from "../entities/KanbanTask";
+import { Project } from "../entities/Project";
+
+/**
+ * TypeORM CLI 전용 DataSource 설정.
+ * migration:generate, migration:run, migration:revert 명령에서 사용한다.
+ * Next.js path alias(@/*)가 CLI에서 동작하지 않으므로 상대 경로를 사용한다.
+ */
+export default new DataSource({
+  type: "postgres",
+  url: process.env.DATABASE_URL ?? "postgresql://kanvibe:kanvibe@localhost:5432/kanvibe",
+  entities: [KanbanTask, Project],
+  migrations: ["src/migrations/*.ts"],
+  synchronize: false,
+  logging: true,
+});

--- a/src/migrations/1770854400000-InitialSchema.ts
+++ b/src/migrations/1770854400000-InitialSchema.ts
@@ -1,0 +1,91 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * 초기 스키마 마이그레이션.
+ * projects, kanban_tasks 테이블과 관련 enum 타입을 생성한다.
+ * synchronize: true로 이미 생성된 DB에서도 안전하게 실행되도록 IF NOT EXISTS를 사용한다.
+ */
+export class InitialSchema1770854400000 implements MigrationInterface {
+  name = "InitialSchema1770854400000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE "kanban_tasks_status_enum" AS ENUM('todo', 'progress', 'review', 'done');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `);
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE "kanban_tasks_session_type_enum" AS ENUM('tmux', 'zellij');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "projects" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "name" character varying(255) NOT NULL,
+        "repo_path" character varying(500) NOT NULL,
+        "default_branch" character varying(255) NOT NULL DEFAULT 'main',
+        "ssh_host" character varying(255),
+        "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_projects" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        ALTER TABLE "projects" ADD CONSTRAINT "UQ_projects_name" UNIQUE ("name");
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "kanban_tasks" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "title" character varying(255) NOT NULL,
+        "description" text,
+        "status" "kanban_tasks_status_enum" NOT NULL DEFAULT 'todo',
+        "branch_name" character varying(255),
+        "worktree_path" character varying(500),
+        "session_type" "kanban_tasks_session_type_enum",
+        "session_name" character varying(255),
+        "ssh_host" character varying(255),
+        "agent_type" character varying(50),
+        "project_id" uuid,
+        "base_branch" character varying(255),
+        "display_order" integer NOT NULL DEFAULT 0,
+        "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_kanban_tasks" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        ALTER TABLE "kanban_tasks" ADD CONSTRAINT "UQ_kanban_tasks_branch_name" UNIQUE ("branch_name");
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        ALTER TABLE "kanban_tasks"
+          ADD CONSTRAINT "FK_kanban_tasks_project_id"
+          FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE SET NULL;
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "kanban_tasks" DROP CONSTRAINT IF EXISTS "FK_kanban_tasks_project_id"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "kanban_tasks"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "projects"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "kanban_tasks_session_type_enum"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "kanban_tasks_status_enum"`);
+  }
+}

--- a/start.sh
+++ b/start.sh
@@ -6,22 +6,30 @@ cd "$SCRIPT_DIR"
 
 echo "=== KanVibe 시작 ==="
 
+# 의존성 설치
+echo "[1/6] 의존성 설치..."
+npm install
+
 # PostgreSQL Docker 컨테이너 시작
-echo "[1/4] PostgreSQL 시작..."
+echo "[2/6] PostgreSQL 시작..."
 docker compose up -d db
 
 # DB 준비 대기
-echo "[2/4] DB 준비 대기..."
+echo "[3/6] DB 준비 대기..."
 until docker compose exec db pg_isready -U kanvibe -q 2>/dev/null; do
   sleep 1
 done
 echo "       DB 준비 완료"
 
+# DB 마이그레이션 실행
+echo "[4/6] DB 마이그레이션 실행..."
+npm run migration:run
+
 # Next.js 빌드
-echo "[3/4] Next.js 빌드..."
+echo "[5/6] Next.js 빌드..."
 export NODE_ENV=production
 npm run build
 
 # 앱 시작 (production 모드로 실행하여 auto reload 비활성화)
-echo "[4/4] KanVibe 서버 시작..."
+echo "[6/6] KanVibe 서버 시작..."
 exec npm run start


### PR DESCRIPTION
## Summary
- `synchronize: true` 제거 후 TypeORM migration 기반 스키마 관리로 전환
- CLI 설정(`typeorm-cli.config.ts`), 초기 마이그레이션, `migration:generate/run/revert` npm 스크립트 추가
- `start.sh`에 `npm install` 및 `migration:run` 단계 추가 (4단계 → 6단계)
- 프로덕션 빌드 SWC minify로 인한 `EntityMetadataNotFoundError` 해결 (테이블 이름 기반 리포지토리 조회)
- `CLAUDE.md`에 Database Migration 가이드 섹션 추가

## Changes
| 파일 | 변경 |
|------|------|
| `src/lib/typeorm-cli.config.ts` | CLI 전용 DataSource 설정 (신규) |
| `src/migrations/1770854400000-InitialSchema.ts` | 초기 스키마 마이그레이션 (신규, idempotent) |
| `src/lib/database.ts` | `synchronize: false`, `getRepositoryByTable` 도입 |
| `package.json` | `typeorm`, `migration:*` 스크립트 추가 |
| `start.sh` | `npm install` + `migration:run` 단계 추가 |
| `CLAUDE.md` | Migration 가이드 문서화 |

## Test plan
- [ ] 기존 DB에서 `npm run migration:run` 실행 시 에러 없이 완료되는지 확인
- [ ] 신규 DB에서 초기 마이그레이션으로 테이블 정상 생성 확인
- [ ] `start.sh` 실행 시 6단계 모두 순차 완료 확인
- [ ] 프로덕션 빌드 후 EntityMetadataNotFoundError 발생하지 않는지 확인