### PR TITLE
feat(task): Done 이동 시 리소스 삭제 경고 모달 추가 (#61)

### DIFF
--- a/.claude/plan/ui/2602/17-done-status-alert.plan.md
+++ b/.claude/plan/ui/2602/17-done-status-alert.plan.md
@@ -1,0 +1,96 @@
+# Done 상태 이동 시 리소스 삭제 경고
+
+## Business Goal
+태스크를 Done으로 이동하면 worktree, branch, tmux session이 삭제되는데, 사용자가 이를 인지하지 못하고 실수로 리소스를 잃는 것을 방지하기 위해 확인 다이얼로그를 표시한다.
+
+## Scope
+- **In Scope**: 칸반 D&D와 상세 페이지에서 Done 이동 시 confirm 경고 추가, 3개 언어 번역
+- **Out of Scope**: 커스텀 모달 UI, 다른 상태 전환 경고
+
+## Codebase Analysis Summary
+
+Done 상태 전환 시 `cleanupTaskResources()`가 호출되어 session(tmux/zellij), worktree, branch를 삭제한다.
+두 경로 존재: Board.tsx `handleDragEnd` → `moveTaskToColumn`, 상세 페이지 `handleStatusChange` → `updateTaskStatus`.
+기존 삭제 경고는 `confirm()` 네이티브 다이얼로그 사용 (`DeleteTaskButton`, `handleDeleteFromCard`).
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/components/Board.tsx` | 칸반 보드 D&D 핸들러 | Modify |
+| `src/app/[locale]/task/[id]/page.tsx` | 상세 페이지 상태 변경 | Modify |
+| `src/components/DoneStatusButton.tsx` | Done 버튼 클라이언트 래퍼 (신규) | Create |
+| `messages/ko.json` | 한국어 번역 | Modify |
+| `messages/en.json` | 영어 번역 | Modify |
+| `messages/zh.json` | 중국어 번역 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 확인 다이얼로그 | `DeleteTaskButton.tsx` | `confirm()` 네이티브 사용 |
+| i18n 키 추가 | `messages/*.json` | 3개 언어 동시 추가 |
+| 클라이언트 컴포넌트 | `DeleteTaskButton.tsx` | `"use client"` + `useTranslations` |
+| 한국어 주석 | CODE_PRINCIPLES.md | 주석은 한국어 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 다이얼로그 타입 | `confirm()` | 기존 삭제 패턴 동일 | 커스텀 모달 |
+| 상세 페이지 구현 | `DoneStatusButton` 클라이언트 컴포넌트 | `DeleteTaskButton` 패턴과 동일 | 페이지 전체 client 전환 |
+| 경고 조건 | 리소스(branch/session) 존재 시만 | 불필요한 UX 방해 방지 | 항상 경고 |
+
+## Implementation Todos
+
+### Todo 1: 번역 키 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: Done 이동 경고 메시지 번역 키를 3개 언어에 추가
+- **Work**:
+  - `messages/ko.json`의 `board` 네임스페이스에 `doneConfirm` 키 추가
+  - `messages/ko.json`의 `taskDetail` 네임스페이스에 `doneConfirm` 키 추가
+  - `messages/en.json`, `messages/zh.json`에 동일 키 추가
+  - 메시지 내용: "Done으로 이동하면 worktree, branch, tmux session이 삭제됩니다. 계속하시겠습니까?"
+- **Convention Notes**: 3개 언어 동시 수정
+- **Verification**: JSON 파싱 오류 없음 확인
+- **Exit Criteria**: 3개 언어 파일에 `doneConfirm` 키 존재
+- **Status**: pending
+
+### Todo 2: Board.tsx D&D 경고 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 칸반 드래그 앤 드롭으로 Done 이동 시 confirm 표시
+- **Work**:
+  - `Board.tsx`의 `handleDragEnd`에서 `destStatus === TaskStatus.DONE`이고 태스크에 리소스(branchName 또는 sessionType)가 있을 때 `confirm()` 호출
+  - 취소 시 `return` (카드가 원래 위치로 복귀)
+  - 번역은 `useTranslations("board")`의 `doneConfirm` 사용
+- **Convention Notes**: 기존 `handleDragEnd` 구조 유지, 최소 변경
+- **Verification**: 빌드 성공
+- **Exit Criteria**: D&D로 Done 이동 시 리소스 있는 태스크에 confirm 표시
+- **Status**: pending
+
+### Todo 3: DoneStatusButton 컴포넌트 생성 + 상세 페이지 적용
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 상세 페이지 Done 버튼에 confirm 경고 추가
+- **Work**:
+  - `src/components/DoneStatusButton.tsx` 생성 (클라이언트 컴포넌트)
+  - `DeleteTaskButton` 패턴 참고: props로 `statusChangeAction`, `label`, `hasResources` 수신
+  - `hasResources`가 true일 때만 `onSubmit`에서 `confirm()` 호출
+  - `src/app/[locale]/task/[id]/page.tsx`에서 Done 전환 버튼만 `DoneStatusButton`으로 교체
+- **Convention Notes**: `"use client"`, `useTranslations("taskDetail")` 패턴 준수
+- **Verification**: 빌드 성공
+- **Exit Criteria**: 상세 페이지 Done 버튼 클릭 시 리소스 있으면 confirm 표시
+- **Status**: pending
+
+## Verification Strategy
+- `pnpm build` 성공
+- 3개 언어 JSON 유효성
+- Board D&D / 상세 페이지 양쪽 경로에서 경고 동작 확인
+
+## Progress Tracking
+- Total Todos: 3
+- Completed: 3
+- Status: Execution complete
+
+## Change Log
+- 2026-02-17: Plan created
+- 2026-02-17: All todos completed, TypeScript + JSON validation passed

--- a/messages/en.json
+++ b/messages/en.json
@@ -10,7 +10,14 @@
     "local": "Local",
     "settings": "Settings",
     "logout": "Logout",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "doneAlert": {
+      "title": "Move to Done",
+      "message": "Moving to Done will delete the worktree, branch, and tmux session.",
+      "dontAskAgain": "Don't ask again",
+      "confirm": "Move",
+      "cancel": "Cancel"
+    }
   },
   "login": {
     "username": "Username",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -10,7 +10,14 @@
     "local": "로컬",
     "settings": "설정",
     "logout": "로그아웃",
-    "loading": "로딩 중..."
+    "loading": "로딩 중...",
+    "doneAlert": {
+      "title": "Done 이동 경고",
+      "message": "Done으로 이동하면 worktree, branch, tmux session이 삭제됩니다.",
+      "dontAskAgain": "다시 묻지 않기",
+      "confirm": "이동",
+      "cancel": "취소"
+    }
   },
   "login": {
     "username": "사용자 이름",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -10,7 +10,14 @@
     "local": "本地",
     "settings": "设置",
     "logout": "退出登录",
-    "loading": "加载中..."
+    "loading": "加载中...",
+    "doneAlert": {
+      "title": "移动到完成",
+      "message": "移动到完成状态将删除 worktree、branch 和 tmux session。",
+      "dontAskAgain": "不再提示",
+      "confirm": "移动",
+      "cancel": "取消"
+    }
   },
   "login": {
     "username": "用户名",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^20
         version: 20.19.33
@@ -1135,6 +1138,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -4118,6 +4127,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
 import Board from "@/components/Board";
 import { getTasksByStatus } from "@/app/actions/kanban";
 import { getAllProjects } from "@/app/actions/project";
-import { getSidebarDefaultCollapsed } from "@/app/actions/appSettings";
+import { getSidebarDefaultCollapsed, getDoneAlertDismissed } from "@/app/actions/appSettings";
 import { getAvailableHosts } from "@/lib/sshConfig";
 
 export const dynamic = "force-dynamic";
@@ -11,6 +11,7 @@ export default async function HomePage() {
   const sshHosts = await getAvailableHosts();
   const projects = await getAllProjects();
   const sidebarDefaultCollapsed = await getSidebarDefaultCollapsed();
+  const doneAlertDismissed = await getDoneAlertDismissed();
 
   return (
     <Board
@@ -20,6 +21,7 @@ export default async function HomePage() {
       sshHosts={sshHosts}
       projects={projects}
       sidebarDefaultCollapsed={sidebarDefaultCollapsed}
+      doneAlertDismissed={doneAlertDismissed}
     />
   );
 }

--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -12,10 +12,11 @@ import TaskStatusBadge from "@/components/TaskStatusBadge";
 import TerminalLoader from "@/components/TerminalLoader";
 import ConnectTerminalForm from "@/components/ConnectTerminalForm";
 import DeleteTaskButton from "@/components/DeleteTaskButton";
+import DoneStatusButton from "@/components/DoneStatusButton";
 import HooksStatusCard from "@/components/HooksStatusCard";
 import CollapsibleSidebar from "@/components/CollapsibleSidebar";
 import { getTaskHooksStatus } from "@/app/actions/project";
-import { getSidebarDefaultCollapsed, getSidebarHintDismissed } from "@/app/actions/appSettings";
+import { getSidebarDefaultCollapsed, getSidebarHintDismissed, getDoneAlertDismissed } from "@/app/actions/appSettings";
 import { Link } from "@/i18n/navigation";
 
 export const dynamicConfig = "force-dynamic";
@@ -55,6 +56,7 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
   const hooksStatus = task.projectId ? await getTaskHooksStatus(id) : null;
   const sidebarDefaultCollapsed = await getSidebarDefaultCollapsed();
   const sidebarHintDismissed = await getSidebarHintDismissed();
+  const doneAlertDismissed = await getDoneAlertDismissed();
 
   async function handleStatusChange(formData: FormData) {
     "use server";
@@ -200,21 +202,31 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
           <div className="flex flex-wrap gap-2">
             {STATUS_TRANSITIONS.filter(
               (transition) => transition.status !== task.status
-            ).map((transition) => (
-              <form key={transition.status} action={handleStatusChange}>
-                <input
-                  type="hidden"
-                  name="status"
-                  value={transition.status}
+            ).map((transition) =>
+              transition.status === TaskStatus.DONE ? (
+                <DoneStatusButton
+                  key={transition.status}
+                  statusChangeAction={handleStatusChange}
+                  label={t(transition.labelKey)}
+                  hasCleanableResources={!!(task.branchName || task.sessionType)}
+                  doneAlertDismissed={doneAlertDismissed}
                 />
-                <button
-                  type="submit"
-                  className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors"
-                >
-                  {t(transition.labelKey)}
-                </button>
-              </form>
-            ))}
+              ) : (
+                <form key={transition.status} action={handleStatusChange}>
+                  <input
+                    type="hidden"
+                    name="status"
+                    value={transition.status}
+                  />
+                  <button
+                    type="submit"
+                    className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors"
+                  >
+                    {t(transition.labelKey)}
+                  </button>
+                </form>
+              )
+            )}
           </div>
           <div className="mt-3 pt-3 border-t border-border-subtle">
             <DeleteTaskButton deleteAction={handleDelete} />

--- a/src/app/actions/appSettings.ts
+++ b/src/app/actions/appSettings.ts
@@ -57,3 +57,16 @@ export async function getSidebarHintDismissed(): Promise<boolean> {
 export async function dismissSidebarHint(): Promise<void> {
   await setAppSetting(SIDEBAR_HINT_DISMISSED_KEY, "true");
 }
+
+const DONE_ALERT_DISMISSED_KEY = "done_alert_dismissed";
+
+/** Done 이동 경고 다시 묻지 않기 여부를 조회한다 */
+export async function getDoneAlertDismissed(): Promise<boolean> {
+  const value = await getAppSetting(DONE_ALERT_DISMISSED_KEY);
+  return value === "true";
+}
+
+/** Done 이동 경고를 다시 묻지 않기로 설정한다 */
+export async function dismissDoneAlert(): Promise<void> {
+  await setAppSetting(DONE_ALERT_DISMISSED_KEY, "true");
+}

--- a/src/components/DoneConfirmDialog.tsx
+++ b/src/components/DoneConfirmDialog.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
+import { dismissDoneAlert } from "@/app/actions/appSettings";
+
+interface DoneConfirmDialogProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/** Done 이동 시 리소스 삭제 경고 모달. "다시 묻지 않기" 체크 시 DB에 설정을 저장한다 */
+export default function DoneConfirmDialog({
+  isOpen,
+  onConfirm,
+  onCancel,
+}: DoneConfirmDialogProps) {
+  const t = useTranslations("common.doneAlert");
+  const [dontAskAgain, setDontAskAgain] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  if (!isOpen) return null;
+
+  function handleConfirm() {
+    if (dontAskAgain) {
+      startTransition(async () => {
+        await dismissDoneAlert();
+        onConfirm();
+      });
+    } else {
+      onConfirm();
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[500] flex items-center justify-center bg-bg-overlay">
+      <div className="w-full max-w-sm bg-bg-surface rounded-xl border border-border-default shadow-lg p-6">
+        <h2 className="text-lg font-semibold text-text-primary mb-2">
+          {t("title")}
+        </h2>
+        <p className="text-sm text-text-secondary mb-4">
+          {t("message")}
+        </p>
+
+        <label className="flex items-center gap-2 mb-5 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={dontAskAgain}
+            onChange={(e) => setDontAskAgain(e.target.checked)}
+            className="w-4 h-4 rounded border-border-default text-brand-primary focus:ring-brand-primary"
+          />
+          <span className="text-xs text-text-muted">{t("dontAskAgain")}</span>
+        </label>
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isPending}
+            className="px-4 py-1.5 text-sm bg-bg-page border border-border-default hover:border-brand-primary text-text-secondary rounded-md transition-colors"
+          >
+            {t("cancel")}
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={isPending}
+            className="px-4 py-1.5 text-sm bg-brand-primary hover:bg-brand-hover text-text-inverse rounded-md transition-colors disabled:opacity-50"
+          >
+            {t("confirm")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DoneStatusButton.tsx
+++ b/src/components/DoneStatusButton.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useRef } from "react";
+import DoneConfirmDialog from "./DoneConfirmDialog";
+
+interface DoneStatusButtonProps {
+  statusChangeAction: (formData: FormData) => Promise<void>;
+  label: string;
+  hasCleanableResources: boolean;
+  doneAlertDismissed: boolean;
+}
+
+/** Done 상태 전환 버튼. 정리 대상 리소스가 있으면 확인 모달을 표시한다 */
+export default function DoneStatusButton({
+  statusChangeAction,
+  label,
+  hasCleanableResources,
+  doneAlertDismissed,
+}: DoneStatusButtonProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(doneAlertDismissed);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const shouldShowAlert = hasCleanableResources && !isDismissed;
+
+  function handleClick(e: React.MouseEvent) {
+    if (shouldShowAlert) {
+      e.preventDefault();
+      setIsDialogOpen(true);
+    }
+  }
+
+  function handleConfirm() {
+    setIsDialogOpen(false);
+    setIsDismissed(true);
+    formRef.current?.requestSubmit();
+  }
+
+  return (
+    <>
+      <form ref={formRef} action={statusChangeAction}>
+        <input type="hidden" name="status" value="done" />
+        <button
+          type="submit"
+          onClick={handleClick}
+          className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors"
+        >
+          {label}
+        </button>
+      </form>
+
+      <DoneConfirmDialog
+        isOpen={isDialogOpen}
+        onConfirm={handleConfirm}
+        onCancel={() => setIsDialogOpen(false)}
+      />
+    </>
+  );
+}

--- a/src/components/__tests__/DoneConfirmDialog.test.tsx
+++ b/src/components/__tests__/DoneConfirmDialog.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// --- Mocks ---
+
+const mockDismissDoneAlert = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/app/actions/appSettings", () => ({
+  dismissDoneAlert: (...args: unknown[]) => mockDismissDoneAlert(...args),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const messages: Record<string, string> = {
+      title: "Move to Done",
+      message: "Moving to Done will delete resources.",
+      dontAskAgain: "Don't ask again",
+      confirm: "Move",
+      cancel: "Cancel",
+    };
+    return messages[key] ?? key;
+  },
+}));
+
+import DoneConfirmDialog from "../DoneConfirmDialog";
+
+describe("DoneConfirmDialog", () => {
+  const defaultProps = {
+    isOpen: true,
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("should render nothing when isOpen is false", () => {
+    // Given
+    const props = { ...defaultProps, isOpen: false };
+
+    // When
+    const { container } = render(<DoneConfirmDialog {...props} />);
+
+    // Then
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("should render title, message, checkbox and buttons when open", () => {
+    // Given & When
+    render(<DoneConfirmDialog {...defaultProps} />);
+
+    // Then
+    expect(screen.getByText("Move to Done")).toBeTruthy();
+    expect(screen.getByText("Moving to Done will delete resources.")).toBeTruthy();
+    expect(screen.getByText("Don't ask again")).toBeTruthy();
+    expect(screen.getByText("Move")).toBeTruthy();
+    expect(screen.getByText("Cancel")).toBeTruthy();
+  });
+
+  it("should call onCancel when cancel button is clicked", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<DoneConfirmDialog {...defaultProps} />);
+
+    // When
+    await user.click(screen.getByText("Cancel"));
+
+    // Then
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("should call onConfirm without dismissDoneAlert when checkbox is unchecked", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<DoneConfirmDialog {...defaultProps} />);
+
+    // When
+    await user.click(screen.getByText("Move"));
+
+    // Then
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+    expect(mockDismissDoneAlert).not.toHaveBeenCalled();
+  });
+
+  it("should call dismissDoneAlert then onConfirm when checkbox is checked", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<DoneConfirmDialog {...defaultProps} />);
+
+    // When
+    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByText("Move"));
+
+    // Then
+    expect(mockDismissDoneAlert).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/__tests__/DoneStatusButton.test.tsx
+++ b/src/components/__tests__/DoneStatusButton.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// --- Mocks ---
+
+vi.mock("@/app/actions/appSettings", () => ({
+  dismissDoneAlert: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const messages: Record<string, string> = {
+      title: "Move to Done",
+      message: "Moving to Done will delete resources.",
+      dontAskAgain: "Don't ask again",
+      confirm: "Move",
+      cancel: "Cancel",
+    };
+    return messages[key] ?? key;
+  },
+}));
+
+import DoneStatusButton from "../DoneStatusButton";
+
+describe("DoneStatusButton", () => {
+  const mockAction = vi.fn().mockResolvedValue(undefined);
+
+  const defaultProps = {
+    statusChangeAction: mockAction,
+    label: "Done",
+    hasCleanableResources: true,
+    doneAlertDismissed: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("should render the button with provided label", () => {
+    // Given & When
+    render(<DoneStatusButton {...defaultProps} />);
+
+    // Then
+    expect(screen.getByText("Done")).toBeTruthy();
+  });
+
+  it("should show confirm dialog when clicked with cleanable resources and not dismissed", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<DoneStatusButton {...defaultProps} />);
+
+    // When
+    await user.click(screen.getByText("Done"));
+
+    // Then
+    expect(screen.getByText("Move to Done")).toBeTruthy();
+    expect(screen.getByText("Moving to Done will delete resources.")).toBeTruthy();
+  });
+
+  it("should not show confirm dialog when doneAlertDismissed is true", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<DoneStatusButton {...defaultProps} doneAlertDismissed={true} />);
+
+    // When
+    await user.click(screen.getByText("Done"));
+
+    // Then
+    expect(screen.queryByText("Move to Done")).toBeNull();
+  });
+
+  it("should not show confirm dialog when hasCleanableResources is false", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<DoneStatusButton {...defaultProps} hasCleanableResources={false} />);
+
+    // When
+    await user.click(screen.getByText("Done"));
+
+    // Then
+    expect(screen.queryByText("Move to Done")).toBeNull();
+  });
+
+  it("should close dialog and submit form when confirmed", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<DoneStatusButton {...defaultProps} />);
+    await user.click(screen.getByText("Done"));
+    expect(screen.getByText("Move to Done")).toBeTruthy();
+
+    // When
+    await user.click(screen.getByText("Move"));
+
+    // Then
+    expect(screen.queryByText("Move to Done")).toBeNull();
+  });
+
+  it("should close dialog without submitting when cancelled", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<DoneStatusButton {...defaultProps} />);
+    await user.click(screen.getByText("Done"));
+    expect(screen.getByText("Move to Done")).toBeTruthy();
+
+    // When
+    await user.click(screen.getByText("Cancel"));
+
+    // Then
+    expect(screen.queryByText("Move to Done")).toBeNull();
+  });
+
+  it("should include hidden status input with value 'done'", () => {
+    // Given & When
+    render(<DoneStatusButton {...defaultProps} />);
+
+    // Then
+    const hiddenInput = document.querySelector("input[type='hidden'][name='status']") as HTMLInputElement;
+    expect(hiddenInput).toBeTruthy();
+    expect(hiddenInput.value).toBe("done");
+  });
+});


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/ui/2602/17-done-status-alert.plan.md)

