### PR TITLE
feat(task): todo 생성 후 태스크 상세 페이지로 자동 이동

### DIFF
--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useTransition } from "react";
 import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
 import { createTask } from "@/app/actions/kanban";
 import { getProjectBranches } from "@/app/actions/project";
 import { SessionType } from "@/entities/KanbanTask";
@@ -25,6 +26,7 @@ export default function CreateTaskModal({
 }: CreateTaskModalProps) {
   const t = useTranslations("task");
   const tc = useTranslations("common");
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [selectedProjectId, setSelectedProjectId] = useState(defaultProjectId || "");
   const [branches, setBranches] = useState<string[]>([]);
@@ -64,7 +66,7 @@ export default function CreateTaskModal({
     if (!branchName || !selectedProjectId) return;
 
     startTransition(async () => {
-      await createTask({
+      const created = await createTask({
         title: branchName,
         description: (formData.get("description") as string) || undefined,
         branchName,
@@ -74,6 +76,7 @@ export default function CreateTaskModal({
         projectId: selectedProjectId,
       });
       onClose();
+      router.push(`/task/${created.id}`);
     });
   }
 


### PR DESCRIPTION
## 어떤 작업인가요?
- Todo 생성 후 보드에 머무르지 않고 해당 태스크 상세 페이지(`/task/{id}`)로 자동 이동하도록 개선

## 어떻게 해결했나요?
**태스크 생성 후 자동 네비게이션 추가**
- `CreateTaskModal`에서 `createTask()` 반환값으로 생성된 태스크 ID를 받아 `router.push`로 상세 페이지 이동
- `@/i18n/navigation`의 `useRouter`를 사용하여 locale-aware 라우팅 적용

## 중요한 변경 사항은 무엇인가요?
### 태스크 생성 후 자동 이동

**`CreateTaskModal` 네비게이션 추가**
- **변경 이유**: 태스크 생성 후 바로 상세 페이지에서 작업을 이어갈 수 있도록 UX 개선
- **수정 파일**: `src/components/CreateTaskModal.tsx`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
