### PR TITLE
feat(task-detail): 상세 페이지 Hooks 상태 확인 및 설치 카드 추가

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -157,6 +157,14 @@
     "updatedAt": "Updated",
     "prLink": "PR Link",
     "actions": "Change Status",
-    "deleteConfirm": "Are you sure you want to delete this task?"
+    "deleteConfirm": "Are you sure you want to delete this task?",
+    "hooksStatus": "Hooks Status",
+    "hooksInstalled": "Installed",
+    "hooksNotInstalled": "Not Installed",
+    "installHooks": "Install Hooks",
+    "installingHooks": "Installing...",
+    "hooksInstallSuccess": "Hooks installed successfully",
+    "hooksInstallFailed": "Hooks installation failed",
+    "hooksRemoteNotSupported": "Remote projects are not supported"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -157,6 +157,14 @@
     "updatedAt": "수정일",
     "prLink": "PR 링크",
     "actions": "상태 변경",
-    "deleteConfirm": "이 작업을 삭제하시겠습니까?"
+    "deleteConfirm": "이 작업을 삭제하시겠습니까?",
+    "hooksStatus": "Hooks 상태",
+    "hooksInstalled": "설치됨",
+    "hooksNotInstalled": "미설치",
+    "installHooks": "Hooks 설치",
+    "installingHooks": "설치 중...",
+    "hooksInstallSuccess": "Hooks 설치 완료",
+    "hooksInstallFailed": "Hooks 설치 실패",
+    "hooksRemoteNotSupported": "원격 프로젝트는 지원하지 않습니다"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -157,6 +157,14 @@
     "updatedAt": "更新时间",
     "prLink": "PR 链接",
     "actions": "状态变更",
-    "deleteConfirm": "确定要删除此任务吗？"
+    "deleteConfirm": "确定要删除此任务吗？",
+    "hooksStatus": "Hooks 状态",
+    "hooksInstalled": "已安装",
+    "hooksNotInstalled": "未安装",
+    "installHooks": "安装 Hooks",
+    "installingHooks": "安装中...",
+    "hooksInstallSuccess": "Hooks 安装完成",
+    "hooksInstallFailed": "Hooks 安装失败",
+    "hooksRemoteNotSupported": "不支持远程项目"
   }
 }

--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -12,6 +12,8 @@ import TaskStatusBadge from "@/components/TaskStatusBadge";
 import TerminalLoader from "@/components/TerminalLoader";
 import ConnectTerminalForm from "@/components/ConnectTerminalForm";
 import DeleteTaskButton from "@/components/DeleteTaskButton";
+import HooksStatusCard from "@/components/HooksStatusCard";
+import { getTaskHooksStatus } from "@/app/actions/project";
 import { Link } from "@/i18n/navigation";
 
 export const dynamicConfig = "force-dynamic";
@@ -48,6 +50,7 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
   }
 
   const hasTerminal = task.sessionType && task.sessionName;
+  const hooksStatus = task.projectId ? await getTaskHooksStatus(id) : null;
 
   async function handleStatusChange(formData: FormData) {
     "use server";
@@ -210,6 +213,15 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
               ))}
             </div>
           </div>
+
+          {/* Hooks 상태 카드 */}
+          {task.projectId && (
+            <HooksStatusCard
+              taskId={task.id}
+              initialStatus={hooksStatus}
+              isRemote={!!task.sshHost}
+            />
+          )}
         </aside>
 
         {/* 터미널 영역 */}

