### PR TITLE
fix(task): 프로젝트 배지에 실제 프로젝트명 표시 및 worktree 필터 제거

### DIFF
--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -120,11 +120,11 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
             {t("info")}
           </h3>
           <dl className="space-y-3">
-            {task.project && !task.project.repoPath?.includes("__worktrees") && (
+            {task.project && (
               <div className="flex items-center justify-between gap-2">
                 <dt className="text-xs text-text-muted">{t("project")}</dt>
-                <dd className="text-xs px-2 py-0.5 rounded-full font-medium bg-tag-base-bg text-tag-base-text">
-                  {t("baseProject")}
+                <dd className="text-xs px-2 py-0.5 rounded-full font-medium bg-tag-project-bg text-tag-project-text truncate max-w-[160px]">
+                  {task.project.name}
                 </dd>
               </div>
             )}


### PR DESCRIPTION
## 관련 자료
- 이슈 : 

## 어떤 작업인가요?
- 태스크 상세 페이지의 프로젝트 배지가 "Base Project"라는 고정 텍스트 대신 실제 프로젝트 이름을 표시하도록 수정

## 어떻게 해결했나요?
**프로젝트 배지 표시 로직 개선**
- worktree 경로 필터링 조건(`__worktrees` 포함 여부 체크) 제거하여 모든 프로젝트에서 배지 표시
- 고정 번역 키(`t("baseProject")`) 대신 `task.project.name`으로 실제 프로젝트명 표시
- 배지 스타일을 `tag-base` → `tag-project` 디자인 토큰으로 변경
- 긴 프로젝트명 대응을 위해 `truncate max-w-[160px]` 적용

## 중요한 변경 사항은 무엇인가요?
### 프로젝트 배지 렌더링 변경

**worktree 필터 제거**
- **변경 이유**: worktree 프로젝트도 배지를 표시해야 함. 기존에는 `repoPath`에 `__worktrees`가 포함된 프로젝트가 필터링되어 배지가 표시되지 않았음
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`

**프로젝트명 동적 표시**
- **변경 이유**: "Base Project"라는 고정 텍스트는 실제 프로젝트를 구분하는 데 도움이 되지 않으므로 실제 이름을 표시
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`
