### PR TITLE
fix(scan): worktree 스캔 시 메인 브랜치 중복 생성 방지 및 Base Project 배지 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6656,6 +6656,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",

--- a/prd/design-system.json
+++ b/prd/design-system.json
@@ -126,7 +126,8 @@
       "ssh": { "background": "{green.50}", "text": "{green.600}" },
       "project": { "background": "{yellow.50}", "text": "{gray.800}" },
       "branch": { "background": "{gray.100}", "text": "{gray.700}" },
-      "neutral": { "background": "{gray.100}", "text": "{gray.600}" }
+      "neutral": { "background": "{gray.100}", "text": "{gray.600}" },
+      "base": { "background": "#EDE7F6", "text": "#5E35B1" }
     }
   },
   "typography": {

--- a/src/app/actions/project.ts
+++ b/src/app/actions/project.ts
@@ -217,6 +217,9 @@ export async function scanAndRegisterProjects(
       for (const wt of worktrees) {
         if (wt.isBare || !wt.branch) continue;
 
+        /** 메인 작업 디렉토리(프로젝트 루트)는 기본 브랜치 태스크와 중복되므로 건너뛴다 */
+        if (wt.path === project.repoPath) continue;
+
         const existingTask = await taskRepo.findOneBy({ branchName: wt.branch });
         if (existingTask) continue;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,6 +103,8 @@
   --color-tag-neutral-text: var(--gray-600);
   --color-tag-pr-bg: #ddf4ff;
   --color-tag-pr-text: #0969da;
+  --color-tag-base-bg: #EDE7F6;
+  --color-tag-base-text: #5E35B1;
 
   /* Terminal Chrome */
   --color-terminal-chrome: #1e1e1e;
@@ -194,6 +196,8 @@
   --color-tag-neutral-text: var(--color-tag-neutral-text);
   --color-tag-pr-bg: var(--color-tag-pr-bg);
   --color-tag-pr-text: var(--color-tag-pr-text);
+  --color-tag-base-bg: var(--color-tag-base-bg);
+  --color-tag-base-text: var(--color-tag-base-text);
 
   /* Terminal Chrome */
   --color-terminal-chrome: var(--color-terminal-chrome);

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -50,6 +50,12 @@ export default function TaskCard({ task, index, onContextMenu, projectName }: Ta
                 </span>
               )}
 
+              {!task.branchName && task.baseBranch && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-tag-base-bg text-tag-base-text font-medium">
+                  Base Project
+                </span>
+              )}
+
               {task.prUrl && (
                 <span
                   role="link"


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- 프로젝트 스캔 시 메인 worktree 엔트리가 기본 브랜치 태스크와 중복 생성되는 버그를 수정하고, 칸반 카드에서 워크트리가 아닌 메인 브랜치 태스크를 "Base Project" 배지로 시각 구분한다.

## 어떻게 해결했나요?
**worktree 스캔 중복 방지**
- `git worktree list`가 반환하는 메인 작업 디렉토리 엔트리를 스킵하여 기본 브랜치 태스크와 중복 생성 방지

**Base Project 배지 추가**
- 칸반 카드에서 메인 브랜치 태스크(branchName이 없고 baseBranch가 있는 태스크)에 보라색 "Base Project" 배지 표시

## 중요한 변경 사항은 무엇인가요?
### worktree 스캔 중복 방지

**메인 worktree 엔트리 스킵 조건 추가**
- **변경 이유**: `scanAndRegisterProjects`에서 `git worktree list`의 메인 worktree 엔트리(branch=main)가 `createDefaultBranchTask`로 생성된 기존 태스크(branchName=null)와 매칭되지 않아 중복 태스크가 생성됨
- **수정 파일**: `src/app/actions/project.ts`

### Base Project 배지

**디자인 토큰 및 배지 UI 추가**
- **변경 이유**: 워크트리 태스크와 메인 브랜치 태스크를 시각적으로 구분하기 위해 보라색 계열 "Base Project" 배지 추가
- **수정 파일**: `prd/design-system.json`, `src/app/globals.css`, `src/components/TaskCard.tsx`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
