### PR TITLE
feat(hooks): AskUserQuestion 질문/답변 시 칸반 상태 전환 hook 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ npm run dev
   → POST /api/hooks/status { branchName, projectName, status: "progress" }
   → Kanban 보드에서 작업이 PROGRESS로 이동
 
+AI가 사용자에게 질문 (PreToolUse: AskUserQuestion)
+  → kanvibe-question-hook.sh 실행
+  → POST /api/hooks/status { branchName, projectName, status: "review" }
+  → Kanban 보드에서 작업이 REVIEW로 이동
+
+사용자가 질문에 답변 (PostToolUse: AskUserQuestion)
+  → kanvibe-prompt-hook.sh 실행
+  → POST /api/hooks/status { branchName, projectName, status: "progress" }
+  → Kanban 보드에서 작업이 PROGRESS로 이동
+
 AI 응답 완료 (Stop)
   → kanvibe-stop-hook.sh 실행
   → POST /api/hooks/status { branchName, projectName, status: "review" }
@@ -105,6 +115,7 @@ KanVibe 웹 UI의 **프로젝트 설정 > 디렉토리 스캔**으로 프로젝�
 
 자동 설치되는 파일:
 - `.claude/hooks/kanvibe-prompt-hook.sh` — prompt 입력 시 PROGRESS 전환
+- `.claude/hooks/kanvibe-question-hook.sh` — AI 질문 시 REVIEW 전환
 - `.claude/hooks/kanvibe-stop-hook.sh` — AI 응답 완료 시 REVIEW 전환
 - `.claude/settings.json` — hooks 이벤트 등록 (기존 설정이 있으면 병합)
 
