### PR TITLE
docs: README 데모 영상 URL 변경 및 스크린샷 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,11 @@ Automatically track task status via [Claude Code Hooks](#claude-code-hooks---aut
 
 <div align="center">
 
-[![Demo Video](https://img.youtube.com/vi/PBST0RIqlAA/maxresdefault.jpg)](https://www.youtube.com/watch?v=PBST0RIqlAA)
+[![▶ Watch Demo on YouTube](https://img.youtube.com/vi/8JTrvd3T_Z0/maxresdefault.jpg)](https://www.youtube.com/watch?v=8JTrvd3T_Z0)
 
-*Click the image above to watch the demo on YouTube*
+**▶ [Watch Demo on YouTube](https://www.youtube.com/watch?v=8JTrvd3T_Z0)**
 
-<table>
-  <tr>
-    <td><img src="./docs/images/kanvibe1.png" alt="Kanban Board" width="100%"></td>
-    <td><img src="./docs/images/kanvibe2.png" alt="Task Detail & Terminal" width="100%"></td>
-  </tr>
-  <tr>
-    <td align="center"><em>Kanban Board</em></td>
-    <td align="center"><em>Task Detail & Terminal</em></td>
-  </tr>
-</table>
+<img src="./docs/images/kanvibe2.png" alt="Task Detail & Terminal" width="80%">
 
 </div>
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -18,20 +18,11 @@ AI 코딩 에이전트(Claude Code 등)의 작업을 실시간으로 관리하�
 
 <div align="center">
 
-[![Demo Video](https://img.youtube.com/vi/PBST0RIqlAA/maxresdefault.jpg)](https://www.youtube.com/watch?v=PBST0RIqlAA)
+[![▶ YouTube에서 데모 보기](https://img.youtube.com/vi/8JTrvd3T_Z0/maxresdefault.jpg)](https://www.youtube.com/watch?v=8JTrvd3T_Z0)
 
-*이미지를 클릭하면 YouTube에서 데모 영상을 볼 수 있습니다*
+**▶ [YouTube에서 데모 보기](https://www.youtube.com/watch?v=8JTrvd3T_Z0)**
 
-<table>
-  <tr>
-    <td><img src="./images/kanvibe1.png" alt="칸반 보드" width="100%"></td>
-    <td><img src="./images/kanvibe2.png" alt="태스크 상세 & 터미널" width="100%"></td>
-  </tr>
-  <tr>
-    <td align="center"><em>칸반 보드</em></td>
-    <td align="center"><em>태스크 상세 & 터미널</em></td>
-  </tr>
-</table>
+<img src="./images/kanvibe2.png" alt="태스크 상세 & 터미널" width="80%">
 
 </div>
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -18,20 +18,11 @@
 
 <div align="center">
 
-[![Demo Video](https://img.youtube.com/vi/PBST0RIqlAA/maxresdefault.jpg)](https://www.youtube.com/watch?v=PBST0RIqlAA)
+[![▶ 在 YouTube 上观看演示](https://img.youtube.com/vi/8JTrvd3T_Z0/maxresdefault.jpg)](https://www.youtube.com/watch?v=8JTrvd3T_Z0)
 
-*点击上方图片在 YouTube 上观看演示视频*
+**▶ [在 YouTube 上观看演示](https://www.youtube.com/watch?v=8JTrvd3T_Z0)**
 
-<table>
-  <tr>
-    <td><img src="./images/kanvibe1.png" alt="看板" width="100%"></td>
-    <td><img src="./images/kanvibe2.png" alt="任务详情 & 终端" width="100%"></td>
-  </tr>
-  <tr>
-    <td align="center"><em>看板</em></td>
-    <td align="center"><em>任务详情 & 终端</em></td>
-  </tr>
-</table>
+<img src="./images/kanvibe2.png" alt="任务详情 & 终端" width="80%">
 
 </div>
 


### PR DESCRIPTION
## 어떤 작업인가요?
- README 데모 영상 URL 변경 및 스크린샷 구성 개선

## 어떻게 해결했나요?
**데모 영상 업데이트**
- YouTube 데모 영상 URL을 새 영상으로 교체
- 썸네일 alt 텍스트에 ▶ 재생 아이콘 추가 및 썸네일 하단에 텍스트 링크를 별도 추가하여 YouTube 영상임을 명확히 표시

**스크린샷 단일 이미지로 교체**
- 칸반 보드 + 태스크 상세 2열 테이블을 태스크 상세 단일 이미지(`kanvibe2.png`)로 교체

## 중요한 변경 사항은 무엇인가요?
### 데모 영상 및 스크린샷 개선

**YouTube 영상 URL 변경**
- **변경 이유**: 새로운 데모 영상으로 교체
- **수정 파일**: `README.md`, `docs/README.ko.md`, `docs/README.zh.md`

**YouTube 클릭 유도 개선**
- **변경 이유**: 썸네일만으로는 YouTube 영상인지 인지하기 어려워 클릭률이 낮음
- **수정 파일**: `README.md`, `docs/README.ko.md`, `docs/README.zh.md`

**스크린샷 단일 이미지로 변경**
- **변경 이유**: 칸반 보드 스크린샷(`kanvibe1.png`) 제거 요청 반영
- **수정 파일**: `README.md`, `docs/README.ko.md`, `docs/README.zh.md`
