### PR TITLE
feat(task): 우선순위(Priority) 필드 추가

### DIFF
--- a/.claude/plan/task/2602/17-add-priority-field.plan.md
+++ b/.claude/plan/task/2602/17-add-priority-field.plan.md
@@ -1,0 +1,209 @@
+# Add Priority Field to Kanban Tasks
+
+## Business Goal
+칸반 태스크에 우선순위(Priority) 필드를 추가하여 시각적 가시성을 높인다. `!` (파란색), `!!` (주황색), `!!!` (빨간색)으로 표현하며 null 허용. 칸반 보드 카드, 태스크 상세 페이지, 태스크 생성 모달에서 표시/설정 가능하게 한다.
+
+## Scope
+- **In Scope**: TaskPriority Enum, KanbanTask Entity 수정, DB Migration, Server Action 수정, 디자인 토큰 추가, TaskCard UI, Detail Page UI, CreateTaskModal UI, i18n 번역
+- **Out of Scope**: 우선순위 기반 자동 정렬, 우선순위 필터링, Context Menu에서 우선순위 변경
+
+## Codebase Analysis Summary
+- Entity: `src/entities/KanbanTask.ts` — TypeORM 엔티티, Enum은 별도 파일 분리 패턴
+- Server Actions: `src/app/actions/kanban.ts` — createTask, updateTask 함수
+- TaskCard: `src/components/TaskCard.tsx` — 태그 스타일 기반 뱃지 표시
+- Detail Page: `src/app/[locale]/task/[id]/page.tsx` — 메타데이터 카드에 정보 표시
+- CreateTaskModal: `src/components/CreateTaskModal.tsx` — 태스크 생성 폼
+- Migration: `src/lib/database.ts`에 마이그레이션 import 배열 관리
+- Design: `prd/design-system.json` + `src/app/globals.css` CSS 변수
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/entities/TaskPriority.ts` | Priority Enum 정의 | Create |
+| `src/entities/KanbanTask.ts` | Task 엔티티 | Modify (priority 컬럼 추가) |
+| `src/migrations/TIMESTAMP-AddPriorityToKanbanTasks.ts` | DB 마이그레이션 | Create |
+| `src/lib/database.ts` | 마이그레이션 import 배열 | Modify |
+| `src/app/actions/kanban.ts` | createTask, updateTask 서버 액션 | Modify |
+| `prd/design-system.json` | 디자인 토큰 | Modify |
+| `src/app/globals.css` | CSS 변수 | Modify |
+| `src/components/TaskCard.tsx` | 칸반 카드 UI | Modify |
+| `src/components/CreateTaskModal.tsx` | 생성 모달 UI | Modify |
+| `src/app/[locale]/task/[id]/page.tsx` | Detail 페이지 UI | Modify |
+| `src/components/PrioritySelector.tsx` | 우선순위 선택 컴포넌트 | Create |
+| `messages/ko.json` | 한국어 번역 | Modify |
+| `messages/en.json` | 영어 번역 | Modify |
+| `messages/zh.json` | 중국어 번역 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| Enum 분리 | BACKEND.md | Enum은 별도 파일로 분리 |
+| DB varchar 저장 | BACKEND.md | Enum은 varchar로 저장, Enum class로 변환 |
+| 디자인 토큰 | CLAUDE.md | design-system.json → globals.css → @theme inline |
+| i18n 3개 언어 | CLAUDE.md | ko, en, zh 동시 수정 |
+| Migration import | CLAUDE.md | database.ts migrations 배열에 추가 |
+| 한국어 주석 | CODE_PRINCIPLES.md | 주석은 한국어 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| Enum 값 | `low`/`medium`/`high` | 의미 명확, 기존 TaskStatus 패턴 일치 | 숫자 1/2/3 |
+| 색상 매핑 | low=파란, medium=주황, high=빨강 | 사용자 요구 (!=파란, !!=주황, !!!=빨강) | - |
+| 표시 기호 | `!`/`!!`/`!!!` 텍스트 | 사용자 요구 사항 그대로 | 아이콘, dot |
+| 편집 UI | PrioritySelector 공용 컴포넌트 | CreateTaskModal + Detail 페이지 양쪽에서 재사용 | 각각 인라인 |
+| nullable | yes | 사용자 요구 — 우선순위 미지정 가능 | default low |
+
+## Data Models
+
+### TaskPriority Enum
+| Value | Display | Color |
+|-------|---------|-------|
+| `low` | `!` | 파란색 (#4285F4) |
+| `medium` | `!!` | 주황색 (#F5A623) |
+| `high` | `!!!` | 빨간색 (#EA4335) |
+| `null` | - | 표시 안 함 |
+
+### KanbanTask (수정)
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `priority` | `varchar` (enum TaskPriority) | nullable, default null |
+
+## Implementation Todos
+
+### Todo 1: TaskPriority Enum 생성 + Entity 수정
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 우선순위 데이터 모델 정의
+- **Work**:
+  - `src/entities/TaskPriority.ts` 생성 — `export enum TaskPriority { LOW = "low", MEDIUM = "medium", HIGH = "high" }`
+  - `src/entities/KanbanTask.ts`에 `priority` 컬럼 추가 — `@Column({ type: "enum", enum: TaskPriority, nullable: true, default: null })`
+- **Convention Notes**: Enum은 별도 파일 분리, varchar 저장
+- **Verification**: TypeScript 컴파일 에러 없음
+- **Exit Criteria**: KanbanTask 엔티티에 priority 필드 존재
+- **Status**: pending
+
+### Todo 2: DB Migration 생성
+- **Priority**: 1
+- **Dependencies**: none (수동 작성)
+- **Goal**: priority 컬럼을 DB에 추가하는 마이그레이션 생성
+- **Work**:
+  - `src/migrations/TIMESTAMP-AddPriorityToKanbanTasks.ts` 수동 작성
+  - `ALTER TABLE kanban_tasks ADD COLUMN priority varchar DEFAULT NULL`
+  - TypeORM enum type 생성: `CREATE TYPE kanban_tasks_priority_enum AS ENUM('low', 'medium', 'high')`
+  - `src/lib/database.ts`의 migrations 배열에 import 추가
+- **Convention Notes**: 기존 마이그레이션 파일 패턴 참조, timestamp 기반 이름
+- **Verification**: migration 파일 문법 확인
+- **Exit Criteria**: 마이그레이션 파일 존재 + database.ts에 등록
+- **Status**: pending
+
+### Todo 3: Design Tokens + CSS 변수 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 우선순위 색상 디자인 토큰 정의
+- **Work**:
+  - `prd/design-system.json`에 priority 색상 토큰 추가 (bg + text)
+    - `priority-low-bg`, `priority-low-text` (파란 계열)
+    - `priority-medium-bg`, `priority-medium-text` (주황 계열)
+    - `priority-high-bg`, `priority-high-text` (빨간 계열)
+  - `src/app/globals.css`의 `:root`에 CSS 변수 추가
+  - `@theme inline` 블록에 Tailwind 등록
+- **Convention Notes**: 기존 tag 색상 토큰 패턴 (bg + text) 따르기
+- **Verification**: CSS 변수 선언 확인
+- **Exit Criteria**: Tailwind에서 `bg-priority-low-bg`, `text-priority-low-text` 등 사용 가능
+- **Status**: pending
+
+### Todo 4: i18n 번역 키 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 우선순위 관련 번역 키 추가
+- **Work**:
+  - `messages/ko.json` — task 네임스페이스에 `priority`, `priorityLow`, `priorityMedium`, `priorityHigh`, `priorityNone` 추가; taskDetail에 `priority` 추가
+  - `messages/en.json` — 동일 키 영어 번역
+  - `messages/zh.json` — 동일 키 중국어 번역
+- **Convention Notes**: 3개 언어 동시 수정
+- **Verification**: JSON 문법 에러 없음
+- **Exit Criteria**: 모든 번역 키가 3개 언어 파일에 존재
+- **Status**: pending
+
+### Todo 5: Server Action 수정 (createTask, updateTask)
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 서버 액션에서 priority 필드 처리
+- **Work**:
+  - `src/app/actions/kanban.ts`의 `CreateTaskInput` 인터페이스에 `priority?: TaskPriority` 추가
+  - `createTask` 함수에서 `priority` 필드 설정 (`input.priority || null`)
+  - `updateTask` 함수의 `updates` 타입에 `priority` 추가 + 처리 로직
+- **Convention Notes**: 기존 nullable 필드 패턴 따르기 (agentType 등과 동일)
+- **Verification**: TypeScript 컴파일 에러 없음
+- **Exit Criteria**: createTask, updateTask 모두 priority 처리 가능
+- **Status**: pending
+
+### Todo 6: PrioritySelector 공용 컴포넌트 생성
+- **Priority**: 2
+- **Dependencies**: Todo 3
+- **Goal**: CreateTaskModal과 Detail 페이지에서 재사용할 우선순위 선택 컴포넌트
+- **Work**:
+  - `src/components/PrioritySelector.tsx` 생성
+  - Props: `value: TaskPriority | null`, `onChange: (priority: TaskPriority | null) => void`
+  - 각 우선순위 옵션을 색상 태그 버튼으로 표시 (none / ! / !! / !!!)
+  - 선택된 옵션 하이라이트
+- **Convention Notes**: "use client" 디렉티브, 기존 태그 스타일 패턴
+- **Verification**: 컴포넌트 렌더링 확인
+- **Exit Criteria**: PrioritySelector가 priority 선택/해제 가능
+- **Status**: pending
+
+### Todo 7: TaskCard UI에 우선순위 표시
+- **Priority**: 2
+- **Dependencies**: Todo 3
+- **Goal**: 칸반 보드 카드에 우선순위 뱃지 표시
+- **Work**:
+  - `src/components/TaskCard.tsx` 수정
+  - task.priority가 존재할 때 제목 앞 또는 태그 영역에 `!`/`!!`/`!!!` 뱃지 추가
+  - 색상: priority-{level}-bg / priority-{level}-text 토큰 사용
+- **Convention Notes**: 기존 agentType 태그와 동일한 스타일 패턴
+- **Verification**: 시각적 확인
+- **Exit Criteria**: 우선순위 있는 태스크에 색상 뱃지 표시
+- **Status**: pending
+
+### Todo 8: CreateTaskModal에 우선순위 선택 추가
+- **Priority**: 3
+- **Dependencies**: Todo 5, Todo 6
+- **Goal**: 태스크 생성 시 우선순위 설정 가능
+- **Work**:
+  - `src/components/CreateTaskModal.tsx` 수정
+  - PrioritySelector 컴포넌트 추가
+  - handleSubmit에서 priority 값을 createTask에 전달
+- **Convention Notes**: 기존 폼 필드 스타일과 일관성
+- **Verification**: 모달에서 우선순위 선택 후 생성 시 DB에 저장 확인
+- **Exit Criteria**: 생성 시 priority 값 전달 및 저장
+- **Status**: pending
+
+### Todo 9: Detail 페이지에 우선순위 표시 + 변경 기능
+- **Priority**: 3
+- **Dependencies**: Todo 5, Todo 6
+- **Goal**: 상세 페이지에서 우선순위 표시 및 변경
+- **Work**:
+  - `src/app/[locale]/task/[id]/page.tsx` 수정
+  - 메타데이터 카드에 우선순위 항목 추가 (PrioritySelector 사용)
+  - 클라이언트 컴포넌트로 우선순위 변경 핸들러 구현 (updateTask 호출)
+  - 필요 시 `PriorityEditor.tsx` 클라이언트 컴포넌트 별도 생성
+- **Convention Notes**: 서버 컴포넌트 + 클라이언트 컴포넌트 분리 패턴
+- **Verification**: Detail 페이지에서 우선순위 변경 시 DB 반영 확인
+- **Exit Criteria**: 우선순위 표시 + 변경 + revalidate 동작
+- **Status**: completed
+
+## Verification Strategy
+- `pnpm build` 성공 (TypeScript 컴파일 + Next.js 빌드)
+- 칸반 보드에서 우선순위 뱃지가 올바른 색상으로 표시
+- Detail 페이지에서 우선순위 표시 및 변경 가능
+- CreateTaskModal에서 우선순위 선택 후 생성 가능
+- null priority 태스크에서 뱃지 미표시 확인
+
+## Progress Tracking
+- Total Todos: 9
+- Completed: 9
+- Status: Execution complete
+
+## Change Log
+- 2026-02-17: Plan created
+- 2026-02-17: All 9 todos executed and completed

--- a/messages/en.json
+++ b/messages/en.json
@@ -46,7 +46,12 @@
     "sessionType": "Session type",
     "sshHost": "SSH Host (optional)",
     "createTitle": "Create New Task",
-    "deleteConfirm": "Are you sure you want to delete this task?"
+    "deleteConfirm": "Are you sure you want to delete this task?",
+    "priority": "Priority",
+    "priorityLow": "!",
+    "priorityMedium": "!!",
+    "priorityHigh": "!!!",
+    "priorityNone": "None"
   },
   "branch": {
     "title": "Branch Off",
@@ -177,6 +182,7 @@
     "hooksInstallSuccess": "Hooks installed successfully",
     "hooksInstallFailed": "Hooks installation failed",
     "hooksRemoteNotSupported": "Remote projects are not supported",
+    "priority": "Priority",
     "collapseSidebar": "Collapse sidebar",
     "expandSidebar": "Expand sidebar",
     "sidebarTooltip": "You can change the default state in Settings",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -46,7 +46,12 @@
     "sessionType": "세션 타입",
     "sshHost": "SSH 호스트 (선택)",
     "createTitle": "새 작업 생성",
-    "deleteConfirm": "이 작업을 삭제하시겠습니까?"
+    "deleteConfirm": "이 작업을 삭제하시겠습니까?",
+    "priority": "우선순위",
+    "priorityLow": "!",
+    "priorityMedium": "!!",
+    "priorityHigh": "!!!",
+    "priorityNone": "없음"
   },
   "branch": {
     "title": "브랜치 분기",
@@ -177,6 +182,7 @@
     "hooksInstallSuccess": "Hooks 설치 완료",
     "hooksInstallFailed": "Hooks 설치 실패",
     "hooksRemoteNotSupported": "원격 프로젝트는 지원하지 않습니다",
+    "priority": "우선순위",
     "collapseSidebar": "사이드바 접기",
     "expandSidebar": "사이드바 펼치기",
     "sidebarTooltip": "설정에서 기본 접힘 상태를 변경할 수 있습니다",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -46,7 +46,12 @@
     "sessionType": "会话类型",
     "sshHost": "SSH 主机（可选）",
     "createTitle": "创建新任务",
-    "deleteConfirm": "确定要删除此任务吗？"
+    "deleteConfirm": "确定要删除此任务吗？",
+    "priority": "优先级",
+    "priorityLow": "!",
+    "priorityMedium": "!!",
+    "priorityHigh": "!!!",
+    "priorityNone": "无"
   },
   "branch": {
     "title": "创建分支",
@@ -177,6 +182,7 @@
     "hooksInstallSuccess": "Hooks 安装完成",
     "hooksInstallFailed": "Hooks 安装失败",
     "hooksRemoteNotSupported": "不支持远程项目",
+    "priority": "优先级",
     "collapseSidebar": "折叠侧栏",
     "expandSidebar": "展开侧栏",
     "sidebarTooltip": "可以在设置中更改默认折叠状态",

--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -8,7 +8,9 @@ import {
   fetchAndSavePrUrl,
 } from "@/app/actions/kanban";
 import { TaskStatus } from "@/entities/KanbanTask";
+import { TaskPriority } from "@/entities/TaskPriority";
 import TaskStatusBadge from "@/components/TaskStatusBadge";
+import PriorityEditor from "@/components/PriorityEditor";
 import TerminalLoader from "@/components/TerminalLoader";
 import ConnectTerminalForm from "@/components/ConnectTerminalForm";
 import DeleteTaskButton from "@/components/DeleteTaskButton";
@@ -128,6 +130,12 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
                 </dd>
               </div>
             )}
+            <div className="flex items-center justify-between gap-2">
+              <dt className="text-xs text-text-muted">{t("priority")}</dt>
+              <dd>
+                <PriorityEditor taskId={task.id} currentPriority={task.priority} />
+              </dd>
+            </div>
             {task.prUrl && (
               <div className="flex items-center justify-between gap-2">
                 <dt className="text-xs text-text-muted">{t("prLink")}</dt>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -107,6 +107,14 @@
   --color-tag-base-bg: #202632;
   --color-tag-base-text: #FFFFFF;
 
+  /* Semantic: Priority */
+  --color-priority-low-bg: var(--blue-50);
+  --color-priority-low-text: var(--blue-600);
+  --color-priority-medium-bg: #FFF3E0;
+  --color-priority-medium-text: #E65100;
+  --color-priority-high-bg: var(--red-50);
+  --color-priority-high-text: var(--red-600);
+
   /* Terminal Chrome */
   --color-terminal-chrome: #1e1e1e;
   --color-terminal-bg: #0a0a0a;
@@ -200,6 +208,14 @@
   --color-tag-pr-text: var(--color-tag-pr-text);
   --color-tag-base-bg: var(--color-tag-base-bg);
   --color-tag-base-text: var(--color-tag-base-text);
+
+  /* Priority */
+  --color-priority-low-bg: var(--color-priority-low-bg);
+  --color-priority-low-text: var(--color-priority-low-text);
+  --color-priority-medium-bg: var(--color-priority-medium-bg);
+  --color-priority-medium-text: var(--color-priority-medium-text);
+  --color-priority-high-bg: var(--color-priority-high-bg);
+  --color-priority-high-text: var(--color-priority-high-text);
 
   /* Terminal Chrome */
   --color-terminal-chrome: var(--color-terminal-chrome);

--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -6,8 +6,10 @@ import { useRouter } from "@/i18n/navigation";
 import { createTask } from "@/app/actions/kanban";
 import { getProjectBranches } from "@/app/actions/project";
 import { SessionType } from "@/entities/KanbanTask";
+import { TaskPriority } from "@/entities/TaskPriority";
 import type { Project } from "@/entities/Project";
 import ProjectSelector from "./ProjectSelector";
+import PrioritySelector from "./PrioritySelector";
 
 interface CreateTaskModalProps {
   isOpen: boolean;
@@ -31,6 +33,7 @@ export default function CreateTaskModal({
   const [selectedProjectId, setSelectedProjectId] = useState(defaultProjectId || "");
   const [branches, setBranches] = useState<string[]>([]);
   const [baseBranch, setBaseBranch] = useState("");
+  const [priority, setPriority] = useState<TaskPriority | null>(null);
 
   /** 모달이 열릴 때 필터에서 선택된 프로젝트를 자동 설정한다 */
   useEffect(() => {
@@ -74,6 +77,7 @@ export default function CreateTaskModal({
         sessionType: (formData.get("sessionType") as SessionType) || undefined,
         sshHost: (formData.get("sshHost") as string) || undefined,
         projectId: selectedProjectId,
+        priority: priority || undefined,
       });
       onClose();
       router.push(`/task/${created.id}`);
@@ -145,6 +149,13 @@ export default function CreateTaskModal({
               className="w-full px-3 py-2 bg-bg-page border border-border-default rounded-md text-text-primary focus:outline-none focus:border-brand-primary resize-none transition-colors"
               placeholder={t("descriptionPlaceholder")}
             />
+          </div>
+
+          <div>
+            <label className="block text-sm text-text-secondary mb-1">
+              {t("priority")}
+            </label>
+            <PrioritySelector value={priority} onChange={setPriority} />
           </div>
 
           <div>

--- a/src/components/PriorityEditor.tsx
+++ b/src/components/PriorityEditor.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "@/i18n/navigation";
+import { TaskPriority } from "@/entities/TaskPriority";
+import { updateTask } from "@/app/actions/kanban";
+import PrioritySelector from "./PrioritySelector";
+
+interface PriorityEditorProps {
+  taskId: string;
+  currentPriority: TaskPriority | null;
+}
+
+export default function PriorityEditor({ taskId, currentPriority }: PriorityEditorProps) {
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  function handleChange(priority: TaskPriority | null) {
+    startTransition(async () => {
+      await updateTask(taskId, { priority });
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className={isPending ? "opacity-50 pointer-events-none" : ""}>
+      <PrioritySelector value={currentPriority} onChange={handleChange} />
+    </div>
+  );
+}

--- a/src/components/PrioritySelector.tsx
+++ b/src/components/PrioritySelector.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { TaskPriority } from "@/entities/TaskPriority";
+import { useTranslations } from "next-intl";
+
+interface PrioritySelectorProps {
+  value: TaskPriority | null;
+  onChange: (priority: TaskPriority | null) => void;
+}
+
+const PRIORITY_OPTIONS: { value: TaskPriority | null; labelKey: string; colorClass: string }[] = [
+  { value: null, labelKey: "priorityNone", colorClass: "bg-bg-page text-text-muted border-border-default" },
+  { value: TaskPriority.LOW, labelKey: "priorityLow", colorClass: "bg-priority-low-bg text-priority-low-text border-priority-low-text/30" },
+  { value: TaskPriority.MEDIUM, labelKey: "priorityMedium", colorClass: "bg-priority-medium-bg text-priority-medium-text border-priority-medium-text/30" },
+  { value: TaskPriority.HIGH, labelKey: "priorityHigh", colorClass: "bg-priority-high-bg text-priority-high-text border-priority-high-text/30" },
+];
+
+export default function PrioritySelector({ value, onChange }: PrioritySelectorProps) {
+  const t = useTranslations("task");
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {PRIORITY_OPTIONS.map((option) => {
+        const isSelected = value === option.value;
+        return (
+          <button
+            key={option.value ?? "none"}
+            type="button"
+            onClick={() => onChange(option.value)}
+            className={`px-2.5 py-1 text-xs font-medium rounded-md border transition-all ${
+              option.colorClass
+            } ${
+              isSelected
+                ? "ring-2 ring-offset-1 ring-brand-primary shadow-sm"
+                : "opacity-60 hover:opacity-100"
+            }`}
+          >
+            {t(option.labelKey)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -3,6 +3,7 @@
 import { Draggable } from "@hello-pangea/dnd";
 import { Link } from "@/i18n/navigation";
 import type { KanbanTask } from "@/entities/KanbanTask";
+import { TaskPriority } from "@/entities/TaskPriority";
 
 interface TaskCardProps {
   task: KanbanTask;
@@ -16,6 +17,12 @@ const agentTagColors: Record<string, string> = {
   claude: "bg-tag-claude-bg text-tag-claude-text",
   gemini: "bg-tag-gemini-bg text-tag-gemini-text",
   codex: "bg-tag-codex-bg text-tag-codex-text",
+};
+
+const priorityConfig: Record<TaskPriority, { label: string; colorClass: string }> = {
+  [TaskPriority.LOW]: { label: "!", colorClass: "bg-priority-low-bg text-priority-low-text" },
+  [TaskPriority.MEDIUM]: { label: "!!", colorClass: "bg-priority-medium-bg text-priority-medium-text" },
+  [TaskPriority.HIGH]: { label: "!!!", colorClass: "bg-priority-high-bg text-priority-high-text" },
 };
 
 export default function TaskCard({ task, index, onContextMenu, projectName, isBaseProject }: TaskCardProps) {
@@ -94,6 +101,14 @@ export default function TaskCard({ task, index, onContextMenu, projectName, isBa
               {task.sshHost && (
                 <span className="text-xs px-2 py-0.5 rounded-full bg-tag-ssh-bg text-tag-ssh-text">
                   {task.sshHost}
+                </span>
+              )}
+
+              {task.priority && (
+                <span
+                  className={`ml-auto text-xs font-bold px-2 py-0.5 rounded-full ${priorityConfig[task.priority].colorClass}`}
+                >
+                  {priorityConfig[task.priority].label}
                 </span>
               )}
             </div>

--- a/src/components/__tests__/PriorityEditor.test.tsx
+++ b/src/components/__tests__/PriorityEditor.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import PriorityEditor from "../PriorityEditor";
+import { TaskPriority } from "@/entities/TaskPriority";
+
+const mockRefresh = vi.fn();
+const mockUpdateTask = vi.fn().mockResolvedValue({});
+
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({
+    refresh: mockRefresh,
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const translations: Record<string, string> = {
+      priorityNone: "없음",
+      priorityLow: "!",
+      priorityMedium: "!!",
+      priorityHigh: "!!!",
+    };
+    return translations[key] ?? key;
+  },
+}));
+
+vi.mock("@/app/actions/kanban", () => ({
+  updateTask: (...args: unknown[]) => mockUpdateTask(...args),
+}));
+
+describe("PriorityEditor", () => {
+  beforeEach(() => {
+    mockRefresh.mockClear();
+    mockUpdateTask.mockClear();
+  });
+
+  it("should render PrioritySelector with current priority", () => {
+    // Given & When
+    render(<PriorityEditor taskId="task-1" currentPriority={TaskPriority.HIGH} />);
+
+    // Then
+    const highButton = screen.getByText("!!!");
+    expect(highButton.className).toContain("ring-2");
+  });
+
+  it("should call updateTask with new priority when selection changes", async () => {
+    // Given
+    render(<PriorityEditor taskId="task-1" currentPriority={null} />);
+
+    // When
+    await act(async () => {
+      fireEvent.click(screen.getByText("!!"));
+    });
+
+    // Then
+    expect(mockUpdateTask).toHaveBeenCalledWith("task-1", { priority: TaskPriority.MEDIUM });
+  });
+
+  it("should call updateTask with null when 없음 is selected", async () => {
+    // Given
+    render(<PriorityEditor taskId="task-1" currentPriority={TaskPriority.LOW} />);
+
+    // When
+    await act(async () => {
+      fireEvent.click(screen.getByText("없음"));
+    });
+
+    // Then
+    expect(mockUpdateTask).toHaveBeenCalledWith("task-1", { priority: null });
+  });
+
+  it("should call router.refresh() after updateTask completes", async () => {
+    // Given
+    render(<PriorityEditor taskId="task-1" currentPriority={null} />);
+
+    // When
+    await act(async () => {
+      fireEvent.click(screen.getByText("!"));
+    });
+
+    // Then
+    expect(mockUpdateTask).toHaveBeenCalled();
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/PrioritySelector.test.tsx
+++ b/src/components/__tests__/PrioritySelector.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import PrioritySelector from "../PrioritySelector";
+import { TaskPriority } from "@/entities/TaskPriority";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const translations: Record<string, string> = {
+      priorityNone: "없음",
+      priorityLow: "!",
+      priorityMedium: "!!",
+      priorityHigh: "!!!",
+    };
+    return translations[key] ?? key;
+  },
+}));
+
+describe("PrioritySelector", () => {
+  let onChange: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onChange = vi.fn();
+  });
+
+  it("should render all 4 priority options", () => {
+    // Given
+    render(<PrioritySelector value={null} onChange={onChange} />);
+
+    // When
+    const buttons = screen.getAllByRole("button");
+
+    // Then
+    expect(buttons).toHaveLength(4);
+    expect(buttons[0].textContent).toBe("없음");
+    expect(buttons[1].textContent).toBe("!");
+    expect(buttons[2].textContent).toBe("!!");
+    expect(buttons[3].textContent).toBe("!!!");
+  });
+
+  it("should call onChange with TaskPriority.LOW when ! button is clicked", () => {
+    // Given
+    render(<PrioritySelector value={null} onChange={onChange} />);
+
+    // When
+    fireEvent.click(screen.getByText("!"));
+
+    // Then
+    expect(onChange).toHaveBeenCalledWith(TaskPriority.LOW);
+  });
+
+  it("should call onChange with TaskPriority.MEDIUM when !! button is clicked", () => {
+    // Given
+    render(<PrioritySelector value={null} onChange={onChange} />);
+
+    // When
+    fireEvent.click(screen.getByText("!!"));
+
+    // Then
+    expect(onChange).toHaveBeenCalledWith(TaskPriority.MEDIUM);
+  });
+
+  it("should call onChange with TaskPriority.HIGH when !!! button is clicked", () => {
+    // Given
+    render(<PrioritySelector value={null} onChange={onChange} />);
+
+    // When
+    fireEvent.click(screen.getByText("!!!"));
+
+    // Then
+    expect(onChange).toHaveBeenCalledWith(TaskPriority.HIGH);
+  });
+
+  it("should call onChange with null when 없음 button is clicked", () => {
+    // Given
+    render(<PrioritySelector value={TaskPriority.HIGH} onChange={onChange} />);
+
+    // When
+    fireEvent.click(screen.getByText("없음"));
+
+    // Then
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("should apply ring style to selected option", () => {
+    // Given & When
+    render(<PrioritySelector value={TaskPriority.MEDIUM} onChange={onChange} />);
+
+    // Then
+    const mediumButton = screen.getByText("!!");
+    expect(mediumButton.className).toContain("ring-2");
+
+    const lowButton = screen.getByText("!");
+    expect(lowButton.className).toContain("opacity-60");
+  });
+});

--- a/src/components/__tests__/PrioritySelector.test.tsx
+++ b/src/components/__tests__/PrioritySelector.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import PrioritySelector from "../PrioritySelector";
 import { TaskPriority } from "@/entities/TaskPriority";
@@ -16,10 +16,10 @@ vi.mock("next-intl", () => ({
 }));
 
 describe("PrioritySelector", () => {
-  let onChange: ReturnType<typeof vi.fn>;
+  let onChange: Mock<(priority: TaskPriority | null) => void>;
 
   beforeEach(() => {
-    onChange = vi.fn();
+    onChange = vi.fn<(priority: TaskPriority | null) => void>();
   });
 
   it("should render all 4 priority options", () => {

--- a/src/components/__tests__/TaskCard.test.tsx
+++ b/src/components/__tests__/TaskCard.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TaskCard from "../TaskCard";
+import { TaskPriority } from "@/entities/TaskPriority";
+import { TaskStatus } from "@/entities/KanbanTask";
+import type { KanbanTask } from "@/entities/KanbanTask";
+
+vi.mock("@hello-pangea/dnd", () => ({
+  Draggable: ({ children }: { children: (provided: unknown, snapshot: unknown) => React.ReactNode }) =>
+    children(
+      {
+        innerRef: vi.fn(),
+        draggableProps: { "data-rfd-draggable-id": "test" },
+        dragHandleProps: {},
+      },
+      { isDragging: false },
+    ),
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ children, ...props }: { children: React.ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+function createTask(overrides: Partial<KanbanTask> = {}): KanbanTask {
+  return {
+    id: "task-1",
+    title: "Test Task",
+    description: null,
+    status: TaskStatus.TODO,
+    branchName: null,
+    worktreePath: null,
+    sessionType: null,
+    sessionName: null,
+    sshHost: null,
+    agentType: null,
+    project: null,
+    projectId: null,
+    baseBranch: null,
+    prUrl: null,
+    priority: null,
+    displayOrder: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("TaskCard - Priority Badge", () => {
+  const onContextMenu = vi.fn();
+
+  it("should not render priority badge when priority is null", () => {
+    // Given
+    const task = createTask({ priority: null });
+
+    // When
+    render(<TaskCard task={task} index={0} onContextMenu={onContextMenu} />);
+
+    // Then
+    expect(screen.queryByText("!")).toBeNull();
+    expect(screen.queryByText("!!")).toBeNull();
+    expect(screen.queryByText("!!!")).toBeNull();
+  });
+
+  it("should render ! badge with low priority color when priority is LOW", () => {
+    // Given
+    const task = createTask({ priority: TaskPriority.LOW });
+
+    // When
+    render(<TaskCard task={task} index={0} onContextMenu={onContextMenu} />);
+
+    // Then
+    const badge = screen.getByText("!");
+    expect(badge).toBeTruthy();
+    expect(badge.className).toContain("bg-priority-low-bg");
+    expect(badge.className).toContain("text-priority-low-text");
+  });
+
+  it("should render !! badge with medium priority color when priority is MEDIUM", () => {
+    // Given
+    const task = createTask({ priority: TaskPriority.MEDIUM });
+
+    // When
+    render(<TaskCard task={task} index={0} onContextMenu={onContextMenu} />);
+
+    // Then
+    const badge = screen.getByText("!!");
+    expect(badge).toBeTruthy();
+    expect(badge.className).toContain("bg-priority-medium-bg");
+    expect(badge.className).toContain("text-priority-medium-text");
+  });
+
+  it("should render !!! badge with high priority color when priority is HIGH", () => {
+    // Given
+    const task = createTask({ priority: TaskPriority.HIGH });
+
+    // When
+    render(<TaskCard task={task} index={0} onContextMenu={onContextMenu} />);
+
+    // Then
+    const badge = screen.getByText("!!!");
+    expect(badge).toBeTruthy();
+    expect(badge.className).toContain("bg-priority-high-bg");
+    expect(badge.className).toContain("text-priority-high-text");
+  });
+
+  it("should render priority badge with ml-auto for right alignment", () => {
+    // Given
+    const task = createTask({ priority: TaskPriority.HIGH });
+
+    // When
+    render(<TaskCard task={task} index={0} onContextMenu={onContextMenu} />);
+
+    // Then
+    const badge = screen.getByText("!!!");
+    expect(badge.className).toContain("ml-auto");
+  });
+});

--- a/src/entities/KanbanTask.ts
+++ b/src/entities/KanbanTask.ts
@@ -9,6 +9,7 @@ import {
   JoinColumn,
 } from "typeorm";
 import { Project } from "./Project";
+import { TaskPriority } from "./TaskPriority";
 
 export enum TaskStatus {
   TODO = "todo",
@@ -71,6 +72,9 @@ export class KanbanTask {
 
   @Column({ name: "pr_url", type: "varchar", length: 500, nullable: true })
   prUrl!: string | null;
+
+  @Column({ type: "enum", enum: TaskPriority, nullable: true, default: null })
+  priority!: TaskPriority | null;
 
   @Column({ name: "display_order", type: "int", default: 0 })
   displayOrder!: number;

--- a/src/entities/TaskPriority.ts
+++ b/src/entities/TaskPriority.ts
@@ -1,0 +1,5 @@
+export enum TaskPriority {
+  LOW = "low",
+  MEDIUM = "medium",
+  HIGH = "high",
+}

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -12,6 +12,7 @@ import { AssignDisplayOrder1771166346785 } from "@/migrations/1771166346785-Assi
 import { AddAppSettings1771166907165 } from "@/migrations/1771166907165-AddAppSettings";
 import { AddPendingStatus1771171200000 } from "@/migrations/1771171200000-AddPendingStatus";
 import { RemoveBranchNameUnique1771257600000 } from "@/migrations/1771257600000-RemoveBranchNameUnique";
+import { AddPriorityToKanbanTasks1771344000000 } from "@/migrations/1771344000000-AddPriorityToKanbanTasks";
 
 /**
  * TypeORM DataSource 싱글턴.
@@ -33,7 +34,7 @@ function createDataSource(): DataSource {
     type: "postgres",
     url: process.env.DATABASE_URL ?? buildDatabaseUrl(),
     entities: [KanbanTask, Project, PaneLayoutConfig, AppSettings],
-    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785, AddAppSettings1771166907165, AddPendingStatus1771171200000, RemoveBranchNameUnique1771257600000],
+    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785, AddAppSettings1771166907165, AddPendingStatus1771171200000, RemoveBranchNameUnique1771257600000, AddPriorityToKanbanTasks1771344000000],
     synchronize: false,
     logging: process.env.NODE_ENV !== "production",
   });

--- a/src/migrations/1771344000000-AddPriorityToKanbanTasks.ts
+++ b/src/migrations/1771344000000-AddPriorityToKanbanTasks.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * kanban_tasks 테이블에 priority 컬럼을 추가한다.
+ * priority는 low/medium/high enum 값을 가지며 nullable이다.
+ */
+export class AddPriorityToKanbanTasks1771344000000 implements MigrationInterface {
+  name = "AddPriorityToKanbanTasks1771344000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "kanban_tasks_priority_enum" AS ENUM('low', 'medium', 'high')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "kanban_tasks" ADD "priority" "kanban_tasks_priority_enum" DEFAULT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "kanban_tasks" DROP COLUMN "priority"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "kanban_tasks_priority_enum"`,
+    );
+  }
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/task/2602/17-add-priority-field.plan.md)

