### PR TITLE
feat(notification): 브라우저 알림 설정 UI 추가

### DIFF
--- a/.claude/plan/notification/2602/17-browser-notification-on-hooks-status.plan.md
+++ b/.claude/plan/notification/2602/17-browser-notification-on-hooks-status.plan.md
@@ -1,0 +1,121 @@
+# Hooks 상태 변경 시 브라우저 알림
+
+## Business Goal
+Claude Code hooks가 task 상태를 변경할 때 브라우저 알림을 발송하여, 사용자가 KanVibe 보드를 보고 있지 않아도 AI 에이전트의 작업 상태 변화를 즉시 인지할 수 있도록 한다.
+
+## Scope
+- **In Scope**: `/api/hooks/status` API 경유 상태 변경 시 Browser Notification 발송
+- **Out of Scope**: 수동 드래그앤드롭/UI 상태 변경 알림, 알림 설정 UI, 사운드/진동
+
+## Codebase Analysis Summary
+- Claude Code hooks (`src/lib/claudeHooksSetup.ts`)가 `/api/hooks/status`로 POST 요청
+- `/api/hooks/status/route.ts`에서 DB 업데이트 후 `broadcastBoardUpdate()` 호출
+- `broadcastBoardUpdate()` (`src/lib/boardNotifier.ts`)가 WebSocket으로 `{ type: "board-updated" }` 전송
+- `useAutoRefresh` (`src/hooks/useAutoRefresh.ts`)가 WebSocket 메시지 수신 시 `router.refresh()` 호출
+- 기존 WebSocket: port+10000에서 운영, `boardClients` Set으로 클라이언트 관리
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/lib/boardNotifier.ts` | WebSocket 브로드캐스트 | Modify — 상세 정보 포함 브로드캐스트 함수 추가 |
+| `src/app/api/hooks/status/route.ts` | hooks 상태 변경 API | Modify — task 상세 정보 브로드캐스트 |
+| `src/hooks/useTaskNotification.ts` | 브라우저 알림 훅 | Create |
+| `src/hooks/useAutoRefresh.ts` | WebSocket 연결 관리 | Modify — 알림 메시지 처리 추가 |
+| `src/components/Board.tsx` | 메인 보드 컴포넌트 | Modify — 알림 훅 통합 |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 한국어 주석 | CODE_PRINCIPLES.md | 주석/답변은 한국어 |
+| "use client" | project-architecture | 클라이언트 컴포넌트에 디렉티브 필수 |
+| 훅 위치 | 프로젝트 구조 | `src/hooks/` 디렉토리 |
+| Boolean 네이밍 | CODE_PRINCIPLES.md | `is`, `has`, `can`, `should` 접두사 |
+| KISS | CODE_PRINCIPLES.md | 단순하고 명확한 코드, 불필요한 복잡성 없음 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 알림 트리거 | hooks API 경유 시에만 | 사용자 요청 범위 | 모든 상태 변경 |
+| 전달 채널 | 기존 WebSocket 확장 | 인프라 재사용, 추가 의존성 없음 | SSE, polling |
+| 메시지 분리 | 새 타입 `task-status-changed` | 기존 `board-updated` 동작 유지 | 기존 타입에 data 추가 |
+| 권한 요청 시점 | Board 마운트 시 | 사용자가 보드 진입 시 자연스럽게 요청 | 설정 페이지 |
+
+## Implementation Todos
+
+### Todo 1: boardNotifier에 상세 브로드캐스트 함수 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: WebSocket으로 task 상태 변경 상세 정보를 전송할 수 있도록 한다
+- **Work**:
+  - `src/lib/boardNotifier.ts`에 `TaskStatusChangedPayload` 인터페이스 추가: `{ projectName: string; branchName: string; taskTitle: string; description: string | null; newStatus: string }`
+  - `broadcastTaskStatusChanged(payload: TaskStatusChangedPayload)` 함수 추가
+  - 메시지 형식: `{ type: "task-status-changed", ...payload }`
+- **Convention Notes**: export 함수, 한국어 JSDoc 주석
+- **Verification**: TypeScript 컴파일 통과
+- **Exit Criteria**: `broadcastTaskStatusChanged` 함수가 정상 export됨
+- **Status**: pending
+
+### Todo 2: hooks/status API에서 상세 브로드캐스트 호출
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: hooks API가 상태 변경 시 task 상세 정보를 WebSocket으로 브로드캐스트한다
+- **Work**:
+  - `src/app/api/hooks/status/route.ts`에서 `broadcastTaskStatusChanged` import
+  - `broadcastBoardUpdate()` 호출 직후 `broadcastTaskStatusChanged()` 호출
+  - payload: `{ projectName, branchName, taskTitle: task.title, description: task.description, newStatus: taskStatus }`
+- **Convention Notes**: 기존 `broadcastBoardUpdate()` 호출은 그대로 유지
+- **Verification**: TypeScript 컴파일 통과, API 동작 확인
+- **Exit Criteria**: hooks API가 두 가지 브로드캐스트 모두 수행
+
+### Todo 3: useTaskNotification 커스텀 훅 생성
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: Browser Notification API를 캡슐화한 커스텀 훅을 만든다
+- **Work**:
+  - `src/hooks/useTaskNotification.ts` 파일 생성
+  - `useTaskNotification()` 훅 구현:
+    - 마운트 시 `Notification.requestPermission()` 호출
+    - `notifyTaskStatusChanged(payload)` 콜백 함수 반환
+    - 알림 title: `"{projectName} — {branchName}"`
+    - 알림 body: `"{taskTitle}: {newStatus}로 변경"` (description이 있으면 함께 표시)
+    - `Notification.permission === "granted"` 일 때만 발송
+- **Convention Notes**: `"use client"` 디렉티브, 한국어 주석, `is`/`has` 접두사로 boolean
+- **Verification**: TypeScript 컴파일 통과
+- **Exit Criteria**: 훅이 정상 export되고 Notification API 호출 로직이 포함됨
+
+### Todo 4: useAutoRefresh에 알림 통합
+- **Priority**: 2
+- **Dependencies**: Todo 1, Todo 3
+- **Goal**: WebSocket에서 `task-status-changed` 메시지 수신 시 브라우저 알림을 발송한다
+- **Work**:
+  - `src/hooks/useAutoRefresh.ts`에서 `useTaskNotification` import
+  - `ws.onmessage` 핸들러에 `task-status-changed` 타입 처리 추가
+  - `notifyTaskStatusChanged(data)` 호출
+- **Convention Notes**: 기존 `board-updated` 처리 로직은 그대로 유지
+- **Verification**: TypeScript 컴파일 통과
+- **Exit Criteria**: WebSocket 메시지 수신 시 브라우저 알림이 트리거됨
+
+### Todo 5: 빌드 검증
+- **Priority**: 3
+- **Dependencies**: Todo 2, Todo 4
+- **Goal**: 전체 빌드가 정상 통과하는지 확인한다
+- **Work**:
+  - `pnpm build` 실행
+  - TypeScript 에러 및 lint 에러 확인
+  - 에러 발생 시 수정
+- **Convention Notes**: N/A
+- **Verification**: `pnpm build` 성공
+- **Exit Criteria**: 빌드 에러 없음
+
+## Verification Strategy
+- `pnpm build` 통과
+- 코드 리뷰: 기존 `board-updated` 동작이 그대로 유지되는지 확인
+- 알림 흐름: hooks API → broadcastTaskStatusChanged → WebSocket → useAutoRefresh → useTaskNotification → Browser Notification
+
+## Progress Tracking
+- Total Todos: 5
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-17: Plan created

--- a/.claude/plan/notification/2602/17-notification-settings-ui.plan.md
+++ b/.claude/plan/notification/2602/17-notification-settings-ui.plan.md
@@ -1,0 +1,138 @@
+# 알림 설정 UI 구현
+
+## Business Goal
+사용자가 Chrome 브라우저 알림을 세밀하게 제어할 수 있도록 한다. 알림 전역 ON/OFF와 상태별 필터링(TODO, PROGRESS, PENDING, REVIEW, DONE)을 설정하여, 원하는 상태 변경에 대해서만 알림을 받을 수 있게 한다.
+
+## Scope
+- **In Scope**: 알림 전역 토글, 상태별 필터 체크박스, ProjectSettings 패널 내 UI, AppSettings DB 저장, NotificationListener 필터링, 3개 언어 번역
+- **Out of Scope**: 사운드/진동, 프로젝트별 필터링, 알림 히스토리, 알림 커스텀 메시지
+
+## Codebase Analysis Summary
+- 기존 알림 시스템: WebSocket → NotificationListener → useTaskNotification → Browser Notification
+- `AppSettings` 엔티티: key-value 패턴, `getAppSetting`/`setAppSetting` 헬퍼 존재
+- `ProjectSettings.tsx`: 기존 설정 패널, toggle switch 패턴(`role="switch"`, `aria-checked`) 존재
+- `NotificationListener.tsx`: layout.tsx에서 마운트, WebSocket 연결 및 알림 발송
+- `useTaskNotification.ts`: Browser Notification API 캡슐화
+- TaskStatus: TODO, PROGRESS, PENDING, REVIEW, DONE
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/app/actions/appSettings.ts` | AppSettings CRUD | Modify — 알림 설정 getter/setter 추가 |
+| `src/components/ProjectSettings.tsx` | 설정 패널 UI | Modify — 알림 설정 섹션 추가 |
+| `src/components/NotificationListener.tsx` | 알림 수신 | Modify — 설정 props 받아 필터링 적용 |
+| `src/hooks/useTaskNotification.ts` | 알림 발송 훅 | Modify — 상태 필터링 로직 추가 |
+| `src/app/[locale]/layout.tsx` | 루트 레이아웃 | Modify — 알림 설정을 NotificationListener에 전달 |
+| `messages/ko.json` | 한국어 번역 | Modify — 알림 설정 키 추가 |
+| `messages/en.json` | 영어 번역 | Modify — 알림 설정 키 추가 |
+| `messages/zh.json` | 중국어 번역 | Modify — 알림 설정 키 추가 |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 한국어 주석 | CODE_PRINCIPLES.md | 주석/답변은 한국어 |
+| "use client" | project-architecture | 클라이언트 컴포넌트에 디렉티브 필수 |
+| Boolean 네이밍 | CODE_PRINCIPLES.md | `is`, `has`, `can`, `should` 접두사 |
+| AppSettings 패턴 | appSettings.ts | `getAppSetting`/`setAppSetting` 사용 |
+| Toggle 패턴 | ProjectSettings.tsx | `role="switch"`, `aria-checked` |
+| i18n | CLAUDE.md | 3개 언어 동시 번역, `useTranslations("settings")` |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 저장소 | AppSettings key-value | 기존 패턴 재사용, migration 불필요 | 전용 Entity |
+| 키 구조 | `notification_enabled` + `notification_statuses` | 단순하고 확장 가능 | 단일 JSON |
+| 설정 전달 | layout → props → NotificationListener | `revalidatePath`로 자동 반영, 기존 패턴과 일관 | API fetch |
+| 기본값 | 전체 활성화 | 기존 동작 유지 (backward compatible) | 전체 비활성화 |
+
+## Implementation Todos
+
+### Todo 1: AppSettings에 알림 설정 server action 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 알림 설정을 DB에서 읽고 쓸 수 있는 server action을 추가한다
+- **Work**:
+  - `src/app/actions/appSettings.ts`에 상수 추가: `NOTIFICATION_ENABLED_KEY = "notification_enabled"`, `NOTIFICATION_STATUSES_KEY = "notification_statuses"`
+  - `getNotificationSettings()` 함수 추가: `{ isEnabled: boolean, enabledStatuses: string[] }` 반환. 키 없으면 기본값 `{ isEnabled: true, enabledStatuses: ["todo","progress","pending","review","done"] }`
+  - `setNotificationEnabled(enabled: boolean)` 함수 추가: `setAppSetting` 사용 + `revalidatePath("/")`
+  - `setNotificationStatuses(statuses: string[])` 함수 추가: JSON.stringify로 저장 + `revalidatePath("/")`
+- **Convention Notes**: `"use server"` 디렉티브, 한국어 주석, 기존 `setSidebarDefaultCollapsed` 패턴 따름
+- **Verification**: TypeScript 컴파일 통과
+- **Exit Criteria**: 4개 함수가 정상 export됨
+- **Status**: pending
+
+### Todo 2: i18n 번역 키 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 알림 설정 UI에 필요한 번역 키를 3개 언어에 추가한다
+- **Work**:
+  - `messages/ko.json`의 `settings` 객체에 추가:
+    - `"notificationSection"`: `"알림"`
+    - `"notificationEnabled"`: `"브라우저 알림"`
+    - `"notificationEnabledDescription"`: `"작업 상태 변경 시 브라우저 알림을 받습니다."`
+    - `"notificationStatusFilter"`: `"알림 받을 상태"`
+    - `"notificationStatusFilterDescription"`: `"선택한 상태로 변경될 때만 알림을 받습니다."`
+  - `messages/en.json`의 `settings` 객체에 동일 키로 영어 번역 추가
+  - `messages/zh.json`의 `settings` 객체에 동일 키로 중국어 번역 추가
+- **Convention Notes**: 3개 언어 동시 추가, 기존 키 네이밍 패턴(`camelCase`) 따름
+- **Verification**: JSON 파싱 정상
+- **Exit Criteria**: 3개 파일에 5개 키씩 추가됨
+- **Status**: pending
+
+### Todo 3: NotificationListener에 설정 props 추가 및 필터링 적용
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: NotificationListener가 알림 설정을 props로 받아 필터링을 적용한다
+- **Work**:
+  - `src/components/NotificationListener.tsx`에 props 인터페이스 추가: `{ isNotificationEnabled: boolean; enabledStatuses: string[] }`
+  - `useTaskNotification` 훅에 `enabledStatuses` 전달
+  - `src/hooks/useTaskNotification.ts`의 `notifyTaskStatusChanged`에 필터링 추가: `isNotificationEnabled`가 false이면 리턴, `enabledStatuses`에 포함되지 않으면 리턴
+  - `src/app/[locale]/layout.tsx`에서 `getNotificationSettings()` 호출하여 props 전달
+- **Convention Notes**: `"use client"` 디렉티브 유지, Boolean prop은 `is` 접두사
+- **Verification**: TypeScript 컴파일 통과
+- **Exit Criteria**: 설정에 따라 알림이 필터링됨
+- **Status**: pending
+
+### Todo 4: ProjectSettings에 알림 설정 UI 섹션 추가
+- **Priority**: 2
+- **Dependencies**: Todo 1, Todo 2
+- **Goal**: ProjectSettings 패널에 알림 설정 섹션을 추가한다
+- **Work**:
+  - `src/components/ProjectSettings.tsx`에 props 추가: `notificationSettings: { isEnabled: boolean; enabledStatuses: string[] }`
+  - "상세 페이지" 섹션 아래에 "알림" 섹션 추가
+  - 전역 토글: 기존 `sidebarDefaultCollapsed` 토글 패턴 재사용 (`role="switch"`, `aria-checked`)
+  - 상태별 체크박스: TODO, PROGRESS, PENDING, REVIEW, DONE 5개 체크박스
+  - 전역 토글 OFF 시 체크박스 영역 비활성화 (opacity + pointer-events)
+  - `startTransition` 내에서 `setNotificationEnabled`, `setNotificationStatuses` 호출
+  - Board.tsx에서 notificationSettings를 ProjectSettings에 전달
+- **Convention Notes**: 기존 toggle 패턴, `useTranslations("settings")`, Tailwind CSS 변수
+- **Verification**: TypeScript 컴파일 통과, UI 렌더링 정상
+- **Exit Criteria**: 토글과 체크박스가 정상 동작하고 DB에 저장됨
+- **Status**: pending
+
+### Todo 5: 빌드 검증
+- **Priority**: 3
+- **Dependencies**: Todo 3, Todo 4
+- **Goal**: 전체 빌드가 정상 통과하는지 확인한다
+- **Work**:
+  - `pnpm build` 실행
+  - TypeScript 에러 및 lint 에러 확인
+  - 에러 발생 시 수정
+- **Convention Notes**: N/A
+- **Verification**: `pnpm build` 성공
+- **Exit Criteria**: 빌드 에러 없음
+- **Status**: pending
+
+## Verification Strategy
+- `pnpm build` 통과
+- 알림 설정 흐름: ProjectSettings → Server Action → DB → layout.tsx → NotificationListener → 필터링
+- 기존 알림 동작: 설정 미변경 시 기존과 동일하게 전체 상태에 대해 알림
+
+## Progress Tracking
+- Total Todos: 5
+- Completed: 5
+- Status: All todos completed
+
+## Change Log
+- 2026-02-17: Plan created
+- 2026-02-17: All todos executed and verified (build + tests pass)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ Both hooks are **auto-installed** when you register a project through KanVibe's 
 | Claude Code | `.claude/hooks/` | `.claude/settings.json` |
 | Gemini CLI | `.gemini/hooks/` | `.gemini/settings.json` |
 
