### PR TITLE
feat(task): done 처리 시 kanban 보드로 자동 이동

### DIFF
--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -65,6 +65,9 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
     "use server";
     const newStatus = formData.get("status") as TaskStatus;
     await updateTaskStatus(id, newStatus);
+    if (newStatus === TaskStatus.DONE) {
+      redirect({ href: "/", locale });
+    }
   }
 
   async function handleDelete() {


### PR DESCRIPTION
## 관련 자료
- 작업 계획: .claude/plan/task/2602/17-done-status-alert.plan.md

## 어떤 작업인가요?
Task Detail 페이지에서 done 처리 시 자동으로 Kanban 보드 메인 페이지로 이동하도록 UX 개선

## 어떻게 해결했나요?
**done 상태 전환 시 redirect 추가**
- 기존에는 done 처리 후 Task Detail 페이지에 그대로 남아 있어 사용자가 수동으로 보드로 돌아가야 했음
- `handleStatusChange` 서버 액션에서 `TaskStatus.DONE`으로 전환 시 `/`(Kanban 보드)로 redirect

## 중요한 변경 사항은 무엇인가요?
### done 상태 전환 후 자동 이동

**handleStatusChange에 redirect 조건 추가**
- **변경 이유**: done 처리 후 완료된 태스크를 계속 보고 있는 UX가 불편하여, 보드로 자동 이동하도록 개선
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`
