### PR TITLE
feat(task): Base 프로젝트 리본 배지 추가 및 디자인 개선

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -165,6 +165,8 @@
     "createdAt": "Created",
     "updatedAt": "Updated",
     "prLink": "PR Link",
+    "project": "Project",
+    "baseProject": "Base",
     "actions": "Change Status",
     "deleteConfirm": "Are you sure you want to delete this task?",
     "hooksStatus": "Hooks Status",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -165,6 +165,8 @@
     "createdAt": "생성일",
     "updatedAt": "수정일",
     "prLink": "PR 링크",
+    "project": "프로젝트",
+    "baseProject": "Base",
     "actions": "상태 변경",
     "deleteConfirm": "이 작업을 삭제하시겠습니까?",
     "hooksStatus": "Hooks 상태",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -165,6 +165,8 @@
     "createdAt": "创建时间",
     "updatedAt": "更新时间",
     "prLink": "PR 链接",
+    "project": "项目",
+    "baseProject": "Base",
     "actions": "状态变更",
     "deleteConfirm": "确定要删除此任务吗？",
     "hooksStatus": "Hooks 状态",

--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -120,6 +120,14 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
             {t("info")}
           </h3>
           <dl className="space-y-3">
+            {task.project && !task.project.repoPath?.includes("__worktrees") && (
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-xs text-text-muted">{t("project")}</dt>
+                <dd className="text-xs px-2 py-0.5 rounded-full font-medium bg-tag-base-bg text-tag-base-text">
+                  {t("baseProject")}
+                </dd>
+              </div>
+            )}
             {task.prUrl && (
               <div className="flex items-center justify-between gap-2">
                 <dt className="text-xs text-text-muted">{t("prLink")}</dt>

--- a/src/app/actions/kanban.ts
+++ b/src/app/actions/kanban.ts
@@ -82,7 +82,7 @@ export async function getMoreDoneTasks(
 /** 단일 작업을 ID로 조회한다 */
 export async function getTaskById(taskId: string): Promise<KanbanTask | null> {
   const repo = await getTaskRepository();
-  const task = await repo.findOneBy({ id: taskId });
+  const task = await repo.findOne({ where: { id: taskId }, relations: ["project"] });
   return task ? serialize(task) : null;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,8 +104,8 @@
   --color-tag-neutral-text: var(--gray-600);
   --color-tag-pr-bg: #ddf4ff;
   --color-tag-pr-text: #0969da;
-  --color-tag-base-bg: #EDE7F6;
-  --color-tag-base-text: #5E35B1;
+  --color-tag-base-bg: #202632;
+  --color-tag-base-text: #FFFFFF;
 
   /* Terminal Chrome */
   --color-terminal-chrome: #1e1e1e;

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -49,6 +49,7 @@ export default function Column({ status, tasks, label, colorClass, onContextMenu
                 index={index}
                 onContextMenu={onContextMenu}
                 projectName={task.projectId ? projectNameMap[task.projectId] : undefined}
+                isBaseProject={!!task.worktreePath && !task.worktreePath.includes("__worktrees")}
               />
             ))}
             {provided.placeholder}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -9,6 +9,7 @@ interface TaskCardProps {
   index: number;
   onContextMenu: (e: React.MouseEvent, task: KanbanTask) => void;
   projectName?: string;
+  isBaseProject?: boolean;
 }
 
 const agentTagColors: Record<string, string> = {
@@ -17,7 +18,7 @@ const agentTagColors: Record<string, string> = {
   codex: "bg-tag-codex-bg text-tag-codex-text",
 };
 
-export default function TaskCard({ task, index, onContextMenu, projectName }: TaskCardProps) {
+export default function TaskCard({ task, index, onContextMenu, projectName, isBaseProject }: TaskCardProps) {
   return (
     <Draggable draggableId={task.id} index={index}>
       {(provided, snapshot) => (
@@ -27,12 +28,19 @@ export default function TaskCard({ task, index, onContextMenu, projectName }: Ta
             {...provided.draggableProps}
             {...provided.dragHandleProps}
             onContextMenu={(e) => onContextMenu(e, task)}
-            className={`p-3 mb-2 rounded-lg border transition-colors transition-shadow cursor-pointer ${
+            className={`relative overflow-hidden p-3 mb-2 rounded-lg border transition-colors transition-shadow cursor-pointer ${
               snapshot.isDragging
                 ? "bg-bg-surface border-brand-primary shadow-md"
                 : "bg-bg-surface border-border-default hover:border-border-strong hover:shadow-sm"
             }`}
           >
+            {/* Base 프로젝트 리본 배지 */}
+            {isBaseProject && (
+              <div className="absolute -right-7 top-2.5 rotate-45 bg-tag-base-bg text-tag-base-text text-[10px] font-bold px-7 py-0.5 pointer-events-none select-none">
+                Base
+              </div>
+            )}
+
             <h3 className="text-sm font-medium text-text-primary truncate">
               {task.title}
             </h3>
@@ -47,12 +55,6 @@ export default function TaskCard({ task, index, onContextMenu, projectName }: Ta
               {projectName && (
                 <span className="text-xs px-2 py-0.5 rounded-full bg-tag-project-bg text-tag-project-text font-medium truncate max-w-[120px]">
                   {projectName}
-                </span>
-              )}
-
-              {!task.branchName && task.baseBranch && (
-                <span className="text-xs px-2 py-0.5 rounded-full bg-tag-base-bg text-tag-base-text font-medium">
-                  Base Project
                 </span>
               )}
 


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/ui/2602/16-add-base-project-badge.plan.md)

## 어떤 작업인가요?
- 칸반 보드 태스크 카드와 태스크 상세 페이지에 Base 프로젝트 리본 배지를 추가하여, worktree가 아닌 기본 프로젝트의 태스크를 시각적으로 구분할 수 있도록 개선

## 어떻게 해결했나요?
**리본 스타일 Base 배지**
- 기존 인라인 텍스트 "Base Project" 배지를 제거하고, 카드 우상단에 45도 회전된 리본 배지로 교체
- 다크 색상(#202632/#FFFFFF)으로 변경하여 시인성 향상

**태스크 상세 페이지 프로젝트 정보 표시**
- 상세 페이지 사이드바에 프로젝트 정보 섹션 추가
- Base 프로젝트인 경우 rounded 배지로 표시

**데이터 로딩 개선**
- `getTaskById`에 project relation 로딩 추가

## 중요한 변경 사항은 무엇인가요?
### 리본 배지 UI 변경

**TaskCard 리본 배지**
- **변경 이유**: 기존 인라인 텍스트 배지는 다른 태그들과 섞여 구분이 어려워, 카드 우상단 리본 스타일로 변경하여 시각적 강조
- **수정 파일**: `src/components/TaskCard.tsx`, `src/components/Column.tsx`

**Base 태그 색상 변경**
- **변경 이유**: 기존 보라색(#EDE7F6/#5E35B1)에서 다크(#202632/#FFFFFF)로 변경하여 리본 배지에 적합한 대비 확보
- **수정 파일**: `src/app/globals.css`

### 태스크 상세 페이지

**프로젝트 정보 표시 추가**
- **변경 이유**: 상세 페이지에서도 해당 태스크가 Base 프로젝트 소속인지 확인 가능하도록
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`, `src/app/actions/kanban.ts`

**i18n 키 추가**
- **변경 이유**: project, baseProject 번역 키 추가 (ko, en, zh)
- **수정 파일**: `messages/ko.json`, `messages/en.json`, `messages/zh.json`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
