### PR TITLE
fix(notification): Chrome 알림 클릭 시 URL 이중 경로 버그 수정

### DIFF
--- a/src/components/NotificationListener.tsx
+++ b/src/components/NotificationListener.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { usePathname } from "@/i18n/navigation";
+import { useLocale } from "next-intl";
 import { useTaskNotification } from "@/hooks/useTaskNotification";
 
 const RECONNECT_DELAY_MS = 3000;
@@ -17,16 +17,13 @@ export default function NotificationListener({
   enabledStatuses,
 }: NotificationListenerProps) {
   const { notifyTaskStatusChanged } = useTaskNotification();
-  const pathname = usePathname();
+  const locale = useLocale();
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   /** useEffect 내 stale closure 방지용 ref */
   const settingsRef = useRef({ isNotificationEnabled, enabledStatuses });
   settingsRef.current = { isNotificationEnabled, enabledStatuses };
-
-  // pathname에서 locale 추출: /[locale]/...
-  const locale = pathname.split("/")[1] || "ko";
 
   // Service Worker 등록
   useEffect(() => {

--- a/src/components/__tests__/NotificationListener.test.tsx
+++ b/src/components/__tests__/NotificationListener.test.tsx
@@ -11,8 +11,8 @@ vi.mock("@/hooks/useTaskNotification", () => ({
   }),
 }));
 
-vi.mock("@/i18n/navigation", () => ({
-  usePathname: () => "/ko/board",
+vi.mock("next-intl", () => ({
+  useLocale: () => "ko",
 }));
 
 /** WebSocket 목 클래스. 인스턴스를 추적하여 테스트에서 메시지 수신을 시뮬레이션한다 */


### PR DESCRIPTION
## 어떤 작업인가요?
- Chrome 브라우저 알림 클릭 시 `/{locale}/task/task/{taskId}`로 이동하는 URL 이중 경로 버그 수정

## 어떻게 해결했나요?
**locale 추출 방식 변경**
- `usePathname()` + 문자열 파싱 대신 `useLocale()`을 사용하여 정확한 locale 값을 직접 가져오도록 변경

## 중요한 변경 사항은 무엇인가요?
### locale 추출 로직 수정

**usePathname → useLocale 교체**
- **변경 이유**: next-intl의 `usePathname()`은 locale 접두사가 제거된 경로를 반환하므로 `pathname.split("/")[1]`이 locale(`ko`) 대신 `task`를 반환하여 Service Worker에서 `/task/task/{taskId}` URL이 생성되는 버그 발생
- **수정 파일**: `src/components/NotificationListener.tsx`, `src/components/__tests__/NotificationListener.test.tsx`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
