### PR TITLE
feat(terminal): tmux window/tab 이름에 모니터 이모지 접두사 추가

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -6,6 +6,7 @@ import { WebSocketServer, type WebSocket } from "ws";
 import { validateSessionFromCookie } from "@/lib/auth";
 import { getTaskRepository } from "@/lib/database";
 import { attachLocalSession, attachRemoteSession } from "@/lib/terminal";
+import { formatWindowName } from "@/lib/worktree";
 import { parseSSHConfig } from "@/lib/sshConfig";
 
 const dev = process.env.NODE_ENV !== "production";
@@ -69,7 +70,7 @@ app.prepare().then(() => {
       }
 
       /** branchName에서 window/tab 이름을 파생한다 */
-      const windowName = task.branchName?.replace(/\//g, "-") || "";
+      const windowName = task.branchName ? formatWindowName(task.branchName) : "";
 
       if (task.sshHost) {
         const sshHosts = await parseSSHConfig();

--- a/src/app/actions/project.ts
+++ b/src/app/actions/project.ts
@@ -6,7 +6,7 @@ import { Project } from "@/entities/Project";
 import { validateGitRepo, getDefaultBranch, listBranches, scanGitRepos, listWorktrees } from "@/lib/gitOperations";
 import { getTaskRepository } from "@/lib/database";
 import { TaskStatus, SessionType } from "@/entities/KanbanTask";
-import { isWindowAlive } from "@/lib/worktree";
+import { isWindowAlive, formatWindowName } from "@/lib/worktree";
 import path from "path";
 
 /** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
@@ -175,7 +175,7 @@ export async function scanAndRegisterProjects(
 
         /** tmux 세션에 동일한 session-window가 있으면 연결 정보를 설정한다 */
         const sessionName = path.basename(project.repoPath);
-        const windowName = wt.branch.replace(/\//g, "-");
+        const windowName = formatWindowName(wt.branch);
         const hasWindow = await isWindowAlive(
           SessionType.TMUX,
           sessionName,


### PR DESCRIPTION
## 어떤 작업인가요?
- tmux window / zellij tab 이름을 workmux 스타일로 변경하여 모니터 이모지 접두사를 붙이고, `feat/post` → ` feat-post` 형식으로 표시되도록 수정

## 어떻게 해결했나요?
**formatWindowName 유틸 함수 도입**
- 4곳에 분산되어 있던 `branchName.replace(/\//g, "-")` 로직을 `formatWindowName()` 함수로 통합
- 이모지 접두사(` `) + 슬래시→하이픈 변환을 한 곳에서 관리

## 중요한 변경 사항은 무엇인가요?
### formatWindowName 유틸 함수 추가

**중앙화된 윈도우 이름 변환**
- **변경 이유**: 4곳에 동일 로직이 분산되어 있어 이모지 접두사 추가 시 누락 위험이 있었음
- **수정 파일**: `src/lib/worktree.ts`

### 기존 호출부 교체

**server.ts, project.ts 호출부 통합**
- **변경 이유**: 모든 windowName 생성 경로에서 일관된 포맷을 보장
- **수정 파일**: `server.ts`, `src/app/actions/project.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