+#### Browser Notifications
+
+When a task status changes via Claude Code Hooks, KanVibe sends a **browser notification** with the project name, branch name, and new status. Notifications work on any KanVibe page — you don't need to keep the board open. Allow notifications in your browser when prompted.
+
+You can configure notifications in **Project Settings**:
+- **Global toggle** — Enable or disable all notifications
+- **Status filter** — Choose which statuses (Progress, Pending, Review) trigger notifications
+
 #### Hook API Endpoints
 
 | Endpoint | Method | Description |

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -162,6 +162,14 @@ AfterAgent (에이전트 완료)   → REVIEW
 | Claude Code | `.claude/hooks/` | `.claude/settings.json` |
 | Gemini CLI | `.gemini/hooks/` | `.gemini/settings.json` |
 
+#### 브라우저 알림
+
+Claude Code Hooks를 통해 태스크 상태가 변경되면 **브라우저 알림**으로 프로젝트명, 브랜치명, 변경된 상태를 표시합니다. 보드 페이지를 열어두지 않아도 KanVibe의 어떤 페이지에서든 알림을 받을 수 있습니다. 최초 접속 시 브라우저 알림 권한을 허용해 주세요.
+
+**프로젝트 설정**에서 알림을 세부 조정할 수 있습니다:
+- **전역 토글** — 모든 알림 활성화/비활성화
+- **상태 필터** — Progress, Pending, Review 중 원하는 상태 변경만 알림 수신
+
 #### Hook API 엔드포인트
 
 | 엔드포인트 | 메서드 | 설명 |

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -162,6 +162,14 @@ AfterAgent（代理完成）       → REVIEW
 | Claude Code | `.claude/hooks/` | `.claude/settings.json` |
 | Gemini CLI | `.gemini/hooks/` | `.gemini/settings.json` |
 
