### PR TITLE
feat(hooks): AskUserQuestion hook에 Pending 상태 추가

### DIFF
--- a/.claude/plan/hooks/2602/16-add-pending-status.plan.md
+++ b/.claude/plan/hooks/2602/16-add-pending-status.plan.md
@@ -1,0 +1,141 @@
+# Add PENDING Status Between Progress and Review
+
+## Business Goal
+Claude Code hooks에서 AskUserQuestion 발생 시 사용자 의사결정 대기 상태를 별도 칸반 컬럼으로 시각화하여, progress(작업 중)와 review(검토 대기)를 명확히 구분한다.
+
+## Scope
+- **In Scope**: TaskStatus enum에 PENDING 추가, DB migration, Hook 스크립트 수정, API STATUS_MAP 갱신, Board UI 컬럼 추가, TaskStatusBadge 스타일, i18n 번역, CSS/디자인 토큰 추가
+- **Out of Scope**: Done cleanup 로직, 기타 hook 동작 변경, Stop hook 동작 변경
+
+## Codebase Analysis Summary
+- `TaskStatus` enum (src/entities/KanbanTask.ts:12-17): TODO, PROGRESS, REVIEW, DONE
+- Hook 스크립트 생성 (src/lib/claudeHooksSetup.ts): generatePromptHookScript(→progress), generateStopHookScript(→review), generateQuestionHookScript(→review)
+- API route (src/app/api/hooks/status/route.ts): STATUS_MAP으로 string→TaskStatus 매핑
+- Board UI (src/components/Board.tsx:26-31): COLUMNS 배열로 컬럼 정의
+- TaskStatusBadge (src/components/TaskStatusBadge.tsx): 상태별 스타일 설정
+- CSS (src/app/globals.css:78-81): status 색상 변수
+- i18n (messages/*.json): columns 번역 키
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| src/entities/KanbanTask.ts | TaskStatus enum 정의 | Modify |
+| src/migrations/*.ts | DB migration | Create |
+| src/lib/database.ts | migration 등록 | Modify |
+| src/lib/claudeHooksSetup.ts | Hook 스크립트 생성 | Modify |
+| src/app/api/hooks/status/route.ts | Hook API endpoint | Modify |
+| src/components/Board.tsx | 칸반 보드 UI | Modify |
+| src/components/TaskStatusBadge.tsx | 상태 뱃지 스타일 | Modify |
+| messages/ko.json | 한국어 번역 | Modify |
+| messages/en.json | 영어 번역 | Modify |
+| messages/zh.json | 중국어 번역 | Modify |
+| src/app/globals.css | CSS 변수 | Modify |
+| prd/design-system.json | 디자인 토큰 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| Enum은 파일 분리 | BACKEND.md | enum은 별도 파일이지만, 기존 KanbanTask.ts에 이미 정의됨 → 유지 |
+| Migration 후 database.ts에 등록 | CLAUDE.md | migrations 배열에 새 migration 클래스 import 추가 |
+| CSS 변수 네이밍 | design-system.json | --color-status-{name} 패턴 |
+| i18n 3개 파일 동시 수정 | CLAUDE.md | ko, en, zh 모두 동일 키로 번역 추가 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|------------|
+| 새 상태 이름 | PENDING | 사용자 선택 | ASKING, DECISION |
+| 컬럼 색상 | Purple (#8B5CF6) | 사용자 선택 | Orange, Red |
+| Hook 변경 범위 | PreToolUse(AskUserQuestion)만 pending으로 변경 | Stop hook은 기존대로 review 유지 | - |
+
+## Data Models
+
+### TaskStatus Enum (변경)
+| Value | DB Value | Description |
+|-------|----------|-------------|
+| TODO | "todo" | 할 일 |
+| PROGRESS | "progress" | 진행 중 |
+| **PENDING** | **"pending"** | **사용자 의사결정 대기** |
+| REVIEW | "review" | 검토 대기 |
+| DONE | "done" | 완료 |
+
+## Implementation Todos
+
+### Todo 1: TaskStatus enum에 PENDING 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: TaskStatus enum에 PENDING 값을 PROGRESS와 REVIEW 사이에 추가
+- **Work**:
+  - `src/entities/KanbanTask.ts`의 `TaskStatus` enum에 `PENDING = "pending"` 추가 (PROGRESS 다음, REVIEW 이전)
+- **Convention Notes**: enum 값은 소문자 문자열
+- **Verification**: TypeScript 컴파일 에러 없음
+- **Exit Criteria**: TaskStatus.PENDING이 정상적으로 참조 가능
+- **Status**: pending
+
+### Todo 2: DB migration 생성
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: PostgreSQL의 kanban_tasks.status enum 타입에 'pending' 값을 추가
+- **Work**:
+  - `npm run migration:generate` 또는 수동으로 migration 파일 작성
+  - PostgreSQL ALTER TYPE ... ADD VALUE 'pending' BEFORE 'review' 사용
+  - `src/lib/database.ts`의 migrations 배열에 새 migration 클래스 import 추가
+- **Convention Notes**: migration 파일은 타임스탬프 기반 정렬, database.ts에 반드시 등록
+- **Verification**: `npm run migration:run` 성공
+- **Exit Criteria**: DB에 pending enum 값이 존재
+- **Status**: pending
+
+### Todo 3: Hook 스크립트 및 API 수정
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: AskUserQuestion hook이 pending 상태를 전송하도록 변경
+- **Work**:
+  - `src/lib/claudeHooksSetup.ts`의 `generateQuestionHookScript`: status를 "review" → "pending"으로 변경
+  - `src/app/api/hooks/status/route.ts`의 `STATUS_MAP`에 `pending: TaskStatus.PENDING` 추가
+- **Convention Notes**: 기존 코드 스타일 유지
+- **Verification**: API에 `{"status": "pending"}` 전송 시 정상 처리
+- **Exit Criteria**: PreToolUse(AskUserQuestion) hook이 pending 상태를 전송하고, API가 이를 처리
+- **Status**: pending
+
+### Todo 4: UI 업데이트 (Board, TaskStatusBadge, CSS, 디자인 토큰)
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 칸반 보드에 Pending 컬럼을 추가하고 시각적 스타일 적용
+- **Work**:
+  - `src/app/globals.css`:
+    - `:root`에 `--color-status-pending: #8B5CF6` 추가
+    - `@theme inline`에 `--color-status-pending` 등록
+  - `prd/design-system.json`에 status-pending 토큰 추가
+  - `src/components/Board.tsx`의 `COLUMNS` 배열에 PENDING 컬럼 추가 (PROGRESS 다음, REVIEW 이전)
+  - `src/components/Board.tsx`의 `filteredTasks`에 `[TaskStatus.PENDING]: []` 추가
+  - `src/components/TaskStatusBadge.tsx`의 `statusConfig`에 PENDING 스타일 추가 (purple 계열)
+- **Convention Notes**: Tailwind CSS 변수 사용, bg-status-pending 클래스 사용
+- **Verification**: 보드에 Pending 컬럼이 표시되고 올바른 색상 적용
+- **Exit Criteria**: 5개 컬럼이 Todo → Progress → Pending → Review → Done 순서로 표시
+- **Status**: pending
+
+### Todo 5: i18n 번역 추가
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 3개 언어 파일에 pending 컬럼 번역 추가
+- **Work**:
+  - `messages/ko.json`의 `board.columns`에 `"pending": "Pending"` 추가
+  - `messages/en.json`의 `board.columns`에 `"pending": "Pending"` 추가
+  - `messages/zh.json`의 `board.columns`에 `"pending": "待决定"` 추가
+- **Convention Notes**: 동일 키로 3개 파일 모두 업데이트
+- **Verification**: 각 locale에서 Pending 컬럼 이름이 올바르게 표시
+- **Exit Criteria**: ko, en, zh 번역 파일에 pending 키 존재
+- **Status**: pending
+
+## Verification Strategy
+- TypeScript 컴파일: `npx tsc --noEmit`
+- 빌드: `npm run build`
+- DB migration 검토: 생성된 migration SQL 확인
+
+## Progress Tracking
+- Total Todos: 5
+- Completed: 5
+- Status: Execution complete
+
+## Change Log
+- 2026-02-16: Plan created
+- 2026-02-16: All todos completed, build verification passed

--- a/messages/en.json
+++ b/messages/en.json
@@ -27,6 +27,7 @@
     "columns": {
       "todo": "Todo",
       "progress": "Progress",
+      "pending": "Pending",
       "review": "Review",
       "done": "Done"
     },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -27,6 +27,7 @@
     "columns": {
       "todo": "Todo",
       "progress": "Progress",
+      "pending": "Pending",
       "review": "Review",
       "done": "Done"
     },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -27,6 +27,7 @@
     "columns": {
       "todo": "待办",
       "progress": "进行中",
+      "pending": "待决定",
       "review": "审核",
       "done": "完成"
     },

--- a/prd/design-system.json
+++ b/prd/design-system.json
@@ -108,6 +108,7 @@
       "status": {
         "todo": "{gray.500}",
         "progress": "{yellow.500}",
+        "pending": "#8B5CF6",
         "review": "{blue.500}",
         "done": "{green.500}",
         "success": "{green.500}",

--- a/src/app/actions/kanban.ts
+++ b/src/app/actions/kanban.ts
@@ -50,6 +50,7 @@ export async function getTasksByStatus(): Promise<TasksByStatusWithMeta> {
   const grouped: TasksByStatus = {
     [TaskStatus.TODO]: [],
     [TaskStatus.PROGRESS]: [],
+    [TaskStatus.PENDING]: [],
     [TaskStatus.REVIEW]: [],
     [TaskStatus.DONE]: doneTasks,
   };

--- a/src/app/api/hooks/status/route.ts
+++ b/src/app/api/hooks/status/route.ts
@@ -8,6 +8,7 @@ import { broadcastBoardUpdate } from "@/lib/boardNotifier";
 const STATUS_MAP: Record<string, TaskStatus> = {
   todo: TaskStatus.TODO,
   progress: TaskStatus.PROGRESS,
+  pending: TaskStatus.PENDING,
   review: TaskStatus.REVIEW,
   done: TaskStatus.DONE,
 };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,6 +77,7 @@
   /* Semantic: Status */
   --color-status-todo: var(--gray-500);
   --color-status-progress: var(--yellow-500);
+  --color-status-pending: #8B5CF6;
   --color-status-review: var(--blue-500);
   --color-status-done: var(--green-500);
   --color-status-success: var(--green-500);
@@ -170,6 +171,7 @@
   /* Status */
   --color-status-todo: var(--color-status-todo);
   --color-status-progress: var(--color-status-progress);
+  --color-status-pending: var(--color-status-pending);
   --color-status-review: var(--color-status-review);
   --color-status-done: var(--color-status-done);
   --color-status-success: var(--color-status-success);

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -28,6 +28,7 @@ interface BoardProps {
 const COLUMNS: { status: TaskStatus; labelKey: string; colorClass: string }[] = [
   { status: TaskStatus.TODO, labelKey: "todo", colorClass: "bg-status-todo" },
   { status: TaskStatus.PROGRESS, labelKey: "progress", colorClass: "bg-status-progress" },
+  { status: TaskStatus.PENDING, labelKey: "pending", colorClass: "bg-status-pending" },
   { status: TaskStatus.REVIEW, labelKey: "review", colorClass: "bg-status-review" },
   { status: TaskStatus.DONE, labelKey: "done", colorClass: "bg-status-done" },
 ];
@@ -159,6 +160,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
     const filtered: TasksByStatus = {
       [TaskStatus.TODO]: [],
       [TaskStatus.PROGRESS]: [],
+      [TaskStatus.PENDING]: [],
       [TaskStatus.REVIEW]: [],
       [TaskStatus.DONE]: [],
     };

--- a/src/components/TaskStatusBadge.tsx
+++ b/src/components/TaskStatusBadge.tsx
@@ -13,6 +13,10 @@ const statusConfig: Record<TaskStatus, { label: string; className: string }> = {
     label: "Progress",
     className: "bg-yellow-50 text-status-progress",
   },
+  [TaskStatus.PENDING]: {
+    label: "Pending",
+    className: "bg-purple-50 text-status-pending",
+  },
   [TaskStatus.REVIEW]: {
     label: "Review",
     className: "bg-blue-50 text-status-review",

--- a/src/entities/KanbanTask.ts
+++ b/src/entities/KanbanTask.ts
@@ -13,6 +13,7 @@ import { Project } from "./Project";
 export enum TaskStatus {
   TODO = "todo",
   PROGRESS = "progress",
+  PENDING = "pending",
   REVIEW = "review",
   DONE = "done",
 }

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -54,7 +54,7 @@ function generateQuestionHookScript(kanvibeUrl: string, projectName: string): st
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: PreToolUse (AskUserQuestion)
-# Claude가 사용자에게 질문할 때 현재 브랜치의 작업을 REVIEW로 변경한다.
+# Claude가 사용자에게 질문할 때 현재 브랜치의 작업을 PENDING으로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
 PROJECT_NAME="${projectName}"
@@ -66,7 +66,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"pending\\"}" \\
   > /dev/null 2>&1
 
 exit 0

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -10,6 +10,7 @@ import { AddIsWorktreeToProjects1770854400002 } from "@/migrations/1770854400002
 import { AddPaneLayoutConfig1771048256887 } from "@/migrations/1771048256887-AddPaneLayoutConfig";
 import { AssignDisplayOrder1771166346785 } from "@/migrations/1771166346785-AssignDisplayOrder";
 import { AddAppSettings1771166907165 } from "@/migrations/1771166907165-AddAppSettings";
+import { AddPendingStatus1771171200000 } from "@/migrations/1771171200000-AddPendingStatus";
 
 /**
  * TypeORM DataSource 싱글턴.
@@ -31,7 +32,7 @@ function createDataSource(): DataSource {
     type: "postgres",
     url: process.env.DATABASE_URL ?? buildDatabaseUrl(),
     entities: [KanbanTask, Project, PaneLayoutConfig, AppSettings],
-    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785, AddAppSettings1771166907165],
+    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785, AddAppSettings1771166907165, AddPendingStatus1771171200000],
     synchronize: false,
     logging: process.env.NODE_ENV !== "production",
   });

--- a/src/migrations/1771171200000-AddPendingStatus.ts
+++ b/src/migrations/1771171200000-AddPendingStatus.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * kanban_tasks의 status enum 타입에 'pending' 값을 추가한다.
+ * PROGRESS와 REVIEW 사이에 위치하는 사용자 의사결정 대기 상태이다.
+ */
+export class AddPendingStatus1771171200000 implements MigrationInterface {
+  name = "AddPendingStatus1771171200000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "kanban_tasks_status_enum" ADD VALUE IF NOT EXISTS 'pending' BEFORE 'review'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    /**
+     * PostgreSQL에서는 ALTER TYPE ... DROP VALUE를 직접 지원하지 않는다.
+     * 롤백이 필요한 경우 새로운 enum 타입을 만들어 교체해야 한다.
+     */
+    await queryRunner.query(`
+      UPDATE "kanban_tasks" SET "status" = 'review' WHERE "status" = 'pending'
+    `);
+    await queryRunner.query(`
+      ALTER TYPE "kanban_tasks_status_enum" RENAME TO "kanban_tasks_status_enum_old"
+    `);
+    await queryRunner.query(`
+      CREATE TYPE "kanban_tasks_status_enum" AS ENUM('todo', 'progress', 'review', 'done')
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "kanban_tasks" ALTER COLUMN "status" TYPE "kanban_tasks_status_enum" USING "status"::text::"kanban_tasks_status_enum"
+    `);
+    await queryRunner.query(`
+      DROP TYPE "kanban_tasks_status_enum_old"
+    `);
+  }
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/hooks/2602/16-add-pending-status.plan.md)

## 어떤 작업인가요?
- Claude Code hooks에서 AskUserQuestion 발생 시 사용자 의사결정 대기 상태를 기존 Review와 분리하여 별도 Pending 컬럼으로 시각화

## 어떻게 해결했나요?
**TaskStatus enum에 PENDING 값 추가**
- `progress`와 `review` 사이에 `pending` 상태를 도입
- DB migration으로 PostgreSQL enum 타입에 새 값 추가

**Hook 스크립트 변경**
- `PreToolUse(AskUserQuestion)` hook이 기존 `review` 대신 `pending`을 전송하도록 수정
- Stop hook은 기존대로 `review` 유지

**칸반 보드 UI 업데이트**
- Pending 컬럼 추가 (Purple #8B5CF6 색상)
- TaskStatusBadge에 Pending 상태 스타일 추가
- i18n 번역 3개 언어(ko, en, zh) 업데이트

## 중요한 변경 사항은 무엇인가요?
### Hook 상태 전환 플로우 변경

**PreToolUse(AskUserQuestion) hook 상태 변경**
- **변경 이유**: Claude가 사용자에게 질문하는 상황과 AI 응답 완료 후 검토 대기 상태를 구분
- **수정 파일**: `src/lib/claudeHooksSetup.ts`, `src/app/api/hooks/status/route.ts`

### DB 스키마 변경

**kanban_tasks.status enum에 'pending' 값 추가**
- **변경 이유**: 새 상태를 DB에 저장하기 위한 enum 확장
- **수정 파일**: `src/entities/KanbanTask.ts`, `src/migrations/1771171200000-AddPendingStatus.ts`, `src/lib/database.ts`

### UI 컬럼 순서 변경

**칸반 보드 5컬럼 체계**
- **변경 이유**: Todo → Progress → Pending → Review → Done 순서로 작업 흐름 세분화
- **수정 파일**: `src/components/Board.tsx`, `src/components/TaskStatusBadge.tsx`, `src/app/globals.css`, `prd/design-system.json`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
