### PR TITLE
docs: README 스크린샷 이미지 비율 균일화

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Automatically track task status via [Claude Code Hooks](#claude-code-hooks---aut
 
 <table>
   <tr>
-    <td width="53%"><img src="./docs/images/kanvibe1.png" alt="Kanban Board" width="100%"></td>
-    <td width="47%"><img src="./docs/images/kanvibe2.png" alt="Task Detail & Terminal" width="100%"></td>
+    <td width="50%"><img src="./docs/images/kanvibe1.png" alt="Kanban Board" width="100%"></td>
+    <td width="50%"><img src="./docs/images/kanvibe2.png" alt="Task Detail & Terminal" width="100%"></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Automatically track task status via [Claude Code Hooks](#claude-code-hooks---aut
 
 <table>
   <tr>
-    <td><img src="./docs/images/kanvibe1.png" alt="Kanban Board" width="100%"></td>
-    <td><img src="./docs/images/kanvibe2.png" alt="Task Detail & Terminal" width="100%"></td>
+    <td width="53%"><img src="./docs/images/kanvibe1.png" alt="Kanban Board" width="100%"></td>
+    <td width="47%"><img src="./docs/images/kanvibe2.png" alt="Task Detail & Terminal" width="100%"></td>
   </tr>
 </table>
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -24,8 +24,8 @@ AI 코딩 에이전트(Claude Code 등)의 작업을 실시간으로 관리하�
 
 <table>
   <tr>
-    <td><img src="./images/kanvibe1.png" alt="칸반 보드" width="100%"></td>
-    <td><img src="./images/kanvibe2.png" alt="태스크 상세 & 터미널" width="100%"></td>
+    <td width="53%"><img src="./images/kanvibe1.png" alt="칸반 보드" width="100%"></td>
+    <td width="47%"><img src="./images/kanvibe2.png" alt="태스크 상세 & 터미널" width="100%"></td>
   </tr>
 </table>
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -24,8 +24,8 @@ AI 코딩 에이전트(Claude Code 등)의 작업을 실시간으로 관리하�
 
 <table>
   <tr>
-    <td width="53%"><img src="./images/kanvibe1.png" alt="칸반 보드" width="100%"></td>
-    <td width="47%"><img src="./images/kanvibe2.png" alt="태스크 상세 & 터미널" width="100%"></td>
+    <td width="50%"><img src="./images/kanvibe1.png" alt="칸반 보드" width="100%"></td>
+    <td width="50%"><img src="./images/kanvibe2.png" alt="태스크 상세 & 터미널" width="100%"></td>
   </tr>
 </table>
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -24,8 +24,8 @@
 
 <table>
   <tr>
-    <td><img src="./images/kanvibe1.png" alt="看板" width="100%"></td>
-    <td><img src="./images/kanvibe2.png" alt="任务详情 & 终端" width="100%"></td>
+    <td width="53%"><img src="./images/kanvibe1.png" alt="看板" width="100%"></td>
+    <td width="47%"><img src="./images/kanvibe2.png" alt="任务详情 & 终端" width="100%"></td>
   </tr>
 </table>
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -24,8 +24,8 @@
 
 <table>
   <tr>
-    <td width="53%"><img src="./images/kanvibe1.png" alt="看板" width="100%"></td>
-    <td width="47%"><img src="./images/kanvibe2.png" alt="任务详情 & 终端" width="100%"></td>
+    <td width="50%"><img src="./images/kanvibe1.png" alt="看板" width="100%"></td>
+    <td width="50%"><img src="./images/kanvibe2.png" alt="任务详情 & 终端" width="100%"></td>
   </tr>
 </table>
 


### PR DESCRIPTION
## 어떤 작업인가요?
- README 스크린샷 두 장의 높이가 맞지 않아 레이아웃이 불균형한 문제 수정

## 어떻게 해결했나요?
**이미지 비율 기반 테이블 컬럼 너비 조정**
- 두 이미지의 aspect ratio(1.76:1 vs 1.53:1)를 기반으로 `<td>` 너비를 53%/47%로 지정
- 이를 통해 두 스크린샷이 동일한 높이로 렌더링되도록 수정

## 중요한 변경 사항은 무엇인가요?
### 스크린샷 테이블 레이아웃 수정

**td width 속성 추가**
- **변경 이유**: GitHub에서 이미지 원본 크기 비율로 컬럼을 나누어 높이 차이가 크게 발생
- **수정 파일**: `README.md`, `docs/README.ko.md`, `docs/README.zh.md`