+#### 浏览器通知
+
+当任务状态通过 Claude Code Hooks 发生变化时，KanVibe 会发送**浏览器通知**，显示项目名称、分支名称和新状态。无需保持看板页面打开——在 KanVibe 的任何页面都可以收到通知。首次访问时请允许浏览器通知权限。
+
+可以在**项目设置**中配置通知：
+- **全局开关** — 启用或禁用所有通知
+- **状态筛选** — 选择哪些状态（Progress、Pending、Review）触发通知
+
 #### Hook API 端点
 
 | 端点 | 方法 | 说明 |

--- a/messages/en.json
+++ b/messages/en.json
@@ -115,7 +115,12 @@
     "folderNavHint": "↑↓ Navigate · Tab Drill down · Enter Select · Backspace Go up · Esc Close",
     "detailPageSection": "Detail Page",
     "sidebarDefaultCollapsed": "Collapse sidebar by default",
-    "sidebarDefaultCollapsedDescription": "Start with the left sidebar collapsed when entering the detail page."
+    "sidebarDefaultCollapsedDescription": "Start with the left sidebar collapsed when entering the detail page.",
+    "notificationSection": "Notifications",
+    "notificationEnabled": "Browser notifications",
+    "notificationEnabledDescription": "Receive browser notifications when task status changes.",
+    "notificationStatusFilter": "Notify for statuses",
+    "notificationStatusFilterDescription": "Only receive notifications when tasks change to selected statuses."
   },
   "paneLayout": {
     "title": "Pane Layout Settings",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -115,7 +115,12 @@
     "folderNavHint": "↑↓ 이동 · Tab 하위 폴더 · Enter 선택 · Backspace 상위 폴더 · Esc 닫기",
     "detailPageSection": "상세 페이지",
     "sidebarDefaultCollapsed": "사이드바 기본 접기",
-    "sidebarDefaultCollapsedDescription": "상세 페이지 진입 시 왼쪽 사이드바를 접은 상태로 시작합니다."
+    "sidebarDefaultCollapsedDescription": "상세 페이지 진입 시 왼쪽 사이드바를 접은 상태로 시작합니다.",
+    "notificationSection": "알림",
+    "notificationEnabled": "브라우저 알림",
+    "notificationEnabledDescription": "작업 상태 변경 시 브라우저 알림을 받습니다.",
+    "notificationStatusFilter": "알림 받을 상태",
+    "notificationStatusFilterDescription": "선택한 상태로 변경될 때만 알림을 받습니다."
   },
   "paneLayout": {
     "title": "Pane 레이아웃 설정",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -115,7 +115,12 @@
     "folderNavHint": "↑↓ 导航 · Tab 进入子文件夹 · Enter 选择 · Backspace 返回上级 · Esc 关闭",
     "detailPageSection": "详情页",
     "sidebarDefaultCollapsed": "默认折叠侧栏",
-    "sidebarDefaultCollapsedDescription": "进入详情页时左侧栏默认折叠。"
+    "sidebarDefaultCollapsedDescription": "进入详情页时左侧栏默认折叠。",
+    "notificationSection": "通知",
+    "notificationEnabled": "浏览器通知",
+    "notificationEnabledDescription": "任务状态变更时接收浏览器通知。",
+    "notificationStatusFilter": "通知状态",
+    "notificationStatusFilterDescription": "仅在任务变更为所选状态时接收通知。"
   },
   "paneLayout": {
     "title": "面板布局设置",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,6 +4,8 @@ import { setRequestLocale, getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { Inter } from "next/font/google";
 import { routing } from "@/i18n/routing";
+import NotificationListener from "@/components/NotificationListener";
+import { getNotificationSettings } from "@/app/actions/appSettings";
 import "../globals.css";
 
 const inter = Inter({
@@ -28,12 +30,19 @@ export default async function LocaleLayout({ children, params }: Props) {
   }
 
   setRequestLocale(locale);
-  const messages = await getMessages();
+  const [messages, notificationSettings] = await Promise.all([
+    getMessages(),
+    getNotificationSettings(),
+  ]);
 
   return (
     <html lang={locale}>
       <body suppressHydrationWarning className={`${inter.variable} font-sans bg-bg-page text-text-primary antialiased`}>
         <NextIntlClientProvider messages={messages}>
+          <NotificationListener
+            isNotificationEnabled={notificationSettings.isEnabled}
+            enabledStatuses={notificationSettings.enabledStatuses}
+          />
           {children}
         </NextIntlClientProvider>
       </body>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,17 +1,21 @@
 import Board from "@/components/Board";
 import { getTasksByStatus } from "@/app/actions/kanban";
 import { getAllProjects } from "@/app/actions/project";
-import { getSidebarDefaultCollapsed, getDoneAlertDismissed } from "@/app/actions/appSettings";
+import { getSidebarDefaultCollapsed, getDoneAlertDismissed, getNotificationSettings } from "@/app/actions/appSettings";
 import { getAvailableHosts } from "@/lib/sshConfig";
 
 export const dynamic = "force-dynamic";
 
 export default async function HomePage() {
-  const { tasks, doneTotal, doneLimit } = await getTasksByStatus();
-  const sshHosts = await getAvailableHosts();
-  const projects = await getAllProjects();
-  const sidebarDefaultCollapsed = await getSidebarDefaultCollapsed();
-  const doneAlertDismissed = await getDoneAlertDismissed();
+  const [{ tasks, doneTotal, doneLimit }, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings] =
+    await Promise.all([
+      getTasksByStatus(),
+      getAvailableHosts(),
+      getAllProjects(),
+      getSidebarDefaultCollapsed(),
+      getDoneAlertDismissed(),
+      getNotificationSettings(),
+    ]);
 
   return (
     <Board
@@ -22,6 +26,7 @@ export default async function HomePage() {
       projects={projects}
       sidebarDefaultCollapsed={sidebarDefaultCollapsed}
       doneAlertDismissed={doneAlertDismissed}
+      notificationSettings={notificationSettings}
     />
   );
 }

--- a/src/app/actions/appSettings.ts
+++ b/src/app/actions/appSettings.ts
@@ -5,6 +5,11 @@ import { getAppSettingsRepository } from "@/lib/database";
 
 const SIDEBAR_COLLAPSED_KEY = "sidebar_default_collapsed";
 const SIDEBAR_HINT_DISMISSED_KEY = "sidebar_hint_dismissed";
+const NOTIFICATION_ENABLED_KEY = "notification_enabled";
+const NOTIFICATION_STATUSES_KEY = "notification_statuses";
+
+/** 기본 알림 대상 상태 (사용자가 직접 설정하는 todo/done은 제외) */
+const DEFAULT_NOTIFICATION_STATUSES = ["progress", "pending", "review"];
 
 /**
  * 키로 앱 설정값을 조회한다.
@@ -69,4 +74,39 @@ export async function getDoneAlertDismissed(): Promise<boolean> {
 /** Done 이동 경고를 다시 묻지 않기로 설정한다 */
 export async function dismissDoneAlert(): Promise<void> {
   await setAppSetting(DONE_ALERT_DISMISSED_KEY, "true");
+}
+
+/** 알림 설정을 조회한다. 키가 없으면 기본값(전체 활성화)을 반환한다 */
+export async function getNotificationSettings(): Promise<{
+  isEnabled: boolean;
+  enabledStatuses: string[];
+}> {
+  const [enabledValue, statusesValue] = await Promise.all([
+    getAppSetting(NOTIFICATION_ENABLED_KEY),
+    getAppSetting(NOTIFICATION_STATUSES_KEY),
+  ]);
+
+  const isEnabled = enabledValue !== "false";
+  let enabledStatuses = DEFAULT_NOTIFICATION_STATUSES;
+  if (statusesValue) {
+    try {
+      enabledStatuses = JSON.parse(statusesValue);
+    } catch {
+      /* 파싱 실패 시 기본값 사용 */
+    }
+  }
+
+  return { isEnabled, enabledStatuses };
+}
+
+/** 알림 전역 활성화 상태를 저장한다 */
+export async function setNotificationEnabled(enabled: boolean): Promise<void> {
+  await setAppSetting(NOTIFICATION_ENABLED_KEY, String(enabled));
+  revalidatePath("/");
+}
+
+/** 알림 수신 대상 상태 목록을 저장한다 */
+export async function setNotificationStatuses(statuses: string[]): Promise<void> {
+  await setAppSetting(NOTIFICATION_STATUSES_KEY, JSON.stringify(statuses));
+  revalidatePath("/");
 }

--- a/src/app/api/hooks/status/route.ts
+++ b/src/app/api/hooks/status/route.ts
@@ -3,7 +3,7 @@ import { getTaskRepository, getProjectRepository } from "@/lib/database";
 import { TaskStatus } from "@/entities/KanbanTask";
 import { cleanupTaskResources } from "@/app/actions/kanban";
 import { revalidatePath } from "next/cache";
-import { broadcastBoardUpdate } from "@/lib/boardNotifier";
+import { broadcastBoardUpdate, broadcastTaskStatusChanged } from "@/lib/boardNotifier";
 
 const STATUS_MAP: Record<string, TaskStatus> = {
   todo: TaskStatus.TODO,
@@ -72,6 +72,13 @@ export async function POST(request: NextRequest) {
     const saved = await taskRepo.save(task);
     revalidatePath("/[locale]", "page");
     broadcastBoardUpdate();
+    broadcastTaskStatusChanged({
+      projectName,
+      branchName,
+      taskTitle: saved.title,
+      description: saved.description,
+      newStatus: taskStatus,
+    });
 
     return NextResponse.json({
       success: true,

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -25,6 +25,7 @@ interface BoardProps {
   projects: Project[];
   sidebarDefaultCollapsed: boolean;
   doneAlertDismissed: boolean;
+  notificationSettings: { isEnabled: boolean; enabledStatuses: string[] };
 }
 
 const COLUMNS: { status: TaskStatus; labelKey: string; colorClass: string }[] = [
@@ -86,7 +87,7 @@ function insertAtFilteredIndex(
   return arr;
 }
 
-export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed }: BoardProps) {
+export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings }: BoardProps) {
   useAutoRefresh();
   const t = useTranslations("board");
   const tt = useTranslations("task");
@@ -476,6 +477,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         projects={projects}
         sshHosts={sshHosts}
         sidebarDefaultCollapsed={sidebarDefaultCollapsed}
+        notificationSettings={notificationSettings}
       />
 
       {contextMenu.isOpen && contextMenu.task && (

--- a/src/components/NotificationListener.tsx
+++ b/src/components/NotificationListener.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useTaskNotification } from "@/hooks/useTaskNotification";
+
+const RECONNECT_DELAY_MS = 3000;
+
+interface NotificationListenerProps {
+  isNotificationEnabled: boolean;
+  enabledStatuses: string[];
+}
+
+/** 모든 페이지에서 WebSocket을 통해 task 상태 변경 알림을 수신하는 컴포넌트 */
+export default function NotificationListener({
+  isNotificationEnabled,
+  enabledStatuses,
+}: NotificationListenerProps) {
+  const { notifyTaskStatusChanged } = useTaskNotification();
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /** useEffect 내 stale closure 방지용 ref */
+  const settingsRef = useRef({ isNotificationEnabled, enabledStatuses });
+  settingsRef.current = { isNotificationEnabled, enabledStatuses };
+
+  useEffect(() => {
+    function connect() {
+      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+      const port = parseInt(window.location.port || "4885", 10) + 10000;
+      const wsUrl = `${protocol}//${window.location.hostname}:${port}/api/board/events`;
+
+      const ws = new WebSocket(wsUrl);
+      wsRef.current = ws;
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.type === "task-status-changed") {
+            console.debug("[WS] task-status-changed 수신:", data);
+
+            const { isNotificationEnabled: isEnabled, enabledStatuses: statuses } = settingsRef.current;
+            if (!isEnabled) return;
+            if (!statuses.includes(data.newStatus)) return;
+
+            const { projectName, branchName, taskTitle, description, newStatus } = data;
+            notifyTaskStatusChanged({ projectName, branchName, taskTitle, description, newStatus });
+          }
+        } catch {
+          /* 파싱 실패 무시 */
+        }
+      };
+
+      ws.onclose = () => {
+        wsRef.current = null;
+        reconnectTimerRef.current = setTimeout(connect, RECONNECT_DELAY_MS);
+      };
+
+      ws.onerror = () => {
+        ws.close();
+      };
+    }
+
+    connect();
+
+    return () => {
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+      }
+      wsRef.current?.close();
+    };
+  }, [notifyTaskStatusChanged]);
+
+  return null;
+}

--- a/src/components/__tests__/NotificationListener.test.tsx
+++ b/src/components/__tests__/NotificationListener.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+
+// --- Mocks ---
+
+const mockNotifyTaskStatusChanged = vi.fn();
+
+vi.mock("@/hooks/useTaskNotification", () => ({
+  useTaskNotification: () => ({
+    notifyTaskStatusChanged: mockNotifyTaskStatusChanged,
+  }),
+}));
+
+/** WebSocket 목 클래스. 인스턴스를 추적하여 테스트에서 메시지 수신을 시뮬레이션한다 */
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = vi.fn();
+
+  constructor() {
+    MockWebSocket.instances.push(this);
+  }
+}
+
+vi.stubGlobal("WebSocket", MockWebSocket);
+
+/** 테스트용 기본 props (전체 상태 알림 활성화) */
+const defaultProps = {
+  isNotificationEnabled: true,
+  enabledStatuses: ["todo", "progress", "pending", "review", "done"],
+};
+
+describe("NotificationListener", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockNotifyTaskStatusChanged.mockClear();
+    MockWebSocket.instances = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("should call notifyTaskStatusChanged when receiving task-status-changed message", async () => {
+    // Given
+    const { default: NotificationListener } = await import("@/components/NotificationListener");
+    render(<NotificationListener {...defaultProps} />);
+    const ws = MockWebSocket.instances[0];
+
+    const wsMessage = {
+      type: "task-status-changed",
+      projectName: "kanvibe",
+      branchName: "feat/test",
+      taskTitle: "테스트",
+      description: null,
+      newStatus: "review",
+    };
+
+    // When
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify(wsMessage),
+      } as MessageEvent);
+    });
+
+    // Then — type 필드는 destructuring에서 제외되어 전달되지 않음
+    const { type: _, ...expectedPayload } = wsMessage;
+    expect(mockNotifyTaskStatusChanged).toHaveBeenCalledWith(expectedPayload);
+  });
+
+  it("should not call notifyTaskStatusChanged for board-updated messages", async () => {
+    // Given
+    const { default: NotificationListener } = await import("@/components/NotificationListener");
+    render(<NotificationListener {...defaultProps} />);
+    const ws = MockWebSocket.instances[0];
+
+    // When
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({ type: "board-updated" }),
+      } as MessageEvent);
+    });
+
+    // Then
+    expect(mockNotifyTaskStatusChanged).not.toHaveBeenCalled();
+  });
+
+  it("should attempt reconnection after WebSocket close", async () => {
+    // Given
+    vi.useFakeTimers();
+    const { default: NotificationListener } = await import("@/components/NotificationListener");
+    render(<NotificationListener {...defaultProps} />);
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    // When
+    act(() => {
+      MockWebSocket.instances[0].onclose?.();
+    });
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    // Then
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    vi.useRealTimers();
+  });
+
+  it("should close WebSocket connection on unmount", async () => {
+    // Given
+    const { default: NotificationListener } = await import("@/components/NotificationListener");
+    const { unmount } = render(<NotificationListener {...defaultProps} />);
+    const ws = MockWebSocket.instances[0];
+
+    // When
+    unmount();
+
+    // Then
+    expect(ws.close).toHaveBeenCalled();
+  });
+
+  it("should not notify when isNotificationEnabled is false", async () => {
+    // Given
+    const { default: NotificationListener } = await import("@/components/NotificationListener");
+    render(
+      <NotificationListener isNotificationEnabled={false} enabledStatuses={["progress", "review"]} />
+    );
+    const ws = MockWebSocket.instances[0];
+
+    // When
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "task-status-changed",
+          projectName: "kanvibe",
+          branchName: "feat/test",
+          taskTitle: "테스트",
+          description: null,
+          newStatus: "review",
+        }),
+      } as MessageEvent);
+    });
+
+    // Then
+    expect(mockNotifyTaskStatusChanged).not.toHaveBeenCalled();
+  });
+
+  it("should not notify when newStatus is not in enabledStatuses", async () => {
+    // Given
+    const { default: NotificationListener } = await import("@/components/NotificationListener");
+    render(
+      <NotificationListener isNotificationEnabled={true} enabledStatuses={["progress", "review"]} />
+    );
+    const ws = MockWebSocket.instances[0];
+
+    // When
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "task-status-changed",
+          projectName: "kanvibe",
+          branchName: "feat/test",
+          taskTitle: "테스트",
+          description: null,
+          newStatus: "pending",
+        }),
+      } as MessageEvent);
+    });
+
+    // Then
+    expect(mockNotifyTaskStatusChanged).not.toHaveBeenCalled();
+  });
+
+  it("should render nothing", async () => {
+    // Given
+    const { default: NotificationListener } = await import("@/components/NotificationListener");
+
+    // When
+    const { container } = render(<NotificationListener {...defaultProps} />);
+
+    // Then
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/src/hooks/__tests__/useTaskNotification.test.ts
+++ b/src/hooks/__tests__/useTaskNotification.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, cleanup, act } from "@testing-library/react";
+
+// --- Mocks ---
+
+const mockNotification = vi.fn();
+
+vi.stubGlobal("Notification", Object.assign(mockNotification, {
+  permission: "granted",
+  requestPermission: vi.fn().mockResolvedValue("granted"),
+}));
+
+describe("useTaskNotification", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockNotification.mockClear();
+    (Notification as unknown as { permission: string }).permission = "granted";
+    (Notification.requestPermission as ReturnType<typeof vi.fn>).mockResolvedValue("granted");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("should create notification with correct title and body when permission is granted", async () => {
+    // Given
+    const { useTaskNotification } = await import("@/hooks/useTaskNotification");
+    const { result } = renderHook(() => useTaskNotification());
+
+    // When
+    act(() => {
+      result.current.notifyTaskStatusChanged({
+        projectName: "kanvibe",
+        branchName: "feat/login",
+        taskTitle: "로그인 구현",
+        description: "OAuth 연동",
+        newStatus: "review",
+      });
+    });
+
+    // Then
+    expect(mockNotification).toHaveBeenCalledWith(
+      "kanvibe — feat/login",
+      { body: "로그인 구현: review로 변경\nOAuth 연동" }
+    );
+  });
+
+  it("should omit description from body when description is null", async () => {
+    // Given
+    const { useTaskNotification } = await import("@/hooks/useTaskNotification");
+    const { result } = renderHook(() => useTaskNotification());
+
+    // When
+    act(() => {
+      result.current.notifyTaskStatusChanged({
+        projectName: "kanvibe",
+        branchName: "feat/test",
+        taskTitle: "테스트 작업",
+        description: null,
+        newStatus: "progress",
+      });
+    });
+
+    // Then
+    expect(mockNotification).toHaveBeenCalledWith(
+      "kanvibe — feat/test",
+      { body: "테스트 작업: progress로 변경" }
+    );
+  });
+
+  it("should not create notification when permission is denied", async () => {
+    // Given
+    (Notification as unknown as { permission: string }).permission = "denied";
+    const { useTaskNotification } = await import("@/hooks/useTaskNotification");
+    const { result } = renderHook(() => useTaskNotification());
+
+    // When
+    act(() => {
+      result.current.notifyTaskStatusChanged({
+        projectName: "kanvibe",
+        branchName: "feat/test",
+        taskTitle: "테스트",
+        description: null,
+        newStatus: "done",
+      });
+    });
+
+    // Then
+    expect(mockNotification).not.toHaveBeenCalled();
+  });
+
+  it("should request permission when permission is default", async () => {
+    // Given
+    (Notification as unknown as { permission: string }).permission = "default";
+    const { useTaskNotification } = await import("@/hooks/useTaskNotification");
+
+    // When
+    renderHook(() => useTaskNotification());
+
+    // Then
+    expect(Notification.requestPermission).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useTaskNotification.ts
+++ b/src/hooks/useTaskNotification.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useCallback, useRef } from "react";
+
+export interface TaskStatusNotification {
+  projectName: string;
+  branchName: string;
+  taskTitle: string;
+  description: string | null;
+  newStatus: string;
+}
+
+/** hooks 경유 task 상태 변경 시 Browser Notification을 발송하는 훅 */
+export function useTaskNotification() {
+  const isPermissionGranted = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("Notification" in window)) return;
+
+    if (Notification.permission === "granted") {
+      isPermissionGranted.current = true;
+    } else if (Notification.permission !== "denied") {
+      Notification.requestPermission().then((permission) => {
+        isPermissionGranted.current = permission === "granted";
+      });
+    }
+  }, []);
+
+  const notifyTaskStatusChanged = useCallback(
+    (payload: TaskStatusNotification) => {
+      if (!isPermissionGranted.current) return;
+
+      const title = `${payload.projectName} — ${payload.branchName}`;
+      const bodyParts = [`${payload.taskTitle}: ${payload.newStatus}로 변경`];
+      if (payload.description) {
+        bodyParts.push(payload.description);
+      }
+
+      new Notification(title, { body: bodyParts.join("\n") });
+    },
+    []
+  );
+
+  return { notifyTaskStatusChanged };
+}

