### PR TITLE
Done 컬럼 페이지네이션 추가

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -29,7 +29,9 @@
       "progress": "Progress",
       "review": "Review",
       "done": "Done"
-    }
+    },
+    "loadMore": "Load More",
+    "loadingMore": "Loading..."
   },
   "task": {
     "descriptionLabel": "Description",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -29,7 +29,9 @@
       "progress": "Progress",
       "review": "Review",
       "done": "Done"
-    }
+    },
+    "loadMore": "더 보기",
+    "loadingMore": "불러오는 중..."
   },
   "task": {
     "descriptionLabel": "설명",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -29,7 +29,9 @@
       "progress": "进行中",
       "review": "审核",
       "done": "完成"
-    }
+    },
+    "loadMore": "加载更多",
+    "loadingMore": "加载中..."
   },
   "task": {
     "descriptionLabel": "描述",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -6,13 +6,15 @@ import { getAvailableHosts } from "@/lib/sshConfig";
 export const dynamic = "force-dynamic";
 
 export default async function HomePage() {
-  const tasks = await getTasksByStatus();
+  const { tasks, doneTotal, doneLimit } = await getTasksByStatus();
   const sshHosts = await getAvailableHosts();
   const projects = await getAllProjects();
 
   return (
     <Board
       initialTasks={tasks}
+      initialDoneTotal={doneTotal}
+      initialDoneLimit={doneLimit}
       sshHosts={sshHosts}
       projects={projects}
     />

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Droppable } from "@hello-pangea/dnd";
 import TaskCard from "./TaskCard";
 import type { KanbanTask, TaskStatus } from "@/entities/KanbanTask";
@@ -11,9 +12,15 @@ interface ColumnProps {
   colorClass: string;
   onContextMenu: (e: React.MouseEvent, task: KanbanTask) => void;
   projectNameMap: Record<string, string>;
+  totalCount?: number;
+  hasMore?: boolean;
+  onLoadMore?: () => void;
+  isLoadingMore?: boolean;
 }
 
-export default function Column({ status, tasks, label, colorClass, onContextMenu, projectNameMap }: ColumnProps) {
+export default function Column({ status, tasks, label, colorClass, onContextMenu, projectNameMap, totalCount, hasMore, onLoadMore, isLoadingMore }: ColumnProps) {
+  const t = useTranslations("board");
+
   return (
     <div className="flex-1 min-w-[280px] max-w-[350px]">
       <div className="flex items-center gap-2 mb-3 px-2">
@@ -21,7 +28,7 @@ export default function Column({ status, tasks, label, colorClass, onContextMenu
         <h2 className="text-sm font-semibold text-text-secondary uppercase tracking-wide">
           {label}
         </h2>
-        <span className="text-xs text-text-muted ml-auto">{tasks.length}</span>
+        <span className="text-xs text-text-muted ml-auto">{totalCount ?? tasks.length}</span>
       </div>
 
       <Droppable droppableId={status}>
@@ -45,6 +52,15 @@ export default function Column({ status, tasks, label, colorClass, onContextMenu
               />
             ))}
             {provided.placeholder}
+            {hasMore && onLoadMore && (
+              <button
+                onClick={onLoadMore}
+                disabled={isLoadingMore}
+                className="w-full mt-2 py-2 text-sm text-text-muted hover:text-text-secondary hover:bg-bg-surface rounded-md transition-colors disabled:opacity-50"
+              >
+                {isLoadingMore ? t("loadingMore") : t("loadMore")}
+              </button>
+            )}
           </div>
         )}
       </Droppable>


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- Done 컬럼에 완료된 태스크가 대량으로 쌓였을 때 초기 로딩 성능이 저하되는 문제를 해결하기 위해, Done 컬럼에 페이지네이션을 적용

## 어떻게 해결했나요?
**서버 액션 페이지네이션 분리**
- Done 태스크를 초기 로드 시 20개만 조회하도록 변경
- 추가 로드를 위한 `getMoreDoneTasks` 서버 액션 신규 추가

**클라이언트 "더 보기" UI**
- Column 컴포넌트에 "더 보기" 버튼 추가
- Board에서 offset/total 상태 관리 및 드래그&드롭 시 카운트 동기화

## 중요한 변경 사항은 무엇인가요?
### Done 태스크 분리 조회

**getTasksByStatus 반환 타입 변경**
- **변경 이유**: Done 태스크의 전체 개수와 페이지 크기 메타데이터를 함께 전달하기 위해 `TasksByStatusWithMeta` 인터페이스 도입
- **수정 파일**: `src/app/actions/kanban.ts`, `src/app/[locale]/page.tsx`

**getMoreDoneTasks 액션 추가**
- **변경 이유**: 클라이언트에서 offset 기반으로 Done 태스크를 추가 로드할 수 있도록 별도 서버 액션 제공
- **수정 파일**: `src/app/actions/kanban.ts`

### 클라이언트 페이지네이션 UI

**Board 컴포넌트 상태 관리**
- **변경 이유**: doneTotal, doneOffset, isLoadingMore 상태를 관리하고, 드래그&드롭으로 Done 컬럼 간 이동 시 카운트를 동기화
- **수정 파일**: `src/components/Board.tsx`

**Column "더 보기" 버튼**
- **변경 이유**: Done 컬럼 하단에 로드 버튼을 표시하고, 전체 개수를 헤더에 반영
- **수정 파일**: `src/components/Column.tsx`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
