### PR TITLE
fix: 다중 프로젝트 동일 브랜치 태스크 미발견 및 tmux window 중복 문제 수정

### DIFF
--- a/src/entities/KanbanTask.ts
+++ b/src/entities/KanbanTask.ts
@@ -41,7 +41,7 @@ export class KanbanTask {
   @Column({ type: "enum", enum: TaskStatus, default: TaskStatus.TODO })
   status!: TaskStatus;
 
-  @Column({ name: "branch_name", type: "varchar", length: 255, nullable: true, unique: true })
+  @Column({ name: "branch_name", type: "varchar", length: 255, nullable: true })
   branchName!: string | null;
 
   @Column({ name: "worktree_path", type: "varchar", length: 500, nullable: true })

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -11,6 +11,7 @@ import { AddPaneLayoutConfig1771048256887 } from "@/migrations/1771048256887-Add
 import { AssignDisplayOrder1771166346785 } from "@/migrations/1771166346785-AssignDisplayOrder";
 import { AddAppSettings1771166907165 } from "@/migrations/1771166907165-AddAppSettings";
 import { AddPendingStatus1771171200000 } from "@/migrations/1771171200000-AddPendingStatus";
+import { RemoveBranchNameUnique1771257600000 } from "@/migrations/1771257600000-RemoveBranchNameUnique";
 
 /**
  * TypeORM DataSource 싱글턴.
@@ -32,7 +33,7 @@ function createDataSource(): DataSource {
     type: "postgres",
     url: process.env.DATABASE_URL ?? buildDatabaseUrl(),
     entities: [KanbanTask, Project, PaneLayoutConfig, AppSettings],
-    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785, AddAppSettings1771166907165, AddPendingStatus1771171200000],
+    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785, AddAppSettings1771166907165, AddPendingStatus1771171200000, RemoveBranchNameUnique1771257600000],
     synchronize: false,
     logging: process.env.NODE_ENV !== "production",
   });

--- a/src/migrations/1771257600000-RemoveBranchNameUnique.ts
+++ b/src/migrations/1771257600000-RemoveBranchNameUnique.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * branch_name 컬럼의 UNIQUE 제약을 제거한다.
+ * 서로 다른 프로젝트에서 동일한 브랜치명(예: main)을 가진 태스크를 허용한다.
+ */
+export class RemoveBranchNameUnique1771257600000 implements MigrationInterface {
+  name = "RemoveBranchNameUnique1771257600000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "kanban_tasks" DROP CONSTRAINT IF EXISTS "UQ_kanban_tasks_branch_name"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$ BEGIN
+        ALTER TABLE "kanban_tasks" ADD CONSTRAINT "UQ_kanban_tasks_branch_name" UNIQUE ("branch_name");
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `);
+  }
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/database/)

## 어떤 작업인가요?
- 서로 다른 프로젝트에서 동일 브랜치명(main 등)의 태스크를 생성할 수 없는 문제와, tmux window 중복 생성 문제를 수정한다.

## 어떻게 해결했나요?
**branch_name UNIQUE 제약 제거 및 다중 프로젝트 태스크 조회 수정**
- `branch_name` 컬럼의 UNIQUE 제약을 제거하여 프로젝트별 동일 브랜치명 태스크 허용
- 프로젝트 스캔 시 `(branchName, projectId)` 조합으로 조회하고, orphan 태스크는 `IsNull()`로 식별

**tmux window 중복 생성 방지 및 인덱스 기반 attach 적용**
- 동일 이름의 tmux window가 이미 존재하면 중복 생성하지 않음
- attach 시 window 이름 대신 인덱스를 사용하여 이름 중복 시에도 정확한 window에 연결

## 중요한 변경 사항은 무엇인가요?
### branch_name UNIQUE 제약 제거

**마이그레이션으로 UNIQUE 제약 삭제**
- **변경 이유**: 서로 다른 프로젝트가 각각 `main` 브랜치 태스크를 가질 수 있어야 한다
- **수정 파일**: `src/entities/KanbanTask.ts`, `src/migrations/1771257600000-RemoveBranchNameUnique.ts`, `src/lib/database.ts`

**프로젝트 스캔 로직 수정**
- **변경 이유**: `branchName`만으로 조회하면 다른 프로젝트의 태스크를 잘못 매칭할 수 있다. `projectId` 조건을 추가하고 orphan 태스크는 `IsNull()`로 정확히 식별한다
- **수정 파일**: `src/app/actions/project.ts`

### tmux window 중복 방지

**window 존재 확인 후 생성**
- **변경 이유**: tmux는 동일 이름의 window를 여러 개 만들 수 있어 select 시 혼란이 발생한다
- **수정 파일**: `src/lib/terminal.ts`, `src/lib/worktree.ts`

**인덱스 기반 window attach**
- **변경 이유**: tmux에서 동일 이름의 window가 여러 개일 때 이름으로 attach하면 예측 불가능한 window에 연결된다
- **수정 파일**: `src/lib/terminal.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