--- a/src/components/HooksStatusCard.tsx
+++ b/src/components/HooksStatusCard.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState, useTransition } from "react";
+import { installTaskHooks } from "@/app/actions/project";
+import type { ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
+
+interface HooksStatusCardProps {
+  taskId: string;
+  initialStatus: ClaudeHooksStatus | null;
+  isRemote: boolean;
+}
+
+export default function HooksStatusCard({
+  taskId,
+  initialStatus,
+  isRemote,
+}: HooksStatusCardProps) {
+  const t = useTranslations("taskDetail");
+  const [isPending, startTransition] = useTransition();
+  const [hooksStatus, setHooksStatus] = useState(initialStatus);
+  const [message, setMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
+
+  function handleInstall() {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await installTaskHooks(taskId);
+      if (result.success) {
+        setHooksStatus({ installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true });
+        setMessage({ type: "success", text: t("hooksInstallSuccess") });
+      } else {
+        setMessage({ type: "error", text: t("hooksInstallFailed") });
+      }
+    });
+  }
+
+  return (
+    <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
+      <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
+        {t("hooksStatus")}
+      </h3>
+
+      <div className="flex items-center justify-between gap-2">
+        {isRemote ? (
+          <span className="text-xs px-2 py-0.5 bg-bg-page border border-border-default rounded text-text-muted">
+            {t("hooksRemoteNotSupported")}
+          </span>
+        ) : hooksStatus?.installed ? (
+          <>
+            <span className="text-xs px-2 py-0.5 bg-status-done/15 text-status-done rounded">
+              {t("hooksInstalled")}
+            </span>
+            <button
+              onClick={handleInstall}
+              disabled={isPending}
+              className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors disabled:opacity-50"
+            >
+              {isPending ? t("installingHooks") : t("installHooks")}
+            </button>
+          </>
+        ) : (
+          <>
+            <span className="text-xs px-2 py-0.5 bg-status-error/15 text-status-error rounded">
+              {t("hooksNotInstalled")}
+            </span>
+            <button
+              onClick={handleInstall}
+              disabled={isPending}
+              className="px-3 py-1.5 text-xs bg-brand-primary hover:bg-brand-hover text-text-inverse rounded-md transition-colors disabled:opacity-50"
+            >
+              {isPending ? t("installingHooks") : t("installHooks")}
+            </button>
+          </>
+        )}
+      </div>
+
+      {message && (
+        <p
+          className={`text-xs mt-2 ${
+            message.type === "success" ? "text-status-done" : "text-status-error"
+          }`}
+        >
+          {message.text}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/ui/2602/15-hooks-status-card.plan.md)

## 어떤 작업인가요?
- 태스크 상세 페이지에서 Claude Code hooks 설치 상태를 확인하고, 미설치 시 수동으로 설치할 수 있는 UI를 추가한다.

## 어떻게 해결했나요?
**worktree 기반 hooks 서버 액션 추가**
- 기존 `getProjectHooksStatus`/`installProjectHooks`는 프로젝트 repo 기준이므로, 태스크의 worktree 경로를 우선 확인하는 `getTaskHooksStatus`/`installTaskHooks` 서버 액션을 추가

**HooksStatusCard 클라이언트 컴포넌트 생성**
- 설치/미설치/원격 3가지 상태를 표시하며, 설치 버튼 클릭 시 `useTransition`으로 서버 액션 호출

**상세 페이지 사이드바 통합**
- 상태 변경 카드 아래에 hooks 상태 카드 배치, `projectId`가 있는 태스크에만 표시

## 중요한 변경 사항은 무엇인가요?
### 서버 액션 추가

**`getTaskHooksStatus(taskId)` / `installTaskHooks(taskId)`**
- **변경 이유**: 기존 프로젝트 기반 액션은 worktree 경로를 고려하지 않아, 태스크 단위로 hooks 상태를 확인/설치할 수 없었음
- **수정 파일**: `src/app/actions/project.ts`

### UI 컴포넌트

**HooksStatusCard**
- **변경 이유**: 상세 페이지에서 hooks 상태 확인 및 수동 설치 기능 필요
- **수정 파일**: `src/components/HooksStatusCard.tsx`, `src/app/[locale]/task/[id]/page.tsx`

### 번역 키 추가

**taskDetail 네임스페이스에 hooks 관련 번역 키 8개**
- **변경 이유**: ko/en/zh 3개 언어 지원
- **수정 파일**: `messages/ko.json`, `messages/en.json`, `messages/zh.json`