--- a/src/lib/__tests__/boardNotifier.test.ts
+++ b/src/lib/__tests__/boardNotifier.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// --- Mocks ---
+
+const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+vi.stubGlobal("fetch", mockFetch);
+
+describe("boardNotifier", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should send board-updated message via internal broadcast endpoint", async () => {
+    // Given
+    const { broadcastBoardUpdate } = await import("@/lib/boardNotifier");
+
+    // When
+    broadcastBoardUpdate();
+
+    // Then
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/_internal/broadcast"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ type: "board-updated" }),
+      })
+    );
+  });
+
+  it("should send task-status-changed message with payload via internal broadcast endpoint", async () => {
+    // Given
+    const { broadcastTaskStatusChanged } = await import("@/lib/boardNotifier");
+    const payload = {
+      projectName: "kanvibe",
+      branchName: "feat/test",
+      taskTitle: "테스트 작업",
+      description: "설명",
+      newStatus: "review",
+    };
+
+    // When
+    broadcastTaskStatusChanged(payload);
+
+    // Then
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/_internal/broadcast"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ type: "task-status-changed", ...payload }),
+      })
+    );
+  });
+
+  it("should include description as null in payload when not provided", async () => {
+    // Given
+    const { broadcastTaskStatusChanged } = await import("@/lib/boardNotifier");
+
+    // When
+    broadcastTaskStatusChanged({
+      projectName: "test",
+      branchName: "main",
+      taskTitle: "작업",
+      description: null,
+      newStatus: "done",
+    });
+
+    // Then
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.description).toBeNull();
+    expect(body.type).toBe("task-status-changed");
+  });
+
+  it("should silently catch fetch errors", async () => {
+    // Given
+    mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+    const { broadcastBoardUpdate } = await import("@/lib/boardNotifier");
+
+    // When & Then
+    expect(() => broadcastBoardUpdate()).not.toThrow();
+  });
+});

