### PR TITLE
fix(board): 다중 프로젝트 선택 시 작업 생성 기본값 오류 수정

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -409,7 +409,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         onClose={() => setIsModalOpen(false)}
         sshHosts={sshHosts}
         projects={projects}
-        defaultProjectId={selectedProjectIds[0] || ""}
+        defaultProjectId={selectedProjectIds.length === 1 ? selectedProjectIds[0] : ""}
       />
 
       <ProjectSettings


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- 프로젝트 필터에서 2개 이상 프로젝트를 선택한 상태에서 작업 생성 시, 항상 첫 번째 프로젝트만 기본값으로 설정되던 버그를 수정합니다.

## 어떻게 해결했나요?
**기본 프로젝트 선택 로직 변경**
- `selectedProjectIds[0]`으로 항상 첫 번째 요소를 전달하던 방식을 변경
- 프로젝트가 정확히 1개 선택된 경우에만 해당 프로젝트를 기본값으로 설정하고, 0개 또는 2개 이상 선택 시에는 기본값 없이 사용자가 직접 선택하도록 수정

## 중요한 변경 사항은 무엇인가요?
### CreateTaskModal 기본 프로젝트 설정 로직

**defaultProjectId 전달 조건 변경**
- **변경 이유**: 다중 프로젝트 선택 시 첫 번째 프로젝트만 기본값으로 설정되어 사용자가 의도하지 않은 프로젝트에 작업이 생성될 수 있음
- **수정 파일**: `src/components/Board.tsx`
