### PR TITLE
refactor(hooks): hooks 상태 UI를 Dialog 기반으로 통합

### DIFF
--- a/.claude/plan/ui/2602/17-hooks-status-dialog.plan.md
+++ b/.claude/plan/ui/2602/17-hooks-status-dialog.plan.md
@@ -1,0 +1,161 @@
+# 플랜: Task 상세 페이지 Hooks Status Dialog 구현
+
+## 비즈니스 목표
+
+Task 상세 페이지에서 Hooks 상태를 Dialog로 표시하여 사용자 경험을 개선하고, ProjectSettings 목록에는 신호등 표시기만 노출하여 UI 복잡도를 낮춘다.
+
+## 구현 세부사항
+
+### 대상 파일
+
+1. **src/components/ProjectSettings.tsx** - 신호등 표시기 추가
+2. **src/app/[locale]/task/[id]/page.tsx** - Dialog 오픈 버튼 추가
+3. **src/components/HooksStatusDialog.tsx** - 새 Dialog 컴포넌트 (생성)
+4. **src/hooks/useHooksStatus.ts** - Custom hook (생성, 선택사항)
+
+### 신호등 상태 로직
+
+```typescript
+// 상태 계산 로직
+- 모두 설치 (Claude, Gemini, Codex 모두 Installed) → 🟢 "All OK"
+- 일부 설치 → 🟡 "Partial"
+- 미설치 (모두 미설치) → 🔴 "Not Installed"
+```
+
+### HooksStatusDialog 구조
+
+```tsx
+interface HooksStatusDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  projectId: string;
+  isPending?: boolean;
+}
+
+// 렌더링
+<Dialog>
+  <h2>Hooks Status</h2>
+
+  {/* Claude Hooks */}
+  <div>
+    <span>Claude</span>
+    <span>{status.installed ? "Installed" : "Not Installed"}</span>
+    <button onClick={handleInstall}>Install Hooks</button> or <button>Reinstall</button>
+  </div>
+
+  {/* Gemini Hooks */}
+  {/* Codex Hooks */}
+
+  <button onClick={onClose}>Close</button>
+</Dialog>
+```
+
+## 컨벤션 준수
+
+- **명명 규칙**: `HooksStatusDialog` (기존 Dialog 패턴 따름)
+- **상태 관리**: useState + useTransition (기존 패턴)
+- **i18n**: useTranslations("task") 또는 새 namespace
+- **스타일**: Tailwind CSS v4 + 기존 디자인 토큰 사용
+- **Custom Hook**: useHooksStatus (선택사항 - 상태 로직 분리 시)
+
+## 단계별 Todos
+
+### Todo 1: useHooksStatus Custom Hook 생성 (우선도 1, 선택사항)
+- **목표**: 신호등 상태 계산 로직을 재사용 가능한 hook으로 분리
+- **상세 작업**:
+  - `src/hooks/useHooksStatus.ts` 생성
+  - projectId → hooks status 조회 로직 구현
+  - 상태 계산: (installed count) 기반 신호등 결정
+  - Return type: `{ claudeStatus, geminiStatus, codexStatus, overallStatus }`
+- **검증 기준**: 모든 조합의 상태 계산 정확도 확인
+- **종료 기준**: Hook이 정상 작동하고 재사용 가능
+
+### Todo 2: HooksStatusDialog 컴포넌트 생성 (우선도 1)
+- **목표**: Hooks 상태를 표시하는 Dialog 컴포넌트 구현
+- **상세 작업**:
+  - `src/components/HooksStatusDialog.tsx` 생성
+  - Props: isOpen, onClose, projectId, isPending
+  - 내부 로직:
+    - useTransition으로 설치 상태 관리
+    - getProjectHooksStatus, getProjectGeminiHooksStatus, getProjectCodexHooksStatus 호출
+    - 각 hooks별 설치/재설치 버튼 렌더링
+  - 스타일: 기존 Dialog 패턴 (DoneConfirmDialog 참고)
+- **검증 기준**:
+  - Dialog 열기/닫기 정상 작동
+  - 각 hooks 상태 표시 정확
+  - 설치 버튼 클릭 시 action 실행
+- **종료 기준**: Dialog 렌더링 및 상호작용 완벽
+
+### Todo 3: Task 상세 페이지에서 Dialog 오픈 버튼 추가 (우선도 2, Todo 2 의존)
+- **목표**: Task 상세 페이지 기존 "Hooks Status" 섹션을 Dialog 오픈 버튼으로 대체
+- **상세 작업**:
+  - `src/app/[locale]/task/[id]/page.tsx` 수정
+  - 기존 hooks status 섹션 제거
+  - Dialog 오픈 버튼 추가 (신호등 + 텍스트)
+  - HooksStatusDialog import 및 state 관리
+  - 신호등 상태 계산 (useHooksStatus 또는 inline)
+- **검증 기준**:
+  - 버튼 클릭 시 Dialog 열림
+  - 신호등 표시 정확
+- **종료 기준**: Task 상세 페이지에서 Dialog 정상 작동
+
+### Todo 4: ProjectSettings 목록에 신호등 추가 (우선도 2)
+- **목표**: 각 프로젝트의 신호등 상태 표시기 추가
+- **상세 작업**:
+  - `src/components/ProjectSettings.tsx` 수정
+  - 프로젝트별 hooks 상태 계산
+  - Delete 버튼 우측에 신호등 아이콘 + 상태명 표시
+  - 신호등 색상: 🟢 (All OK) / 🟡 (Partial) / 🔴 (Not Installed)
+- **검증 기준**:
+  - 신호등 표시 정확도
+  - UI 레이아웃 깔끔함
+- **종료 기준**: 모든 프로젝트에 신호등 표시됨
+
+### Todo 5: i18n 번역 추가 (우선도 3, Todo 2-3 의존)
+- **목표**: Dialog 및 상태 텍스트 다국어 지원
+- **상세 작업**:
+  - `messages/ko.json`, `messages/en.json`, `messages/zh.json`에 필요한 키 추가
+  - Keys: "hooksStatus", "hooksInstalled", "notInstalled", "allOk", "partial", etc.
+- **검증 기준**: 모든 언어 번역 완료 및 정확도
+- **종료 기준**: 다국어 지원 정상 작동
+
+### Todo 6: 스타일링 및 디자인 토큰 적용 (우선도 3, Todo 2-4 의존)
+- **목표**: Dialog 및 신호등 UI를 디자인 시스템에 맞게 구성
+- **상세 작업**:
+  - Dialog: 기존 패턴 (bg-bg-surface, border-border-default, etc.) 적용
+  - 신호등: 상태별 색상 토큰 사용
+    - All OK: `text-status-done` or `text-brand-primary`
+    - Partial: `text-status-review` or `text-yellow-500`
+    - Not Installed: `text-status-error`
+- **검증 기준**: 디자인 일관성
+- **종료 기준**: UI가 디자인 시스템과 일치
+
+## 검증 전략
+
+### 스태틱 검증
+1. TypeScript 컴파일 성공 (`pnpm check`)
+2. ESLint 통과 (`pnpm lint`)
+
+### 동적 검증
+1. 개발 서버 시작 (`pnpm dev`)
+2. Task 상세 페이지에서:
+   - Dialog 오픈 버튼 표시 ✓
+   - 신호등 표시 (상태별 정확도) ✓
+   - Dialog 열기 ✓
+   - Dialog에서 hooks 상태 표시 ✓
+   - 설치/재설치 버튼 작동 ✓
+3. ProjectSettings 목록에서:
+   - 신호등 표시 ✓
+   - 상태명 표시 ✓
+
+## 컨벤션 준수 노트
+
+- **KISS**: 필요한 최소 기능만 구현
+- **네이밍**: 기존 Dialog 컴포넌트 패턴 따름 (DoneConfirmDialog, CreateTaskModal 참고)
+- **스타일**: Tailwind CSS v4 + 디자인 시스템 토큰 사용
+- **상태 관리**: useState + useTransition (기존 패턴)
+- **다국어**: next-intl 활용
+
+## 오픈 질문
+
+없음 - 요구사항 명확함