--- a/src/lib/boardNotifier.ts
+++ b/src/lib/boardNotifier.ts
@@ -11,12 +11,41 @@ export function removeBoardClient(ws: WebSocket) {
   boardClients.delete(ws);
 }
 
+/** server.ts에서 직접 WS 클라이언트에 접근할 때 사용한다 */
+export function getBoardClients(): Set<WebSocket> {
+  return boardClients;
+}
+
+const BROADCAST_URL = `http://localhost:${process.env.PORT || 4885}/_internal/broadcast`;
+
+/**
+ * 내부 HTTP 요청으로 custom server에 broadcast를 위임한다.
+ * Turbopack이 API route를 별도 워커에서 실행하므로 in-memory Set이 공유되지 않는다.
+ */
+function sendBroadcast(message: string) {
+  fetch(BROADCAST_URL, {
+    method: "POST",
+    body: message,
+    headers: { "Content-Type": "application/json" },
+  }).catch(() => {
+    /* 연결 실패 무시 (서버 시작 전 등) */
+  });
+}
+
 /** 연결된 모든 보드 클라이언트에 업데이트 알림을 전송한다 */
 export function broadcastBoardUpdate() {
-  const message = JSON.stringify({ type: "board-updated" });
-  for (const client of boardClients) {
-    if (client.readyState === client.OPEN) {
-      client.send(message);
-    }
-  }
+  sendBroadcast(JSON.stringify({ type: "board-updated" }));
+}
+
+export interface TaskStatusChangedPayload {
+  projectName: string;
+  branchName: string;
+  taskTitle: string;
+  description: string | null;
+  newStatus: string;
+}
+
+/** hooks 경유 상태 변경 시 task 상세 정보를 포함하여 브로드캐스트한다 */
+export function broadcastTaskStatusChanged(payload: TaskStatusChangedPayload) {
+  sendBroadcast(JSON.stringify({ type: "task-status-changed", ...payload }));
 }


