### PR TITLE
fix(ui): 카드/상세 페이지 브랜치 태그 중복 제거 및 description 미리보기 추가

### DIFF
--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -126,16 +126,6 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
               {t("info")}
             </h3>
             <dl className="space-y-3">
-              {task.branchName && (
-                <div className="flex items-start justify-between gap-2">
-                  <dt className="text-xs text-text-muted shrink-0">
-                    {t("branch")}
-                  </dt>
-                  <dd className="text-xs font-mono bg-tag-branch-bg text-tag-branch-text px-2 py-0.5 rounded text-right truncate max-w-[180px]">
-                    {task.branchName}
-                  </dd>
-                </div>
-              )}
               {task.prUrl && (
                 <div className="flex items-center justify-between gap-2">
                   <dt className="text-xs text-text-muted">{t("prLink")}</dt>

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -37,6 +37,12 @@ export default function TaskCard({ task, index, onContextMenu, projectName }: Ta
               {task.title}
             </h3>
 
+            {task.description && (
+              <p className="text-xs text-text-secondary mt-1 line-clamp-2 leading-relaxed">
+                {task.description}
+              </p>
+            )}
+
             <div className="flex items-center gap-2 mt-2 flex-wrap">
               {projectName && (
                 <span className="text-xs px-2 py-0.5 rounded-full bg-tag-project-bg text-tag-project-text font-medium truncate max-w-[120px]">
@@ -44,11 +50,6 @@ export default function TaskCard({ task, index, onContextMenu, projectName }: Ta
                 </span>
               )}
 
-              {task.branchName && (
-                <span className="text-xs px-2 py-0.5 rounded-full bg-tag-branch-bg text-tag-branch-text font-mono truncate max-w-[140px]">
-                  {task.branchName}
-                </span>
-              )}
 
               {task.prUrl && (
                 <span


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/ui/2602/14-fix-duplicated-branch-name.plan.md)

## 어떤 작업인가요?
- 칸반 카드와 상세 페이지에서 브랜치 이름이 제목과 중복 표시되는 문제를 수정하고, 카드에 description 미리보기를 추가

## 어떻게 해결했나요?
**브랜치 태그 중복 제거**
- title과 branchName이 동일한 값이므로 브랜치 태그 렌더링을 완전히 제거
- 카드(TaskCard)와 상세 페이지(TaskDetailPage) 모두에서 제거

**카드 description 미리보기 추가**
- TaskCard에 description을 `line-clamp-2`로 최대 2줄까지 표시

## 중요한 변경 사항은 무엇인가요?
### 브랜치 태그 제거

**TaskCard 브랜치 태그 제거**
- **변경 이유**: title = branchName이므로 브랜치 태그가 제목과 중복 표시됨
- **수정 파일**: `src/components/TaskCard.tsx`

**상세 페이지 브랜치 메타데이터 제거**
- **변경 이유**: 동일한 중복 문제가 상세 페이지 메타데이터 섹션에서도 발생
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`

### 카드 description 미리보기

**description 2줄 미리보기 추가**
- **변경 이유**: 카드에서 태스크 내용을 한눈에 파악할 수 있도록 개선
- **수정 파일**: `src/components/TaskCard.tsx`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