@@ -147,6 +158,30 @@ chmod +x .claude/hooks/kanvibe-*.sh
   "hooks": {
     "UserPromptSubmit": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/kanvibe-prompt-hook.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/kanvibe-question-hook.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "AskUserQuestion",
         "hooks": [
           {
             "type": "command",

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -49,6 +49,30 @@ exit 0
 `;
 }
 
+/** PreToolUse(AskUserQuestion) hook bash 스크립트를 생성한다 */
+function generateQuestionHookScript(kanvibeUrl: string, projectName: string): string {
+  return `#!/bin/bash
+
+# KanVibe Claude Code Hook: PreToolUse (AskUserQuestion)
+# Claude가 사용자에게 질문할 때 현재 브랜치의 작업을 REVIEW로 변경한다.
+
+KANVIBE_URL="${kanvibeUrl}"
+PROJECT_NAME="${projectName}"
+
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
+  exit 0
+fi
+
+curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
+  -H "Content-Type: application/json" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
+  > /dev/null 2>&1
+
+exit 0
+`;
+}
+
 interface ClaudeSettings {
   hooks?: Record<string, unknown[]>;
   [key: string]: unknown;
@@ -56,6 +80,10 @@ interface ClaudeSettings {
 
 interface HookEntry {
   hooks: { type: string; command: string; timeout: number }[];
+}
+
+interface MatcherHookEntry extends HookEntry {
+  matcher: string;
 }
 
 /** 기존 settings.json을 읽거나 빈 객체를 반환한다 */
@@ -94,11 +122,14 @@ export async function setupClaudeHooks(
 
   const promptScriptPath = path.join(hooksDir, "kanvibe-prompt-hook.sh");
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
+  const questionScriptPath = path.join(hooksDir, "kanvibe-question-hook.sh");
 
   await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectName), "utf-8");
   await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, projectName), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
+  await chmod(questionScriptPath, 0o755);
 
   const settings = await readSettingsJson(settingsPath);
   if (!settings.hooks) {
@@ -112,6 +143,38 @@ export async function setupClaudeHooks(
   }
   if (!hasKanvibeHook(hooks.UserPromptSubmit, "kanvibe-prompt-hook.sh")) {
     (hooks.UserPromptSubmit as HookEntry[]).push({
+      hooks: [
+        {
+          type: "command",
+          command: ".claude/hooks/kanvibe-prompt-hook.sh",
+          timeout: 10,
+        },
+      ],
+    });
+  }
+
+  if (!hooks.PreToolUse) {
+    hooks.PreToolUse = [];
+  }
+  if (!hasKanvibeHook(hooks.PreToolUse, "kanvibe-question-hook.sh")) {
+    (hooks.PreToolUse as MatcherHookEntry[]).push({
+      matcher: "AskUserQuestion",
+      hooks: [
+        {
+          type: "command",
+          command: ".claude/hooks/kanvibe-question-hook.sh",
+          timeout: 10,
+        },
+      ],
+    });
+  }
+
+  if (!hooks.PostToolUse) {
+    hooks.PostToolUse = [];
+  }
+  if (!hasKanvibeHook(hooks.PostToolUse, "kanvibe-prompt-hook.sh")) {
+    (hooks.PostToolUse as MatcherHookEntry[]).push({
+      matcher: "AskUserQuestion",
       hooks: [
         {
           type: "command",
@@ -144,6 +207,7 @@ export interface ClaudeHooksStatus {
   installed: boolean;
   hasPromptHook: boolean;
   hasStopHook: boolean;
+  hasQuestionHook: boolean;
   hasSettingsEntry: boolean;
 }
 
@@ -159,6 +223,9 @@ export async function getClaudeHooksStatus(repoPath: string): Promise<ClaudeHook
   const stopScriptExists = await access(path.join(hooksDir, "kanvibe-stop-hook.sh"))
     .then(() => true)
     .catch(() => false);
+  const questionScriptExists = await access(path.join(hooksDir, "kanvibe-question-hook.sh"))
+    .then(() => true)
+    .catch(() => false);
 
   let hasSettingsEntry = false;
   try {
@@ -167,18 +234,21 @@ export async function getClaudeHooksStatus(repoPath: string): Promise<ClaudeHook
     if (hooks) {
       const hasPrompt = hasKanvibeHook(hooks.UserPromptSubmit || [], "kanvibe-prompt-hook.sh");
       const hasStop = hasKanvibeHook(hooks.Stop || [], "kanvibe-stop-hook.sh");
-      hasSettingsEntry = hasPrompt && hasStop;
+      const hasQuestion = hasKanvibeHook(hooks.PreToolUse || [], "kanvibe-question-hook.sh");
+      const hasAnswerResume = hasKanvibeHook(hooks.PostToolUse || [], "kanvibe-prompt-hook.sh");
+      hasSettingsEntry = hasPrompt && hasStop && hasQuestion && hasAnswerResume;
     }
   } catch {
     /* settings.json 없음 */
   }
 
-  const installed = promptScriptExists && stopScriptExists && hasSettingsEntry;
+  const installed = promptScriptExists && stopScriptExists && questionScriptExists && hasSettingsEntry;
 
   return {
     installed,
     hasPromptHook: promptScriptExists,
     hasStopHook: stopScriptExists,
+    hasQuestionHook: questionScriptExists,
     hasSettingsEntry,
   };
 }


### PR DESCRIPTION
## 어떤 작업인가요?
- Claude가 AskUserQuestion으로 질문할 때 칸반 보드 상태가 REVIEW로 전환되지 않는 문제를 해결하고, 사용자가 답변하면 다시 PROGRESS로 복귀하도록 hook을 추가

## 어떻게 해결했나요?
**PreToolUse/PostToolUse hook 추가**
- `PreToolUse(AskUserQuestion)` hook으로 Claude 질문 시 REVIEW 전환
- `PostToolUse(AskUserQuestion)` hook으로 사용자 답변 시 PROGRESS 복귀
- 자동 설치 기능(`setupClaudeHooks`)에 통합하여 디렉토리 스캔 시 자동 적용

## 중요한 변경 사항은 무엇인가요?
### Claude Code Hook 자동 설치에 AskUserQuestion 대응 추가

**kanvibe-question-hook.sh 스크립트 생성 추가**
- **변경 이유**: Claude가 AskUserQuestion 사용 시 Stop hook이 실행되지 않아 상태 전환이 누락됨
- **수정 파일**: `src/lib/claudeHooksSetup.ts`

**PreToolUse/PostToolUse settings.json 등록 추가**
- **변경 이유**: AskUserQuestion 질문→답변 사이클에서 REVIEW↔PROGRESS 전환을 지원
- **수정 파일**: `src/lib/claudeHooksSetup.ts`

**hooks 상태 확인 로직 업데이트**
- **변경 이유**: 새 hook 파일/설정이 설치 상태 체크에 반영되어야 함
- **수정 파일**: `src/lib/claudeHooksSetup.ts`

**README 문서 업데이트**
- **변경 이유**: Hook 동작 흐름 및 수동 설정 예시에 AskUserQuestion 관련 내용 추가
- **수정 파일**: `README.md`
