### PR TITLE
fix(worktree): 작업 삭제 시 worktree 경로 불일치 버그 수정

### DIFF
--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -107,10 +107,14 @@ export async function removeWorktreeAndSession(
   }
 
   try {
-    const worktreeDir = `kanvibe-${branchName.replace(/\//g, "-")}`;
-    const worktreePath = path.posix.join(
+    const projectName = path.basename(projectPath);
+    const worktreeBase = path.posix.join(
       path.dirname(projectPath),
-      worktreeDir,
+      `${projectName}__worktrees`,
+    );
+    const worktreePath = path.posix.join(
+      worktreeBase,
+      branchName.replace(/\//g, "-"),
     );
     await execGit(
       `git -C "${projectPath}" worktree remove "${worktreePath}" --force`,


### PR DESCRIPTION
## 어떤 작업인가요?
- 작업 삭제 시 worktree가 실제로 삭제되지 않는 버그를 수정합니다.

## 어떻게 해결했나요?
**worktree 경로 계산 버그 수정**
- `removeWorktreeAndSession`의 worktree 경로 계산을 `createWorktreeWithSession`과 동일한 로직으로 수정

## 중요한 변경 사항은 무엇인가요?
### worktree 삭제 경로 수정

**경로 계산 로직 일치화**
- **변경 이유**: 삭제 시 `kanvibe-<branch>` 패턴으로 경로를 계산하여 실제 생성된 `<projectName>__worktrees/<branch>` 경로와 불일치. worktree 삭제가 항상 실패하고 catch에서 무시되었음.
- **수정 파일**: `src/lib/worktree.ts`
