### PR TITLE
feat(board): 칸반 보드 프로젝트 필터 및 프로젝트 이름 태그 추가

### DIFF
--- a/.claude/plan/ui/2602/13-kanban-project-filter.plan.md
+++ b/.claude/plan/ui/2602/13-kanban-project-filter.plan.md
@@ -1,0 +1,84 @@
+# 칸반 보드 프로젝트 필터
+
+## Business Goal
+칸반 보드에 프로젝트 필터를 추가하여 특정 프로젝트의 태스크만 볼 수 있게 한다. 필터는 localStorage에 저장되어 세션 간 유지된다. 프로젝트 선택 시 해당 프로젝트 + worktree 프로젝트의 태스크를 함께 표시한다. 태스크 생성 시 필터된 프로젝트가 자동 설정된다.
+
+## Scope
+- **In Scope**: 프로젝트 필터 드롭다운 UI, localStorage 저장/복원, 클라이언트 필터링, worktree 프로젝트 포함 필터, CreateTaskModal에 기본 프로젝트 전달, 필터 적용 시 드래그 핸들러 보정
+- **Out of Scope**: 서버사이드 필터링, DB 변경, 프로젝트 간 드래그 이동
+
+## Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `messages/ko.json` | 한국어 번역 | Modify |
+| `messages/en.json` | 영어 번역 | Modify |
+| `messages/zh.json` | 중국어 번역 | Modify |
+| `src/components/Board.tsx` | 메인 보드 컨테이너 | Modify |
+| `src/components/CreateTaskModal.tsx` | 태스크 생성 모달 | Modify |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 필터 방식 | 클라이언트 필터링 | 데이터 구조/API 변경 없음 | 서버사이드 필터 |
+| 저장소 | localStorage | 단순, 서버 불필요 | cookie, URL param |
+| Worktree 포함 | repoPath 기반 매칭 | 기존 __worktrees 패턴 활용 | isWorktree 플래그 + parentId |
+| 드래그 핸들러 | 필터 인덱스→전체 인덱스 매핑 | 정확한 위치 삽입 | 단순 append (부정확) |
+
+## Implementation Todos
+
+### Todo 1: i18n 번역 키 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 프로젝트 필터 UI에 사용할 번역 키 추가
+- **Work**:
+  - `messages/ko.json`의 `board` 객체에 `"allProjects": "전체 프로젝트"` 추가
+  - `messages/en.json`의 `board` 객체에 `"allProjects": "All Projects"` 추가
+  - `messages/zh.json`의 `board` 객체에 `"allProjects": "所有项目"` 추가
+- **Verification**: JSON 파싱 오류 없음
+- **Exit Criteria**: `t("board.allProjects")` 사용 가능
+- **Status**: pending
+
+### Todo 2: Board에 프로젝트 필터 구현
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: Board 컴포넌트에 프로젝트 필터 state, localStorage 저장/복원, 필터 UI, 필터링 로직, 드래그 핸들러 보정을 구현
+- **Work**:
+  - `selectedProjectId` state 추가 (초기값: "")
+  - localStorage 복원 useEffect (`kanvibe:projectFilter` 키)
+  - localStorage 저장 useEffect
+  - `projectFilterSet: Set<string>` useMemo: 선택된 프로젝트 + repoPath 기반 worktree 프로젝트 ID 집합
+  - `filteredTasks: TasksByStatus` useMemo: projectFilterSet으로 필터링
+  - `insertAtFilteredIndex` 헬퍼 함수: 필터된 인덱스를 전체 배열 위치로 매핑하여 삽입
+  - `handleDragEnd` 수정: `draggableId`로 태스크 찾기, `insertAtFilteredIndex`로 정확한 위치 삽입
+  - 헤더에 `<select>` 드롭다운 추가: "전체 프로젝트" + 개별 프로젝트 (isWorktree 제외)
+  - Column에 `filteredTasks[col.status]` 전달
+  - CreateTaskModal에 `defaultProjectId={selectedProjectId}` 전달
+- **Convention Notes**: 기존 디자인 토큰 사용, useCallback/useMemo 패턴 유지
+- **Verification**: TypeScript 타입 에러 없음
+- **Exit Criteria**: 필터 선택 시 해당 프로젝트+worktree 태스크만 표시, localStorage 저장/복원 동작, 드래그 정상 동작
+- **Status**: pending
+
+### Todo 3: CreateTaskModal 기본 프로젝트 설정
+- **Priority**: 2
+- **Dependencies**: Todo 2
+- **Goal**: Board에서 전달된 defaultProjectId로 프로젝트를 자동 선택
+- **Work**:
+  - `CreateTaskModalProps`에 `defaultProjectId?: string` 추가
+  - `selectedProjectId` useState 초기값을 `defaultProjectId || ""` 사용
+  - 모달이 열릴 때(isOpen 변경 시) defaultProjectId로 리셋하는 useEffect 추가
+- **Convention Notes**: 기존 props 패턴 유지
+- **Verification**: TypeScript 타입 에러 없음
+- **Exit Criteria**: 필터 선택 후 "새 작업" 클릭 시 해당 프로젝트가 자동 선택됨
+- **Status**: pending
+
+## Verification Strategy
+- TypeScript 타입 에러 없음 (`npx tsc --noEmit`)
+- 3개 언어 JSON 파싱 오류 없음
+
+## Progress Tracking
+- Total Todos: 3
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-13: Plan created

