### PR TITLE
feat(board): 칸반 태스크 사용자 정의 정렬 및 DnD 개선

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -9,7 +9,7 @@ import ProjectSelector from "./ProjectSelector";
 import ProjectSettings from "./ProjectSettings";
 import TaskContextMenu from "./TaskContextMenu";
 import BranchTaskModal from "./BranchTaskModal";
-import { updateTaskStatus, reorderTasks, deleteTask, getMoreDoneTasks } from "@/app/actions/kanban";
+import { reorderTasks, deleteTask, getMoreDoneTasks, moveTaskToColumn } from "@/app/actions/kanban";
 import type { TasksByStatus } from "@/app/actions/kanban";
 import { TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
@@ -291,7 +291,17 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
             setDoneOffset((prev) => prev - 1);
           }
 
-          updateTaskStatus(draggableId, destStatus);
+          /** 상태 변경 + 목적지 컬럼 순서를 한 번에 DB에 반영한다 (revalidation 없음) */
+          const destReorderIds = (
+            projectFilterSet
+              ? updated[destStatus].filter(
+                  (task) =>
+                    task.projectId && projectFilterSet.has(task.projectId)
+                )
+              : updated[destStatus]
+          ).map((task) => task.id);
+
+          moveTaskToColumn(draggableId, destStatus, destReorderIds);
         }
 
         return updated;

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -27,7 +27,7 @@ export default function TaskCard({ task, index, onContextMenu, projectName }: Ta
             {...provided.draggableProps}
             {...provided.dragHandleProps}
             onContextMenu={(e) => onContextMenu(e, task)}
-            className={`p-3 mb-2 rounded-lg border transition-all cursor-pointer ${
+            className={`p-3 mb-2 rounded-lg border transition-colors transition-shadow cursor-pointer ${
               snapshot.isDragging
                 ? "bg-bg-surface border-brand-primary shadow-md"
                 : "bg-bg-surface border-border-default hover:border-border-strong hover:shadow-sm"

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -7,6 +7,7 @@ import { InitialSchema1770854400000 } from "@/migrations/1770854400000-InitialSc
 import { AddPrUrlToKanbanTasks1770854400001 } from "@/migrations/1770854400001-AddPrUrlToKanbanTasks";
 import { AddIsWorktreeToProjects1770854400002 } from "@/migrations/1770854400002-AddIsWorktreeToProjects";
 import { AddPaneLayoutConfig1771048256887 } from "@/migrations/1771048256887-AddPaneLayoutConfig";
+import { AssignDisplayOrder1771166346785 } from "@/migrations/1771166346785-AssignDisplayOrder";
 
 /**
  * TypeORM DataSource 싱글턴.
@@ -28,7 +29,7 @@ function createDataSource(): DataSource {
     type: "postgres",
     url: process.env.DATABASE_URL ?? buildDatabaseUrl(),
     entities: [KanbanTask, Project, PaneLayoutConfig],
-    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887],
+    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785],
     synchronize: false,
     logging: process.env.NODE_ENV !== "production",
   });

--- a/src/migrations/1771166346785-AssignDisplayOrder.ts
+++ b/src/migrations/1771166346785-AssignDisplayOrder.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * 기존 태스크에 status별 createdAt 순서 기반으로 display_order를 부여한다.
+ * 모든 기존 태스크가 display_order = 0이므로, ROW_NUMBER로 0-based 순서를 할당한다.
+ */
+export class AssignDisplayOrder1771166346785 implements MigrationInterface {
+  name = "AssignDisplayOrder1771166346785";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE kanban_tasks
+      SET display_order = sub.rn
+      FROM (
+        SELECT id, ROW_NUMBER() OVER (PARTITION BY status ORDER BY created_at ASC) - 1 AS rn
+        FROM kanban_tasks
+      ) sub
+      WHERE kanban_tasks.id = sub.id
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`UPDATE kanban_tasks SET display_order = 0`);
+  }
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/kanban/2602/15-implement-task-ordering.plan.md)

## 어떤 작업인가요?
- 칸반 보드에서 사용자가 드래그 앤 드롭으로 태스크 순서를 자유롭게 정의할 수 있도록 정렬 기능을 완성하고, 드래그 시 발생하던 이중 렌더링 및 낙하 애니메이션 문제를 수정

## 어떻게 해결했나요?
**태스크 정렬 기능 완성**
- 기존 displayOrder 필드를 활용한 정렬 로직 구현
- 기존 데이터에 status별 createdAt 순서로 displayOrder를 부여하는 마이그레이션 추가
- 새 태스크 생성 시 해당 컬럼 맨 아래에 배치되도록 MAX(displayOrder)+1 할당

**드래그 앤 드롭 UX 개선**
- 크로스 컬럼 이동 시 상태 변경 + 순서 저장을 단일 서버 액션으로 통합
- 드래그 작업에서 불필요한 서버 리페치(revalidatePath) 제거
- TaskCard의 CSS transition 충돌 해소

## 중요한 변경 사항은 무엇인가요?
### 태스크 정렬 기능

**마이그레이션 스크립트 추가**
- **변경 이유**: 기존 태스크들의 displayOrder가 전부 0이므로 createdAt 기반으로 초기 순서 부여
- **수정 파일**: `src/migrations/1771166346785-AssignDisplayOrder.ts`, `src/lib/database.ts`

**새 태스크 생성 시 순서 할당**
- **변경 이유**: 새 태스크가 컬럼 맨 아래에 배치되도록 displayOrder 자동 설정
- **수정 파일**: `src/app/actions/kanban.ts` (createTask)

### 드래그 앤 드롭 개선

**moveTaskToColumn 서버 액션 추가**
- **변경 이유**: 크로스 컬럼 이동 시 updateTaskStatus + reorderTasks 2회 호출로 인한 이중 렌더링 제거
- **수정 파일**: `src/app/actions/kanban.ts`, `src/components/Board.tsx`

**TaskCard transition-all 제거**
- **변경 이유**: transition-all이 DnD 라이브러리의 transform 속성까지 애니메이션 처리하여 "위에서 아래로 떨어지는" 효과 발생
- **수정 파일**: `src/components/TaskCard.tsx`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
