### PR TITLE
fix(terminal): xterm 터미널 풀스크린 미적용 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -203,3 +203,14 @@ body {
   color: var(--color-text-primary);
   font-family: var(--font-sans);
 }
+
+/* xterm 터미널이 컨테이너를 꽉 채우도록 강제 */
+.xterm {
+  height: 100%;
+}
+.xterm-viewport {
+  height: 100% !important;
+}
+.xterm-screen {
+  height: 100%;
+}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -39,7 +39,9 @@ export default function Terminal({ taskId }: TerminalProps) {
     term.loadAddon(fitAddon);
     term.loadAddon(new WebLinksAddon());
     term.open(terminalRef.current);
-    fitAddon.fit();
+
+    /** 레이아웃 계산 완료 후 초기 fit 실행 */
+    requestAnimationFrame(() => fitAddon.fit());
 
     xtermRef.current = term;
 
@@ -87,11 +89,12 @@ export default function Terminal({ taskId }: TerminalProps) {
       }
     });
 
-    const handleWindowResize = () => fitAddon.fit();
-    window.addEventListener("resize", handleWindowResize);
+    /** 컨테이너 크기 변경을 직접 감지하여 터미널 재적용 */
+    const resizeObserver = new ResizeObserver(() => fitAddon.fit());
+    resizeObserver.observe(terminalRef.current);
 
     return () => {
-      window.removeEventListener("resize", handleWindowResize);
+      resizeObserver.disconnect();
       ws.close();
       term.dispose();
     };


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- xterm.js 터미널이 컨테이너 영역을 꽉 채우지 못하고 상단 일부만 차지하는 문제를 수정합니다.

## 어떻게 해결했나요?
**ResizeObserver 적용 및 초기 fit 타이밍 개선**
- `window.addEventListener("resize")` 대신 `ResizeObserver`로 터미널 컨테이너의 크기 변경을 직접 감지
- 초기 `fitAddon.fit()`을 `requestAnimationFrame`으로 래핑하여 레이아웃 계산 완료 후 실행

**xterm 내부 DOM에 height 100% CSS 추가**
- `.xterm`, `.xterm-viewport`, `.xterm-screen`에 `height: 100%` 적용하여 컨테이너를 꽉 채우도록 강제

## 중요한 변경 사항은 무엇인가요?
### 터미널 크기 맞춤 로직 개선

**ResizeObserver로 컨테이너 크기 감지 방식 변경**
- **변경 이유**: `window.resize` 이벤트는 브라우저 창 크기 변경만 감지하며, flex 레이아웃 내 컨테이너 자체의 크기 변경은 감지하지 못함
- **수정 파일**: `src/components/Terminal.tsx`

**초기 fit 타이밍을 requestAnimationFrame으로 지연**
- **변경 이유**: `term.open()` 직후 호출되는 `fitAddon.fit()`이 flexbox 레이아웃 계산 완료 전에 실행되어 rows 수가 부족하게 계산됨
- **수정 파일**: `src/components/Terminal.tsx`

**xterm 내부 요소에 height: 100% CSS 추가**
- **변경 이유**: xterm.js 내부 DOM이 계산된 rows만큼만 렌더링하여 컨테이너 하단에 빈 공간이 발생
- **수정 파일**: `src/app/globals.css`
