### PR TITLE
feat(task): 우클릭 컨텍스트 메뉴에 브랜치 기반 TODO 생성 옵션 추가

### DIFF
--- a/.claude/plan/ui/2602/17-right-click-create-branch-todo.plan.md
+++ b/.claude/plan/ui/2602/17-right-click-create-branch-todo.plan.md
@@ -1,0 +1,108 @@
+# Right-click Create Branch TODO
+
+## Business Goal
+기존 태스크 카드를 우클릭하여 해당 태스크의 브랜치를 base로 삼아 새 브랜치 기반 TODO를 생성하는 기능을 추가한다. 이를 통해 기존 작업에서 파생 작업을 빠르게 만들 수 있다.
+
+## Scope
+- **In Scope**: TaskContextMenu에 새 옵션 추가, CreateTaskModal에 defaultBaseBranch prop 추가, Board.tsx 핸들러 연결, 3개 언어 번역 키 추가
+- **Out of Scope**: 컬럼 빈 영역 우클릭, BranchTaskModal 수정, 새 API endpoint 추가
+
+## Codebase Analysis Summary
+- `TaskContextMenu`: hasBranch prop으로 분기 옵션 표시 제어. 현재 hasBranch일 때는 삭제만 표시됨
+- `CreateTaskModal`: defaultProjectId optional prop 패턴 존재. baseBranch는 프로젝트 선택 시 자동 설정
+- `Board.tsx`: contextMenu state에 task 정보 포함. isBranchModalOpen 패턴으로 모달 제어
+- `createTask` server action: baseBranch를 input으로 받아 처리
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/components/TaskContextMenu.tsx` | 우클릭 컨텍스트 메뉴 | Modify |
+| `src/components/CreateTaskModal.tsx` | 작업 생성 모달 | Modify |
+| `src/components/Board.tsx` | 메인 보드 컴포넌트 | Modify |
+| `messages/ko.json` | 한국어 번역 | Modify |
+| `messages/en.json` | 영어 번역 | Modify |
+| `messages/zh.json` | 중국어 번역 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| i18n 키 사용 | messages/*.json | 하드코딩 텍스트 금지, 3개 언어 동시 추가 |
+| CSS 토큰 사용 | globals.css | Tailwind 클래스에서 디자인 토큰 사용 |
+| useCallback 패턴 | Board.tsx | 이벤트 핸들러를 useCallback으로 감싸기 |
+| Optional prop 패턴 | CreateTaskModal | defaultProjectId처럼 optional prop으로 기본값 전달 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 모달 | CreateTaskModal 재사용 | 동일한 폼 필드, 코드 중복 방지 | 별도 모달 생성 |
+| Base 브랜치 전달 | defaultBaseBranch prop | 기존 defaultProjectId 패턴과 일관 | 별도 state 주입 |
+| 메뉴 조건 | hasBranch일 때만 표시 | 브랜치 없는 태스크는 base가 없으므로 의미 없음 | 항상 표시 |
+
+## Implementation Todos
+
+### Todo 1: Add i18n translation keys
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 컨텍스트 메뉴의 새 옵션에 대한 번역 키를 3개 언어에 추가
+- **Work**:
+  - `messages/ko.json`의 `contextMenu` 객체에 `"createBranchTodo": "브랜치 기반 TODO 생성"` 추가
+  - `messages/en.json`의 `contextMenu` 객체에 `"createBranchTodo": "Create branch TODO"` 추가
+  - `messages/zh.json`의 `contextMenu` 객체에 `"createBranchTodo": "创建分支TODO"` 추가
+- **Convention Notes**: 3개 언어 파일 동시 수정
+- **Verification**: JSON 파싱 오류 없는지 확인
+- **Exit Criteria**: 3개 언어 파일 모두에 동일 키가 존재
+- **Status**: pending
+
+### Todo 2: Add onCreateBranchTodo callback to TaskContextMenu
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: TaskContextMenu에 새 옵션 UI와 콜백을 추가
+- **Work**:
+  - `TaskContextMenuProps`에 `onCreateBranchTodo: () => void` prop 추가
+  - `hasBranch`일 때 "브랜치 기반 TODO 생성" 버튼 렌더링 (기존 버튼 스타일 따라감)
+  - `t("createBranchTodo")` 번역 키 사용
+- **Convention Notes**: 기존 버튼 CSS 클래스 패턴(`w-full text-left px-4 py-2 text-sm text-text-primary hover:bg-bg-page transition-colors`) 유지
+- **Verification**: TypeScript 타입 에러 없는지 확인
+- **Exit Criteria**: hasBranch일 때 새 버튼이 표시되고 콜백 호출
+- **Status**: pending
+
+### Todo 3: Add defaultBaseBranch prop to CreateTaskModal
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: CreateTaskModal이 외부에서 baseBranch 기본값을 받을 수 있도록 확장
+- **Work**:
+  - `CreateTaskModalProps`에 `defaultBaseBranch?: string` 추가
+  - `useEffect`에서 `defaultBaseBranch`가 있으면 `setBaseBranch(defaultBaseBranch)` 호출
+  - `defaultBaseBranch`가 있을 때는 baseBranch select에 해당 값이 옵션으로 포함되도록 처리
+- **Convention Notes**: 기존 defaultProjectId 패턴과 동일하게 처리
+- **Verification**: TypeScript 타입 에러 없는지 확인
+- **Exit Criteria**: defaultBaseBranch prop이 전달되면 baseBranch가 미리 설정됨
+- **Status**: pending
+
+### Todo 4: Wire up Board.tsx handlers
+- **Priority**: 2
+- **Dependencies**: Todo 1, 2, 3
+- **Goal**: Board 컴포넌트에서 새 컨텍스트 메뉴 옵션과 CreateTaskModal을 연결
+- **Work**:
+  - `handleCreateBranchTodo` 콜백 추가 (useCallback): contextMenu를 닫고 CreateTaskModal을 열되 defaultBaseBranch와 defaultProjectId를 설정
+  - 새 state 추가: `branchTodoDefaults` (`{ baseBranch: string; projectId: string } | null`)
+  - `TaskContextMenu`에 `onCreateBranchTodo={handleCreateBranchTodo}` 전달
+  - `CreateTaskModal`에 `defaultBaseBranch={branchTodoDefaults?.baseBranch}` 전달
+  - 모달 닫힐 때 `branchTodoDefaults` 초기화
+- **Convention Notes**: useCallback 패턴, 기존 handleBranchFromCard 패턴 참조
+- **Verification**: TypeScript 빌드 성공 확인
+- **Exit Criteria**: 우클릭 → "브랜치 기반 TODO 생성" → CreateTaskModal이 baseBranch 미리 채워진 상태로 열림
+- **Status**: pending
+
+## Verification Strategy
+- `pnpm build` 성공 확인
+- 3개 언어 JSON 파일 문법 확인
+- TypeScript 타입 에러 없는지 확인
+
+## Progress Tracking
+- Total Todos: 4
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-17: Plan created

--- a/messages/en.json
+++ b/messages/en.json
@@ -75,6 +75,7 @@
   },
   "contextMenu": {
     "branchOff": "Branch off",
+    "createBranchTodo": "Create branch TODO",
     "delete": "Delete"
   },
   "settings": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -75,6 +75,7 @@
   },
   "contextMenu": {
     "branchOff": "브랜치 분기",
+    "createBranchTodo": "브랜치 기반 TODO 생성",
     "delete": "삭제"
   },
   "settings": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -75,6 +75,7 @@
   },
   "contextMenu": {
     "branchOff": "创建分支",
+    "createBranchTodo": "创建分支TODO",
     "delete": "删除"
   },
   "settings": {

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -96,6 +96,10 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isBranchModalOpen, setIsBranchModalOpen] = useState(false);
+  const [branchTodoDefaults, setBranchTodoDefaults] = useState<{
+    baseBranch: string;
+    projectId: string;
+  } | null>(null);
   const [isMounted, setIsMounted] = useState(false);
   const [selectedProjectIds, setSelectedProjectIds] = useState<string[]>([]);
   const [doneTotal, setDoneTotal] = useState(initialDoneTotal);
@@ -373,6 +377,18 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
     setContextMenu((prev) => ({ ...prev, isOpen: false }));
   }, []);
 
+  /** 우클릭한 태스크의 브랜치를 base로 새 TODO를 생성하는 모달을 연다 */
+  const handleCreateBranchTodo = useCallback(() => {
+    if (contextMenu.task?.branchName && contextMenu.task?.projectId) {
+      setBranchTodoDefaults({
+        baseBranch: contextMenu.task.branchName,
+        projectId: contextMenu.task.projectId,
+      });
+      setIsModalOpen(true);
+    }
+    setContextMenu((prev) => ({ ...prev, isOpen: false }));
+  }, [contextMenu.task]);
+
   const handleDeleteFromCard = useCallback(() => {
     if (contextMenu.task && confirm(tt("deleteConfirm"))) {
       deleteTask(contextMenu.task.id);
@@ -465,10 +481,14 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
 
       <CreateTaskModal
         isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
+        onClose={() => {
+          setIsModalOpen(false);
+          setBranchTodoDefaults(null);
+        }}
         sshHosts={sshHosts}
         projects={projects}
-        defaultProjectId={selectedProjectIds.length === 1 ? selectedProjectIds[0] : ""}
+        defaultProjectId={branchTodoDefaults?.projectId || (selectedProjectIds.length === 1 ? selectedProjectIds[0] : "")}
+        defaultBaseBranch={branchTodoDefaults?.baseBranch}
       />
 
       <ProjectSettings
@@ -486,6 +506,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
           y={contextMenu.y}
           onClose={handleCloseContextMenu}
           onBranch={handleBranchFromCard}
+          onCreateBranchTodo={handleCreateBranchTodo}
           onDelete={handleDeleteFromCard}
           hasBranch={!!contextMenu.task.branchName}
         />

--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -17,6 +17,7 @@ interface CreateTaskModalProps {
   sshHosts: string[];
   projects: Project[];
   defaultProjectId?: string;
+  defaultBaseBranch?: string;
 }
 
 export default function CreateTaskModal({
@@ -25,6 +26,7 @@ export default function CreateTaskModal({
   sshHosts,
   projects,
   defaultProjectId,
+  defaultBaseBranch,
 }: CreateTaskModalProps) {
   const t = useTranslations("task");
   const tc = useTranslations("common");
@@ -54,13 +56,17 @@ export default function CreateTaskModal({
 
     const selectedProject = projects.find((p) => p.id === selectedProjectId);
     if (selectedProject) {
-      setBaseBranch(selectedProject.defaultBranch);
+      setBaseBranch(defaultBaseBranch || selectedProject.defaultBranch);
     }
 
     getProjectBranches(selectedProjectId).then((result) => {
       setBranches(result);
+      /** defaultBaseBranch가 브랜치 목록에 없으면 옵션에 추가한다 */
+      if (defaultBaseBranch && !result.includes(defaultBaseBranch)) {
+        setBranches((prev) => [defaultBaseBranch, ...prev]);
+      }
     });
-  }, [selectedProjectId, projects]);
+  }, [selectedProjectId, projects, defaultBaseBranch]);
 
   if (!isOpen) return null;
 

--- a/src/components/TaskContextMenu.tsx
+++ b/src/components/TaskContextMenu.tsx
@@ -8,6 +8,7 @@ interface TaskContextMenuProps {
   y: number;
   onClose: () => void;
   onBranch: () => void;
+  onCreateBranchTodo: () => void;
   onDelete: () => void;
   hasBranch: boolean;
 }
@@ -18,6 +19,7 @@ export default function TaskContextMenu({
   y,
   onClose,
   onBranch,
+  onCreateBranchTodo,
   onDelete,
   hasBranch,
 }: TaskContextMenuProps) {
@@ -47,6 +49,14 @@ export default function TaskContextMenu({
           className="w-full text-left px-4 py-2 text-sm text-text-primary hover:bg-bg-page transition-colors"
         >
           {t("branchOff")}
+        </button>
+      )}
+      {hasBranch && (
+        <button
+          onClick={onCreateBranchTodo}
+          className="w-full text-left px-4 py-2 text-sm text-text-primary hover:bg-bg-page transition-colors"
+        >
+          {t("createBranchTodo")}
         </button>
       )}
       <button


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/ui/2602/17-right-click-create-branch-todo.plan.md)

## 어떤 작업인가요?
- 브랜치가 있는 태스크 카드를 우클릭하면, 해당 브랜치를 base로 삼아 새 TODO를 생성할 수 있는 기능을 추가합니다.

## 어떻게 해결했나요?
**컨텍스트 메뉴 옵션 추가**
- `hasBranch`일 때 "브랜치 기반 TODO 생성" 버튼을 컨텍스트 메뉴에 표시
- 기존 "브랜치 분기" 옵션과 상호 배타적으로 표시 (브랜치 없을 때만 "브랜치 분기", 있을 때만 "브랜치 기반 TODO 생성")

**CreateTaskModal 확장**
- `defaultBaseBranch` optional prop을 추가하여 외부에서 base 브랜치를 미리 설정 가능
- 브랜치 목록 로드 후 `defaultBaseBranch`가 목록에 없으면 자동으로 옵션에 추가

**Board 핸들러 연결**
- `branchTodoDefaults` state로 우클릭한 태스크의 브랜치명과 프로젝트 ID를 전달
- 모달 닫을 때 defaults 초기화

## 중요한 변경 사항은 무엇인가요?
### TaskContextMenu 옵션 추가

**`onCreateBranchTodo` 콜백 및 버튼 추가**
- **변경 이유**: 기존에 브랜치가 있는 태스크 카드에는 삭제 외에 브랜치 관련 옵션이 없었음
- **수정 파일**: `src/components/TaskContextMenu.tsx`

### CreateTaskModal 확장

**`defaultBaseBranch` prop 추가**
- **변경 이유**: 우클릭한 태스크의 브랜치를 base로 미리 설정하기 위해 기존 `defaultProjectId` 패턴을 따라 확장
- **수정 파일**: `src/components/CreateTaskModal.tsx`

### Board 핸들러 연결

**`handleCreateBranchTodo` 핸들러 및 state 추가**
- **변경 이유**: 컨텍스트 메뉴 옵션과 CreateTaskModal 간의 데이터 흐름 연결
- **수정 파일**: `src/components/Board.tsx`

### i18n 번역 키 추가

**3개 언어 `contextMenu.createBranchTodo` 키 추가**
- **변경 이유**: 새 컨텍스트 메뉴 옵션의 다국어 지원
- **수정 파일**: `messages/ko.json`, `messages/en.json`, `messages/zh.json`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
