### PR TITLE
fix(task): 상세 페이지 삭제 리다이렉트 수정 및 삭제 확인 다이얼로그 추가

### DIFF
--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -1,4 +1,5 @@
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
+import { redirect } from "@/i18n/navigation";
 import { getTranslations } from "next-intl/server";
 import {
   getTaskById,
@@ -10,6 +11,7 @@ import { TaskStatus } from "@/entities/KanbanTask";
 import TaskStatusBadge from "@/components/TaskStatusBadge";
 import TerminalLoader from "@/components/TerminalLoader";
 import ConnectTerminalForm from "@/components/ConnectTerminalForm";
+import DeleteTaskButton from "@/components/DeleteTaskButton";
 import { Link } from "@/i18n/navigation";
 
 export const dynamicConfig = "force-dynamic";
@@ -56,7 +58,7 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
   async function handleDelete() {
     "use server";
     await deleteTask(id);
-    redirect(`/${locale}`);
+    redirect({ href: "/", locale });
   }
 
   const agentTagStyle = task.agentType
@@ -90,14 +92,7 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
         </Link>
 
         <div className="flex items-center gap-2">
-          <form action={handleDelete}>
-            <button
-              type="submit"
-              className="px-3 py-1.5 text-xs bg-red-50 hover:bg-red-100 text-status-error rounded-md transition-colors"
-            >
-              {t("delete")}
-            </button>
-          </form>
+          <DeleteTaskButton deleteAction={handleDelete} />
         </div>
       </header>
 

--- a/src/components/DeleteTaskButton.tsx
+++ b/src/components/DeleteTaskButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+interface DeleteTaskButtonProps {
+  deleteAction: () => Promise<void>;
+}
+
+export default function DeleteTaskButton({
+  deleteAction,
+}: DeleteTaskButtonProps) {
+  const t = useTranslations("taskDetail");
+
+  return (
+    <form
+      action={deleteAction}
+      onSubmit={(e) => {
+        if (!confirm(t("deleteConfirm"))) {
+          e.preventDefault();
+        }
+      }}
+    >
+      <button
+        type="submit"
+        className="px-3 py-1.5 text-xs bg-red-50 hover:bg-red-100 text-status-error rounded-md transition-colors"
+      >
+        {t("delete")}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- 태스크 상세 페이지에서 삭제 시 칸반 보드로 리다이렉트되지 않던 버그 수정 및 삭제 확인 다이얼로그 추가

## 어떻게 해결했나요?
**리다이렉트 수정**
- `redirect`를 `next/navigation` → `@/i18n/navigation`으로 변경하여 locale-aware 리다이렉트 적용
- next-intl v4의 `redirect({ href, locale })` 시그니처에 맞게 호출 방식 수정

**삭제 확인 다이얼로그 추가**
- 기존 프로젝트 패턴(Board.tsx, ProjectSettings.tsx)과 동일하게 `window.confirm` 기반 확인 다이얼로그 추가
- Server Component에서는 클라이언트 이벤트를 처리할 수 없어 `DeleteTaskButton` 클라이언트 컴포넌트 분리

## 중요한 변경 사항은 무엇인가요?
### redirect 방식 변경

**next-intl locale-aware redirect 적용**
- **변경 이유**: `next/navigation`의 `redirect`가 next-intl의 locale 라우팅과 올바르게 동작하지 않아 삭제 후 칸반 보드로 이동하지 않던 문제
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`

### 삭제 확인 UI 추가

**DeleteTaskButton 클라이언트 컴포넌트 생성**
- **변경 이유**: 삭제 클릭 시 확인 없이 즉시 삭제되는 위험한 동작 방지
- **수정 파일**: `src/components/DeleteTaskButton.tsx`, `src/app/[locale]/task/[id]/page.tsx`
