### PR TITLE
fix(project): 메인 브랜치 태스크 제목을 브랜치명으로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6656,6 +6656,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",

--- a/src/app/actions/project.ts
+++ b/src/app/actions/project.ts
@@ -19,7 +19,8 @@ function serialize<T>(data: T): T {
 async function createDefaultBranchTask(project: Project): Promise<void> {
   const taskRepo = await getTaskRepository();
   const task = taskRepo.create({
-    title: project.name,
+    title: project.defaultBranch,
+    branchName: project.defaultBranch,
     status: TaskStatus.TODO,
     projectId: project.id,
     baseBranch: project.defaultBranch,


### PR DESCRIPTION
## 관련 자료
- 이슈 : #22

## 어떤 작업인가요?
- 메인 브랜치 태스크 생성 시 제목이 프로젝트명으로 설정되던 것을 브랜치명으로 변경하여, tmux 세션과의 일관성을 확보합니다.

## 어떻게 해결했나요?
**메인 브랜치 태스크 제목 변경**
- 프로젝트 생성 시 기본 브랜치 태스크의 title을 `project.name` 대신 `project.defaultBranch`로 설정
- `branchName` 필드도 `project.defaultBranch`로 명시적 지정

**의존성 lock 파일 업데이트**
- next-intl의 @swc/helpers 의존성 추가에 따른 package-lock.json 업데이트

## 중요한 변경 사항은 무엇인가요?
### 메인 브랜치 태스크 제목 로직 변경

**태스크 title을 프로젝트명 → 브랜치명으로 변경**
- **변경 이유**: 메인 브랜치 태스크의 제목이 프로젝트명이면 tmux 세션명과 불일치하여 혼동 발생
- **수정 파일**: `src/app/actions/project.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
