### PR TITLE
refactor(db): DB 포트를 PORT+1 자동 계산에서 DB_PORT 환경변수 분리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 PORT=4885
+DB_PORT=4886
 KANVIBE_USER=admin
 KANVIBE_PASSWORD=changeme
-# DB port is automatically set to PORT + 1 (default: 4886)
-# DB credentials use KANVIBE_USER and KANVIBE_PASSWORD

--- a/boot.js
+++ b/boot.js
@@ -16,18 +16,6 @@ if (existsSync(envPath)) {
   }
 }
 
-/** PORT로부터 DB_PORT를 자동 계산하고 .env에 동기화한다 (PORT + 1) */
-if (!process.env.DB_PORT) {
-  process.env.DB_PORT = String(parseInt(process.env.PORT || "4885", 10) + 1);
-}
-if (existsSync(envPath)) {
-  const envContent = readFileSync(envPath, "utf-8");
-  if (!envContent.match(/^DB_PORT=/m)) {
-    const { writeFileSync } = require("node:fs");
-    writeFileSync(envPath, envContent.trimEnd() + "\nDB_PORT=" + process.env.DB_PORT + "\n");
-  }
-}
-
 const { AsyncLocalStorage } = require("node:async_hooks");
 globalThis.AsyncLocalStorage = AsyncLocalStorage;
 require("tsx/cjs");

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "node boot.js",
     "lint": "eslint",
-    "db:up": "DB_PORT=$(($(grep '^PORT=' .env | cut -d= -f2) + 1)) docker compose up -d",
+    "db:up": "docker compose up -d",
     "db:down": "docker compose down",
     "typeorm": "export $(grep -v '^#' .env | grep -v '^$' | xargs) && tsx node_modules/typeorm/cli.js -d src/lib/typeorm-cli.config.ts",
     "migration:generate": "npm run typeorm migration:generate",

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -17,7 +17,7 @@ const globalForDb = globalThis as unknown as {
 function buildDatabaseUrl(): string {
   const user = encodeURIComponent(process.env.KANVIBE_USER || "admin");
   const password = encodeURIComponent(process.env.KANVIBE_PASSWORD || "changeme");
-  const port = parseInt(process.env.PORT || "4885", 10) + 1;
+  const port = process.env.DB_PORT || "4886";
   return `postgresql://${user}:${password}@localhost:${port}/kanvibe`;
 }
 

--- a/src/lib/typeorm-cli.config.ts
+++ b/src/lib/typeorm-cli.config.ts
@@ -11,7 +11,7 @@ import { Project } from "../entities/Project";
 function buildDatabaseUrl(): string {
   const user = encodeURIComponent(process.env.KANVIBE_USER || "admin");
   const password = encodeURIComponent(process.env.KANVIBE_PASSWORD || "changeme");
-  const port = parseInt(process.env.PORT || "4885", 10) + 1;
+  const port = process.env.DB_PORT || "4886";
   return `postgresql://${user}:${password}@localhost:${port}/kanvibe`;
 }
 

--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,11 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# .env 파일에서 환경변수 로드
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | grep -v '^$' | xargs)
+fi
+
 echo "=== KanVibe 시작 ==="
 
 # 의존성 설치
@@ -20,7 +25,7 @@ docker compose up -d db
 
 # DB 준비 대기
 echo "[3/6] DB 준비 대기..."
-until docker compose exec db pg_isready -U kanvibe -q 2>/dev/null; do
+until docker compose exec db pg_isready -U "${KANVIBE_USER:-admin}" -q 2>/dev/null; do
   sleep 1
 done
 echo "       DB 준비 완료"


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- DB 포트를 `PORT+1` 자동 계산 방식에서 `DB_PORT` 환경변수로 독립 분리하여 포트 설정의 명시성과 유연성을 확보

## 어떻게 해결했나요?
**DB 포트 환경변수 분리**
- `PORT+1` 자동 계산 로직을 모두 제거하고 `DB_PORT` 환경변수를 직접 참조하도록 변경
- 기본값은 기존과 동일한 `4886` 유지

**start.sh 환경변수 로드 및 하드코딩 수정**
- `.env` 파일을 스크립트 시작 시 로드하여 `docker compose`에 환경변수 전달
- `pg_isready`의 하드코딩된 사용자명을 `KANVIBE_USER` 환경변수 참조로 수정

## 중요한 변경 사항은 무엇인가요?
### DB 포트 설정 방식 변경

**boot.js — PORT+1 자동 계산 로직 제거**
- **변경 이유**: DB 포트가 앱 포트에 암묵적으로 종속되어 있어 설정 의도가 불명확함
- **수정 파일**: `boot.js`

**database.ts, typeorm-cli.config.ts — DB_PORT 직접 참조**
- **변경 이유**: `parseInt(PORT) + 1` 대신 `DB_PORT` env를 명시적으로 사용
- **수정 파일**: `src/lib/database.ts`, `src/lib/typeorm-cli.config.ts`

**package.json — db:up 스크립트 단순화**
- **변경 이유**: `docker-compose.yml`이 이미 `DB_PORT` env를 참조하므로 스크립트에서 계산 불필요
- **수정 파일**: `package.json`

### start.sh 개선

**환경변수 로드 추가 및 하드코딩 수정**
- **변경 이유**: `.env`의 `KANVIBE_USER`, `DB_PORT` 등이 docker compose에 전달되도록 하고, `pg_isready -U kanvibe` 하드코딩 수정
- **수정 파일**: `start.sh`
