### PR TITLE
feat(task): 상세 페이지 브라우저 탭 제목 동적 설정

### DIFF
--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { redirect } from "@/i18n/navigation";
 import { getTranslations } from "next-intl/server";
@@ -22,6 +23,21 @@ import { getSidebarDefaultCollapsed, getSidebarHintDismissed, getDoneAlertDismis
 import { Link } from "@/i18n/navigation";
 
 export const dynamicConfig = "force-dynamic";
+
+/** 브라우저 탭 제목을 "{branchName} - {projectName}" 형식으로 동적 생성 */
+export async function generateMetadata({
+  params,
+}: TaskDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const task = await getTaskById(id);
+
+  if (!task) return { title: "KanVibe" };
+
+  const parts = [task.branchName, task.project?.name].filter(Boolean);
+  const title = parts.length > 0 ? parts.join(" - ") : "KanVibe";
+
+  return { title };
+}
 
 interface TaskDetailPageProps {
   params: Promise<{ locale: string; id: string }>;


### PR DESCRIPTION
## 어떤 작업인가요?
- Task 상세 페이지 접근 시 브라우저 탭 제목을 `{br랜치명} - {프로젝트명}` 형식으로 동적 표시

## 어떻게 해결했나요?
**generateMetadata 추가**
- Next.js App Router의 `generateMetadata` 함수를 Task 상세 페이지에 추가
- 서버 사이드에서 Task 데이터를 조회하여 branchName과 project.name을 조합

## 중요한 변경 사항은 무엇인가요?
### 동적 메타데이터 설정

**generateMetadata 함수 추가**
- **변경 이유**: 여러 Task 탭을 열어둘 때 브랜치/프로젝트명으로 구분 가능
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`

**Fallback 처리**
- branch + project 둘 다 있으면: `{branchName} - {projectName}`
- 하나만 있으면: 해당 값만 표시
- 둘 다 없거나 Task 없으면: `KanVibe`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