### PR DESCRIPTION
## 관련 자료
- [작업 계획 - 브라우저 알림](.claude/plan/notification/2602/17-browser-notification-on-hooks-status.plan.md)
- [작업 계획 - 알림 설정 UI](.claude/plan/notification/2602/17-notification-settings-ui.plan.md)

## 어떤 작업인가요?
- Claude Code Hooks를 통한 태스크 상태 변경 시 브라우저 알림(Chrome Notification)을 발송하고, 사용자가 알림 수신 여부 및 대상 상태를 설정할 수 있는 UI를 추가합니다.

## 어떻게 해결했나요?
**1. WebSocket 기반 브라우저 알림 발송**
- hooks/status API에서 상태 변경 시 WebSocket으로 `task-status-changed` 이벤트 브로드캐스트
- 클라이언트에서 WebSocket 메시지 수신 시 Browser Notification API로 알림 표시
- 자동 재연결 로직 포함

**2. 알림 설정 UI**
- 기존 ProjectSettings 패널 내에 알림 설정 섹션 추가
- 전역 알림 토글 + 상태별 칩 필터(Progress, Pending, Review)
- AppSettings DB에 설정 저장 (별도 마이그레이션 불필요)

**3. 테스트 코드 작성**
- NotificationListener, useTaskNotification, boardNotifier에 대한 단위 테스트 추가

