### PR TITLE
fix(terminal): 메인 브랜치 tmux 터미널 연결 실패 수정

### DIFF
--- a/.claude/plan/terminal/2602/15-fix-main-tmux-connect.plan.md
+++ b/.claude/plan/terminal/2602/15-fix-main-tmux-connect.plan.md
@@ -1,0 +1,63 @@
+# Fix: Main Branch tmux Session Connection
+
+## Business Goal
+메인 브랜치(base branch)에서 터미널 연결 시 "can't find window: main" 에러가 발생하는 버그를 수정한다. 워크트리가 아닌 base project에서도 tmux 세션에 정상 연결되도록 한다.
+
+## Scope
+- **In Scope**: `isTmuxWindowAlive` trim 불일치 수정, `scanAndRegisterProjects` 메인 브랜치 자동 연결 쿼리 수정
+- **Out of Scope**: formatWindowName의 leading space 디자인 변경, zellij 관련 수정, SSH 원격 연결
+
+## Codebase Analysis Summary
+터미널 연결 시 `server.ts` → `attachLocalSession` → `isTmuxWindowAlive` 순으로 호출된다. `formatWindowName`은 모든 브랜치명 앞에 공백을 추가한다 (` main`, ` feat-login` 등). 이 패턴은 tmux window 생성(`worktree.ts`)과 alive 체크(`worktree.ts`의 `isWindowAlive`)에서는 일관되게 동작하지만, `terminal.ts`의 `isTmuxWindowAlive`에서만 `.trim()` 사용으로 불일치가 발생한다.
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/lib/terminal.ts` | 터미널 세션 attach/detach, alive 체크 | Modify |
+| `src/app/actions/project.ts` | 프로젝트 스캔, 메인 브랜치 자동 연결 | Modify |
+| `src/lib/worktree.ts` | tmux window 생성, `isWindowAlive` 참조 구현 | Reference |
+| `server.ts` | WebSocket 핸들러, windowName 파생 | Reference |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 한국어 주석 | CODE_PRINCIPLES.md | 주석은 한국어로 작성 |
+| 기존 패턴 일관성 | worktree.ts `isWindowAlive` | `includes()` 방식으로 window 이름 매치 |
+
+## Implementation Todos
+
+### Todo 1: `isTmuxWindowAlive` trim 불일치 수정
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: tmux window 존재 여부 체크가 leading space가 있는 windowName에서도 정상 동작하도록 수정
+- **Work**:
+  - `src/lib/terminal.ts` 23행의 `w.trim() === windowName`을 `w.includes(windowName)`으로 변경
+  - `worktree.ts`의 `isWindowAlive`와 동일한 매칭 방식 적용
+- **Convention Notes**: 한국어 주석 유지
+- **Verification**: 코드 리뷰로 `isWindowAlive`와 동일한 로직 확인
+- **Exit Criteria**: `isTmuxWindowAlive`가 leading space가 포함된 windowName을 정상 매치
+- **Status**: pending
+
+### Todo 2: 메인 브랜치 자동 연결 쿼리 수정
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: `scanAndRegisterProjects`에서 재스캔 시 메인 브랜치 태스크의 tmux 세션을 자동 감지하여 연결 정보를 설정
+- **Work**:
+  - `src/app/actions/project.ts` 260행의 `branchName: IsNull()`을 `branchName: project.defaultBranch`로 변경
+  - 대응하는 `!mainBranchTask.sessionType` 조건은 유지 (이미 연결된 경우 스킵)
+- **Convention Notes**: TypeORM findOneBy 패턴 유지
+- **Verification**: 코드 리뷰로 `createDefaultBranchTask`의 branchName 값과 일치 확인
+- **Exit Criteria**: 재스캔 시 메인 브랜치 태스크에 활성 tmux 세션이 자동 연결됨
+- **Status**: pending
+
+## Verification Strategy
+- `npm run build`로 TypeScript 컴파일 에러 없음 확인
+- 변경된 두 파일의 로직이 기존 패턴과 일관성 있는지 코드 리뷰
+
+## Progress Tracking
+- Total Todos: 2
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-15: Plan created

--- a/server.ts
+++ b/server.ts
@@ -101,7 +101,7 @@ app.prepare().then(() => {
           hostConfig
         );
       } else {
-        await attachLocalSession(taskId, task.sessionType, task.sessionName, windowName, ws);
+        await attachLocalSession(taskId, task.sessionType, task.sessionName, windowName, ws, task.worktreePath);
       }
     } catch (error) {
       console.error("터미널 연결 오류:", error);

--- a/src/app/actions/project.ts
+++ b/src/app/actions/project.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { IsNull } from "typeorm";
 import { getProjectRepository, getTaskRepository } from "@/lib/database";
 import { Project } from "@/entities/Project";
 import { validateGitRepo, getDefaultBranch, listBranches, scanGitRepos, listWorktrees } from "@/lib/gitOperations";
@@ -260,7 +259,7 @@ export async function scanAndRegisterProjects(
       const mainBranchTask = await taskRepo.findOneBy({
         projectId: project.id,
         baseBranch: project.defaultBranch,
-        branchName: IsNull(),
+        branchName: project.defaultBranch,
       });
 
       if (mainBranchTask && !mainBranchTask.sessionType) {

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -11,7 +11,7 @@ interface WorktreeSession {
 
 /** branchName을 tmux window / zellij tab 이름으로 변환한다 */
 export function formatWindowName(branchName: string): string {
-  return ` ${branchName.replace(/\//g, "-")}`;
+  return branchName.replace(/\//g, "-");
 }
 
 /**
@@ -323,5 +323,5 @@ export async function isWindowAlive(
   sshHost?: string | null,
 ): Promise<boolean> {
   const windows = await listActiveWindows(sessionType, mainSession, sshHost);
-  return windows.some((w) => w.includes(windowName));
+  return windows.some((w) => w.trimEnd() === windowName);
 }


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/terminal/2602/15-fix-main-tmux-connect.plan.md)

## 어떤 작업인가요?
- 메인 브랜치(Base Project)의 tmux 터미널이 연결되지 않던 문제를 수정

## 어떻게 해결했나요?
**tmux window 이름 불일치 수정**
- `formatWindowName`에서 생성되는 window 이름에 불필요한 선행 공백이 포함되어 실제 tmux window 이름과 일치하지 않던 문제 해결
- window 존재 여부 확인 시 `includes` 대신 정확한 문자열 일치 비교로 변경

**tmux 세션/window 자동 생성**
- 메인 브랜치처럼 tmux window가 존재하지 않는 경우 에러 대신 자동으로 세션과 window를 생성하도록 변경

**메인 브랜치 태스크 조회 조건 수정**
- 메인 브랜치 태스크의 `branchName` 조회를 `IsNull()`에서 실제 `defaultBranch` 값으로 수정

## 중요한 변경 사항은 무엇인가요?
### window 이름 정규화

**선행 공백 제거**
- **변경 이유**: `formatWindowName`이 반환하는 이름에 선행 공백(` main`)이 포함되어 tmux에서 생성된 실제 window 이름(`main`)과 불일치
- **수정 파일**: `src/lib/worktree.ts`

**정확한 이름 비교**
- **변경 이유**: `includes` 비교는 부분 문자열 매칭으로 오탐 가능성 있음, `trimEnd()` + 정확 일치로 변경
- **수정 파일**: `src/lib/worktree.ts`, `src/lib/terminal.ts`

### tmux window 자동 생성

**미존재 window 자동 생성 로직 추가**
- **변경 이유**: 메인 브랜치는 worktree가 아니므로 tmux window가 사전에 생성되지 않을 수 있음, 연결 시 자동 생성 필요
- **수정 파일**: `src/lib/terminal.ts`, `server.ts`

### 태스크 조회 조건 수정

**branchName 조회를 IsNull()에서 defaultBranch로 변경**
- **변경 이유**: 메인 브랜치 태스크의 `branchName`이 실제로는 `defaultBranch` 값을 가지고 있어 `IsNull()` 조건으로는 조회 불가
- **수정 파일**: `src/app/actions/project.ts`
