### PR TITLE
feat(task-detail): 상세 페이지 레이아웃 개선 및 접이식 사이드바 추가

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -98,7 +98,10 @@
     "loadingFolders": "Searching folders...",
     "noFoldersFound": "No matching folders found.",
     "folderCount": "{count} folders",
-    "folderNavHint": "↑↓ Navigate · Tab Drill down · Enter Select · Backspace Go up · Esc Close"
+    "folderNavHint": "↑↓ Navigate · Tab Drill down · Enter Select · Backspace Go up · Esc Close",
+    "detailPageSection": "Detail Page",
+    "sidebarDefaultCollapsed": "Collapse sidebar by default",
+    "sidebarDefaultCollapsedDescription": "Start with the left sidebar collapsed when entering the detail page."
   },
   "paneLayout": {
     "title": "Pane Layout Settings",
@@ -170,6 +173,10 @@
     "installingHooks": "Installing...",
     "hooksInstallSuccess": "Hooks installed successfully",
     "hooksInstallFailed": "Hooks installation failed",
-    "hooksRemoteNotSupported": "Remote projects are not supported"
+    "hooksRemoteNotSupported": "Remote projects are not supported",
+    "collapseSidebar": "Collapse sidebar",
+    "expandSidebar": "Expand sidebar",
+    "sidebarTooltip": "You can change the default state in Settings",
+    "dismissHint": "Don't show again"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -98,7 +98,10 @@
     "loadingFolders": "폴더 검색 중...",
     "noFoldersFound": "일치하는 폴더가 없습니다.",
     "folderCount": "{count}개의 폴더",
-    "folderNavHint": "↑↓ 이동 · Tab 하위 폴더 · Enter 선택 · Backspace 상위 폴더 · Esc 닫기"
+    "folderNavHint": "↑↓ 이동 · Tab 하위 폴더 · Enter 선택 · Backspace 상위 폴더 · Esc 닫기",
+    "detailPageSection": "상세 페이지",
+    "sidebarDefaultCollapsed": "사이드바 기본 접기",
+    "sidebarDefaultCollapsedDescription": "상세 페이지 진입 시 왼쪽 사이드바를 접은 상태로 시작합니다."
   },
   "paneLayout": {
     "title": "Pane 레이아웃 설정",
@@ -170,6 +173,10 @@
     "installingHooks": "설치 중...",
     "hooksInstallSuccess": "Hooks 설치 완료",
     "hooksInstallFailed": "Hooks 설치 실패",
-    "hooksRemoteNotSupported": "원격 프로젝트는 지원하지 않습니다"
+    "hooksRemoteNotSupported": "원격 프로젝트는 지원하지 않습니다",
+    "collapseSidebar": "사이드바 접기",
+    "expandSidebar": "사이드바 펼치기",
+    "sidebarTooltip": "설정에서 기본 접힘 상태를 변경할 수 있습니다",
+    "dismissHint": "다시 보지 않기"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -98,7 +98,10 @@
     "loadingFolders": "正在搜索文件夹...",
     "noFoldersFound": "未找到匹配的文件夹。",
     "folderCount": "{count} 个文件夹",
-    "folderNavHint": "↑↓ 导航 · Tab 进入子文件夹 · Enter 选择 · Backspace 返回上级 · Esc 关闭"
+    "folderNavHint": "↑↓ 导航 · Tab 进入子文件夹 · Enter 选择 · Backspace 返回上级 · Esc 关闭",
+    "detailPageSection": "详情页",
+    "sidebarDefaultCollapsed": "默认折叠侧栏",
+    "sidebarDefaultCollapsedDescription": "进入详情页时左侧栏默认折叠。"
   },
   "paneLayout": {
     "title": "面板布局设置",
@@ -170,6 +173,10 @@
     "installingHooks": "安装中...",
     "hooksInstallSuccess": "Hooks 安装完成",
     "hooksInstallFailed": "Hooks 安装失败",
-    "hooksRemoteNotSupported": "不支持远程项目"
+    "hooksRemoteNotSupported": "不支持远程项目",
+    "collapseSidebar": "折叠侧栏",
+    "expandSidebar": "展开侧栏",
+    "sidebarTooltip": "可以在设置中更改默认折叠状态",
+    "dismissHint": "不再显示"
   }
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,7 @@
 import Board from "@/components/Board";
 import { getTasksByStatus } from "@/app/actions/kanban";
 import { getAllProjects } from "@/app/actions/project";