--- a/.claude/plan/ui/2602/13-kanban-project-name-tag.plan.md
+++ b/.claude/plan/ui/2602/13-kanban-project-name-tag.plan.md
@@ -1,0 +1,78 @@
+# Kanban TaskCard에 프로젝트 이름 태그 표시
+
+## Business Goal
+칸반 보드의 TaskCard에 프로젝트 이름을 표시하여 어떤 프로젝트의 작업인지 한눈에 파악할 수 있게 한다. Worktree 프로젝트인 경우 메인 프로젝트 이름을 표시한다.
+
+## Scope
+- **In Scope**: TaskCard에 프로젝트 이름 태그 추가, worktree→main project name 해석 로직, 프로젝트 태그 디자인 토큰, Board→Column→TaskCard props 전달
+- **Out of Scope**: 백엔드 쿼리 변경, 엔티티 수정, 프로젝트 정렬/필터링, Task Detail 페이지 변경
+
+## Codebase Analysis Summary
+Board 컴포넌트는 `projects: Project[]`를 이미 props로 받고 있으나 Column/TaskCard로 전달하지 않음. getTasksByStatus()는 project relation을 로드하지 않으며, TaskCard는 task.projectId만 접근 가능. 기존 태그 패턴은 `text-xs px-2 py-0.5 rounded-full bg-tag-*-bg text-tag-*-text` 형식.
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `prd/design-system.json` | 디자인 토큰 정의 | Modify |
+| `src/app/globals.css` | CSS 변수 선언 + Tailwind 등록 | Modify |
+| `src/components/Board.tsx` | 메인 보드 컨테이너 | Modify |
+| `src/components/Column.tsx` | 상태별 컬럼 | Modify |
+| `src/components/TaskCard.tsx` | 작업 카드 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 태그 스타일 | TaskCard.tsx | `text-xs px-2 py-0.5 rounded-full` 패턴 |
+| 디자인 토큰 절차 | CLAUDE.md | design-system.json → globals.css :root → @theme inline |
+| Props 타입 | Column.tsx, TaskCard.tsx | interface로 명시적 타입 정의 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 데이터 전달 | Board에서 projectNameMap 구성 후 props drilling | 기존 projects 데이터 활용, 백엔드 변경 없음 | getTasksByStatus에 relations 추가 |
+| Worktree 해석 | repoPath에서 `__worktrees` 패턴 파싱 | 기존 디렉토리 컨벤션 활용 | isWorktree 플래그 + parentProjectId 컬럼 |
+| 태그 색상 | yellow-50 bg + gray-800 text | 따뜻한 톤으로 시각적 구분, 기존 primitive 활용, 충분한 대비 | purple 계열 (비 Google 브랜드) |
+
+## Implementation Todos
+
+### Todo 1: 프로젝트 태그 디자인 토큰 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: `tag-project-bg/text` 디자인 토큰을 추가하여 프로젝트 태그에 사용할 색상을 정의한다
+- **Work**:
+  - `prd/design-system.json`의 `colors.tags` 객체에 `"project": { "background": "{yellow.50}", "text": "{gray.800}" }` 추가
+  - `src/app/globals.css`의 `:root`에 `--color-tag-project-bg: var(--yellow-50)`, `--color-tag-project-text: var(--gray-800)` 추가
+  - `src/app/globals.css`의 `@theme inline` 블록에 `--color-tag-project-bg`, `--color-tag-project-text` 등록
+- **Convention Notes**: 기존 tag 토큰 패턴(bg + text 쌍)과 동일한 구조 유지
+- **Verification**: CSS 파싱 오류 없는지 빌드 확인
+- **Exit Criteria**: `bg-tag-project-bg text-tag-project-text` Tailwind 클래스 사용 가능
+- **Status**: pending
+
+### Todo 2: Board → Column → TaskCard 프로젝트 이름 전달 및 표시
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: Board에서 projectNameMap을 구성하고 Column을 거쳐 TaskCard까지 전달, 카드에 프로젝트 이름 태그 렌더링
+- **Work**:
+  - `Board.tsx`: `projects` 배열로 `projectNameMap: Record<string, string>` 생성 (`useMemo`)
+    - worktree 프로젝트(`repoPath`에 `__worktrees` 포함)는 메인 프로젝트 이름으로 resolve
+    - 메인 프로젝트 찾기: repoPath에서 `__worktrees` 이전 경로 추출 → 동일 repoPath의 프로젝트 name 사용, 없으면 경로의 basename 사용
+  - `Column.tsx`: `ColumnProps`에 `projectNameMap: Record<string, string>` 추가, TaskCard로 전달
+  - `TaskCard.tsx`: `TaskCardProps`에 `projectName?: string` 추가, 브랜치 태그 앞에 프로젝트 이름 태그 렌더링
+  - Board에서 Column 호출 시 `projectNameMap` 전달
+  - Column에서 TaskCard 호출 시 `projectNameMap[task.projectId]`를 `projectName`으로 전달
+- **Convention Notes**: 기존 태그 스타일(`text-xs px-2 py-0.5 rounded-full`) 재사용, truncate로 긴 이름 처리
+- **Verification**: `npm run build` 성공, 타입 에러 없음
+- **Exit Criteria**: TaskCard에 프로젝트 이름 태그가 브랜치 태그 앞에 표시됨, worktree 프로젝트는 메인 프로젝트 이름 표시
+- **Status**: pending
+
+## Verification Strategy
+- `npm run build` 성공 확인
+- TypeScript 타입 에러 없음 확인
+
+## Progress Tracking
+- Total Todos: 2
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-13: Plan created

