### PR TITLE
fix: Next.js 16 middleware → proxy 파일 컨벤션 마이그레이션

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,10 +8,10 @@ const intlMiddleware = createMiddleware(routing);
 const PUBLIC_PATHS = ["/login"];
 
 /**
- * locale 라우팅과 인증을 결합한 미들웨어.
+ * locale 라우팅과 인증을 결합한 프록시.
  * next-intl이 locale을 처리한 뒤, 공개 경로가 아니면 세션 쿠키를 확인한다.
  */
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   const isApiPath = pathname.startsWith("/api/");


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- Next.js 16에서 `middleware` 파일 컨벤션이 `proxy`로 변경됨에 따라 deprecation 경고를 해소하는 마이그레이션

## 어떻게 해결했나요?
**middleware → proxy 파일 컨벤션 마이그레이션**
- Next.js 16 공식 가이드에 따라 `src/middleware.ts`를 `src/proxy.ts`로 리네이밍
- export 함수명을 `middleware`에서 `proxy`로 변경

## 중요한 변경 사항은 무엇인가요?
### middleware → proxy 리네이밍

**파일명 및 함수명 변경**
- **변경 이유**: Next.js 16에서 middleware 파일 컨벤션이 proxy로 리네이밍되어 deprecation 경고 발생
- **수정 파일**: `src/middleware.ts` → `src/proxy.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