## 어떤 작업인가요?
- 칸반 태스크에 우선순위(Priority) 필드를 추가하여 시각적 가시성을 높인다. `!` (파란색), `!!` (주황색), `!!!` (빨간색) 3단계로 표현하며 null 허용.

## 어떻게 해결했나요?
**데이터 모델 및 마이그레이션**
- TaskPriority enum (low/medium/high) 생성 및 KanbanTask entity에 nullable priority 컬럼 추가
- DB 마이그레이션으로 kanban_tasks_priority_enum 타입과 컬럼 추가

**서버 액션**
- createTask, updateTask에 priority 필드 처리 로직 추가

**UI 컴포넌트**
- PrioritySelector: 공용 우선순위 선택 버튼 컴포넌트 (없음/!/!!/!!! 4개 옵션)
- PriorityEditor: Detail 페이지용 클라이언트 컴포넌트 (updateTask + router.refresh)
- TaskCard에 우선순위 뱃지 표시 (오른쪽 정렬)
- CreateTaskModal에 우선순위 선택 옵션 추가
- Detail 페이지 메타데이터 카드에 우선순위 편집 기능 추가

**테스트**
- PrioritySelector, PriorityEditor, TaskCard 컴포넌트 테스트 추가 (15 tests)

## 중요한 변경 사항은 무엇인가요?
### 데이터 모델

**TaskPriority enum 추가**
- **변경 이유**: 우선순위를 타입 안전하게 관리하기 위해 별도 enum 파일로 분리
- **수정 파일**: `src/entities/TaskPriority.ts`, `src/entities/KanbanTask.ts`

**DB 마이그레이션**
- **변경 이유**: priority enum 타입 생성 및 nullable 컬럼 추가
- **수정 파일**: `src/migrations/1771344000000-AddPriorityToKanbanTasks.ts`, `src/lib/database.ts`

### UI

**디자인 토큰**
- **변경 이유**: 우선순위별 색상을 디자인 시스템에 등록 (low=파란, medium=주황, high=빨간)
- **수정 파일**: `src/app/globals.css`

**칸반 보드 뱃지**
- **변경 이유**: 칸반 카드에서 우선순위를 한눈에 파악할 수 있도록 오른쪽 정렬 뱃지 추가
- **수정 파일**: `src/components/TaskCard.tsx`

**Detail 페이지 편집**
- **변경 이유**: 태스크 상세 페이지에서 우선순위를 직접 변경할 수 있도록 PriorityEditor 추가
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`, `src/components/PriorityEditor.tsx`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