## 중요한 변경 사항은 무엇인가요?
### WebSocket 브로드캐스트

**boardNotifier에 task-status-changed 이벤트 추가**
- **변경 이유**: 기존 `board-updated` 이벤트와 별도로, 알림에 필요한 상세 정보(프로젝트명, 브랜치명, 태스크 제목, 상태)를 포함한 이벤트 필요
- **수정 파일**: `src/lib/boardNotifier.ts`, `server.ts`

**hooks/status API에서 상태 변경 시 알림 브로드캐스트**
- **변경 이유**: Claude Code Hooks가 상태를 변경할 때 클라이언트에 실시간 알림 전달
- **수정 파일**: `src/app/api/hooks/status/route.ts`

### 클라이언트 알림 처리

**NotificationListener 컴포넌트**
- **변경 이유**: WebSocket 메시지를 수신하여 Browser Notification API로 알림을 표시하는 전역 컴포넌트
- **수정 파일**: `src/components/NotificationListener.tsx`, `src/app/[locale]/layout.tsx`

**useTaskNotification 훅**
- **변경 이유**: Notification 권한 요청 및 알림 표시 로직을 재사용 가능한 훅으로 분리
- **수정 파일**: `src/hooks/useTaskNotification.ts`

### 알림 설정 UI

**ProjectSettings에 알림 섹션 추가**
- **변경 이유**: 사용자가 알림 수신 여부와 대상 상태를 직접 설정할 수 있도록 UI 제공
- **수정 파일**: `src/components/ProjectSettings.tsx`, `src/app/actions/appSettings.ts`

**설정 데이터 전달 체인**
- **변경 이유**: 서버에서 알림 설정을 로드하여 layout → NotificationListener, page → Board → ProjectSettings로 전달
- **수정 파일**: `src/app/[locale]/layout.tsx`, `src/app/[locale]/page.tsx`, `src/components/Board.tsx`

### i18n 및 문서

**번역 키 추가**
- **변경 이유**: 알림 설정 UI의 다국어 지원
- **수정 파일**: `messages/ko.json`, `messages/en.json`, `messages/zh.json`

**README 업데이트**
- **변경 이유**: 새 기능에 대한 사용자 문서 추가
- **수정 파일**: `README.md`, `docs/README.ko.md`, `docs/README.zh.md`