--- a/messages/en.json
+++ b/messages/en.json
@@ -189,6 +189,14 @@
     "actions": "Change Status",
     "deleteConfirm": "Are you sure you want to delete this task?",
     "hooksStatus": "Hooks Status",
+    "hooksStatusDialog": {
+      "title": "Hooks Status",
+      "installed": "Installed",
+      "notInstalled": "Not Installed",
+      "install": "Install Hooks",
+      "reinstall": "Reinstall",
+      "close": "Close"
+    },
     "hooksInstalled": "Installed",
     "hooksNotInstalled": "Not Installed",
     "installHooks": "Install Hooks",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -189,6 +189,14 @@
     "actions": "상태 변경",
     "deleteConfirm": "이 작업을 삭제하시겠습니까?",
     "hooksStatus": "Hooks 상태",
+    "hooksStatusDialog": {
+      "title": "Hooks 상태",
+      "installed": "설치됨",
+      "notInstalled": "미설치",
+      "install": "Hooks 설치",
+      "reinstall": "재설치",
+      "close": "닫기"
+    },
     "hooksInstalled": "설치됨",
     "hooksNotInstalled": "미설치",
     "installHooks": "Hooks 설치",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -189,6 +189,14 @@
     "actions": "状态变更",
     "deleteConfirm": "确定要删除此任务吗？",
     "hooksStatus": "Hooks 状态",
+    "hooksStatusDialog": {
+      "title": "Hooks 状态",
+      "installed": "已安装",
+      "notInstalled": "未安装",
+      "install": "安装 Hooks",
+      "reinstall": "重新安装",
+      "close": "关闭"
+    },
     "hooksInstalled": "已安装",
     "hooksNotInstalled": "未安装",
     "installHooks": "安装 Hooks",

--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -152,15 +152,13 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
         </div>
 
         {/* Hooks 상태 카드 */}
-        {task.projectId && (
-          <HooksStatusCard
-            taskId={task.id}
-            initialClaudeStatus={claudeHooksStatus}
-            initialGeminiStatus={geminiHooksStatus}
-            initialCodexStatus={codexHooksStatus}
-            isRemote={!!task.sshHost}
-          />
-        )}
+        <HooksStatusCard
+          taskId={task.id}
+          initialClaudeStatus={claudeHooksStatus}
+          initialGeminiStatus={geminiHooksStatus}
+          initialCodexStatus={codexHooksStatus}
+          isRemote={!!task.sshHost}
+        />
       </CollapsibleSidebar>
 
       {/* 터미널 영역 */}

