### PR TITLE
feat(task): 프로젝트 배지 색상 통일 및 브랜치 작업 네비게이션 추가

### DIFF
--- a/.claude/plan/ui/2602/17-project-branch-task-navigation.plan.md
+++ b/.claude/plan/ui/2602/17-project-branch-task-navigation.plan.md
@@ -1,0 +1,231 @@
+# 프로젝트 이름 색상 변경 및 브랜치 작업 네비게이션
+
+## Business Goal
+Task Detail 페이지에서 프로젝트 이름을 더 진하고 가시성 높은 색상(#202632)으로 표시하고, 브랜치 이름을 클릭할 수 있게 만들어 같은 프로젝트의 다른 작업들을 빠르게 탐색할 수 있도록 개선한다.
+
+## Scope
+- **In Scope**:
+  - 설계 시스템 토큰에 새로운 프로젝트 배경색 추가 (#202632)
+  - Task Detail 페이지 메타데이터에 브랜치 이름 섹션 추가
+  - 브랜치 이름 옆에 오른쪽 화살표(→) 아이콘 버튼 추가
+  - 클릭 시 같은 프로젝트의 모든 작업을 브랜치별로 그룹화한 칸반 다이얼로그 표시
+  - 다이얼로그에서 브랜치/작업 선택 후 해당 작업으로 이동
+
+- **Out of Scope**:
+  - 기존 브랜치 이름 태그의 스타일 변경 (현재 gray.100 유지)
+  - 보드 페이지의 TaskCard 컴포넌트 수정
+  - 새로운 API 엔드포인트 추가
+
+## Codebase Analysis Summary
+
+### 설계 시스템
+- 토큰: `prd/design-system.json`에서 정의, `src/app/globals.css`의 CSS 변수로 구현
+- 프로젝트 태그: 현재 `yellow.50` 배경(`#FEF7E0`), `gray.800` 텍스트(`#424242`)
+- 새로운 색상 #202632는 text.primary와 유사한 진한 회색
+
+### Task Detail Page
+- 파일: `src/app/[locale]/task/[id]/page.tsx` (서버 컴포넌트)
+- 메타데이터 섹션: line 126-206, `<dl>` 구조로 정보 표시
+- 현재 표시 정보: project, priority, prUrl, agentType, sessionType, sshHost, createdAt, updatedAt
+- `task.branchName` 필드 존재하지만 아직 UI에 표시되지 않음
+
+### 기존 Dialog 패턴
+- BranchTaskModal: 브랜치 분기 모달 사용 (`src/components/BranchTaskModal.tsx`)
+- 고정 오버레이(`z-[400]`), 중앙 정렬, shadow/border 스타일
+- form 기반으로 구현되어 있음
+
+### Task 데이터 구조
+- `KanbanTask` 엔티티: `branchName`, `projectId`, `baseBranch`, `project` (관계) 필드
+- Board에서 같은 프로젝트의 작업들을 필터링하는 로직 이미 존재 (projectNameMap, projectFilterSet)
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `prd/design-system.json` | 설계 토큰 정의 | Modify - 프로젝트 배경색 토큰 추가 |
+| `src/app/globals.css` | CSS 변수 선언 | Modify - 새 색상 변수 추가 |
+| `src/app/[locale]/task/[id]/page.tsx` | Task Detail 페이지 | Modify - 메타데이터에 브랜치 섹션 추가, 모달 상태 관리 추가 |
+| `src/components/ProjectBranchTasksModal.tsx` | 새 모달 컴포넌트 | Create - 같은 프로젝트 작업 브랜치별 표시 |
+| `src/app/actions/kanban.ts` | 작업 조회 로직 | Reference - getTasksByProjectId 함수 확인 |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 색상 토큰 네이밍 | design-system.json | `tags.project.background` 형식으로 정의 |
+| 컴포넌트 파일명 | 기존 컴포넌트들 | PascalCase, .tsx 확장자 |
+| 클라이언트 컴포넌트 | 기존 모달들 | `"use client"` 지시문 필수 |
+| CSS 클래스 | tailwind + design-system | `bg-tag-project-bg` 같은 시맨틱 클래스 사용 |
+| 주석 | CODE_PRINCIPLES.md | 한국어로 작성, JSDoc 형식 |
+| 상태 관리 | Task Detail | useState/useTransition으로 모달 열기/닫기 |
+| i18n | next-intl | `useTranslations()` 훅 사용 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 색상 저장 방식 | 설계 토큰 추가 후 Tailwind arbitrary로 적용 | 일관성 유지, 다른 토큰과 동일 방식 | 직접 hex 색상 사용 (권장 안 함) |
+| 모달 컴포넌트 위치 | `src/components/ProjectBranchTasksModal.tsx` | 기존 모달들과 같은 위치 | ProjectBranchTasksDialog.tsx (naming) |
+| 모달 표시 방식 | 고정 오버레이 + 중앙 정렬 | 기존 BranchTaskModal과 동일 패턴 | Drawer/Sidebar (다른 UX) |
+| 브랜치별 그룹화 | Map<branchName, KanbanTask[]> 구조 | 프론트엔드에서 처리, 간단하고 효율적 | 백엔드 정렬 (불필요한 복잡성) |
+| 작업 조회 | 클라이언트에서 same projectId 필터링 | 기존 Board 로직과 동일 패턴 | API 엔드포인트 추가 (과설계) |
+
+## Implementation Todos
+
+### Todo 1: 설계 시스템 토큰 및 CSS 변수 업데이트
+- **Priority**: 1 (독립적)
+- **Dependencies**: none
+- **Goal**: 프로젝트 배경색을 #202632로 변경하여 설계 시스템에 반영
+- **Work**:
+  - `prd/design-system.json` 열기
+  - `colors.tags.project` 객체의 `background` 값을 `"#202632"`로 변경 (현재: `"{yellow.50}"`)
+  - `src/app/globals.css`의 `:root` 섹션에서 `--color-tag-project-bg: var(--color-yellow-50);` 줄을 `--color-tag-project-bg: #202632;`로 변경
+  - Tailwind @theme inline 블록 확인 (자동 생성되므로 수정 불필요)
+- **Convention Notes**:
+  - design-system.json은 시맨틱 참조 형식 지원 → primitive 색상 참조 가능하지만 직접 hex도 가능
+  - CSS 변수명은 기존 규칙 유지: `--color-tag-project-bg`
+- **Verification**:
+  - design-system.json 문법 검증 (JSON 유효성)
+  - globals.css 문법 검증 (CSS 유효성)
+  - 빌드 성공 확인: `pnpm build`
+  - 색상 변경 시각 확인 (브라우저에서 프로젝트 태그 색상이 #202632로 표시되는지)
+- **Exit Criteria**:
+  - 파일 수정 완료
+  - 빌드 성공
+  - task detail 페이지 프로젝트 태그가 어두운 회색(#202632) 배경으로 표시됨
+
+### Todo 2: ProjectBranchTasksModal 컴포넌트 생성
+- **Priority**: 1 (독립적)
+- **Dependencies**: none
+- **Goal**: 같은 프로젝트의 모든 작업을 브랜치별로 그룹화하여 표시하는 모달 컴포넌트 구현
+- **Work**:
+  - 새 파일 `src/components/ProjectBranchTasksModal.tsx` 생성
+  - `"use client"` 지시문 추가
+  - Props 타입: `{ projectId: string; currentBranchName: string | null; tasks: KanbanTask[]; onClose: () => void; onSelectTask: (taskId: string) => void; }`
+  - 모달 구조:
+    - 고정 오버레이: `z-[400]`, `bg-bg-overlay`, 클릭 시 닫기
+    - 모달 본체: `max-w-2xl`, `bg-bg-surface`, `rounded-xl`, `border-border-default`, `shadow-lg`
+    - 헤더: 제목 "프로젝트 작업 목록" (i18n), 닫기 버튼
+    - 본문: 브랜치별 섹션으로 그룹화
+      - `Map<branchName, KanbanTask[]>` 구조로 그룹화
+      - 각 브랜치마다 `<details>` 또는 `<div className="mb-4">` 섹션
+      - 브랜치명 표시: `<span className="text-sm font-semibold text-text-primary">`
+      - 작업 목록: TaskCard 컴포넌트 재사용 또는 간단한 리스트 (링크 클릭 시 `onSelectTask(taskId)` 호출)
+  - 국제화: `useTranslations("projectBranchTasks")` 사용
+  - 스타일: 기존 BranchTaskModal 스타일과 일관성
+- **Convention Notes**:
+  - 컴포넌트 네이밍: `ProjectBranchTasksModal` (모달 타입 명시)
+  - Props는 명확하게 named parameters
+  - 브랜치별 그룹화는 프론트엔드에서 수행 (단순성)
+  - TaskCard 재사용이 과할 수 있으니, 간단한 리스트 구조 추천 (projectName 표시 불필요)
+- **Verification**:
+  - TypeScript 컴파일 성공
+  - 모달이 열릴 때 정상 렌더링 (console 에러 없음)
+  - 같은 프로젝트의 작업들이 브랜치별로 그룹화되어 표시됨
+  - 작업 클릭 시 `onSelectTask` 호출 확인 (개발자 도구)
+- **Exit Criteria**:
+  - 파일 생성 완료
+  - 컴포넌트 컴파일 성공
+  - 모달 구조 시각 확인 (브라우저에서)
+
+### Todo 3: Task Detail 페이지 메타데이터에 브랜치 섹션 추가
+- **Priority**: 2 (depends on Todo 1)
+- **Dependencies**: Todo 1
+- **Goal**: Task Detail 페이지의 메타데이터 카드에 브랜치 이름 정보를 추가하고 모달 열기 기능 구현
+- **Work**:
+  - `src/app/[locale]/task/[id]/page.tsx` 파일 수정
+  - **서버 컴포넌트 부분** (기존):
+    - 변경 없음 (task.branchName은 이미 필드로 존재)
+  - **메타데이터 섹션** (line 126-206):
+    - `{task.prUrl && ...}` 블록 뒤에, 새로운 섹션 추가:
+    ```tsx
+    {task.branchName && (
+      <div className="flex items-center justify-between gap-2">
+        <dt className="text-xs text-text-muted">{t("branch")}</dt>
+        <dd className="flex items-center gap-2">
+          <span className="text-xs px-2 py-0.5 rounded-full bg-tag-branch-bg text-tag-branch-text font-medium">
+            {task.branchName}
+          </span>
+          <button
+            onClick={() => setShowBranchTasksModal(true)}
+            className="text-text-secondary hover:text-text-primary transition-colors"
+            aria-label="View other tasks in this project"
+            title="다른 작업 보기"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M6 12L10 8L6 4" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </button>
+        </dd>
+      </div>
+    )}
+    ```
+  - 메타데이터 섹션 상단에 상태 선언 필요: `const [showBranchTasksModal, setShowBranchTasksModal] = useState(false);`
+  - 메타데이터 카드 하단에 모달 렌더링: `{showBranchTasksModal && <ProjectBranchTasksModal ... />}`
+  - 이를 위해 "use client" 지시문이 필요하므로 클라이언트 래퍼 컴포넌트 고려
+- **Convention Notes**:
+  - 서버/클라이언트 컴포넌트 분리 고려: 기존 page.tsx는 서버 컴포넌트이므로, TaskDetailSidebar 같은 클라이언트 컴포넌트로 메타데이터 섹션 분리 가능
+  - 또는 상태 관리를 위해 기존 page.tsx를 클라이언트 컴포넌트로 변경 (이미 form/state 사용 중이므로 가능)
+  - 화살표 아이콘: SVG 직접 구현 (기존 TaskCard의 PR 아이콘 스타일 참고)
+  - 국제화: `t("branch")`, `t("viewOtherTasks")` 등 필요
+- **Verification**:
+  - Task Detail 페이지 열기
+  - branchName이 있는 작업에서 "Branch" 메타데이터 섹션 표시 확인
+  - 화살표 버튼 클릭 가능성 확인
+  - console 에러 없음
+- **Exit Criteria**:
+  - 메타데이터 섹션에 브랜치 이름이 tag 형식으로 표시됨
+  - 오른쪽 화살표(→) 아이콘이 브랜치명 옆에 표시됨
+  - 버튼이 클릭 가능한 상태 (hover 효과 포함)
+
+### Todo 4: ProjectBranchTasksModal 통합 및 네비게이션 완성
+- **Priority**: 2 (depends on Todo 2, 3)
+- **Dependencies**: Todo 2, 3
+- **Goal**: 모달이 정상 작동하며 작업 선택 시 해당 페이지로 이동
+- **Work**:
+  - Task Detail page에 ProjectBranchTasksModal import: `import ProjectBranchTasksModal from "@/components/ProjectBranchTasksModal";`
+  - 모달 렌더링 위치: 메타데이터 카드 하단 또는 사이드바 끝
+  - Props 전달:
+    - `projectId={task.projectId || ""}`
+    - `currentBranchName={task.branchName}`
+    - `tasks={initialTasks}` (page에서 받은 initialTasks 사용) 또는 API 호출로 다시 조회
+    - `onClose={() => setShowBranchTasksModal(false)}`
+    - `onSelectTask={(taskId) => { router.push(`/task/${taskId}`); }}`
+  - 라우터 import: `import { useRouter } from "@/i18n/navigation";`
+  - initialTasks 필터링: 같은 projectId를 가진 작업만 전달
+  - 모달 열기: `{showBranchTasksModal && task.projectId && <ProjectBranchTasksModal ... />}`
+- **Convention Notes**:
+  - 클라이언트/서버 경계: 필요 시 기존 page.tsx를 클라이언트 컴포넌트로 변경 또는 래퍼 생성
+  - 네비게이션: `useRouter().push()` 사용 (next/navigation 대신 @/i18n/navigation)
+  - 작업 목록: initialTasks에서 필터링하여 사용 (효율성)
+- **Verification**:
+  - 모달 열기 성공
+  - 같은 프로젝트의 모든 작업이 모달에 표시됨
+  - 작업 클릭 시 해당 Task Detail 페이지로 이동
+  - 뒤로가기 버튼으로 이전 페이지 돌아오기 가능
+  - 화살표 아이콘 호버 시 커서 변경
+- **Exit Criteria**:
+  - 모달이 완전히 작동함
+  - 작업 선택 후 해당 페이지로 이동 성공
+  - UI 일관성 확인 (색상, 텍스트, 레이아웃)
+
+## Verification Strategy
+전체 구현 완료 후 검증:
+1. **빌드 성공**: `pnpm build` - TypeScript 컴파일 에러 없음
+2. **색상 변경**: Task Detail 페이지에서 프로젝트 태그 배경색이 #202632(진한 회색)로 표시됨
+3. **브랜치 표시**: branchName이 있는 작업의 메타데이터에 "Branch" 섹션 표시
+4. **모달 열기**: 화살표 아이콘 클릭 시 모달 오픈
+5. **모달 콘텐츠**: 같은 프로젝트의 작업들이 브랜치별로 그룹화되어 표시됨
+6. **네비게이션**: 모달 내 작업 클릭 시 해당 Task Detail 페이지로 이동
+7. **UI 일관성**: 기존 모달/컴포넌트와 스타일 일치
+8. **i18n**: 한국어/영어/중국어 모두 표시 확인 (번역 추가 필요)
+
+## Progress Tracking
+- Total Todos: 4
+- Completed: 4
+- Status: Execution complete
+
+## Change Log
+- 2026-02-17: Plan created
+- 2026-02-17: All todos executed successfully
+  - Todo 1: Design system color token updated (#202632)
+  - Todo 2: ProjectBranchTasksModal component created
+  - Todo 3: TaskDetailInfoCard created with branch section
+  - Todo 4: Modal integration, navigation, and i18n translations added

--- a/messages/en.json
+++ b/messages/en.json
@@ -203,5 +203,9 @@
     "expandSidebar": "Expand sidebar",
     "sidebarTooltip": "You can change the default state in Settings",
     "dismissHint": "Don't show again"
+  },
+  "projectBranchTasks": {
+    "title": "Project Tasks",
+    "noTasks": "No tasks in this project"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -203,5 +203,9 @@
     "expandSidebar": "사이드바 펼치기",
     "sidebarTooltip": "설정에서 기본 접힘 상태를 변경할 수 있습니다",
     "dismissHint": "다시 보지 않기"
+  },
+  "projectBranchTasks": {
+    "title": "프로젝트 작업",
+    "noTasks": "이 프로젝트에는 작업이 없습니다"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -203,5 +203,9 @@
     "expandSidebar": "展开侧栏",
     "sidebarTooltip": "可以在设置中更改默认折叠状态",
     "dismissHint": "不再显示"
+  },
+  "projectBranchTasks": {
+    "title": "项目任务",
+    "noTasks": "此项目中没有任务"
   }
 }

--- a/prd/design-system.json
+++ b/prd/design-system.json
@@ -125,7 +125,7 @@
       },
       "session": { "background": "{blue.50}", "text": "{blue.600}" },
       "ssh": { "background": "{green.50}", "text": "{green.600}" },
-      "project": { "background": "{yellow.50}", "text": "{gray.800}" },
+      "project": { "background": "#202632", "text": "{white}" },
       "branch": { "background": "{gray.100}", "text": "{gray.700}" },
       "neutral": { "background": "{gray.100}", "text": "{gray.600}" },
       "base": { "background": "#EDE7F6", "text": "#5E35B1" }

--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -9,14 +9,14 @@ import {
 } from "@/app/actions/kanban";
 import { TaskStatus } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
-import TaskStatusBadge from "@/components/TaskStatusBadge";
-import PriorityEditor from "@/components/PriorityEditor";
 import TerminalLoader from "@/components/TerminalLoader";
 import ConnectTerminalForm from "@/components/ConnectTerminalForm";
 import DeleteTaskButton from "@/components/DeleteTaskButton";
 import DoneStatusButton from "@/components/DoneStatusButton";
 import HooksStatusCard from "@/components/HooksStatusCard";
 import CollapsibleSidebar from "@/components/CollapsibleSidebar";
+import TaskDetailTitleCard from "@/components/TaskDetailTitleCard";
+import TaskDetailInfoCard from "@/components/TaskDetailInfoCard";
 import { getTaskHooksStatus, getTaskGeminiHooksStatus, getTaskCodexHooksStatus } from "@/app/actions/project";
 import { getSidebarDefaultCollapsed, getSidebarHintDismissed, getDoneAlertDismissed } from "@/app/actions/appSettings";
 import { Link } from "@/i18n/navigation";
@@ -108,104 +108,9 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
           {t("backToBoard")}
         </Link>
 
-        {/* 제목 + 상태 카드 */}
-        <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
-          <div className="flex items-center gap-2 mb-3">
-            <TaskStatusBadge status={task.status} />
-          </div>
-          <h1 className="text-xl font-bold text-text-primary leading-tight">
-            {task.title}
-          </h1>
-          {task.description && (
-            <p className="text-sm text-text-secondary mt-3 leading-relaxed">
-              {task.description}
-            </p>
-          )}
-        </div>
+        <TaskDetailTitleCard task={task} />
 
-        {/* 메타데이터 카드 */}
-        <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
-          <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-4">
-            {t("info")}
-          </h3>
-          <dl className="space-y-3">
-            {task.project && (
-              <div className="flex items-center justify-between gap-2">
-                <dt className="text-xs text-text-muted">{t("project")}</dt>
-                <dd className="text-xs px-2 py-0.5 rounded-full font-medium bg-tag-project-bg text-tag-project-text truncate max-w-[160px]">
-                  {task.project.name}
-                </dd>
-              </div>
-            )}
-            <div className="flex items-center justify-between gap-2">
-              <dt className="text-xs text-text-muted">{t("priority")}</dt>
-              <dd>
-                <PriorityEditor taskId={task.id} currentPriority={task.priority} />
-              </dd>
-            </div>
-            {task.prUrl && (
-              <div className="flex items-center justify-between gap-2">
-                <dt className="text-xs text-text-muted">{t("prLink")}</dt>
-                <dd>
-                  <a
-                    href={task.prUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-xs bg-tag-pr-bg text-tag-pr-text px-2 py-0.5 rounded hover:opacity-80 transition-opacity"
-                  >
-                    <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-                      <path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
-                    </svg>
-                    PR
-                    <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                      <path d="M4 12L12 4M12 4H6M12 4v6" strokeLinecap="round" strokeLinejoin="round"/>
-                    </svg>
-                  </a>
-                </dd>
-              </div>
-            )}
-            {task.agentType && (
-              <div className="flex items-center justify-between gap-2">
-                <dt className="text-xs text-text-muted">{t("agent")}</dt>
-                <dd
-                  className={`text-xs px-2 py-0.5 rounded-full font-medium ${agentTagStyle}`}
-                >
-                  {task.agentType}
-                </dd>
-              </div>
-            )}
-            {task.sessionType && (
-              <div className="flex items-center justify-between gap-2">
-                <dt className="text-xs text-text-muted">{t("session")}</dt>
-                <dd className="text-xs bg-tag-session-bg text-tag-session-text px-2 py-0.5 rounded-full">
-                  {task.sessionType}
-                </dd>
-              </div>
-            )}
-            {task.sshHost && (
-              <div className="flex items-center justify-between gap-2">
-                <dt className="text-xs text-text-muted">{t("sshHost")}</dt>
-                <dd className="text-xs font-mono bg-tag-ssh-bg text-tag-ssh-text px-2 py-0.5 rounded">
-                  {task.sshHost}
-                </dd>
-              </div>
-            )}
-            <div className="border-t border-border-subtle pt-3 mt-3">
-              <div className="flex items-center justify-between gap-2 mb-2">
-                <dt className="text-xs text-text-muted">{t("createdAt")}</dt>
-                <dd className="text-xs text-text-secondary">
-                  {new Date(task.createdAt).toLocaleDateString()}
-                </dd>
-              </div>
-              <div className="flex items-center justify-between gap-2">
-                <dt className="text-xs text-text-muted">{t("updatedAt")}</dt>
-                <dd className="text-xs text-text-secondary">
-                  {new Date(task.updatedAt).toLocaleDateString()}
-                </dd>
-              </div>
-            </div>
-          </dl>
-        </div>
+        <TaskDetailInfoCard task={task} agentTagStyle={agentTagStyle} />
 
         {/* 상태 변경 + 네비게이션 카드 */}
         <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,8 +96,8 @@
   --color-tag-session-text: var(--blue-600);
   --color-tag-ssh-bg: var(--green-50);
   --color-tag-ssh-text: var(--green-600);
-  --color-tag-project-bg: var(--yellow-50);
-  --color-tag-project-text: var(--gray-800);
+  --color-tag-project-bg: #202632;
+  --color-tag-project-text: #FFFFFF;
   --color-tag-branch-bg: var(--gray-100);
   --color-tag-branch-text: var(--gray-700);
   --color-tag-neutral-bg: var(--gray-100);

--- a/src/components/ProjectBranchTasksModal.tsx
+++ b/src/components/ProjectBranchTasksModal.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
+import { getTasksByStatus } from "@/app/actions/kanban";
+import { TaskStatus } from "@/entities/KanbanTask";
+import type { KanbanTask } from "@/entities/KanbanTask";
+
+interface ProjectBranchTasksModalProps {
+  projectId: string;
+  currentBranchName: string | null;
+  onClose: () => void;
+}
+
+const COLUMNS = [
+  { status: TaskStatus.PROGRESS, labelKey: "progress", colorClass: "bg-status-progress" },
+  { status: TaskStatus.PENDING, labelKey: "pending", colorClass: "bg-purple-500" },
+  { status: TaskStatus.REVIEW, labelKey: "review", colorClass: "bg-status-review" },
+];
+
+export default function ProjectBranchTasksModal({
+  projectId,
+  currentBranchName,
+  onClose,
+}: ProjectBranchTasksModalProps) {
+  const t = useTranslations("board.columns");
+  const tc = useTranslations("common");
+  const router = useRouter();
+  const [tasksByStatus, setTasksByStatus] = useState<Record<TaskStatus, KanbanTask[]>>({
+    [TaskStatus.TODO]: [],
+    [TaskStatus.PROGRESS]: [],
+    [TaskStatus.PENDING]: [],
+    [TaskStatus.REVIEW]: [],
+    [TaskStatus.DONE]: [],
+  }); // 모달에서는 TODO, PENDING, REVIEW만 표시
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 같은 프로젝트의 작업 로드
+  useEffect(() => {
+    (async () => {
+      try {
+        const result = await getTasksByStatus();
+        // 같은 projectId로 필터링
+        const filtered: typeof tasksByStatus = {
+          [TaskStatus.TODO]: [],
+          [TaskStatus.PROGRESS]: [],
+          [TaskStatus.PENDING]: [],
+          [TaskStatus.REVIEW]: [],
+          [TaskStatus.DONE]: [],
+        };
+
+        Object.entries(result.tasks).forEach(([status, tasks]) => {
+          filtered[status as TaskStatus] = tasks.filter(
+            (task) => task.projectId === projectId
+          );
+        });
+
+        setTasksByStatus(filtered);
+      } catch (error) {
+        console.error("Failed to load tasks:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [projectId]);
+
+  const handleTaskClick = (taskId: string) => {
+    router.push(`/task/${taskId}`);
+    onClose();
+  };
+
+  const totalTasks = Object.values(tasksByStatus).reduce((sum, tasks) => sum + tasks.length, 0);
+
+  return (
+    <div
+      className="fixed inset-0 z-[400] flex items-center justify-center bg-bg-overlay"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-6xl max-h-[85vh] overflow-hidden bg-bg-page rounded-xl border border-border-default shadow-lg flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 헤더 */}
+        <div className="flex items-center justify-between gap-2 p-6 border-b border-border-subtle bg-bg-surface">
+          <div>
+            <h2 className="text-lg font-semibold text-text-primary">프로젝트 작업</h2>
+            <p className="text-xs text-text-secondary mt-1">총 {totalTasks}개</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-text-secondary hover:text-text-primary transition-colors"
+            aria-label="Close"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            >
+              <path d="M12 4L4 12M4 4L12 12" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        {/* 본문 - Kanban 보드 */}
+        {isLoading ? (
+          <div className="flex-1 flex items-center justify-center">
+            <p className="text-sm text-text-secondary">로딩 중...</p>
+          </div>
+        ) : (
+          <div className="flex-1 overflow-x-auto p-6">
+            <div className="flex gap-4 min-w-full">
+              {COLUMNS.map((column) => (
+                <div key={column.status} className="flex-shrink-0 w-80">
+                  {/* 칼럼 헤더 */}
+                  <div className="flex items-center gap-2 mb-3 pb-3 border-b border-border-subtle">
+                    <div className={`w-2 h-2 rounded-full ${column.colorClass}`} />
+                    <h3 className="text-sm font-semibold text-text-primary">
+                      {t(column.labelKey)}
+                    </h3>
+                    <span className="ml-auto text-xs text-text-muted">
+                      {tasksByStatus[column.status].length}
+                    </span>
+                  </div>
+
+                  {/* 작업 목록 */}
+                  <div className="space-y-2">
+                    {tasksByStatus[column.status].length === 0 ? (
+                      <div className="text-xs text-text-muted text-center py-8">
+                        작업 없음
+                      </div>
+                    ) : (
+                      tasksByStatus[column.status].map((task) => (
+                        <div
+                          key={task.id}
+                          className="p-3 rounded-lg bg-bg-surface border border-border-default hover:border-brand-primary hover:shadow-sm transition-all group flex items-start justify-between gap-2"
+                        >
+                          <button
+                            onClick={() => handleTaskClick(task.id)}
+                            className="flex-1 text-left"
+                          >
+                            <h4 className="text-sm font-medium text-text-primary group-hover:text-brand-primary transition-colors truncate">
+                              {task.title}
+                            </h4>
+                            {task.branchName && (
+                              <p className="text-xs text-text-secondary mt-1 truncate">
+                                {task.branchName}
+                              </p>
+                            )}
+                          </button>
+                          <button
+                            onClick={() => handleTaskClick(task.id)}
+                            className="flex-shrink-0 w-6 h-6 rounded-full bg-tag-project-bg hover:opacity-80 text-tag-project-text flex items-center justify-center transition-opacity"
+                            aria-label="Open task"
+                            title={task.title}
+                          >
+                            <svg
+                              width="12"
+                              height="12"
+                              viewBox="0 0 16 16"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="1.5"
+                            >
+                              <path
+                                d="M6 12L10 8L6 4"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TaskDetailInfoCard.tsx
+++ b/src/components/TaskDetailInfoCard.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { KanbanTask } from "@/entities/KanbanTask";
+import PriorityEditor from "@/components/PriorityEditor";
+
+interface TaskDetailInfoCardProps {
+  task: KanbanTask;
+  agentTagStyle: string | null;
+}
+
+export default function TaskDetailInfoCard({
+  task,
+  agentTagStyle,
+}: TaskDetailInfoCardProps) {
+  const t = useTranslations("taskDetail");
+
+  return (
+    <>
+      {/* 메타데이터 카드 */}
+      <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
+        <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-4">
+          {t("info")}
+        </h3>
+        <dl className="space-y-3">
+          {task.project && (
+            <div className="flex items-center justify-between gap-2">
+              <dt className="text-xs text-text-muted">{t("project")}</dt>
+              <dd className="text-xs px-2 py-0.5 rounded-full font-medium bg-tag-project-bg text-tag-project-text truncate max-w-[160px]">
+                {task.project.name}
+              </dd>
+            </div>
+          )}
+          <div className="flex items-center justify-between gap-2">
+            <dt className="text-xs text-text-muted">{t("priority")}</dt>
+            <dd>
+              <PriorityEditor
+                taskId={task.id}
+                currentPriority={task.priority}
+              />
+            </dd>
+          </div>
+          {task.prUrl && (
+            <div className="flex items-center justify-between gap-2">
+              <dt className="text-xs text-text-muted">{t("prLink")}</dt>
+              <dd>
+                <a
+                  href={task.prUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs bg-tag-pr-bg text-tag-pr-text px-2 py-0.5 rounded hover:opacity-80 transition-opacity"
+                >
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 16 16"
+                    fill="currentColor"
+                  >
+                    <path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z" />
+                  </svg>
+                  PR
+                  <svg
+                    width="10"
+                    height="10"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                  >
+                    <path
+                      d="M4 12L12 4M12 4H6M12 4v6"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </a>
+              </dd>
+            </div>
+          )}
+          {task.agentType && (
+            <div className="flex items-center justify-between gap-2">
+              <dt className="text-xs text-text-muted">{t("agent")}</dt>
+              <dd className={`text-xs px-2 py-0.5 rounded-full font-medium ${agentTagStyle}`}>
+                {task.agentType}
+              </dd>
+            </div>
+          )}
+          {task.sessionType && (
+            <div className="flex items-center justify-between gap-2">
+              <dt className="text-xs text-text-muted">{t("session")}</dt>
+              <dd className="text-xs bg-tag-session-bg text-tag-session-text px-2 py-0.5 rounded-full">
+                {task.sessionType}
+              </dd>
+            </div>
+          )}
+          {task.sshHost && (
+            <div className="flex items-center justify-between gap-2">
+              <dt className="text-xs text-text-muted">{t("sshHost")}</dt>
+              <dd className="text-xs font-mono bg-tag-ssh-bg text-tag-ssh-text px-2 py-0.5 rounded">
+                {task.sshHost}
+              </dd>
+            </div>
+          )}
+          <div className="border-t border-border-subtle pt-3 mt-3">
+            <div className="flex items-center justify-between gap-2 mb-2">
+              <dt className="text-xs text-text-muted">{t("createdAt")}</dt>
+              <dd className="text-xs text-text-secondary">
+                {new Date(task.createdAt).toLocaleDateString()}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between gap-2">
+              <dt className="text-xs text-text-muted">{t("updatedAt")}</dt>
+              <dd className="text-xs text-text-secondary">
+                {new Date(task.updatedAt).toLocaleDateString()}
+              </dd>
+            </div>
+          </div>
+        </dl>
+      </div>
+    </>
+  );
+}

--- a/src/components/TaskDetailTitleCard.tsx
+++ b/src/components/TaskDetailTitleCard.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import type { KanbanTask } from "@/entities/KanbanTask";
+import TaskStatusBadge from "@/components/TaskStatusBadge";
+import ProjectBranchTasksModal from "@/components/ProjectBranchTasksModal";
+
+interface TaskDetailTitleCardProps {
+  task: KanbanTask;
+}
+
+export default function TaskDetailTitleCard({ task }: TaskDetailTitleCardProps) {
+  const [showBranchTasksModal, setShowBranchTasksModal] = useState(false);
+
+  return (
+    <>
+      <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
+        <div className="flex items-center gap-2 mb-3">
+          <TaskStatusBadge status={task.status} />
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <h1 className="text-xl font-bold text-text-primary leading-tight">
+            {task.title}
+          </h1>
+          {task.branchName && task.projectId && (
+            <button
+              onClick={() => setShowBranchTasksModal(true)}
+              className="flex-shrink-0 w-6 h-6 rounded-full bg-tag-project-bg hover:opacity-80 text-tag-project-text flex items-center justify-center transition-opacity"
+              aria-label="View other tasks in this project"
+              title="다른 작업 보기"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              >
+                <path
+                  d="M6 12L10 8L6 4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          )}
+        </div>
+        {task.description && (
+          <p className="text-sm text-text-secondary mt-3 leading-relaxed">
+            {task.description}
+          </p>
+        )}
+      </div>
+
+      {/* 모달 */}
+      {showBranchTasksModal && task.projectId && (
+        <ProjectBranchTasksModal
+          projectId={task.projectId}
+          currentBranchName={task.branchName}
+          onClose={() => setShowBranchTasksModal(false)}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## 개요
프로젝트 배지 색상을 통일하고, 브랜치 기반 작업 네비게이션 기능을 추가했습니다.

## 변경 사항

### 컴포넌트 추가
- **TaskDetailTitleCard**: 작업 제목 영역 + 브랜치 네비게이션 버튼
  - 프로젝트와 브랜치가 있을 때 버튼 표시
  - 클릭하면 같은 프로젝트의 모든 작업을 칸반 보드로 표시

- **ProjectBranchTasksModal**: 브랜치 작업 칸반 모달
  - Progress, Pending, Review 3개 칼럼만 표시
  - 같은 projectId로 필터링
  - 각 작업 카드에 네비게이션 버튼 포함

- **TaskDetailInfoCard**: 작업 메타데이터 카드
  - 기존 인라인 메타데이터를 독립적인 컴포넌트로 분리

### 스타일 변경
- **프로젝트 배지 색상**: #202632 (진한 회색/검은색) + 흰색 텍스트
- **네비게이션 버튼**: 모든 버튼을 일관된 원형 스타일로 통일
  - 원형 배경 (w-6 h-6 rounded-full)
  - 프로젝트 배지 색상 적용
  - hover 시 opacity 감소 효과

### i18n 번역
- `projectBranchTasks` namespace 추가
- 한국어, 영어, 중국어 번역 완료

## 스크린샷
- 브랜치가 있을 때: 제목 옆에 화살표 버튼 표시
- 버튼 클릭: 같은 프로젝트의 모든 작업을 칸반 보드로 표시

## 테스트 계획
- [ ] 브랜치가 있는 작업에서 버튼 표시 확인
- [ ] 버튼 클릭 시 모달 표시 확인
- [ ] 모달에서 올바른 작업만 필터링되는지 확인
- [ ] 모달에서 작업 클릭 시 해당 작업 페이지로 이동 확인
- [ ] 버튼 스타일이 모두 통일되었는지 확인