+import { getSidebarDefaultCollapsed } from "@/app/actions/appSettings";
 import { getAvailableHosts } from "@/lib/sshConfig";
 
 export const dynamic = "force-dynamic";
@@ -9,6 +10,7 @@ export default async function HomePage() {
   const { tasks, doneTotal, doneLimit } = await getTasksByStatus();
   const sshHosts = await getAvailableHosts();
   const projects = await getAllProjects();
+  const sidebarDefaultCollapsed = await getSidebarDefaultCollapsed();
 
   return (
     <Board
@@ -17,6 +19,7 @@ export default async function HomePage() {
       initialDoneLimit={doneLimit}
       sshHosts={sshHosts}
       projects={projects}
+      sidebarDefaultCollapsed={sidebarDefaultCollapsed}
     />
   );
 }

--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -13,7 +13,9 @@ import TerminalLoader from "@/components/TerminalLoader";
 import ConnectTerminalForm from "@/components/ConnectTerminalForm";
 import DeleteTaskButton from "@/components/DeleteTaskButton";
 import HooksStatusCard from "@/components/HooksStatusCard";
+import CollapsibleSidebar from "@/components/CollapsibleSidebar";
 import { getTaskHooksStatus } from "@/app/actions/project";
+import { getSidebarDefaultCollapsed, getSidebarHintDismissed } from "@/app/actions/appSettings";
 import { Link } from "@/i18n/navigation";
 
 export const dynamicConfig = "force-dynamic";
@@ -51,6 +53,8 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
 
   const hasTerminal = task.sessionType && task.sessionName;
   const hooksStatus = task.projectId ? await getTaskHooksStatus(id) : null;
+  const sidebarDefaultCollapsed = await getSidebarDefaultCollapsed();
+  const sidebarHintDismissed = await getSidebarHintDismissed();
 
   async function handleStatusChange(formData: FormData) {
     "use server";
@@ -69,9 +73,10 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
     : null;
 
   return (
-    <div className="h-screen flex flex-col bg-bg-page">
-      {/* 헤더 */}
-      <header className="flex items-center justify-between px-6 py-3 border-b border-border-default bg-bg-surface shrink-0">
+    <div className="h-screen flex flex-col lg:flex-row bg-bg-page p-4 gap-4">
+      {/* 사이드바 - 작업 정보 (접기/열기 가능) */}
+      <CollapsibleSidebar defaultCollapsed={sidebarDefaultCollapsed} showHint={!sidebarHintDismissed}>
+        {/* 보드로 돌아가기 */}
         <Link
           href="/"
           className="flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary transition-colors"
@@ -94,165 +99,158 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
           {t("backToBoard")}
         </Link>
 
-        <div className="flex items-center gap-2">
-          <DeleteTaskButton deleteAction={handleDelete} />
+        {/* 제목 + 상태 카드 */}
+        <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
+          <div className="flex items-center gap-2 mb-3">
+            <TaskStatusBadge status={task.status} />
+          </div>
+          <h1 className="text-xl font-bold text-text-primary leading-tight">
+            {task.title}
+          </h1>
+          {task.description && (
+            <p className="text-sm text-text-secondary mt-3 leading-relaxed">
+              {task.description}
+            </p>
+          )}
         </div>
-      </header>
 
-      {/* 메인 콘텐츠: 사이드바 + 터미널 2패널 */}
-      <div className="flex-1 flex flex-col lg:flex-row min-h-0 p-4 gap-4">
-        {/* 사이드바 - 작업 정보 */}
-        <aside className="lg:w-80 shrink-0 flex flex-col gap-4 lg:overflow-y-auto">
-          {/* 제목 + 상태 카드 */}
-          <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
-            <div className="flex items-center gap-2 mb-3">
-              <TaskStatusBadge status={task.status} />
+        {/* 메타데이터 카드 */}
+        <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
+          <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-4">
+            {t("info")}
+          </h3>
+          <dl className="space-y-3">
+            {task.prUrl && (
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-xs text-text-muted">{t("prLink")}</dt>
+                <dd>
+                  <a
+                    href={task.prUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-xs bg-tag-pr-bg text-tag-pr-text px-2 py-0.5 rounded hover:opacity-80 transition-opacity"
+                  >
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                      <path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
+                    </svg>
+                    PR
+                    <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                      <path d="M4 12L12 4M12 4H6M12 4v6" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  </a>
+                </dd>
+              </div>
+            )}
+            {task.agentType && (
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-xs text-text-muted">{t("agent")}</dt>
+                <dd
+                  className={`text-xs px-2 py-0.5 rounded-full font-medium ${agentTagStyle}`}
+                >
+                  {task.agentType}
+                </dd>
+              </div>
+            )}
+            {task.sessionType && (
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-xs text-text-muted">{t("session")}</dt>
+                <dd className="text-xs bg-tag-session-bg text-tag-session-text px-2 py-0.5 rounded-full">
+                  {task.sessionType}
+                </dd>
+              </div>
+            )}
+            {task.sshHost && (
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-xs text-text-muted">{t("sshHost")}</dt>
+                <dd className="text-xs font-mono bg-tag-ssh-bg text-tag-ssh-text px-2 py-0.5 rounded">
+                  {task.sshHost}
+                </dd>
+              </div>
+            )}
+            <div className="border-t border-border-subtle pt-3 mt-3">
+              <div className="flex items-center justify-between gap-2 mb-2">
+                <dt className="text-xs text-text-muted">{t("createdAt")}</dt>
+                <dd className="text-xs text-text-secondary">
+                  {new Date(task.createdAt).toLocaleDateString()}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-xs text-text-muted">{t("updatedAt")}</dt>
+                <dd className="text-xs text-text-secondary">
+                  {new Date(task.updatedAt).toLocaleDateString()}
+                </dd>
+              </div>
             </div>
-            <h1 className="text-xl font-bold text-text-primary leading-tight">
-              {task.title}
-            </h1>
-            {task.description && (
-              <p className="text-sm text-text-secondary mt-3 leading-relaxed">
-                {task.description}
-              </p>
+          </dl>
+        </div>
+
+        {/* 상태 변경 + 네비게이션 카드 */}
+        <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
+          <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
+            {t("actions")}
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {STATUS_TRANSITIONS.filter(
+              (transition) => transition.status !== task.status
+            ).map((transition) => (
+              <form key={transition.status} action={handleStatusChange}>
+                <input
+                  type="hidden"
+                  name="status"
+                  value={transition.status}
+                />
+                <button
+                  type="submit"
+                  className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors"
+                >
+                  {t(transition.labelKey)}
+                </button>
+              </form>
+            ))}
+          </div>
+          <div className="mt-3 pt-3 border-t border-border-subtle">
+            <DeleteTaskButton deleteAction={handleDelete} />
+          </div>
+        </div>
+
+        {/* Hooks 상태 카드 */}
+        {task.projectId && (
+          <HooksStatusCard
+            taskId={task.id}
+            initialStatus={hooksStatus}
+            isRemote={!!task.sshHost}
+          />
+        )}
+      </CollapsibleSidebar>
+
+      {/* 터미널 영역 */}
+      <main className="flex-1 flex flex-col min-h-0 min-w-0">
+        {hasTerminal ? (
+          <div className="flex-1 flex flex-col min-h-0 rounded-lg overflow-hidden shadow-md">
+            {/* macOS 스타일 윈도우 크롬 */}
+            <div className="bg-terminal-chrome flex items-center gap-2 px-4 py-2.5 shrink-0">
+              <span className="w-3 h-3 rounded-full bg-traffic-close" />
+              <span className="w-3 h-3 rounded-full bg-traffic-minimize" />
+              <span className="w-3 h-3 rounded-full bg-traffic-maximize" />
+              <span className="ml-3 text-xs text-terminal-text font-mono truncate">
+                {task.sessionName ?? t("terminal")}
+              </span>
+            </div>
+            {/* 터미널 본체 */}
+            <div className="flex-1 min-h-0 bg-terminal-bg">
+              <TerminalLoader taskId={task.id} />
+            </div>
+          </div>
+        ) : (
+          <div className="flex-1 flex items-center justify-center border border-dashed border-border-default rounded-lg bg-bg-surface">
+            {task.projectId ? (
+              <ConnectTerminalForm taskId={task.id} />
+            ) : (
+              <p className="text-text-muted text-sm">{t("noTerminal")}</p>
             )}
           </div>
-
-          {/* 메타데이터 카드 */}
-          <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
-            <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-4">
-              {t("info")}
-            </h3>
-            <dl className="space-y-3">
-              {task.prUrl && (
-                <div className="flex items-center justify-between gap-2">
-                  <dt className="text-xs text-text-muted">{t("prLink")}</dt>
-                  <dd>
-                    <a
-                      href={task.prUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-xs bg-tag-pr-bg text-tag-pr-text px-2 py-0.5 rounded hover:opacity-80 transition-opacity"
-                    >
-                      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-                        <path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
-                      </svg>
-                      PR
-                      <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                        <path d="M4 12L12 4M12 4H6M12 4v6" strokeLinecap="round" strokeLinejoin="round"/>
-                      </svg>
-                    </a>
-                  </dd>
-                </div>
-              )}
-              {task.agentType && (
-                <div className="flex items-center justify-between gap-2">
-                  <dt className="text-xs text-text-muted">{t("agent")}</dt>
-                  <dd
-                    className={`text-xs px-2 py-0.5 rounded-full font-medium ${agentTagStyle}`}
-                  >
-                    {task.agentType}
-                  </dd>
-                </div>
-              )}
-              {task.sessionType && (
-                <div className="flex items-center justify-between gap-2">
-                  <dt className="text-xs text-text-muted">{t("session")}</dt>
-                  <dd className="text-xs bg-tag-session-bg text-tag-session-text px-2 py-0.5 rounded-full">
-                    {task.sessionType}
-                  </dd>
-                </div>
-              )}
-              {task.sshHost && (
-                <div className="flex items-center justify-between gap-2">
-                  <dt className="text-xs text-text-muted">{t("sshHost")}</dt>
-                  <dd className="text-xs font-mono bg-tag-ssh-bg text-tag-ssh-text px-2 py-0.5 rounded">
-                    {task.sshHost}
-                  </dd>
-                </div>
-              )}
-              <div className="border-t border-border-subtle pt-3 mt-3">
-                <div className="flex items-center justify-between gap-2 mb-2">
-                  <dt className="text-xs text-text-muted">{t("createdAt")}</dt>
-                  <dd className="text-xs text-text-secondary">
-                    {new Date(task.createdAt).toLocaleDateString()}
-                  </dd>
-                </div>
-                <div className="flex items-center justify-between gap-2">
-                  <dt className="text-xs text-text-muted">{t("updatedAt")}</dt>
-                  <dd className="text-xs text-text-secondary">
-                    {new Date(task.updatedAt).toLocaleDateString()}
-                  </dd>
-                </div>
-              </div>
-            </dl>
-          </div>
-
-          {/* 상태 변경 카드 */}
-          <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
-            <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
-              {t("actions")}
-            </h3>
-            <div className="flex flex-wrap gap-2">
-              {STATUS_TRANSITIONS.filter(
-                (transition) => transition.status !== task.status
-              ).map((transition) => (
-                <form key={transition.status} action={handleStatusChange}>
-                  <input
-                    type="hidden"
-                    name="status"
-                    value={transition.status}
-                  />
-                  <button
-                    type="submit"
-                    className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors"
-                  >
-                    {t(transition.labelKey)}
-                  </button>
-                </form>
-              ))}
-            </div>
-          </div>
-
-          {/* Hooks 상태 카드 */}
-          {task.projectId && (
-            <HooksStatusCard
-              taskId={task.id}
-              initialStatus={hooksStatus}
-              isRemote={!!task.sshHost}
-            />
-          )}
-        </aside>
-
-        {/* 터미널 영역 */}
-        <main className="flex-1 flex flex-col min-h-0 min-w-0">
-          {hasTerminal ? (
-            <div className="flex-1 flex flex-col min-h-0 rounded-lg overflow-hidden shadow-md">
-              {/* macOS 스타일 윈도우 크롬 */}
-              <div className="bg-terminal-chrome flex items-center gap-2 px-4 py-2.5 shrink-0">
-                <span className="w-3 h-3 rounded-full bg-traffic-close" />
-                <span className="w-3 h-3 rounded-full bg-traffic-minimize" />
-                <span className="w-3 h-3 rounded-full bg-traffic-maximize" />
-                <span className="ml-3 text-xs text-terminal-text font-mono truncate">
-                  {task.sessionName ?? t("terminal")}
-                </span>
-              </div>
-              {/* 터미널 본체 */}
-              <div className="flex-1 min-h-0 bg-terminal-bg">
-                <TerminalLoader taskId={task.id} />
-              </div>
-            </div>
-          ) : (
-            <div className="flex-1 flex items-center justify-center border border-dashed border-border-default rounded-lg bg-bg-surface">
-              {task.projectId ? (
-                <ConnectTerminalForm taskId={task.id} />
-              ) : (
-                <p className="text-text-muted text-sm">{t("noTerminal")}</p>
-              )}
-            </div>
-          )}
-        </main>
-      </div>
+        )}
+      </main>
     </div>
   );
 }

--- a/src/app/actions/appSettings.ts
+++ b/src/app/actions/appSettings.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getAppSettingsRepository } from "@/lib/database";
+
+const SIDEBAR_COLLAPSED_KEY = "sidebar_default_collapsed";
+const SIDEBAR_HINT_DISMISSED_KEY = "sidebar_hint_dismissed";
+
+/**
+ * 키로 앱 설정값을 조회한다.
+ * @param key 설정 키
+ * @returns 설정값 문자열, 없으면 null
+ */
+export async function getAppSetting(key: string): Promise<string | null> {
+  const repo = await getAppSettingsRepository();
+  const setting = await repo.findOne({ where: { key } });
+  return setting?.value ?? null;
+}
+
+/**
+ * 앱 설정값을 저장한다. 기존 키가 있으면 업데이트, 없으면 생성한다.
+ * @param key 설정 키
+ * @param value 설정값
+ */
+export async function setAppSetting(key: string, value: string): Promise<void> {
+  const repo = await getAppSettingsRepository();
+  const existing = await repo.findOne({ where: { key } });
+
+  if (existing) {
+    existing.value = value;
+    await repo.save(existing);
+  } else {
+    const setting = repo.create({ key, value });
+    await repo.save(setting);
+  }
+}
+
+/** 사이드바 기본 접힘 상태를 조회한다 */
+export async function getSidebarDefaultCollapsed(): Promise<boolean> {
+  const value = await getAppSetting(SIDEBAR_COLLAPSED_KEY);
+  return value === "true";
+}
+
+/** 사이드바 기본 접힘 상태를 저장한다 */
+export async function setSidebarDefaultCollapsed(collapsed: boolean): Promise<void> {
+  await setAppSetting(SIDEBAR_COLLAPSED_KEY, String(collapsed));
+  revalidatePath("/");
+}
+
+/** 사이드바 힌트 숨김 여부를 조회한다 */
+export async function getSidebarHintDismissed(): Promise<boolean> {
+  const value = await getAppSetting(SIDEBAR_HINT_DISMISSED_KEY);
+  return value === "true";
+}
+
+/** 사이드바 힌트를 다시 보지 않기로 설정한다 */
+export async function dismissSidebarHint(): Promise<void> {
+  await setAppSetting(SIDEBAR_HINT_DISMISSED_KEY, "true");
+}

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -22,6 +22,7 @@ interface BoardProps {
   initialDoneLimit: number;
   sshHosts: string[];
   projects: Project[];
+  sidebarDefaultCollapsed: boolean;
 }
 
 const COLUMNS: { status: TaskStatus; labelKey: string; colorClass: string }[] = [
@@ -82,7 +83,7 @@ function insertAtFilteredIndex(
   return arr;
 }
 
-export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit, sshHosts, projects }: BoardProps) {
+export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit, sshHosts, projects, sidebarDefaultCollapsed }: BoardProps) {
   useAutoRefresh();
   const t = useTranslations("board");
   const tt = useTranslations("task");
@@ -429,6 +430,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         onClose={() => setIsSettingsOpen(false)}
         projects={projects}
         sshHosts={sshHosts}
+        sidebarDefaultCollapsed={sidebarDefaultCollapsed}
       />
 
       {contextMenu.isOpen && contextMenu.task && (

--- a/src/components/CollapsibleSidebar.tsx
+++ b/src/components/CollapsibleSidebar.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, useTransition, useRef, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { useTranslations } from "next-intl";
+import { dismissSidebarHint } from "@/app/actions/appSettings";
+
+interface CollapsibleSidebarProps {
+  defaultCollapsed: boolean;
+  showHint: boolean;
+  children: React.ReactNode;
+}
+
+/** 사이드바 패널 토글 아이콘 */
+function SidebarPanelIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      className={className}
+    >
+      <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" />
+      <line x1="6" y1="2.5" x2="6" y2="13.5" />
+    </svg>
+  );
+}
+
+/** 포탈로 body에 렌더링되는 힌트 말풍선. 버튼 위에 fixed 배치. */
+function ToggleButtonWithHint({
+  onClick,
+  buttonClassName,
+  showHint,
+  onDismissHint,
+  children,
+}: {
+  onClick: () => void;
+  buttonClassName: string;
+  showHint: boolean;
+  onDismissHint: () => void;
+  children: React.ReactNode;
+}) {
+  const t = useTranslations("taskDetail");
+  const [isPending, startTransition] = useTransition();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [hintPos, setHintPos] = useState<{ top: number; left: number } | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const updateHintPosition = useCallback(() => {
+    if (!buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    setHintPos({
+      top: rect.top,
+      left: rect.left + rect.width / 2,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!showHint || !mounted) return;
+    updateHintPosition();
+    window.addEventListener("resize", updateHintPosition);
+    window.addEventListener("scroll", updateHintPosition, true);
+    return () => {
+      window.removeEventListener("resize", updateHintPosition);
+      window.removeEventListener("scroll", updateHintPosition, true);
+    };
+  }, [showHint, mounted, updateHintPosition]);
+
+  function handleDismiss() {
+    startTransition(async () => {
+      await dismissSidebarHint();
+      onDismissHint();
+    });
+  }
+
+  return (
+    <>
+      <button ref={buttonRef} onClick={onClick} className={buttonClassName}>
+        {children}
+      </button>
+      {mounted && showHint && hintPos && createPortal(
+        <div
+          style={{ top: hintPos.top, left: hintPos.left }}
+          className="fixed -translate-x-1/2 -translate-y-full z-[9999] pb-2"
+        >
+          <div className="bg-[#333] text-white text-xs rounded-lg px-3 py-2.5 shadow-lg whitespace-nowrap">
+            <div>{t("sidebarTooltip")}</div>
+            <button
+              onClick={handleDismiss}
+              disabled={isPending}
+              className="mt-1.5 text-xs opacity-60 hover:opacity-100 underline underline-offset-2 transition-opacity"
+            >
+              {t("dismissHint")}
+            </button>
+          </div>
+          <div className="flex justify-center">
+            <div className="border-[5px] border-transparent border-t-[#333]" />
+          </div>
+        </div>,
+        document.body
+      )}
+    </>
+  );
+}
+
+export default function CollapsibleSidebar({
+  defaultCollapsed,
+  showHint,
+  children,
+}: CollapsibleSidebarProps) {
+  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
+  const [isHintVisible, setIsHintVisible] = useState(showHint);
+  const t = useTranslations("taskDetail");
+
+  if (isCollapsed) {
+    return (
+      <div className="shrink-0 flex flex-col h-full">
+        <div className="flex-1" />
+        <div className="border-t border-border-default pt-3">
+          <ToggleButtonWithHint
+            onClick={() => setIsCollapsed(false)}
+            buttonClassName="p-2 bg-bg-surface border border-border-default rounded-lg hover:border-brand-primary text-text-muted hover:text-text-primary transition-colors"
+            showHint={isHintVisible}
+            onDismissHint={() => setIsHintVisible(false)}
+          >
+            <SidebarPanelIcon />
+          </ToggleButtonWithHint>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <aside className="lg:w-80 shrink-0 flex flex-col lg:overflow-y-auto">
+      <div className="flex flex-col gap-4 flex-1">
+        {children}
+      </div>
+      <div className="border-t border-border-default mt-4 pt-3 flex justify-end">
+        <ToggleButtonWithHint
+          onClick={() => setIsCollapsed(true)}
+          buttonClassName="p-1.5 text-text-muted hover:text-text-primary transition-colors"
+          showHint={isHintVisible}
+          onDismissHint={() => setIsHintVisible(false)}
+        >
+          <SidebarPanelIcon />
+        </ToggleButtonWithHint>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/ProjectSettings.tsx
+++ b/src/components/ProjectSettings.tsx
@@ -9,6 +9,7 @@ import {
   installProjectHooks,
   type ScanResult,
 } from "@/app/actions/project";
+import { setSidebarDefaultCollapsed } from "@/app/actions/appSettings";
 import { Link } from "@/i18n/navigation";
 import type { Project } from "@/entities/Project";
 import type { ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
@@ -19,6 +20,7 @@ interface ProjectSettingsProps {
   onClose: () => void;
   projects: Project[];
   sshHosts: string[];
+  sidebarDefaultCollapsed: boolean;
 }
 
 export default function ProjectSettings({
@@ -26,6 +28,7 @@ export default function ProjectSettings({
   onClose,
   projects,
   sshHosts,
+  sidebarDefaultCollapsed,
 }: ProjectSettingsProps) {
   const t = useTranslations("settings");
   const tc = useTranslations("common");
@@ -135,6 +138,39 @@ export default function ProjectSettings({
             <span>{t("paneLayoutLink")}</span>
             <span className="text-text-muted">&rarr;</span>
           </Link>
+        </div>
+
+        {/* 상세 페이지 설정 */}
+        <div className="p-4 border-b border-border-default">
+          <h3 className="text-xs text-text-muted uppercase tracking-wide mb-3">
+            {t("detailPageSection")}
+          </h3>
+          <label className="flex items-center justify-between cursor-pointer">
+            <div>
+              <span className="text-sm text-text-primary">{t("sidebarDefaultCollapsed")}</span>
+              <p className="text-xs text-text-muted mt-0.5">{t("sidebarDefaultCollapsedDescription")}</p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={sidebarDefaultCollapsed}
+              onClick={() => {
+                startTransition(async () => {
+                  await setSidebarDefaultCollapsed(!sidebarDefaultCollapsed);
+                });
+              }}
+              disabled={isPending}
+              className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors ${
+                sidebarDefaultCollapsed ? "bg-brand-primary" : "bg-border-default"
+              }`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                  sidebarDefaultCollapsed ? "translate-x-4" : "translate-x-0"
+                }`}
+              />
+            </button>
+          </label>
         </div>
 
         {/* 디렉토리 스캔 등록 */}

--- a/src/entities/AppSettings.ts
+++ b/src/entities/AppSettings.ts
@@ -1,0 +1,30 @@
+import "reflect-metadata";
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+/**
+ * 앱 전역 설정을 저장하는 키-값 엔티티.
+ * 사이드바 기본 접힘 상태 등 UI 설정을 관리한다.
+ */
+@Entity("app_settings")
+export class AppSettings {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar", length: 100, unique: true })
+  key!: string;
+
+  @Column({ type: "text" })
+  value!: string;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt!: Date;
+}

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -3,11 +3,13 @@ import { DataSource, type ObjectLiteral, type Repository } from "typeorm";
 import { KanbanTask } from "@/entities/KanbanTask";
 import { Project } from "@/entities/Project";
 import { PaneLayoutConfig } from "@/entities/PaneLayoutConfig";
+import { AppSettings } from "@/entities/AppSettings";
 import { InitialSchema1770854400000 } from "@/migrations/1770854400000-InitialSchema";
 import { AddPrUrlToKanbanTasks1770854400001 } from "@/migrations/1770854400001-AddPrUrlToKanbanTasks";
 import { AddIsWorktreeToProjects1770854400002 } from "@/migrations/1770854400002-AddIsWorktreeToProjects";
 import { AddPaneLayoutConfig1771048256887 } from "@/migrations/1771048256887-AddPaneLayoutConfig";
 import { AssignDisplayOrder1771166346785 } from "@/migrations/1771166346785-AssignDisplayOrder";
+import { AddAppSettings1771166907165 } from "@/migrations/1771166907165-AddAppSettings";
 
 /**
  * TypeORM DataSource 싱글턴.
@@ -28,8 +30,8 @@ function createDataSource(): DataSource {
   return new DataSource({
     type: "postgres",
     url: process.env.DATABASE_URL ?? buildDatabaseUrl(),
-    entities: [KanbanTask, Project, PaneLayoutConfig],
-    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785],
+    entities: [KanbanTask, Project, PaneLayoutConfig, AppSettings],
+    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785, AddAppSettings1771166907165],
     synchronize: false,
     logging: process.env.NODE_ENV !== "production",
   });
@@ -76,4 +78,9 @@ export async function getProjectRepository(): Promise<Repository<Project>> {
 export async function getPaneLayoutConfigRepository(): Promise<Repository<PaneLayoutConfig>> {
   const ds = await getDataSource();
   return getRepositoryByTable<PaneLayoutConfig>(ds, "pane_layout_configs");
+}
+
+export async function getAppSettingsRepository(): Promise<Repository<AppSettings>> {
+  const ds = await getDataSource();
+  return getRepositoryByTable<AppSettings>(ds, "app_settings");
 }

--- a/src/lib/typeorm-cli.config.ts
+++ b/src/lib/typeorm-cli.config.ts
@@ -3,6 +3,7 @@ import { DataSource } from "typeorm";
 import { KanbanTask } from "../entities/KanbanTask";
 import { Project } from "../entities/Project";
 import { PaneLayoutConfig } from "../entities/PaneLayoutConfig";
+import { AppSettings } from "../entities/AppSettings";
 
 /**
  * TypeORM CLI 전용 DataSource 설정.
@@ -19,7 +20,7 @@ function buildDatabaseUrl(): string {
 export default new DataSource({
   type: "postgres",
   url: process.env.DATABASE_URL ?? buildDatabaseUrl(),
-  entities: [KanbanTask, Project, PaneLayoutConfig],
+  entities: [KanbanTask, Project, PaneLayoutConfig, AppSettings],
   migrations: ["src/migrations/*.ts"],
   synchronize: false,
   logging: true,

--- a/src/migrations/1771166907165-AddAppSettings.ts
+++ b/src/migrations/1771166907165-AddAppSettings.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddAppSettings1771166907165 implements MigrationInterface {
+    name = 'AddAppSettings1771166907165'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "app_settings" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "key" character varying(100) NOT NULL, "value" text NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_app_settings_key" UNIQUE ("key"), CONSTRAINT "PK_app_settings" PRIMARY KEY ("id"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "app_settings"`);
+    }
+
+}


### PR DESCRIPTION
## 어떤 작업인가요?
- 상세 페이지의 헤더를 제거하고, 접이식 사이드바 + 터미널 2단 레이아웃으로 개선하여 터미널 영역을 최대화

## 어떻게 해결했나요?
**레이아웃 구조 변경**
- 기존 상단 헤더(보드로 돌아가기 + 삭제 버튼)를 제거하여 터미널 공간 확보
- 좌측 사이드바 + 우측 터미널의 2단 레이아웃으로 단순화

**접이식 사이드바 구현**
- CollapsibleSidebar 클라이언트 컴포넌트 신규 생성
- 하단 토글 버튼으로 접기/펼치기 전환
- 포탈 기반 힌트 말풍선으로 사이드바 접기 기능 안내 (다시 보지 않기 지원)

**설정 기반 기본 상태 관리**
- app_settings 테이블 신규 생성 (키-값 구조)
- 설정 페이지에서 사이드바 기본 접힘 상태 토글 추가

## 중요한 변경 사항은 무엇인가요?
### 상세 페이지 레이아웃 변경

**헤더 제거 및 2단 레이아웃 적용**
- **변경 이유**: 헤더가 터미널 영역을 과도하게 차지
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`

**보드로 돌아가기 링크를 사이드바 상단으로 이동, 삭제 버튼을 상태 변경 카드 내부로 통합**
- **변경 이유**: 헤더 제거에 따른 UI 요소 재배치
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`

### 접이식 사이드바

**CollapsibleSidebar 컴포넌트 추가**
- **변경 이유**: 사이드바를 접어 터미널 영역을 최대화하는 기능
- **수정 파일**: `src/components/CollapsibleSidebar.tsx`

**포탈 기반 힌트 말풍선**
- **변경 이유**: 사이드바 접기 기능과 설정 변경 가능 여부를 사용자에게 안내
- **수정 파일**: `src/components/CollapsibleSidebar.tsx`

### 앱 설정 시스템

**app_settings 테이블 및 서버 액션 추가**
- **변경 이유**: 사이드바 기본 접힘 상태, 힌트 표시 여부 등 글로벌 UI 설정 저장
- **수정 파일**: `src/entities/AppSettings.ts`, `src/migrations/1771166907165-AddAppSettings.ts`, `src/app/actions/appSettings.ts`, `src/lib/database.ts`

**설정 페이지에 사이드바 기본 접힘 토글 추가**
- **변경 이유**: 사용자가 상세 페이지 진입 시 사이드바 기본 상태를 설정할 수 있도록
- **수정 파일**: `src/components/ProjectSettings.tsx`, `src/components/Board.tsx`, `src/app/[locale]/page.tsx`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