## 어떤 작업인가요?
- 태스크를 Done 상태로 이동할 때 worktree, branch, tmux session이 삭제될 수 있음을 경고하는 확인 모달 추가

## 어떻게 해결했나요?
**Done 이동 경고 모달 구현**
- 커스텀 확인 모달(`DoneConfirmDialog`)을 만들어 Done 이동 시 리소스 삭제 경고를 표시
- "다시 묻지 않기" 체크박스를 통해 DB(`AppSettings`)에 설정을 저장하여 이후 경고를 생략 가능

**칸반 보드 + 상세 페이지 양쪽 적용**
- 칸반 보드에서 D&D로 Done 컬럼 이동 시 모달 표시
- 상세 페이지에서 Done 버튼 클릭 시 모달 표시
- 정리 대상 리소스(worktree/branch)가 없거나 "다시 묻지 않기"가 설정된 경우 모달 없이 바로 이동

**테스트 코드 추가**
- `DoneConfirmDialog`, `DoneStatusButton` 컴포넌트에 대한 Vitest 테스트 작성 (총 12개 테스트)

## 중요한 변경 사항은 무엇인가요?
### Done 경고 모달 컴포넌트

**DoneConfirmDialog 신규 생성**
- **변경 이유**: 리소스 삭제 경고 표시 및 "다시 묻지 않기" 기능을 위한 커스텀 모달 필요
- **수정 파일**: `src/components/DoneConfirmDialog.tsx`

**DoneStatusButton 신규 생성**
- **변경 이유**: 상세 페이지의 Done 상태 전환 버튼을 클라이언트 컴포넌트로 분리하여 모달 연동
- **수정 파일**: `src/components/DoneStatusButton.tsx`

### 칸반 보드 D&D 핸들러 리팩토링

**handleDragEnd → executeDragMove 분리**
- **변경 이유**: D&D 완료 시 모달을 표시하고, 확인 후에 실제 이동을 실행하기 위해 실행 로직을 분리
- **수정 파일**: `src/components/Board.tsx`

### DB 설정 저장

**dismissDoneAlert / getDoneAlertDismissed 서버 액션 추가**
- **변경 이유**: "다시 묻지 않기" 설정을 AppSettings 테이블에 저장하여 영구 반영
- **수정 파일**: `src/app/actions/appSettings.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
