### PR TITLE
modify(settings): Pane 레이아웃 설정 링크 위치를 설정 다이얼로그 최상단으로 이동

### DIFF
--- a/src/components/ProjectSettings.tsx
+++ b/src/components/ProjectSettings.tsx
@@ -123,6 +123,18 @@ export default function ProjectSettings({
           </button>
         </div>
 
+        {/* Pane 레이아웃 설정 링크 */}
+        <div className="p-4 border-b border-border-default">
+          <Link
+            href="/pane-layout"
+            prefetch={false}
+            className="flex items-center justify-between w-full px-3 py-2 text-sm bg-bg-page border border-border-default rounded-md text-text-primary hover:border-brand-primary transition-colors"
+          >
+            <span>{t("paneLayoutLink")}</span>
+            <span className="text-text-muted">&rarr;</span>
+          </Link>
+        </div>
+
         {/* 디렉토리 스캔 등록 */}
         <div className="p-4 border-b border-border-default">
           <h3 className="text-xs text-text-muted uppercase tracking-wide mb-3">
@@ -184,18 +196,6 @@ export default function ProjectSettings({
           {successMessage && (
             <p className="text-xs text-status-success mt-2">{successMessage}</p>
           )}
-        </div>
-
-        {/* Pane 레이아웃 설정 링크 */}
-        <div className="p-4 border-b border-border-default">
-          <Link
-            href="/pane-layout"
-            prefetch={false}
-            className="flex items-center justify-between w-full px-3 py-2 text-sm bg-bg-page border border-border-default rounded-md text-text-primary hover:border-brand-primary transition-colors"
-          >
-            <span>{t("paneLayoutLink")}</span>
-            <span className="text-text-muted">&rarr;</span>
-          </Link>
         </div>
 
         {/* 등록된 프로젝트 목록 */}


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- 설정 다이얼로그에서 Pane 레이아웃 설정 링크 위치를 최상단으로 이동하여 UI 흐름을 개선

## 어떻게 해결했나요?
**Pane 레이아웃 설정 링크 위치 이동**
- 기존: 디렉토리 스캔 섹션과 등록된 프로젝트 목록 사이에 배치 → 스캔 → 결과 확인 흐름이 끊김
- 변경: 헤더 바로 아래(최상단)로 이동하여 스캔 → 프로젝트 목록의 자연스러운 흐름 유지

## 중요한 변경 사항은 무엇인가요?
### Pane 레이아웃 링크 위치 변경

**JSX 블록 순서 재배치**
- **변경 이유**: Pane 레이아웃 링크가 스캔/등록과 스캔 결과 사이에 있어 UI 흐름이 어색함
- **수정 파일**: `src/components/ProjectSettings.tsx`