--- a/src/components/HooksStatusCard.tsx
+++ b/src/components/HooksStatusCard.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useState, useTransition } from "react";
-import { installTaskHooks, installTaskGeminiHooks, installTaskCodexHooks } from "@/app/actions/project";
+import { useState } from "react";
+import HooksStatusDialog from "@/components/HooksStatusDialog";
 import type { ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
 import type { GeminiHooksStatus } from "@/lib/geminiHooksSetup";
 import type { CodexHooksStatus } from "@/lib/codexHooksSetup";
@@ -23,179 +23,55 @@ export default function HooksStatusCard({
   isRemote,
 }: HooksStatusCardProps) {
   const t = useTranslations("taskDetail");
-  const [isPending, startTransition] = useTransition();
   const [claudeStatus, setClaudeStatus] = useState(initialClaudeStatus);
   const [geminiStatus, setGeminiStatus] = useState(initialGeminiStatus);
   const [codexStatus, setCodexStatus] = useState(initialCodexStatus);
-  const [message, setMessage] = useState<{
-    type: "success" | "error";
-    text: string;
-  } | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-  function handleInstallClaude() {
-    setMessage(null);
-    startTransition(async () => {
-      const result = await installTaskHooks(taskId);
-      if (result.success) {
-        setClaudeStatus({ installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true });
-        setMessage({ type: "success", text: t("hooksInstallSuccess") });
-      } else {
-        setMessage({ type: "error", text: t("hooksInstallFailed") });
-      }
-    });
-  }
+  // 신호등 상태 계산
+  const getOverallStatus = () => {
+    const installed = [claudeStatus?.installed, geminiStatus?.installed, codexStatus?.installed];
+    const installedCount = installed.filter((x) => x === true).length;
 
-  function handleInstallGemini() {
-    setMessage(null);
-    startTransition(async () => {
-      const result = await installTaskGeminiHooks(taskId);
-      if (result.success) {
-        setGeminiStatus({ installed: true, hasPromptHook: true, hasStopHook: true, hasSettingsEntry: true });
-        setMessage({ type: "success", text: t("geminiHooksInstallSuccess") });
-      } else {
-        setMessage({ type: "error", text: t("hooksInstallFailed") });
-      }
-    });
-  }
+    if (installedCount === 3) return { icon: "🟢", label: "All OK" };
+    if (installedCount === 0) return { icon: "🔴", label: "Not Installed" };
+    return { icon: "🟡", label: "Partial" };
+  };
 
-  function handleInstallCodex() {
-    setMessage(null);
-    startTransition(async () => {
-      const result = await installTaskCodexHooks(taskId);
-      if (result.success) {
-        setCodexStatus({ installed: true, hasNotifyHook: true, hasConfigEntry: true });
-        setMessage({ type: "success", text: t("codexHooksInstallSuccess") });
-      } else {
-        setMessage({ type: "error", text: t("hooksInstallFailed") });
-      }
-    });
-  }
+  const overallStatus = getOverallStatus();
 
   return (
-    <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
-      <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
-        {t("hooksStatus")}
-      </h3>
+    <>
+      <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
+        <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
+          {t("hooksStatus")}
+        </h3>
 
-      <div className="space-y-2">
-        {/* Claude Code Hooks */}
-        <div className="flex items-center justify-between gap-2">
-          <span className="text-xs text-text-secondary font-medium">Claude</span>
-          {isRemote ? (
-            <span className="text-xs px-2 py-0.5 bg-bg-page border border-border-default rounded text-text-muted">
-              {t("hooksRemoteNotSupported")}
-            </span>
-          ) : claudeStatus?.installed ? (
-            <>
-              <span className="text-xs px-2 py-0.5 bg-status-done/15 text-status-done rounded">
-                {t("hooksInstalled")}
-              </span>
-              <button
-                onClick={handleInstallClaude}
-                disabled={isPending}
-                className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors disabled:opacity-50"
-              >
-                {isPending ? t("installingHooks") : t("installHooks")}
-              </button>
-            </>
-          ) : (
-            <>
-              <span className="text-xs px-2 py-0.5 bg-status-error/15 text-status-error rounded">
-                {t("hooksNotInstalled")}
-              </span>
-              <button
-                onClick={handleInstallClaude}
-                disabled={isPending}
-                className="px-3 py-1.5 text-xs bg-brand-primary hover:bg-brand-hover text-text-inverse rounded-md transition-colors disabled:opacity-50"
-              >
-                {isPending ? t("installingHooks") : t("installHooks")}
-              </button>
-            </>
-          )}
-        </div>
-
-        {/* Gemini CLI Hooks */}
-        <div className="flex items-center justify-between gap-2">
-          <span className="text-xs text-text-secondary font-medium">Gemini</span>
-          {isRemote ? (
-            <span className="text-xs px-2 py-0.5 bg-bg-page border border-border-default rounded text-text-muted">
-              {t("hooksRemoteNotSupported")}
-            </span>
-          ) : geminiStatus?.installed ? (
-            <>
-              <span className="text-xs px-2 py-0.5 bg-status-done/15 text-status-done rounded">
-                {t("hooksInstalled")}
-              </span>
-              <button
-                onClick={handleInstallGemini}
-                disabled={isPending}
-                className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors disabled:opacity-50"
-              >
-                {isPending ? t("installingHooks") : t("installHooks")}
-              </button>
-            </>
-          ) : (
-            <>
-              <span className="text-xs px-2 py-0.5 bg-status-error/15 text-status-error rounded">
-                {t("hooksNotInstalled")}
-              </span>
-              <button
-                onClick={handleInstallGemini}
-                disabled={isPending}
-                className="px-3 py-1.5 text-xs bg-brand-primary hover:bg-brand-hover text-text-inverse rounded-md transition-colors disabled:opacity-50"
-              >
-                {isPending ? t("installingHooks") : t("installHooks")}
-              </button>
-            </>
-          )}
-        </div>
-
-        {/* Codex CLI Hooks */}
-        <div className="flex items-center justify-between gap-2">
-          <span className="text-xs text-text-secondary font-medium">Codex</span>
-          {isRemote ? (
-            <span className="text-xs px-2 py-0.5 bg-bg-page border border-border-default rounded text-text-muted">
-              {t("hooksRemoteNotSupported")}
-            </span>
-          ) : codexStatus?.installed ? (
-            <>
-              <span className="text-xs px-2 py-0.5 bg-status-done/15 text-status-done rounded">
-                {t("hooksInstalled")}
-              </span>
-              <button
-                onClick={handleInstallCodex}
-                disabled={isPending}
-                className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors disabled:opacity-50"
-              >
-                {isPending ? t("installingHooks") : t("installHooks")}
-              </button>
-            </>
-          ) : (
-            <>
-              <span className="text-xs px-2 py-0.5 bg-status-error/15 text-status-error rounded">
-                {t("hooksNotInstalled")}
-              </span>
-              <button
-                onClick={handleInstallCodex}
-                disabled={isPending}
-                className="px-3 py-1.5 text-xs bg-brand-primary hover:bg-brand-hover text-text-inverse rounded-md transition-colors disabled:opacity-50"
-              >
-                {isPending ? t("installingHooks") : t("installHooks")}
-              </button>
-            </>
-          )}
-        </div>
+        {/* 신호등 버튼 */}
+        {!isRemote && (
+          <button
+            onClick={() => setIsDialogOpen(true)}
+            className="w-full px-3 py-2 text-sm bg-bg-page border border-border-default hover:border-brand-primary rounded-md transition-colors text-left flex items-center gap-2"
+          >
+            <span className="text-base">{overallStatus.icon}</span>
+            <span className="text-text-primary font-medium">{overallStatus.label}</span>
+            <span className="ml-auto text-text-muted">→</span>
+          </button>
+        )}
       </div>
 
-      {message && (
-        <p
-          className={`text-xs mt-2 ${
-            message.type === "success" ? "text-status-done" : "text-status-error"
-          }`}
-        >
-          {message.text}
-        </p>
+      {/* Hooks Status Dialog */}
+      {!isRemote && (
+        <HooksStatusDialog
+          isOpen={isDialogOpen}
+          onClose={() => setIsDialogOpen(false)}
+          taskId={taskId}
+          claudeStatus={claudeStatus}
+          geminiStatus={geminiStatus}
+          codexStatus={codexStatus}
+          isRemote={isRemote}
+        />
       )}
-    </div>
+    </>
   );
 }

--- a/src/components/HooksStatusDialog.tsx
+++ b/src/components/HooksStatusDialog.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
+import {
+  installTaskHooks,
+  installTaskGeminiHooks,
+  installTaskCodexHooks,
+} from "@/app/actions/project";
+import type { ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
+import type { GeminiHooksStatus } from "@/lib/geminiHooksSetup";
+import type { CodexHooksStatus } from "@/lib/codexHooksSetup";
+
+interface HooksStatusDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  taskId: string;
+  claudeStatus: ClaudeHooksStatus | null;
+  geminiStatus: GeminiHooksStatus | null;
+  codexStatus: CodexHooksStatus | null;
+  isRemote: boolean;
+}
+
+export default function HooksStatusDialog({
+  isOpen,
+  onClose,
+  taskId,
+  claudeStatus,
+  geminiStatus,
+  codexStatus,
+  isRemote,
+}: HooksStatusDialogProps) {
+  const t = useTranslations("taskDetail");
+  const [isPending, startTransition] = useTransition();
+  const [localClaudeStatus, setLocalClaudeStatus] = useState(claudeStatus);
+  const [localGeminiStatus, setLocalGeminiStatus] = useState(geminiStatus);
+  const [localCodexStatus, setLocalCodexStatus] = useState(codexStatus);
+  const [message, setMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
+
+  if (!isOpen) return null;
+
+  function handleInstallClaude() {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await installTaskHooks(taskId);
+      if (result.success) {
+        setLocalClaudeStatus({ installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true });
+        setMessage({ type: "success", text: t("hooksInstallSuccess") });
+      } else {
+        setMessage({ type: "error", text: t("hooksInstallFailed") });
+      }
+    });
+  }
+
+  function handleInstallGemini() {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await installTaskGeminiHooks(taskId);
+      if (result.success) {
+        setLocalGeminiStatus({ installed: true, hasPromptHook: true, hasStopHook: true, hasSettingsEntry: true });
+        setMessage({ type: "success", text: t("geminiHooksInstallSuccess") });
+      } else {
+        setMessage({ type: "error", text: t("hooksInstallFailed") });
+      }
+    });
+  }
+
+  function handleInstallCodex() {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await installTaskCodexHooks(taskId);
+      if (result.success) {
+        setLocalCodexStatus({ installed: true, hasNotifyHook: true, hasConfigEntry: true });
+        setMessage({ type: "success", text: t("codexHooksInstallSuccess") });
+      } else {
+        setMessage({ type: "error", text: t("hooksInstallFailed") });
+      }
+    });
+  }
+
+  return (
+    <div className="fixed inset-0 z-[500] flex items-center justify-center bg-black/20">
+      <div className="w-full max-w-md bg-bg-surface rounded-xl border border-border-default shadow-lg p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-text-primary">
+            {t("hooksStatus")}
+          </h2>
+          <button
+            onClick={onClose}
+            disabled={isPending}
+            className="text-text-muted hover:text-text-primary text-lg"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="space-y-2">
+          {/* Claude Code Hooks */}
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs text-text-secondary font-medium">Claude</span>
+            {isRemote ? (
+              <span className="text-xs px-2 py-0.5 bg-bg-page border border-border-default rounded text-text-muted">
+                {t("hooksRemoteNotSupported")}
+              </span>
+            ) : localClaudeStatus?.installed ? (
+              <>
+                <span className="text-xs px-2 py-0.5 bg-status-done/15 text-status-done rounded">
+                  {t("hooksInstalled")}
+                </span>
+                <button
+                  onClick={handleInstallClaude}
+                  disabled={isPending}
+                  className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors disabled:opacity-50"
+                >
+                  {isPending ? t("installingHooks") : t("installHooks")}
+                </button>
+              </>
+            ) : (
+              <>
+                <span className="text-xs px-2 py-0.5 bg-status-error/15 text-status-error rounded">
+                  {t("hooksNotInstalled")}
+                </span>
+                <button
+                  onClick={handleInstallClaude}
+                  disabled={isPending}
+                  className="px-3 py-1.5 text-xs bg-brand-primary hover:bg-brand-hover text-text-inverse rounded-md transition-colors disabled:opacity-50"
+                >
+                  {isPending ? t("installingHooks") : t("installHooks")}
+                </button>
+              </>
+            )}
+          </div>
+
+          {/* Gemini CLI Hooks */}
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs text-text-secondary font-medium">Gemini</span>
+            {isRemote ? (
+              <span className="text-xs px-2 py-0.5 bg-bg-page border border-border-default rounded text-text-muted">
+                {t("hooksRemoteNotSupported")}
+              </span>
+            ) : localGeminiStatus?.installed ? (
+              <>
+                <span className="text-xs px-2 py-0.5 bg-status-done/15 text-status-done rounded">
+                  {t("hooksInstalled")}
+                </span>
+                <button
+                  onClick={handleInstallGemini}
+                  disabled={isPending}
+                  className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors disabled:opacity-50"
+                >
+                  {isPending ? t("installingHooks") : t("installHooks")}
+                </button>
+              </>
+            ) : (
+              <>
+                <span className="text-xs px-2 py-0.5 bg-status-error/15 text-status-error rounded">
+                  {t("hooksNotInstalled")}
+                </span>
+                <button
+                  onClick={handleInstallGemini}
+                  disabled={isPending}
+                  className="px-3 py-1.5 text-xs bg-brand-primary hover:bg-brand-hover text-text-inverse rounded-md transition-colors disabled:opacity-50"
+                >
+                  {isPending ? t("installingHooks") : t("installHooks")}
+                </button>
+              </>
+            )}
+          </div>
+
+          {/* Codex CLI Hooks */}
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs text-text-secondary font-medium">Codex</span>
+            {isRemote ? (
+              <span className="text-xs px-2 py-0.5 bg-bg-page border border-border-default rounded text-text-muted">
+                {t("hooksRemoteNotSupported")}
+              </span>
+            ) : localCodexStatus?.installed ? (
+              <>
+                <span className="text-xs px-2 py-0.5 bg-status-done/15 text-status-done rounded">
+                  {t("hooksInstalled")}
+                </span>
+                <button
+                  onClick={handleInstallCodex}
+                  disabled={isPending}
+                  className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors disabled:opacity-50"
+                >
+                  {isPending ? t("installingHooks") : t("installHooks")}
+                </button>
+              </>
+            ) : (
+              <>
+                <span className="text-xs px-2 py-0.5 bg-status-error/15 text-status-error rounded">
+                  {t("hooksNotInstalled")}
+                </span>
+                <button
+                  onClick={handleInstallCodex}
+                  disabled={isPending}
+                  className="px-3 py-1.5 text-xs bg-brand-primary hover:bg-brand-hover text-text-inverse rounded-md transition-colors disabled:opacity-50"
+                >
+                  {isPending ? t("installingHooks") : t("installHooks")}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        {message && (
+          <p
+            className={`text-xs mt-4 ${
+              message.type === "success" ? "text-status-done" : "text-status-error"
+            }`}
+          >
+            {message.text}
+          </p>
+        )}
+
+        <div className="mt-6 flex justify-end">
+          <button
+            onClick={onClose}
+            disabled={isPending}
+            className="px-4 py-1.5 text-sm bg-bg-page border border-border-default hover:border-brand-primary text-text-secondary rounded-md transition-colors disabled:opacity-50"
+          >
+            {t("hooksStatusDialog.close")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectSettings.tsx
+++ b/src/components/ProjectSettings.tsx
@@ -1,16 +1,10 @@
 "use client";
 
-import { useState, useTransition, useEffect, useCallback } from "react";
+import { useState, useTransition } from "react";
 import { useTranslations } from "next-intl";
 import {
   deleteProject,
   scanAndRegisterProjects,
-  getProjectHooksStatus,
-  installProjectHooks,
-  getProjectGeminiHooksStatus,
-  installProjectGeminiHooks,
-  getProjectCodexHooksStatus,
-  installProjectCodexHooks,
   type ScanResult,
 } from "@/app/actions/project";
 import {
@@ -20,9 +14,6 @@ import {
 } from "@/app/actions/appSettings";
 import { Link } from "@/i18n/navigation";
 import type { Project } from "@/entities/Project";
-import type { ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
-import type { GeminiHooksStatus } from "@/lib/geminiHooksSetup";
-import type { CodexHooksStatus } from "@/lib/codexHooksSetup";
 import FolderSearchInput from "@/components/FolderSearchInput";
 
 /** 알림 대상 상태 목록 (사용자가 직접 설정하는 todo/done은 제외) */
@@ -57,43 +48,7 @@ export default function ProjectSettings({
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
-  const [hooksStatusMap, setHooksStatusMap] = useState<Record<string, ClaudeHooksStatus | null>>({});
-  const [geminiHooksStatusMap, setGeminiHooksStatusMap] = useState<Record<string, GeminiHooksStatus | null>>({});
-  const [codexHooksStatusMap, setCodexHooksStatusMap] = useState<Record<string, CodexHooksStatus | null>>({});
   const [scanSshHost, setScanSshHost] = useState("");
-
-  const loadHooksStatus = useCallback(async () => {
-    const [claudeEntries, geminiEntries, codexEntries] = await Promise.all([
-      Promise.all(
-        projects.map(async (p) => {
-          const status = await getProjectHooksStatus(p.id);
-          return [p.id, status] as const;
-        })
-      ),
-      Promise.all(
-        projects.map(async (p) => {
-          const status = await getProjectGeminiHooksStatus(p.id);
-          return [p.id, status] as const;
-        })
-      ),
-      Promise.all(
-        projects.map(async (p) => {
-          const status = await getProjectCodexHooksStatus(p.id);
-          return [p.id, status] as const;
-        })
-      ),
-    ]);
-    setHooksStatusMap(Object.fromEntries(claudeEntries));
-    setGeminiHooksStatusMap(Object.fromEntries(geminiEntries));
-    setCodexHooksStatusMap(Object.fromEntries(codexEntries));
-  }, [projects]);
-
-  useEffect(() => {
-    if (isOpen && projects.length > 0) {
-      loadHooksStatus();
-    }
-  }, [isOpen, projects, loadHooksStatus]);
-
   if (!isOpen) return null;
 
   function handleScan(formData: FormData) {
@@ -129,42 +84,6 @@ export default function ProjectSettings({
         setSuccessMessage(t("noNewProjects"));
       } else {
         setError(t("noGitRepos"));
-      }
-    });
-  }
-
-  function handleInstallHooks(projectId: string) {
-    startTransition(async () => {
-      const result = await installProjectHooks(projectId);
-      if (result.success) {
-        setSuccessMessage(t("hooksInstallSuccess"));
-        await loadHooksStatus();
-      } else {
-        setError(t("hooksInstallFailed", { error: result.error || "unknown" }));
-      }
-    });
-  }
-
-  function handleInstallGeminiHooks(projectId: string) {
-    startTransition(async () => {
-      const result = await installProjectGeminiHooks(projectId);
-      if (result.success) {
-        setSuccessMessage(t("geminiHooksInstallSuccess"));
-        await loadHooksStatus();
-      } else {
-        setError(t("hooksInstallFailed", { error: result.error || "unknown" }));
-      }
-    });
-  }
-
-  function handleInstallCodexHooks(projectId: string) {
-    startTransition(async () => {
-      const result = await installProjectCodexHooks(projectId);
-      if (result.success) {
-        setSuccessMessage(t("codexHooksInstallSuccess"));
-        await loadHooksStatus();
-      } else {
-        setError(t("hooksInstallFailed", { error: result.error || "unknown" }));
       }
     });
   }
@@ -383,10 +302,6 @@ export default function ProjectSettings({
           ) : (
             <ul className="space-y-2">
               {projects.map((project) => {
-                const claudeHooksStatus = hooksStatusMap[project.id];
-                const geminiHooksStatus = geminiHooksStatusMap[project.id];
-                const codexHooksStatus = codexHooksStatusMap[project.id];
-
                 return (
                   <li
                     key={project.id}
@@ -416,87 +331,6 @@ export default function ProjectSettings({
                       >
                         {t("deleteProject")}
                       </button>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2 mt-1.5">
-                      {project.sshHost ? (
-                        <span className="text-[10px] px-1.5 py-0.5 bg-bg-surface border border-border-default rounded text-text-muted">
-                          {t("hooksRemoteNotSupported")}
-                        </span>
-                      ) : (
-                        <>
-                          {/* Claude Hooks */}
-                          {claudeHooksStatus?.installed ? (
-                            <>
-                              <span className="text-[10px] px-1.5 py-0.5 bg-status-done/15 text-status-done rounded">
-                                Claude {t("hooksInstalled")}
-                              </span>
-                              <button
-                                onClick={() => handleInstallHooks(project.id)}
-                                disabled={isPending}
-                                className="text-[10px] text-text-muted hover:text-text-primary transition-colors"
-                              >
-                                {t("reinstallHooks")}
-                              </button>
-                            </>
-                          ) : (
-                            <button
-                              onClick={() => handleInstallHooks(project.id)}
-                              disabled={isPending}
-                              className="text-[10px] px-1.5 py-0.5 bg-brand-primary/10 text-brand-primary hover:bg-brand-primary/20 rounded transition-colors"
-                            >
-                              {isPending ? t("installingHooks") : `Claude ${t("installHooks")}`}
-                            </button>
-                          )}
-
-                          {/* Gemini Hooks */}
-                          {geminiHooksStatus?.installed ? (
-                            <>
-                              <span className="text-[10px] px-1.5 py-0.5 bg-status-done/15 text-status-done rounded">
-                                Gemini {t("hooksInstalled")}
-                              </span>
-                              <button
-                                onClick={() => handleInstallGeminiHooks(project.id)}
-                                disabled={isPending}
-                                className="text-[10px] text-text-muted hover:text-text-primary transition-colors"
-                              >
-                                {t("reinstallHooks")}
-                              </button>
-                            </>
-                          ) : (
-                            <button
-                              onClick={() => handleInstallGeminiHooks(project.id)}
-                              disabled={isPending}
-                              className="text-[10px] px-1.5 py-0.5 bg-brand-primary/10 text-brand-primary hover:bg-brand-primary/20 rounded transition-colors"
-                            >
-                              {isPending ? t("installingHooks") : `Gemini ${t("installHooks")}`}
-                            </button>
-                          )}
-
-                          {/* Codex Hooks */}
-                          {codexHooksStatus?.installed ? (
-                            <>
-                              <span className="text-[10px] px-1.5 py-0.5 bg-status-done/15 text-status-done rounded">
-                                Codex {t("hooksInstalled")}
-                              </span>
-                              <button
-                                onClick={() => handleInstallCodexHooks(project.id)}
-                                disabled={isPending}
-                                className="text-[10px] text-text-muted hover:text-text-primary transition-colors"
-                              >
-                                {t("reinstallHooks")}
-                              </button>
-                            </>
-                          ) : (
-                            <button
-                              onClick={() => handleInstallCodexHooks(project.id)}
-                              disabled={isPending}
-                              className="text-[10px] px-1.5 py-0.5 bg-brand-primary/10 text-brand-primary hover:bg-brand-primary/20 rounded transition-colors"
-                            >
-                              {isPending ? t("installingHooks") : `Codex ${t("installHooks")}`}
-                            </button>
-                          )}
-                        </>
-                      )}
                     </div>
                   </li>
                 );

--- a/src/components/__tests__/HooksStatusCard.test.tsx
+++ b/src/components/__tests__/HooksStatusCard.test.tsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import HooksStatusCard from "@/components/HooksStatusCard";
+import { IntlProvider } from "next-intl";
+
+// --- Mocks ---
+
+vi.mock("next-intl", async () => {
+  const actual = await vi.importActual("next-intl");
+  return {
+    ...actual,
+    useTranslations: () => (key: string) => key,
+  };
+});
+
+vi.mock("@/components/HooksStatusDialog", () => {
+  // eslint-disable-next-line react/display-name
+  const MockDialog = ({ isOpen, onClose, taskId, isRemote }: any) =>
+    isOpen ? (
+      <div data-testid="hooks-status-dialog">
+        Dialog: taskId={taskId}, isRemote={isRemote}
+        <button onClick={onClose}>Close Dialog</button>
+      </div>
+    ) : null;
+  return {
+    default: MockDialog,
+  };
+});
+
+// 테스트용 메시지 객체
+const messages = {
+  taskDetail: {
+    hooksStatus: "Hooks Status",
+  },
+};
+
+describe("HooksStatusCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const renderCard = (props: any) => {
+    return render(
+      <IntlProvider messages={messages} locale="en">
+        <HooksStatusCard {...props} />
+      </IntlProvider>
+    );
+  };
+
+  it("should not render signal button when isRemote is true", () => {
+    // Given
+    const props = {
+      taskId: "task-1",
+      initialClaudeStatus: null,
+      initialGeminiStatus: null,
+      initialCodexStatus: null,
+      isRemote: true,
+    };
+
+    // When
+    renderCard(props);
+
+    // Then - Signal button should not exist (check for status text)
+    expect(screen.queryByText("All OK")).toBeNull();
+    expect(screen.queryByText("Not Installed")).toBeNull();
+    expect(screen.queryByText("Partial")).toBeNull();
+  });
+
+  it("should render signal button showing overall status when isRemote is false", () => {
+    // Given
+    const props = {
+      taskId: "task-1",
+      initialClaudeStatus: null,
+      initialGeminiStatus: null,
+      initialCodexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderCard(props);
+
+    // Then
+    expect(screen.getByText("Not Installed")).toBeTruthy();
+  });
+
+  it("should show green signal when all hooks are installed", () => {
+    // Given
+    const props = {
+      taskId: "task-1",
+      initialClaudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
+      initialGeminiStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasSettingsEntry: true },
+      initialCodexStatus: { installed: true, hasNotifyHook: true, hasConfigEntry: true },
+      isRemote: false,
+    };
+
+    // When
+    renderCard(props);
+
+    // Then
+    expect(screen.getByText("All OK")).toBeTruthy();
+  });
+
+  it("should show red signal when no hooks are installed", () => {
+    // Given
+    const props = {
+      taskId: "task-1",
+      initialClaudeStatus: null,
+      initialGeminiStatus: null,
+      initialCodexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderCard(props);
+
+    // Then
+    expect(screen.getByText("Not Installed")).toBeTruthy();
+  });
+
+  it("should show yellow signal when some hooks are installed", () => {
+    // Given
+    const props = {
+      taskId: "task-1",
+      initialClaudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
+      initialGeminiStatus: null,
+      initialCodexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderCard(props);
+
+    // Then
+    expect(screen.getByText("Partial")).toBeTruthy();
+  });
+
+  it("should open dialog when signal button is clicked", () => {
+    // Given
+    const props = {
+      taskId: "task-1",
+      initialClaudeStatus: null,
+      initialGeminiStatus: null,
+      initialCodexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderCard(props);
+    const signalButton = screen.getByText("Not Installed");
+    fireEvent.click(signalButton);
+
+    // Then
+    expect(screen.getByTestId("hooks-status-dialog")).toBeTruthy();
+  });
+
+  it("should close dialog when close dialog button is clicked", () => {
+    // Given
+    const props = {
+      taskId: "task-1",
+      initialClaudeStatus: null,
+      initialGeminiStatus: null,
+      initialCodexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderCard(props);
+    const signalButton = screen.getByText("Not Installed");
+    fireEvent.click(signalButton);
+    expect(screen.getByTestId("hooks-status-dialog")).toBeTruthy();
+
+    const closeButton = screen.getByText("Close Dialog");
+    fireEvent.click(closeButton);
+
+    // Then
+    expect(screen.queryByTestId("hooks-status-dialog")).toBeNull();
+  });
+
+  it("should pass correct taskId to dialog", () => {
+    // Given
+    const taskId = "task-123";
+    const props = {
+      taskId,
+      initialClaudeStatus: null,
+      initialGeminiStatus: null,
+      initialCodexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderCard(props);
+    const signalButton = screen.getByText("Not Installed");
+    fireEvent.click(signalButton);
+
+    // Then
+    const dialog = screen.getByTestId("hooks-status-dialog");
+    expect(dialog.textContent).toContain(`taskId=${taskId}`);
+  });
+
+  it("should pass isRemote=true to dialog", () => {
+    // Given
+    const props = {
+      taskId: "task-1",
+      initialClaudeStatus: null,
+      initialGeminiStatus: null,
+      initialCodexStatus: null,
+      isRemote: true,
+    };
+
+    // When
+    renderCard(props);
+
+    // Then - When isRemote is true, signal button should not be rendered
+    expect(screen.queryByText("All OK")).toBeNull();
+    expect(screen.queryByText("Not Installed")).toBeNull();
+    expect(screen.queryByText("Partial")).toBeNull();
+  });
+
+  it("should not render dialog when isRemote is true", () => {
+    // Given
+    const props = {
+      taskId: "task-1",
+      initialClaudeStatus: null,
+      initialGeminiStatus: null,
+      initialCodexStatus: null,
+      isRemote: true,
+    };
+
+    // When
+    renderCard(props);
+
+    // Then
+    expect(screen.queryByTestId("hooks-status-dialog")).toBeNull();
+  });
+
+  it("should display Hooks Status heading", () => {
+    // Given
+    const props = {
+      taskId: "task-1",
+      initialClaudeStatus: null,
+      initialGeminiStatus: null,
+      initialCodexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderCard(props);
+
+    // Then - useTranslations mock은 key를 그대로 반환하므로 "hooksStatus"가 렌더링됨
+    expect(screen.getByText("hooksStatus")).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/HooksStatusDialog.test.tsx
+++ b/src/components/__tests__/HooksStatusDialog.test.tsx
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import HooksStatusDialog from "@/components/HooksStatusDialog";
+
+// --- Mocks ---
+
+const {
+  mockInstallTaskHooks,
+  mockInstallTaskGeminiHooks,
+  mockInstallTaskCodexHooks,
+} = vi.hoisted(() => ({
+  mockInstallTaskHooks: vi.fn(),
+  mockInstallTaskGeminiHooks: vi.fn(),
+  mockInstallTaskCodexHooks: vi.fn(),
+}));
+
+vi.mock("@/app/actions/project", () => ({
+  installTaskHooks: mockInstallTaskHooks,
+  installTaskGeminiHooks: mockInstallTaskGeminiHooks,
+  installTaskCodexHooks: mockInstallTaskCodexHooks,
+}));
+
+/** useTranslations mock은 key를 그대로 반환한다 */
+vi.mock("next-intl", async () => {
+  const actual = await vi.importActual("next-intl");
+  return {
+    ...actual,
+    useTranslations: () => (key: string) => key,
+  };
+});
+
+describe("HooksStatusDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const renderDialog = (props: any) => {
+    return render(<HooksStatusDialog {...props} />);
+  };
+
+  it("should not render when isOpen is false", () => {
+    // Given
+    const props = {
+      isOpen: false,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: null,
+      geminiStatus: null,
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    const { container } = renderDialog(props);
+
+    // Then
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render when isOpen is true", () => {
+    // Given
+    const props = {
+      isOpen: true,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: null,
+      geminiStatus: null,
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderDialog(props);
+
+    // Then
+    expect(screen.getByText("hooksStatus")).toBeTruthy();
+    expect(screen.getByText("Claude")).toBeTruthy();
+  });
+
+  it("should show remote not supported message when isRemote is true", () => {
+    // Given
+    const props = {
+      isOpen: true,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: null,
+      geminiStatus: null,
+      codexStatus: null,
+      isRemote: true,
+    };
+
+    // When
+    renderDialog(props);
+
+    // Then
+    const remoteMessages = screen.getAllByText("hooksRemoteNotSupported");
+    expect(remoteMessages.length).toBeGreaterThan(0);
+  });
+
+  it("should call onClose when close button is clicked", () => {
+    // Given
+    const onClose = vi.fn();
+    const props = {
+      isOpen: true,
+      onClose,
+      taskId: "task-1",
+      claudeStatus: null,
+      geminiStatus: null,
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderDialog(props);
+    const closeButton = screen.getByText("hooksStatusDialog.close");
+    fireEvent.click(closeButton);
+
+    // Then
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call installTaskHooks when Claude install button is clicked", async () => {
+    // Given
+    mockInstallTaskHooks.mockResolvedValue({ success: true });
+    const props = {
+      isOpen: true,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: null,
+      geminiStatus: null,
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderDialog(props);
+    const installButtons = screen.getAllByText("installHooks");
+    fireEvent.click(installButtons[0]);
+
+    // Then
+    await waitFor(() => {
+      expect(mockInstallTaskHooks).toHaveBeenCalledWith("task-1");
+    });
+  });
+
+  it("should show success message when Claude hooks installation succeeds", async () => {
+    // Given
+    mockInstallTaskHooks.mockResolvedValue({ success: true });
+    const props = {
+      isOpen: true,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: null,
+      geminiStatus: null,
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderDialog(props);
+    const installButtons = screen.getAllByText("installHooks");
+    fireEvent.click(installButtons[0]);
+
+    // Then
+    await waitFor(() => {
+      expect(screen.getByText("hooksInstallSuccess")).toBeTruthy();
+    });
+  });
+
+  it("should show error message when Claude hooks installation fails", async () => {
+    // Given
+    mockInstallTaskHooks.mockResolvedValue({ success: false });
+    const props = {
+      isOpen: true,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: null,
+      geminiStatus: null,
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderDialog(props);
+    const installButtons = screen.getAllByText("installHooks");
+    fireEvent.click(installButtons[0]);
+
+    // Then
+    await waitFor(() => {
+      expect(screen.getByText("hooksInstallFailed")).toBeTruthy();
+    });
+  });
+
+  it("should call installTaskGeminiHooks when Gemini install button is clicked", async () => {
+    // Given
+    mockInstallTaskGeminiHooks.mockResolvedValue({ success: true });
+    const props = {
+      isOpen: true,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
+      geminiStatus: null,
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderDialog(props);
+    const installButtons = screen.getAllByText("installHooks");
+    fireEvent.click(installButtons[1]);
+
+    // Then
+    await waitFor(() => {
+      expect(mockInstallTaskGeminiHooks).toHaveBeenCalledWith("task-1");
+    });
+  });
+
+  it("should show Gemini success message when Gemini hooks installation succeeds", async () => {
+    // Given
+    mockInstallTaskGeminiHooks.mockResolvedValue({ success: true });
+    const props = {
+      isOpen: true,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
+      geminiStatus: null,
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderDialog(props);
+    const installButtons = screen.getAllByText("installHooks");
+    fireEvent.click(installButtons[1]);
+
+    // Then
+    await waitFor(() => {
+      expect(screen.getByText("geminiHooksInstallSuccess")).toBeTruthy();
+    });
+  });
+
+  it("should call installTaskCodexHooks when Codex install button is clicked", async () => {
+    // Given
+    mockInstallTaskCodexHooks.mockResolvedValue({ success: true });
+    const props = {
+      isOpen: true,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
+      geminiStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasSettingsEntry: true },
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderDialog(props);
+    const installButtons = screen.getAllByText("installHooks");
+    fireEvent.click(installButtons[2]);
+
+    // Then
+    await waitFor(() => {
+      expect(mockInstallTaskCodexHooks).toHaveBeenCalledWith("task-1");
+    });
+  });
+
+  it("should show Codex success message when Codex hooks installation succeeds", async () => {
+    // Given
+    mockInstallTaskCodexHooks.mockResolvedValue({ success: true });
+    const props = {
+      isOpen: true,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
+      geminiStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasSettingsEntry: true },
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderDialog(props);
+    const installButtons = screen.getAllByText("installHooks");
+    fireEvent.click(installButtons[2]);
+
+    // Then
+    await waitFor(() => {
+      expect(screen.getByText("codexHooksInstallSuccess")).toBeTruthy();
+    });
+  });
+
+  it("should show installed status when hook is already installed", () => {
+    // Given
+    const props = {
+      isOpen: true,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
+      geminiStatus: null,
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderDialog(props);
+
+    // Then
+    expect(screen.getByText("Claude")).toBeTruthy();
+    const installedBadges = screen.getAllByText("hooksInstalled");
+    expect(installedBadges.length).toBeGreaterThan(0);
+  });
+
+  it("should disable close button when installation is pending", async () => {
+    // Given
+    mockInstallTaskHooks.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ success: true }), 1000)
+        )
+    );
+    const props = {
+      isOpen: true,
+      onClose: vi.fn(),
+      taskId: "task-1",
+      claudeStatus: null,
+      geminiStatus: null,
+      codexStatus: null,
+      isRemote: false,
+    };
+
+    // When
+    renderDialog(props);
+    const installButtons = screen.getAllByText("installHooks");
+    fireEvent.click(installButtons[0]);
+
+    // Then
+    await waitFor(() => {
+      const closeButton = screen.getByText("hooksStatusDialog.close") as HTMLButtonElement;
+      expect(closeButton.disabled).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/ui/2602/17-hooks-status-dialog.plan.md)

## 어떤 작업인가요?
- Hooks 상태 UI를 ProjectSettings와 HooksStatusCard에서 중복 제거하고, Dialog 기반으로 통합

## 어떻게 해결했나요?
**1. ProjectSettings에서 hooks status UI 제거**
- ProjectSettings.tsx에서 hooks 상태 표시 및 설치 버튼 관련 코드 전체 제거
- 프로젝트 설정 페이지의 책임을 프로젝트 관리에만 집중

**2. HooksStatusCard → Dialog 분리**
- HooksStatusCard에서 개별 hooks 상태 항목(Claude/Gemini/Codex)을 제거
- 신호등 버튼만 남겨 전체 상태를 한눈에 표시 (🟢 All OK / 🟡 Partial / 🔴 Not Installed)
- 클릭 시 HooksStatusDialog 열림 → 상세 상태 확인 및 설치 기능 제공

**3. HooksStatusDialog 신규 컴포넌트**
- Claude/Gemini/Codex 각각의 설치 상태 표시 및 설치/재설치 버튼
- task 단위 server action 호출 (installTaskHooks, installTaskGeminiHooks, installTaskCodexHooks)
- 원격 프로젝트(isRemote) 미지원 안내

**4. 테스트 추가**
- HooksStatusCard: 11개 테스트 (신호등 상태, 다이얼로그 열기/닫기, isRemote 동작)
- HooksStatusDialog: 13개 테스트 (렌더링, 설치 호출, 성공/실패 메시지, 설치 상태 표시)

## 중요한 변경 사항은 무엇인가요?
### ProjectSettings hooks UI 제거

**hooks 상태 표시 및 설치 코드 완전 제거**
- **변경 이유**: Task 상세 페이지로 hooks 관리를 일원화하여 중복 제거
- **수정 파일**: `src/components/ProjectSettings.tsx`

### HooksStatusCard 리팩토링

**개별 hooks 항목 제거 → 신호등 버튼으로 대체**
- **변경 이유**: Card에서는 요약 상태만 표시, 상세는 Dialog에서 처리하도록 관심사 분리
- **수정 파일**: `src/components/HooksStatusCard.tsx`, `src/app/[locale]/task/[id]/page.tsx`

### HooksStatusDialog 신규 추가

**hooks 상태 상세 확인 및 설치 기능 Dialog**
- **변경 이유**: HooksStatusCard에서 분리된 상세 UI를 독립 컴포넌트로 구성
- **수정 파일**: `src/components/HooksStatusDialog.tsx`, `messages/ko.json`, `messages/en.json`, `messages/zh.json`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
