### PR TITLE
fix: 기본 포트 외 다른 포트 사용 시 동작하지 않는 문제 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,9 +3,11 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
+const port = process.env.PORT || "4885";
+
 const nextConfig: NextConfig = {
   serverExternalPackages: ["typeorm", "reflect-metadata", "node-pty", "ssh2"],
-  allowedDevOrigins: ["http://192.168.36.150:4885"],
+  allowedDevOrigins: [`http://192.168.36.150:${port}`],
 };
 
 export default withNextIntl(nextConfig);

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -51,7 +51,7 @@ export default function Terminal({ taskId }: TerminalProps) {
 
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const wsHost = window.location.hostname;
-    const wsPort = parseInt(window.location.port || "4886", 10) + 10000;
+    const wsPort = parseInt(window.location.port || "4885", 10) + 10000;
     const wsUrl = `${protocol}//${wsHost}:${wsPort}/api/terminal/${taskId}`;
     const ws = new WebSocket(wsUrl);
     wsRef.current = ws;


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- 기본 포트(4885) 외 다른 포트로 개발 서버를 실행할 때 allowedDevOrigins 및 WebSocket 연결이 실패하는 문제를 수정

## 어떻게 해결했나요?
**포트 설정 동적화**
- 하드코딩된 포트 번호를 환경변수 기반으로 변경하여 어떤 포트에서든 정상 동작하도록 수정

## 중요한 변경 사항은 무엇인가요?
### allowedDevOrigins 동적 포트 적용

**환경변수 기반 포트 설정**
- **변경 이유**: `allowedDevOrigins`에 포트 4885가 하드코딩되어 있어 다른 포트 사용 시 CORS 에러 발생
- **수정 파일**: `next.config.ts`

### Terminal WebSocket 포트 fallback 수정

**잘못된 기본 포트 값 수정**
- **변경 이유**: WebSocket 포트 계산 시 fallback 값이 4886으로 잘못 설정되어 있어 올바른 기본 포트 4885로 수정
- **수정 파일**: `src/components/Terminal.tsx`
