### PR TITLE
feat(ui): 칸반 카드 및 상세화면에 PR 링크 표시

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -97,6 +97,7 @@
     "sshHost": "SSH Host",
     "createdAt": "Created",
     "updatedAt": "Updated",
+    "prLink": "PR Link",
     "actions": "Change Status",
     "deleteConfirm": "Are you sure you want to delete this task?"
   }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -97,6 +97,7 @@
     "sshHost": "SSH 호스트",
     "createdAt": "생성일",
     "updatedAt": "수정일",
+    "prLink": "PR 링크",
     "actions": "상태 변경",
     "deleteConfirm": "이 작업을 삭제하시겠습니까?"
   }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -97,6 +97,7 @@
     "sshHost": "SSH 主机",
     "createdAt": "创建时间",
     "updatedAt": "更新时间",
+    "prLink": "PR 链接",
     "actions": "状态变更",
     "deleteConfirm": "确定要删除此任务吗？"
   }

--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -4,6 +4,7 @@ import {
   getTaskById,
   updateTaskStatus,
   deleteTask,
+  fetchAndSavePrUrl,
 } from "@/app/actions/kanban";
 import { TaskStatus } from "@/entities/KanbanTask";
 import TaskStatusBadge from "@/components/TaskStatusBadge";
@@ -36,6 +37,12 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
   const t = await getTranslations("taskDetail");
 
   if (!task) notFound();
+
+  /* 브랜치가 있고 PR URL이 아직 없으면 자동 조회 */
+  if (task.branchName && !task.prUrl) {
+    const prUrl = await fetchAndSavePrUrl(task.id);
+    if (prUrl) task.prUrl = prUrl;
+  }
 
   const hasTerminal = task.sessionType && task.sessionName;
 
@@ -124,6 +131,27 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
                   </dt>
                   <dd className="text-xs font-mono bg-tag-branch-bg text-tag-branch-text px-2 py-0.5 rounded text-right truncate max-w-[180px]">
                     {task.branchName}
+                  </dd>
+                </div>
+              )}
+              {task.prUrl && (
+                <div className="flex items-center justify-between gap-2">
+                  <dt className="text-xs text-text-muted">{t("prLink")}</dt>
+                  <dd>
+                    <a
+                      href={task.prUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-xs bg-tag-pr-bg text-tag-pr-text px-2 py-0.5 rounded hover:opacity-80 transition-opacity"
+                    >
+                      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                        <path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
+                      </svg>
+                      PR
+                      <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                        <path d="M4 12L12 4M12 4H6M12 4v6" strokeLinecap="round" strokeLinejoin="round"/>
+                      </svg>
+                    </a>
                   </dd>
                 </div>
               )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -99,6 +99,8 @@
   --color-tag-branch-text: var(--gray-700);
   --color-tag-neutral-bg: var(--gray-100);
   --color-tag-neutral-text: var(--gray-600);
+  --color-tag-pr-bg: #ddf4ff;
+  --color-tag-pr-text: #0969da;
 
   /* Terminal Chrome */
   --color-terminal-chrome: #1e1e1e;
@@ -178,6 +180,8 @@
   --color-tag-branch-text: var(--color-tag-branch-text);
   --color-tag-neutral-bg: var(--color-tag-neutral-bg);
   --color-tag-neutral-text: var(--color-tag-neutral-text);
+  --color-tag-pr-bg: var(--color-tag-pr-bg);
+  --color-tag-pr-text: var(--color-tag-pr-text);
 
   /* Terminal Chrome */
   --color-terminal-chrome: var(--color-terminal-chrome);

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -43,6 +43,23 @@ export default function TaskCard({ task, index, onContextMenu }: TaskCardProps) 
                 </span>
               )}
 
+              {task.prUrl && (
+                <span
+                  role="link"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    window.open(task.prUrl!, "_blank", "noopener,noreferrer");
+                  }}
+                  className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-tag-pr-bg text-tag-pr-text cursor-pointer hover:opacity-80 transition-opacity"
+                >
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
+                  </svg>
+                  PR
+                </span>
+              )}
+
               {task.agentType && (
                 <span
                   className={`text-xs px-2 py-0.5 rounded-full ${

--- a/src/entities/KanbanTask.ts
+++ b/src/entities/KanbanTask.ts
@@ -68,6 +68,9 @@ export class KanbanTask {
   @Column({ name: "base_branch", type: "varchar", length: 255, nullable: true })
   baseBranch!: string | null;
 
+  @Column({ name: "pr_url", type: "varchar", length: 500, nullable: true })
+  prUrl!: string | null;
+
   @Column({ name: "display_order", type: "int", default: 0 })
   displayOrder!: number;
 


### PR DESCRIPTION
KanbanTask 엔티티에 prUrl 컬럼을 추가하고, gh CLI를 통해
브랜치에 연결된 PR URL을 자동 조회하여 DB에 저장한다.
상세화면 진입 시 PR이 있으면 메타데이터 카드에 외부 링크로 표시하고,
칸반 카드에도 PR 아이콘 태그를 추가하여 클릭 시 새 탭으로 이동한다.