### PR TITLE
fix(terminal): Unicode11Addon 제거로 터미널 라인 깨짐 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
         "@xterm/addon-fit": "^0.11.0",
-        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "next": "16.1.6",
@@ -3235,12 +3234,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
-      "license": "MIT"
-    },
-    "node_modules/@xterm/addon-unicode11": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
-      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",
     "@xterm/addon-fit": "^0.11.0",
-    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "next": "16.1.6",

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -42,7 +42,6 @@ export default function Terminal({ taskId }: TerminalProps) {
     const { Terminal } = await import("@xterm/xterm");
     const { FitAddon } = await import("@xterm/addon-fit");
     const { WebLinksAddon } = await import("@xterm/addon-web-links");
-    const { Unicode11Addon } = await import("@xterm/addon-unicode11");
 
     const term = new Terminal({
       allowProposedApi: true,
@@ -60,8 +59,6 @@ export default function Terminal({ taskId }: TerminalProps) {
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.loadAddon(new WebLinksAddon());
-    term.loadAddon(new Unicode11Addon());
-    term.unicode.activeVersion = "11";
     term.open(terminalRef.current);
 
     /** 웹폰트 로드 완료 후 fontFamily를 재설정하여 xterm.js 글리프 캐시를 강제 갱신 */


### PR DESCRIPTION
## 어떤 작업인가요?
- 이모지/유니코드 개선 후 xterm 터미널에서 라인이 깨지는 문제를 수정합니다.

## 어떻게 해결했나요?
**Unicode11Addon 제거**
- xterm.js의 Unicode 11 폭 테이블이 tmux/shell의 시스템 wcwidth()와 불일치하여 커서 위치 및 라인 래핑 오류 발생
- Unicode11Addon을 제거하여 xterm.js 기본 wcwidth를 사용하도록 변경, tmux/shell과 폭 계산 일치

## 중요한 변경 사항은 무엇인가요?
### Unicode11Addon 제거

**@xterm/addon-unicode11 패키지 및 사용 코드 제거**
- **변경 이유**: Unicode 11 폭 테이블이 tmux/shell의 시스템 wcwidth()와 일치하지 않아 TUI 앱(lazygit 등)에서 박스 문자 정렬 및 라인 래핑이 깨짐
- **수정 파일**: `src/components/Terminal.tsx`, `package.json`, `package-lock.json`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