--- a/messages/en.json
+++ b/messages/en.json
@@ -23,6 +23,7 @@
   "board": {
     "title": "KanVibe",
     "newTask": "+ New Task",
+    "allProjects": "All Projects",
     "columns": {
       "todo": "Todo",
       "progress": "Progress",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -23,6 +23,7 @@
   "board": {
     "title": "KanVibe",
     "newTask": "+ 새 작업",
+    "allProjects": "전체 프로젝트",
     "columns": {
       "todo": "Todo",
       "progress": "Progress",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -23,6 +23,7 @@
   "board": {
     "title": "KanVibe",
     "newTask": "+ 新任务",
+    "allProjects": "所有项目",
     "columns": {
       "todo": "待办",
       "progress": "进行中",

--- a/prd/design-system.json
+++ b/prd/design-system.json
@@ -124,6 +124,7 @@
       },
       "session": { "background": "{blue.50}", "text": "{blue.600}" },
       "ssh": { "background": "{green.50}", "text": "{green.600}" },
+      "project": { "background": "{yellow.50}", "text": "{gray.800}" },
       "branch": { "background": "{gray.100}", "text": "{gray.700}" },
       "neutral": { "background": "{gray.100}", "text": "{gray.600}" }
     }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -95,6 +95,8 @@
   --color-tag-session-text: var(--blue-600);
   --color-tag-ssh-bg: var(--green-50);
   --color-tag-ssh-text: var(--green-600);
+  --color-tag-project-bg: var(--yellow-50);
+  --color-tag-project-text: var(--gray-800);
   --color-tag-branch-bg: var(--gray-100);
   --color-tag-branch-text: var(--gray-700);
   --color-tag-neutral-bg: var(--gray-100);
@@ -184,6 +186,8 @@
   --color-tag-session-text: var(--color-tag-session-text);
   --color-tag-ssh-bg: var(--color-tag-ssh-bg);
   --color-tag-ssh-text: var(--color-tag-ssh-text);
+  --color-tag-project-bg: var(--color-tag-project-bg);
+  --color-tag-project-text: var(--color-tag-project-text);
   --color-tag-branch-bg: var(--color-tag-branch-bg);
   --color-tag-branch-text: var(--color-tag-branch-text);
   --color-tag-neutral-bg: var(--color-tag-neutral-bg);

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { DragDropContext, type DropResult } from "@hello-pangea/dnd";
 import Column from "./Column";
 import CreateTaskModal from "./CreateTaskModal";
+import ProjectSelector from "./ProjectSelector";
 import ProjectSettings from "./ProjectSettings";
 import TaskContextMenu from "./TaskContextMenu";
 import BranchTaskModal from "./BranchTaskModal";
@@ -281,19 +282,17 @@ export default function Board({ initialTasks, sshHosts, projects }: BoardProps) 
       <header className="flex items-center justify-between px-6 py-4 border-b border-border-default bg-bg-surface">
         <div className="flex items-center gap-4">
           <h1 className="text-xl font-bold text-text-primary">{t("title")}</h1>
-          <select
-            value={selectedProjectId}
-            onChange={(e) => setSelectedProjectId(e.target.value)}
-            className="px-3 py-1.5 text-sm bg-bg-page border border-border-default rounded-md text-text-primary focus:outline-none focus:border-brand-primary transition-colors"
-          >
-            <option value="">{t("allProjects")}</option>
-            {filterableProjects.map((project) => (
-              <option key={project.id} value={project.id}>
-                {project.name}
-                {project.sshHost ? ` (${project.sshHost})` : ""}
-              </option>
-            ))}
-          </select>
+          <div className="w-56">
+            <ProjectSelector
+              projects={filterableProjects}
+              selectedProjectId={selectedProjectId}
+              onSelect={setSelectedProjectId}
+              placeholder={t("allProjects")}
+              searchPlaceholder={tt("projectSearch")}
+              allOption={{ label: t("allProjects") }}
+              compact
+            />
+          </div>
         </div>
         <div className="flex items-center gap-3">
           <button

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -10,9 +10,10 @@ interface ColumnProps {
   label: string;
   colorClass: string;
   onContextMenu: (e: React.MouseEvent, task: KanbanTask) => void;
+  projectNameMap: Record<string, string>;
 }
 
-export default function Column({ status, tasks, label, colorClass, onContextMenu }: ColumnProps) {
+export default function Column({ status, tasks, label, colorClass, onContextMenu, projectNameMap }: ColumnProps) {
   return (
     <div className="flex-1 min-w-[280px] max-w-[350px]">
       <div className="flex items-center gap-2 mb-3 px-2">
@@ -35,7 +36,13 @@ export default function Column({ status, tasks, label, colorClass, onContextMenu
             }`}
           >
             {tasks.map((task, index) => (
-              <TaskCard key={task.id} task={task} index={index} onContextMenu={onContextMenu} />
+              <TaskCard
+                key={task.id}
+                task={task}
+                index={index}
+                onContextMenu={onContextMenu}
+                projectName={task.projectId ? projectNameMap[task.projectId] : undefined}
+              />
             ))}
             {provided.placeholder}
           </div>

--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -12,6 +12,7 @@ interface CreateTaskModalProps {
   onClose: () => void;
   sshHosts: string[];
   projects: Project[];
+  defaultProjectId?: string;
 }
 
 export default function CreateTaskModal({
@@ -19,11 +20,12 @@ export default function CreateTaskModal({
   onClose,
   sshHosts,
   projects,
+  defaultProjectId,
 }: CreateTaskModalProps) {
   const t = useTranslations("task");
   const tc = useTranslations("common");
   const [isPending, startTransition] = useTransition();
-  const [selectedProjectId, setSelectedProjectId] = useState("");
+  const [selectedProjectId, setSelectedProjectId] = useState(defaultProjectId || "");
   const [branches, setBranches] = useState<string[]>([]);
   const [baseBranch, setBaseBranch] = useState("");
 
@@ -33,6 +35,13 @@ export default function CreateTaskModal({
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  /** 모달이 열릴 때 필터에서 선택된 프로젝트를 자동 설정한다 */
+  useEffect(() => {
+    if (isOpen && defaultProjectId) {
+      setSelectedProjectId(defaultProjectId);
+    }
+  }, [isOpen, defaultProjectId]);
 
   /** worktree가 아닌 프로젝트만 필터링한다 */
   const availableProjects = projects.filter((p) => !p.isWorktree);

--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useEffect, useTransition, useRef, useCallback } from "react";
+import { useState, useEffect, useTransition } from "react";
 import { useTranslations } from "next-intl";
 import { createTask } from "@/app/actions/kanban";
 import { getProjectBranches } from "@/app/actions/project";
 import { SessionType } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
+import ProjectSelector from "./ProjectSelector";
 
 interface CreateTaskModalProps {
   isOpen: boolean;
@@ -29,13 +30,6 @@ export default function CreateTaskModal({
   const [branches, setBranches] = useState<string[]>([]);
   const [baseBranch, setBaseBranch] = useState("");
 
-  /** 프로젝트 검색 관련 state */
-  const [searchQuery, setSearchQuery] = useState("");
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [highlightedIndex, setHighlightedIndex] = useState(-1);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-
   /** 모달이 열릴 때 필터에서 선택된 프로젝트를 자동 설정한다 */
   useEffect(() => {
     if (isOpen && defaultProjectId) {
@@ -45,13 +39,6 @@ export default function CreateTaskModal({
 
   /** worktree가 아닌 프로젝트만 필터링한다 */
   const availableProjects = projects.filter((p) => !p.isWorktree);
-
-  /** 검색어가 있으면 추가 필터링, 없으면 전체 목록을 표시한다 */
-  const filteredProjects = searchQuery
-    ? availableProjects.filter((p) =>
-        p.name.toLowerCase().includes(searchQuery.toLowerCase())
-      )
-    : availableProjects;
 
   useEffect(() => {
     if (!selectedProjectId) {
@@ -69,74 +56,6 @@ export default function CreateTaskModal({
       setBranches(result);
     });
   }, [selectedProjectId, projects]);
-
-  /** 드롭다운 외부 클릭 시 닫고 검색어를 초기화한다 */
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setIsDropdownOpen(false);
-        setSearchQuery("");
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  /** 선택된 프로젝트의 표시 텍스트를 반환한다 */
-  const selectedDisplayText = (() => {
-    const selected = projects.find((p) => p.id === selectedProjectId);
-    if (!selected) return "";
-    return selected.name + (selected.sshHost ? ` (${selected.sshHost})` : "");
-  })();
-
-  const selectProject = useCallback((project: Project) => {
-    setSelectedProjectId(project.id);
-    setSearchQuery("");
-    setIsDropdownOpen(false);
-    setHighlightedIndex(-1);
-  }, []);
-
-  /** 키보드 네비게이션 핸들러 */
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (!isDropdownOpen) {
-        if (e.key === "ArrowDown" || e.key === "Enter") {
-          e.preventDefault();
-          setIsDropdownOpen(true);
-        }
-        return;
-      }
-
-      switch (e.key) {
-        case "ArrowDown":
-          e.preventDefault();
-          setHighlightedIndex((prev) =>
-            prev < filteredProjects.length - 1 ? prev + 1 : 0
-          );
-          break;
-        case "ArrowUp":
-          e.preventDefault();
-          setHighlightedIndex((prev) =>
-            prev > 0 ? prev - 1 : filteredProjects.length - 1
-          );
-          break;
-        case "Enter":
-          e.preventDefault();
-          if (highlightedIndex >= 0 && highlightedIndex < filteredProjects.length) {
-            selectProject(filteredProjects[highlightedIndex]);
-          }
-          break;
-        case "Escape":
-          e.preventDefault();
-          setIsDropdownOpen(false);
-          setSearchQuery("");
-          setHighlightedIndex(-1);
-          inputRef.current?.blur();
-          break;
-      }
-    },
-    [isDropdownOpen, highlightedIndex, filteredProjects, selectProject]
-  );
 
   if (!isOpen) return null;
 
@@ -166,66 +85,17 @@ export default function CreateTaskModal({
         </h2>
 
         <form action={handleSubmit} className="space-y-4">
-          <div ref={dropdownRef} className="relative">
+          <div>
             <label className="block text-sm text-text-secondary mb-1">
               {t("project")} *
             </label>
-            <input
-              ref={inputRef}
-              type="text"
-              value={isDropdownOpen ? searchQuery : selectedDisplayText}
-              onChange={(e) => {
-                setSearchQuery(e.target.value);
-                setHighlightedIndex(-1);
-                if (!e.target.value) {
-                  setSelectedProjectId("");
-                }
-              }}
-              onFocus={() => {
-                setSearchQuery("");
-                setIsDropdownOpen(true);
-                setHighlightedIndex(-1);
-              }}
-              onKeyDown={handleKeyDown}
-              placeholder={isDropdownOpen ? t("projectSearch") : t("projectSelect")}
-              className="w-full px-3 py-2 bg-bg-page border border-border-default rounded-md text-text-primary focus:outline-none focus:border-brand-primary transition-colors cursor-pointer"
+            <ProjectSelector
+              projects={availableProjects}
+              selectedProjectId={selectedProjectId}
+              onSelect={setSelectedProjectId}
+              placeholder={t("projectSelect")}
+              searchPlaceholder={t("projectSearch")}
             />
-            {isDropdownOpen && (
-              <ul className="absolute z-50 mt-1 w-full max-h-48 overflow-y-auto bg-bg-surface border border-border-default rounded-md shadow-md">
-                {filteredProjects.length === 0 ? (
-                  <li className="px-3 py-2 text-sm text-text-muted">
-                    {t("projectSelect")}
-                  </li>
-                ) : (
-                  filteredProjects.map((project, index) => (
-                    <li
-                      key={project.id}
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        selectProject(project);
-                      }}
-                      onMouseEnter={() => setHighlightedIndex(index)}
-                      className={`px-3 py-2 text-sm cursor-pointer transition-colors ${
-                        index === highlightedIndex
-                          ? "bg-brand-primary/10 text-text-primary"
-                          : "text-text-primary hover:bg-bg-page"
-                      } ${
-                        project.id === selectedProjectId
-                          ? "font-medium"
-                          : ""
-                      }`}
-                    >
-                      {project.name}
-                      {project.sshHost && (
-                        <span className="text-text-muted ml-1">
-                          ({project.sshHost})
-                        </span>
-                      )}
-                    </li>
-                  ))
-                )}
-              </ul>
-            )}
           </div>
 
           {selectedProjectId && (

--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { Project } from "@/entities/Project";
+
+interface ProjectSelectorProps {
+  projects: Project[];
+  selectedProjectId: string;
+  onSelect: (projectId: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  /** "전체 프로젝트" 등 전체 선택 옵션. label이 드롭다운에 표시된다 */
+  allOption?: { label: string };
+  /** 헤더 등 좁은 영역에서 사용할 컴팩트 스타일 */
+  compact?: boolean;
+}
+
+export default function ProjectSelector({
+  projects,
+  selectedProjectId,
+  onSelect,
+  placeholder = "",
+  searchPlaceholder = "",
+  allOption,
+  compact = false,
+}: ProjectSelectorProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filteredProjects = searchQuery
+    ? projects.filter((p) =>
+        p.name.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+    : projects;
+
+  /** "전체" 옵션은 검색 중이 아닐 때만 표시한다 */
+  const showAllOption = !!allOption && !searchQuery;
+  const totalItems = (showAllOption ? 1 : 0) + filteredProjects.length;
+
+  const selectedDisplayText = (() => {
+    if (!selectedProjectId && allOption) return allOption.label;
+    const selected = projects.find((p) => p.id === selectedProjectId);
+    if (!selected) return "";
+    return selected.name + (selected.sshHost ? ` (${selected.sshHost})` : "");
+  })();
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+        setSearchQuery("");
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const selectItem = useCallback(
+    (projectId: string) => {
+      onSelect(projectId);
+      setSearchQuery("");
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+    },
+    [onSelect]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!isOpen) {
+        if (e.key === "ArrowDown" || e.key === "Enter") {
+          e.preventDefault();
+          setIsOpen(true);
+        }
+        return;
+      }
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setHighlightedIndex((prev) =>
+            prev < totalItems - 1 ? prev + 1 : 0
+          );
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setHighlightedIndex((prev) =>
+            prev > 0 ? prev - 1 : totalItems - 1
+          );
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (highlightedIndex >= 0 && highlightedIndex < totalItems) {
+            if (showAllOption && highlightedIndex === 0) {
+              selectItem("");
+            } else {
+              const projectIndex = showAllOption
+                ? highlightedIndex - 1
+                : highlightedIndex;
+              if (
+                projectIndex >= 0 &&
+                projectIndex < filteredProjects.length
+              ) {
+                selectItem(filteredProjects[projectIndex].id);
+              }
+            }
+          }
+          break;
+        case "Escape":
+          e.preventDefault();
+          setIsOpen(false);
+          setSearchQuery("");
+          setHighlightedIndex(-1);
+          inputRef.current?.blur();
+          break;
+      }
+    },
+    [
+      isOpen,
+      highlightedIndex,
+      totalItems,
+      showAllOption,
+      filteredProjects,
+      selectItem,
+    ]
+  );
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        ref={inputRef}
+        type="text"
+        value={isOpen ? searchQuery : selectedDisplayText}
+        onChange={(e) => {
+          setSearchQuery(e.target.value);
+          setHighlightedIndex(-1);
+        }}
+        onFocus={() => {
+          setSearchQuery("");
+          setIsOpen(true);
+          setHighlightedIndex(-1);
+        }}
+        onKeyDown={handleKeyDown}
+        placeholder={isOpen ? searchPlaceholder : placeholder}
+        className={`w-full bg-bg-page border border-border-default rounded-md text-text-primary focus:outline-none focus:border-brand-primary transition-colors cursor-pointer ${
+          compact ? "px-3 py-1.5 text-sm" : "px-3 py-2"
+        }`}
+      />
+      {isOpen && (
+        <ul className="absolute z-50 mt-1 w-full max-h-48 overflow-y-auto bg-bg-surface border border-border-default rounded-md shadow-md">
+          {showAllOption && (
+            <li
+              onMouseDown={(e) => {
+                e.preventDefault();
+                selectItem("");
+              }}
+              onMouseEnter={() => setHighlightedIndex(0)}
+              className={`px-3 py-2 text-sm cursor-pointer transition-colors ${
+                highlightedIndex === 0
+                  ? "bg-brand-primary/10 text-text-primary"
+                  : "text-text-primary hover:bg-bg-page"
+              } ${!selectedProjectId ? "font-medium" : ""}`}
+            >
+              {allOption.label}
+            </li>
+          )}
+          {filteredProjects.length === 0 && !showAllOption ? (
+            <li className="px-3 py-2 text-sm text-text-muted">
+              {placeholder}
+            </li>
+          ) : (
+            filteredProjects.map((project, index) => {
+              const itemIndex = showAllOption ? index + 1 : index;
+              return (
+                <li
+                  key={project.id}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    selectItem(project.id);
+                  }}
+                  onMouseEnter={() => setHighlightedIndex(itemIndex)}
+                  className={`px-3 py-2 text-sm cursor-pointer transition-colors ${
+                    itemIndex === highlightedIndex
+                      ? "bg-brand-primary/10 text-text-primary"
+                      : "text-text-primary hover:bg-bg-page"
+                  } ${project.id === selectedProjectId ? "font-medium" : ""}`}
+                >
+                  {project.name}
+                  {project.sshHost && (
+                    <span className="text-text-muted ml-1">
+                      ({project.sshHost})
+                    </span>
+                  )}
+                </li>
+              );
+            })
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -8,6 +8,7 @@ interface TaskCardProps {
   task: KanbanTask;
   index: number;
   onContextMenu: (e: React.MouseEvent, task: KanbanTask) => void;
+  projectName?: string;
 }
 
 const agentTagColors: Record<string, string> = {
@@ -16,7 +17,7 @@ const agentTagColors: Record<string, string> = {
   codex: "bg-tag-codex-bg text-tag-codex-text",
 };
 
-export default function TaskCard({ task, index, onContextMenu }: TaskCardProps) {
+export default function TaskCard({ task, index, onContextMenu, projectName }: TaskCardProps) {
   return (
     <Draggable draggableId={task.id} index={index}>
       {(provided, snapshot) => (
@@ -37,6 +38,12 @@ export default function TaskCard({ task, index, onContextMenu }: TaskCardProps) 
             </h3>
 
             <div className="flex items-center gap-2 mt-2 flex-wrap">
+              {projectName && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-tag-project-bg text-tag-project-text font-medium truncate max-w-[120px]">
+                  {projectName}
+                </span>
+              )}
+
               {task.branchName && (
                 <span className="text-xs px-2 py-0.5 rounded-full bg-tag-branch-bg text-tag-branch-text font-mono truncate max-w-[140px]">
                   {task.branchName}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -21,7 +25,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -32,5 +38,7 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/ui/2602/13-kanban-project-filter.plan.md)

## 어떤 작업인가요?
- 칸반 보드에 프로젝트 필터, 프로젝트 이름 태그를 추가하고 프로젝트 선택 드롭다운을 공통 컴포넌트로 추출하는 작업

## 어떻게 해결했나요?
**프로젝트 이름 태그 표시**
- 칸반 카드에 프로젝트 이름 태그를 추가하여 어떤 프로젝트의 태스크인지 시각적으로 확인 가능
- worktree 프로젝트는 메인 프로젝트 이름으로 resolve하여 표시

**프로젝트 필터 기능**
- 보드 헤더에 프로젝트 필터 드롭다운 추가
- 선택된 프로젝트 + 하위 worktree 태스크만 표시
- 필터 선택값을 localStorage에 저장하여 세션 간 유지
- 필터 활성화 상태에서 드래그앤드롭이 올바르게 동작하도록 인덱스 매핑 처리

**ProjectSelector 공통 컴포넌트 추출**
- CreateTaskModal의 검색 가능 드롭다운 로직을 ProjectSelector로 추출
- Board 헤더 필터와 CreateTaskModal 모두 동일 컴포넌트 사용
- 키보드 네비게이션, 외부 클릭 닫기, 검색 필터링 지원

## 중요한 변경 사항은 무엇인가요?
### 프로젝트 이름 태그

**TaskCard에 프로젝트 태그 추가**
- **변경 이유**: 태스크가 어떤 프로젝트에 속하는지 보드에서 바로 확인할 수 있도록 함
- **수정 파일**: `src/components/TaskCard.tsx`, `src/components/Column.tsx`, `prd/design-system.json`, `src/app/globals.css`

### 프로젝트 필터

**Board 헤더에 필터 드롭다운 추가**
- **변경 이유**: 다수의 프로젝트가 있을 때 특정 프로젝트 태스크만 볼 수 있도록 함
- **수정 파일**: `src/components/Board.tsx`, `messages/ko.json`, `messages/en.json`, `messages/zh.json`

**필터 상태에서의 드래그앤드롭 인덱스 매핑**
- **변경 이유**: 필터 활성화 시 드래그 인덱스가 필터된 리스트 기준이므로 전체 배열에서의 정확한 위치를 계산해야 함
- **수정 파일**: `src/components/Board.tsx` (`insertAtFilteredIndex` 함수)

### ProjectSelector 공통 컴포넌트

**검색 가능 드롭다운 공통화**
- **변경 이유**: Board 필터와 CreateTaskModal에서 동일한 프로젝트 선택 UI를 사용하여 코드 중복 제거
- **수정 파일**: `src/components/ProjectSelector.tsx` (신규), `src/components/Board.tsx`, `src/components/CreateTaskModal.tsx`
