### PR TITLE
Done 상태 변경 시 branch, worktree, session 자동 정리

### DIFF
--- a/src/app/api/hooks/status/route.ts
+++ b/src/app/api/hooks/status/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getTaskRepository, getProjectRepository } from "@/lib/database";
 import { TaskStatus } from "@/entities/KanbanTask";
+import { cleanupTaskResources } from "@/app/actions/kanban";
 
 const STATUS_MAP: Record<string, TaskStatus> = {
   todo: TaskStatus.TODO,
@@ -54,6 +55,14 @@ export async function POST(request: NextRequest) {
         { success: false, error: `작업을 찾을 수 없습니다: ${projectName}/${branchName}` },
         { status: 404 }
       );
+    }
+
+    if (taskStatus === TaskStatus.DONE) {
+      await cleanupTaskResources(task);
+      task.sessionType = null;
+      task.sessionName = null;
+      task.worktreePath = null;
+      task.sshHost = null;
     }
 
     task.status = taskStatus;


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/kanban/2602/15-done-cleanup-resources.plan.md)

## 어떤 작업인가요?
- 작업을 Done 상태로 변경할 때 Delete와 동일하게 git branch, worktree, terminal session을 자동 정리하여 리소스를 깨끗하게 관리한다.

## 어떻게 해결했나요?
**cleanupTaskResources 헬퍼 추출**
- deleteTask의 세션/worktree/branch 정리 로직을 재사용 가능한 함수로 분리
- updateTaskStatus, deleteTask, hooks API 모두에서 동일 로직 호출

**removeWorktreeAndBranch 함수 추출**
- 세션 유무와 관계없이 worktree + branch만 독립적으로 삭제하는 함수 추가
- 기존에는 session 정보가 없으면 cleanup 전체가 스킵되는 버그 존재

## 중요한 변경 사항은 무엇인가요?
### cleanupTaskResources 로직 분리

**세션 정리와 worktree/branch 정리를 독립 실행**
- **변경 이유**: 기존에는 `sessionType`/`sessionName`이 없으면 guard clause에 의해 worktree/branch 정리도 스킵됨
- **수정 파일**: `src/app/actions/kanban.ts`

### DONE 상태 변경 시 cleanup 호출

**updateTaskStatus + hooks API에 cleanup 적용**
- **변경 이유**: Done 상태로 변경 시 리소스 자동 정리
- **수정 파일**: `src/app/actions/kanban.ts`, `src/app/api/hooks/status/route.ts`

### removeWorktreeAndBranch 추출 및 리팩토링

**removeWorktreeAndSession을 removeSessionOnly + removeWorktreeAndBranch 조합으로 리팩토링**
- **변경 이유**: 세션 없이 worktree/branch만 정리하는 경로 지원
- **수정 파일**: `src/lib/worktree.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
