### PR TITLE
feat(kanban): 프로젝트별 태스크 그룹핑, 브랜치 플로우 라인, hex 색상 편집기

### DIFF
--- a/.claude/plan/ui/2602/17-project-group-flow-line.plan.md
+++ b/.claude/plan/ui/2602/17-project-group-flow-line.plan.md
@@ -1,0 +1,173 @@
+# Project Group & Branch Flow Line
+
+## Business Goal
+칸반 보드에서 동일 프로젝트의 태스크를 파스텔톤 테두리로 시각적으로 그룹화하고, 그룹 내에서 baseBranch → childBranch 브랜치 계층 관계를 git-like 트리 라인으로 표시하여 프로젝트별 작업 현황과 브랜치 흐름을 한눈에 파악할 수 있게 한다.
+
+## Scope
+- **In Scope**:
+  - 컬럼 내 태스크를 프로젝트별로 정렬/그룹화 (같은 프로젝트끼리 인접 배치)
+  - 프로젝트 그룹에 파스텔톤 테두리 + 프로젝트명 라벨 표시
+  - 그룹 내 baseBranch → childBranch 트리 라인/화살표 (같은 컬럼 내에서만)
+  - 8개 파스텔 색상 자동 할당 (CSS 변수, 프로젝트명 해시 기반)
+  - worktree 프로젝트는 메인 프로젝트 그룹으로 통합 (기존 projectNameMap 로직 활용)
+  - 프로젝트 없는 태스크는 그룹 없이 하단에 표시
+- **Out of Scope**:
+  - 크로스-컬럼 화살표
+  - 프로젝트별 색상 수동 설정 (DB 필드)
+  - 그룹 접기/펼치기 기능
+
+## Codebase Analysis Summary
+- 칸반 보드 구조: Board → Column → TaskCard (DragDropContext/Droppable/Draggable)
+- `KanbanTask` 엔티티에 `projectId`, `baseBranch`, `branchName` 필드 존재
+- `Project` 엔티티에 `defaultBranch`, `isWorktree` 필드 존재
+- `Board.tsx`에서 `projectNameMap` (worktree → 메인 프로젝트명 resolve), `projectFilterSet` 이미 구현
+- Column은 flat list로 TaskCard 렌더링, DnD index는 순서 기반
+- 디자인 토큰: `:root`에 CSS 변수 → `@theme inline`에 Tailwind 등록 패턴
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/app/globals.css` | 디자인 토큰 정의 | Modify - 파스텔 그룹 색상 토큰 추가 |
+| `prd/design-system.json` | 디자인 시스템 원본 | Modify - 그룹 색상 토큰 추가 |
+| `src/components/Board.tsx` | 메인 보드 컴포넌트 | Modify - projectColorMap 계산, Column에 전달 |
+| `src/components/Column.tsx` | 컬럼 컴포넌트 | Modify - 태스크 그룹핑 로직, ProjectTaskGroup 렌더링 |
+| `src/components/ProjectTaskGroup.tsx` | 프로젝트 그룹 래퍼 | Create - 파스텔 테두리 + 트리 라인 렌더링 |
+| `src/components/TaskCard.tsx` | 태스크 카드 | Reference - 기존 구조 유지 |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| CSS 변수 네이밍 | globals.css | `--color-{category}-{name}` 패턴 |
+| Tailwind 등록 | globals.css | `:root` 정의 후 `@theme inline`에 등록 |
+| 컴포넌트 | 기존 패턴 | `"use client"` 지시자, default export |
+| 주석 | CODE_PRINCIPLES | 한국어 서술형 |
+| 네이밍 | CODE_PRINCIPLES | 명확한 전체 단어, 비즈니스 역할 표현 |
+| i18n | CLAUDE.md | 새 UI 텍스트는 messages/{locale}.json에 번역 키 추가 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 그룹핑 방식 | 컬럼 내 정렬 후 wrapper div | DnD와 호환, 시각적으로 깔끔 | Overlay, Virtual grouping |
+| 색상 할당 | 프로젝트명 해시 → 파스텔 팔레트 인덱스 | 세션 간 일관성, DB 변경 불필요 | 순서 기반, DB 저장 |
+| 트리 라인 | CSS border-left + 작은 화살표 SVG | 경량, 추가 라이브러리 불필요 | Full SVG, Canvas |
+| 새 컴포넌트 | ProjectTaskGroup.tsx | 그룹 렌더링 책임 분리 (SRP) | Column에 직접 구현 |
+| DnD 호환 | Draggable index를 전체 컬럼 기준 유지 | 그룹핑 후에도 DnD 순서 유지 | 그룹 내 local index |
+
+## Implementation Todos
+
+### Todo 1: 파스텔 색상 디자인 토큰 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 8개 프로젝트 그룹 파스텔 색상을 CSS 변수로 정의
+- **Work**:
+  - `src/app/globals.css`의 `:root`에 8개 파스텔 색상 변수 추가:
+    - `--color-group-0-border`, `--color-group-0-bg` ~ `--color-group-7-border`, `--color-group-7-bg`
+    - border: 파스텔 중간 톤 (테두리용), bg: 매우 연한 파스텔 (배경용)
+    - 색상: 핑크, 스카이블루, 민트, 라벤더, 피치, 레몬, 로즈, 세이지
+  - `@theme inline` 블록에 동일 변수 Tailwind 등록
+  - `--color-group-line`: 트리 라인 색상 (gray-300 수준)
+  - `prd/design-system.json`에 해당 토큰 추가
+- **Convention Notes**: `--color-{category}-{name}` 패턴, `:root` 정의 → `@theme inline` 등록
+- **Verification**: CSS 파일 문법 오류 없음, `pnpm build` 성공
+- **Exit Criteria**: 8개 그룹 색상 + 트리 라인 색상이 CSS 변수로 정의되고 Tailwind에서 사용 가능
+- **Status**: pending
+
+### Todo 2: Board에서 projectColorMap 계산 로직 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 프로젝트명 → 색상 인덱스(0-7) 매핑 계산 후 Column에 전달
+- **Work**:
+  - `src/components/Board.tsx`에 `projectColorMap` useMemo 추가:
+    - `projectNameMap`에서 unique한 프로젝트명 추출
+    - 프로젝트명의 간단한 해시값 → 0-7 인덱스 매핑 (일관성 보장)
+    - `Record<string, number>` 타입 (resolvedProjectName → colorIndex)
+  - `ColumnProps`에 `projectColorMap: Record<string, number>` 추가
+  - Column 렌더링 시 `projectColorMap` prop 전달
+- **Convention Notes**: useMemo로 계산, 기존 `projectNameMap` 의존
+- **Verification**: TypeScript 타입 체크 통과
+- **Exit Criteria**: Board가 Column에 프로젝트별 색상 인덱스를 전달하는 구조 완성
+- **Status**: pending
+
+### Todo 3: ProjectTaskGroup 컴포넌트 생성
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 프로젝트 그룹의 파스텔 테두리 + 프로젝트명 라벨 + 브랜치 트리 라인을 렌더링하는 컴포넌트 생성
+- **Work**:
+  - `src/components/ProjectTaskGroup.tsx` 생성
+  - Props: `projectName: string`, `colorIndex: number`, `tasks: KanbanTask[]`, `children: React.ReactNode`
+  - 렌더링 구조:
+    - 외부 div: `border-2 rounded-lg p-2 mb-3` + 동적 파스텔 border/bg 색상
+    - 상단: 프로젝트명 라벨 (작은 텍스트)
+    - 내부: children (TaskCard들)
+  - 브랜치 트리 라인 렌더링:
+    - `tasks` 배열에서 baseBranch → branchName 관계를 분석하여 트리 구조 계산
+    - 루트 노드: baseBranch가 없거나 프로젝트 defaultBranch와 일치하는 태스크
+    - 자식 노드: baseBranch가 다른 태스크의 branchName과 일치하는 태스크
+    - 각 태스크 카드 왼쪽에 트리 라인 표시 (CSS border-left + pseudo-element)
+    - 루트: 세로선 시작, 자식: 세로선에서 가로선으로 분기하는 L자 라인
+  - 브랜치 관계가 없는 태스크(branchName 없음)는 라인 없이 일반 표시
+- **Convention Notes**: `"use client"`, default export, 한국어 주석
+- **Verification**: 컴포넌트 단독 렌더링 가능, 타입 체크 통과
+- **Exit Criteria**: 파스텔 테두리 + 프로젝트명 + 트리 라인이 포함된 그룹 컴포넌트 완성
+- **Status**: pending
+
+### Todo 4: Column에서 태스크 그룹핑 및 ProjectTaskGroup 렌더링
+- **Priority**: 3
+- **Dependencies**: Todo 2, Todo 3
+- **Goal**: Column 내 태스크를 프로젝트별로 그룹화하여 ProjectTaskGroup으로 렌더링
+- **Work**:
+  - `src/components/Column.tsx` 수정
+  - `ColumnProps`에 `projectColorMap: Record<string, number>` 추가
+  - 태스크 그룹핑 로직:
+    - `tasks`를 projectName 기준으로 정렬 (같은 프로젝트끼리 인접)
+    - 프로젝트 있는 태스크: 그룹별로 `ProjectTaskGroup` 래퍼로 감싸기
+    - 프로젝트 없는 태스크: 그룹 없이 하단에 렌더링
+  - DnD 호환:
+    - Draggable `index`는 전체 컬럼 기준 연속 번호 유지
+    - 그룹 wrapper div 안에 Draggable TaskCard 배치 (DnD와 호환)
+  - `Board.tsx`에서 전달하는 `projectColorMap` 활용
+- **Convention Notes**: DnD index 연속성 필수, 그룹 내/외 순서 일관성
+- **Verification**: `pnpm build` 성공, DnD가 그룹핑 후에도 정상 동작
+- **Exit Criteria**: 컬럼 내 태스크가 프로젝트별 파스텔 테두리 그룹으로 표시되고 DnD 동작 유지
+- **Status**: pending
+
+### Todo 5: i18n 번역 키 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 새로 추가되는 UI 텍스트의 번역 키 등록
+- **Work**:
+  - `messages/ko.json`에 추가: `"board.noProject": "프로젝트 없음"` (그룹 없는 태스크 영역 라벨, 필요 시)
+  - `messages/en.json`에 추가: `"board.noProject": "No Project"`
+  - `messages/zh.json`에 추가: `"board.noProject": "无项目"`
+  - Assumption: 현재 UI에서 별도 라벨이 필요 없으면 이 Todo는 skip 가능
+- **Convention Notes**: 3개 언어 파일 동시 수정
+- **Verification**: 빌드 시 번역 키 누락 에러 없음
+- **Exit Criteria**: 새 UI에 필요한 번역 키가 3개 언어로 등록됨
+- **Status**: pending
+
+### Todo 6: 빌드 검증 및 최종 테스트
+- **Priority**: 4
+- **Dependencies**: Todo 4, Todo 5
+- **Goal**: 전체 기능 통합 후 빌드 성공 및 타입 안전성 확인
+- **Work**:
+  - `pnpm build` 실행하여 전체 빌드 성공 확인
+  - TypeScript 타입 에러 없음 확인
+  - 기존 테스트 (`pnpm test`) 통과 확인
+- **Convention Notes**: N/A
+- **Verification**: `pnpm build && pnpm test` 성공
+- **Exit Criteria**: 빌드 성공, 기존 테스트 통과, 타입 에러 없음
+- **Status**: pending
+
+## Verification Strategy
+- `pnpm build`: 전체 빌드 성공
+- `pnpm test`: 기존 테스트 회귀 없음
+- 시각적 확인: 프로젝트 그룹 파스텔 테두리, 트리 라인 렌더링, DnD 동작
+
+## Progress Tracking
+- Total Todos: 6
+- Completed: 6
+- Status: Execution complete
+
+## Change Log
+- 2026-02-17: Plan created
+- 2026-02-17: All todos executed and verified

--- a/.claude/plan/ui/2602/18-project-color-db-depth-opacity.plan.md
+++ b/.claude/plan/ui/2602/18-project-color-db-depth-opacity.plan.md
@@ -1,0 +1,176 @@
+# Project Color DB 저장 + 자식 브랜치 명암 표현
+
+## Business Goal
+프로젝트 그룹 색상을 DB에 영속화하여 사용자가 직접 변경할 수 있게 하고, 브랜치 계층에 따른 색상 명암으로 부모-자식 관계를 시각적으로 표현한다.
+
+## Scope
+- **In Scope**:
+  - Project 엔티티에 `colorIndex` 컬럼 추가 (DB 마이그레이션)
+  - Board에서 DB colorIndex 우선 사용, null이면 해시 fallback
+  - TaskDetail 페이지에 프로젝트 색상 인라인 편집기 추가
+  - 프로젝트 그룹 내 자식 브랜치 태스크에 depth 기반 opacity 적용
+- **Out of Scope**:
+  - HEX 커스텀 색상 입력
+  - worktree 프로젝트 독립 색상 설정
+
+## Codebase Analysis Summary
+- Project 엔티티: `src/entities/Project.ts` (id, name, repoPath, defaultBranch, sshHost, isWorktree, createdAt)
+- Board의 projectColorMap: useMemo 해시 기반 (projectNameMap → 0-7 인덱스)
+- Column: ProjectTaskGroup 래퍼 + BranchConnector + depth 기반 indentation
+- TaskDetailInfoCard: PriorityEditor 패턴 참고 가능
+- 마이그레이션: `src/migrations/` 타임스탬프 기반, `database.ts` migrations 배열에 수동 추가
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/entities/Project.ts` | Project 엔티티 | Modify - colorIndex 추가 |
+| `src/migrations/` | DB 마이그레이션 | Create - AddColorIndexToProjects |
+| `src/lib/database.ts` | 런타임 DataSource | Modify - migrations 배열에 추가 |
+| `src/app/actions/kanban.ts` | Server actions | Modify - updateProjectColor 추가 |
+| `src/components/Board.tsx` | 보드 메인 | Modify - projectColorMap DB 값 우선 사용 |
+| `src/components/ProjectColorEditor.tsx` | 색상 편집기 | Create - 인라인 색상 선택 UI |
+| `src/components/TaskDetailInfoCard.tsx` | Detail 사이드바 | Modify - ProjectColorEditor 통합 |
+| `src/components/Column.tsx` | 컬럼 렌더링 | Modify - 자식 브랜치 opacity 적용 |
+| `src/components/ProjectTaskGroup.tsx` | 그룹 래퍼 | Modify - depth 기반 스타일 전달 |
+| `messages/*.json` | i18n | Modify - 번역 키 추가 |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 마이그레이션 | CLAUDE.md | 엔티티 수정 → generate → database.ts에 import 추가 |
+| Server action | 기존 패턴 | `"use server"`, revalidatePath, serialize |
+| 인라인 편집기 | PriorityEditor | 클릭 시 드롭다운, server action 호출 |
+| i18n | CLAUDE.md | ko/en/zh 3개 파일 동시 수정 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| DB 타입 | smallint nullable | null = 해시 fallback, 0-7 범위 | varchar hex |
+| 편집 UI | 8색 원형 스와치 드롭다운 | PriorityEditor 패턴 일관, 직관적 | 모달, 슬라이더 |
+| 자식 opacity | inline style opacity | CSS 변수 추가 없이 간단 | HSL lightness |
+| worktree 색상 | 메인 프로젝트 colorIndex 조회 | 기존 통합 로직 유지 | 개별 설정 |
+
+## Implementation Todos
+
+### Todo 1: Project 엔티티 + 마이그레이션
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: Project 테이블에 color_index 컬럼 추가
+- **Work**:
+  - `src/entities/Project.ts`에 colorIndex 프로퍼티 추가: `@Column({ name: "color_index", type: "smallint", nullable: true, default: null }) colorIndex!: number | null;`
+  - `pnpm migration:generate -- src/migrations/AddColorIndexToProjects` 실행
+  - 생성된 마이그레이션 파일 검토
+  - `src/lib/database.ts` migrations 배열에 새 마이그레이션 import 추가
+- **Convention Notes**: 마이그레이션 파일은 생성 후 수정하지 않음
+- **Verification**: `pnpm migration:run` 성공
+- **Exit Criteria**: DB에 color_index 컬럼 존재, 기존 데이터는 null
+- **Status**: pending
+
+### Todo 2: Server action - updateProjectColor
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 프로젝트 색상 변경 API 추가
+- **Work**:
+  - `src/app/actions/kanban.ts`에 `updateProjectColor(projectId: string, colorIndex: number)` 추가
+  - 동일 repoPath의 worktree 프로젝트도 같은 colorIndex로 업데이트
+  - revalidatePath 호출
+  - serialize 패턴 따름
+- **Convention Notes**: 기존 server action 패턴, `"use server"`, revalidatePath
+- **Verification**: TypeScript 타입 체크 통과
+- **Exit Criteria**: 프로젝트 색상을 DB에 저장하고 관련 worktree도 동기화하는 server action 완성
+- **Status**: pending
+
+### Todo 3: Board - DB colorIndex 우선 사용
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: projectColorMap에서 DB값 우선, null이면 해시 fallback
+- **Work**:
+  - `src/components/Board.tsx`의 `projectColorMap` useMemo 수정
+  - projects 배열에서 메인 프로젝트의 colorIndex를 조회
+  - colorIndex가 있으면 사용, null이면 기존 해시 로직 fallback
+  - worktree 프로젝트는 메인 프로젝트의 colorIndex 상속
+- **Convention Notes**: 기존 projectNameMap, projectColorMap 구조 유지
+- **Verification**: TypeScript 타입 체크 통과
+- **Exit Criteria**: DB에 colorIndex가 저장된 프로젝트는 해당 색상 사용
+- **Status**: pending
+
+### Todo 4: ProjectColorEditor 컴포넌트
+- **Priority**: 2
+- **Dependencies**: Todo 2
+- **Goal**: 프로젝트 색상을 변경할 수 있는 인라인 편집기 컴포넌트
+- **Work**:
+  - `src/components/ProjectColorEditor.tsx` 생성
+  - Props: `projectId: string`, `currentColorIndex: number | null`
+  - UI: 현재 색상 원형 표시, 클릭 시 8색 스와치 드롭다운
+  - 선택 시 `updateProjectColor` server action 호출
+  - PriorityEditor 패턴 참고 (useTransition, 드롭다운)
+- **Convention Notes**: `"use client"`, 기존 인라인 편집기 패턴
+- **Verification**: 컴포넌트 렌더링 가능, 타입 체크 통과
+- **Exit Criteria**: 8색 중 선택하여 프로젝트 색상 변경 가능
+- **Status**: pending
+
+### Todo 5: TaskDetailInfoCard에 색상 편집기 통합
+- **Priority**: 3
+- **Dependencies**: Todo 4
+- **Goal**: Detail 페이지에서 프로젝트 색상 편집 가능
+- **Work**:
+  - `src/components/TaskDetailInfoCard.tsx` 수정
+  - 기존 project 표시 영역에 ProjectColorEditor 추가
+  - task.project.colorIndex를 전달
+- **Convention Notes**: 기존 PriorityEditor 배치 패턴과 동일
+- **Verification**: Detail 페이지에서 색상 변경 UI 표시
+- **Exit Criteria**: project 정보 옆에 색상 편집기 표시, 변경 가능
+- **Status**: pending
+
+### Todo 6: 자식 브랜치 depth 기반 opacity 적용
+- **Priority**: 2
+- **Dependencies**: none
+- **Goal**: 프로젝트 그룹 내 자식 태스크의 테두리/배경 색상을 depth에 비례하여 연하게
+- **Work**:
+  - `src/components/Column.tsx` 수정
+  - 그룹 내 각 태스크 렌더링 시 depth에 기반한 opacity 적용
+  - depth 0: opacity 100% (원래 색상), depth 1: opacity 65%, depth 2+: opacity 40%
+  - TaskCard 래퍼 div에 style={{ opacity }} 적용 (그룹 테두리 내부)
+  - BranchConnector도 동일 opacity 적용
+- **Convention Notes**: inline style 사용 (동적 값)
+- **Verification**: 타입 체크 통과
+- **Exit Criteria**: 자식 브랜치 태스크가 시각적으로 연한 색상으로 표시
+- **Status**: pending
+
+### Todo 7: i18n 번역 키 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 색상 편집기 관련 번역 키 등록
+- **Work**:
+  - `messages/ko.json`: `"taskDetail.projectColor": "프로젝트 색상"`
+  - `messages/en.json`: `"taskDetail.projectColor": "Project Color"`
+  - `messages/zh.json`: `"taskDetail.projectColor": "项目颜色"`
+- **Convention Notes**: 3개 언어 동시 수정
+- **Verification**: 빌드 시 번역 키 누락 에러 없음
+- **Exit Criteria**: 번역 키 등록 완료
+- **Status**: pending
+
+### Todo 8: 빌드 검증
+- **Priority**: 4
+- **Dependencies**: Todo 3, Todo 5, Todo 6, Todo 7
+- **Goal**: 전체 빌드 + 테스트 통과
+- **Work**:
+  - `npx tsc --noEmit` TypeScript 검증
+  - `pnpm test` 기존 테스트 통과
+- **Verification**: 모든 검증 통과
+- **Exit Criteria**: 타입 에러 0, 테스트 84/84 통과
+- **Status**: pending
+
+## Verification Strategy
+- `npx tsc --noEmit`: TypeScript 타입 안전성
+- `pnpm test`: 기존 테스트 회귀 없음
+- `pnpm migration:run`: 마이그레이션 적용 성공
+
+## Progress Tracking
+- Total Todos: 8
+- Completed: 8
+- Status: Execution complete
+
+## Change Log
+- 2026-02-18: Plan created
+- 2026-02-18: All todos executed and verified

--- a/messages/en.json
+++ b/messages/en.json
@@ -186,6 +186,7 @@
     "prLink": "PR Link",
     "project": "Project",
     "baseProject": "Base",
+    "projectColor": "Project Color",
     "actions": "Change Status",
     "deleteConfirm": "Are you sure you want to delete this task?",
     "hooksStatus": "Hooks Status",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -186,6 +186,7 @@
     "prLink": "PR 링크",
     "project": "프로젝트",
     "baseProject": "Base",
+    "projectColor": "프로젝트 색상",
     "actions": "상태 변경",
     "deleteConfirm": "이 작업을 삭제하시겠습니까?",
     "hooksStatus": "Hooks 상태",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -186,6 +186,7 @@
     "prLink": "PR 链接",
     "project": "项目",
     "baseProject": "Base",
+    "projectColor": "项目颜色",
     "actions": "状态变更",
     "deleteConfirm": "确定要删除此任务吗？",
     "hooksStatus": "Hooks 状态",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "node-pty": "^1.1.0",
     "pg": "^8.18.0",
     "react": "19.2.3",
+    "react-colorful": "^5.6.1",
     "react-dom": "19.2.3",
     "reflect-metadata": "^0.2.2",
     "ssh2": "^1.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       react:
         specifier: 19.2.3
         version: 19.2.3
+      react-colorful:
+        specifier: ^5.6.1
+        version: 5.6.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
@@ -2652,6 +2655,12 @@ packages:
 
   raf-schd@4.0.3:
     resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
+
+  react-colorful@5.6.1:
+    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -5837,6 +5846,11 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   raf-schd@4.0.3: {}
+
+  react-colorful@5.6.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:

--- a/prd/design-system.json
+++ b/prd/design-system.json
@@ -129,6 +129,17 @@
       "branch": { "background": "{gray.100}", "text": "{gray.700}" },
       "neutral": { "background": "{gray.100}", "text": "{gray.600}" },
       "base": { "background": "#EDE7F6", "text": "#5E35B1" }
+    },
+    "projectGroup": {
+      "0": { "border": "#F9A8D4", "background": "#FDF2F8" },
+      "1": { "border": "#93C5FD", "background": "#EFF6FF" },
+      "2": { "border": "#86EFAC", "background": "#F0FDF4" },
+      "3": { "border": "#C4B5FD", "background": "#F5F3FF" },
+      "4": { "border": "#FDBA74", "background": "#FFF7ED" },
+      "5": { "border": "#FDE047", "background": "#FEFCE8" },
+      "6": { "border": "#5EEAD4", "background": "#F0FDFA" },
+      "7": { "border": "#A5B4FC", "background": "#EEF2FF" },
+      "line": "{gray.400}"
     }
   },
   "typography": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -107,6 +107,25 @@
   --color-tag-base-bg: #202632;
   --color-tag-base-text: #FFFFFF;
 
+  /* Semantic: Project Group (pastel) */
+  --color-group-0-border: #F9A8D4;
+  --color-group-0-bg: #FDF2F8;
+  --color-group-1-border: #93C5FD;
+  --color-group-1-bg: #EFF6FF;
+  --color-group-2-border: #86EFAC;
+  --color-group-2-bg: #F0FDF4;
+  --color-group-3-border: #C4B5FD;
+  --color-group-3-bg: #F5F3FF;
+  --color-group-4-border: #FDBA74;
+  --color-group-4-bg: #FFF7ED;
+  --color-group-5-border: #FDE047;
+  --color-group-5-bg: #FEFCE8;
+  --color-group-6-border: #5EEAD4;
+  --color-group-6-bg: #F0FDFA;
+  --color-group-7-border: #A5B4FC;
+  --color-group-7-bg: #EEF2FF;
+  --color-group-line: var(--gray-400);
+
   /* Semantic: Priority */
   --color-priority-low-bg: var(--blue-50);
   --color-priority-low-text: var(--blue-600);
@@ -216,6 +235,25 @@
   --color-priority-medium-text: var(--color-priority-medium-text);
   --color-priority-high-bg: var(--color-priority-high-bg);
   --color-priority-high-text: var(--color-priority-high-text);
+
+  /* Project Group (pastel) */
+  --color-group-0-border: var(--color-group-0-border);
+  --color-group-0-bg: var(--color-group-0-bg);
+  --color-group-1-border: var(--color-group-1-border);
+  --color-group-1-bg: var(--color-group-1-bg);
+  --color-group-2-border: var(--color-group-2-border);
+  --color-group-2-bg: var(--color-group-2-bg);
+  --color-group-3-border: var(--color-group-3-border);
+  --color-group-3-bg: var(--color-group-3-bg);
+  --color-group-4-border: var(--color-group-4-border);
+  --color-group-4-bg: var(--color-group-4-bg);
+  --color-group-5-border: var(--color-group-5-border);
+  --color-group-5-bg: var(--color-group-5-bg);
+  --color-group-6-border: var(--color-group-6-border);
+  --color-group-6-bg: var(--color-group-6-bg);
+  --color-group-7-border: var(--color-group-7-border);
+  --color-group-7-bg: var(--color-group-7-bg);
+  --color-group-line: var(--color-group-line);
 
   /* Terminal Chrome */
   --color-terminal-chrome: var(--color-terminal-chrome);

--- a/src/components/ProjectColorEditor.tsx
+++ b/src/components/ProjectColorEditor.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "@/i18n/navigation";
+import { HexColorPicker, HexColorInput } from "react-colorful";
+import { updateProjectColor } from "@/app/actions/kanban";
+
+const PRESET_COLORS = [
+  "#F9A8D4", "#93C5FD", "#86EFAC", "#C4B5FD",
+  "#FDBA74", "#FDE047", "#5EEAD4", "#A5B4FC",
+];
+
+interface ProjectColorEditorProps {
+  projectId: string;
+  currentColor: string | null;
+}
+
+export default function ProjectColorEditor({ projectId, currentColor }: ProjectColorEditorProps) {
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [color, setColor] = useState(currentColor || PRESET_COLORS[0]);
+
+  function handleOpen() {
+    /** 팝오버를 열 때 최신 prop 값으로 동기화한다 */
+    setColor(currentColor || PRESET_COLORS[0]);
+    setIsOpen(true);
+  }
+
+  function handleApply(hex: string) {
+    setColor(hex);
+    startTransition(async () => {
+      await updateProjectColor(projectId, hex);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="relative">
+      {/* 색상 미리보기 버튼 */}
+      <button
+        type="button"
+        onClick={handleOpen}
+        className={`w-6 h-6 rounded-full border-2 border-border-default cursor-pointer transition-transform hover:scale-110 ${isPending ? "opacity-50" : ""}`}
+        style={{ backgroundColor: color }}
+        aria-label="Pick color"
+      />
+
+      {/* 색상 선택 팝오버 */}
+      {isOpen && (
+        <>
+          {/* 백드롭 */}
+          <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
+
+          <div className="absolute right-0 top-8 z-50 bg-bg-surface border border-border-default rounded-lg shadow-lg p-3 w-[220px]">
+            {/* react-colorful 피커 */}
+            <HexColorPicker
+              color={color}
+              onChange={setColor}
+              style={{ width: "100%", height: "150px" }}
+            />
+
+            {/* Hex 입력 + OK 버튼 */}
+            <div className="flex items-center gap-1.5 mt-2 min-w-0">
+              <span className="text-xs text-text-muted shrink-0">#</span>
+              <HexColorInput
+                color={color}
+                onChange={setColor}
+                className="min-w-0 flex-1 text-xs px-1.5 py-1 rounded border border-border-default bg-bg-page text-text-primary font-mono"
+                prefixed={false}
+              />
+              <button
+                type="button"
+                onClick={() => { handleApply(color); setIsOpen(false); }}
+                disabled={isPending}
+                className="shrink-0 text-xs px-2 py-1 rounded bg-brand-primary text-text-inverse hover:bg-brand-hover transition-colors disabled:opacity-50"
+              >
+                OK
+              </button>
+            </div>
+
+            {/* 프리셋 색상 */}
+            <div className="flex items-center gap-1.5 mt-2 flex-wrap">
+              {PRESET_COLORS.map((preset) => (
+                <button
+                  key={preset}
+                  type="button"
+                  onClick={() => { handleApply(preset); setIsOpen(false); }}
+                  className={`w-5 h-5 rounded-full cursor-pointer transition-all ${
+                    color.toLowerCase() === preset.toLowerCase()
+                      ? "ring-2 ring-offset-1 ring-text-primary scale-110"
+                      : "hover:scale-110"
+                  }`}
+                  style={{ backgroundColor: preset }}
+                  aria-label={`Color ${preset}`}
+                />
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProjectTaskGroup.tsx
+++ b/src/components/ProjectTaskGroup.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { KanbanTask } from "@/entities/KanbanTask";
+
+interface ProjectTaskGroupProps {
+  projectName: string;
+  color: string;
+  hasBranchRelations: boolean;
+  /** 그룹 내에 기본 브랜치가 없는 자식 전용 그룹 */
+  isChildGroup?: boolean;
+  children: React.ReactNode;
+}
+
+export interface BranchTreeNode {
+  depth: number;
+  isLast: boolean;
+  hasChildren: boolean;
+}
+
+/** baseBranch → branchName 관계를 분석하여 태스크를 트리 순서로 정렬하고 각 노드의 트리 정보를 반환한다 */
+export function buildBranchTree(tasks: KanbanTask[]): { sorted: KanbanTask[]; treeInfo: Map<string, BranchTreeNode> } {
+  const treeInfo = new Map<string, BranchTreeNode>();
+
+  /** branchName → task 역매핑 */
+  const branchToTask = new Map<string, KanbanTask>();
+  for (const task of tasks) {
+    if (task.branchName) {
+      branchToTask.set(task.branchName, task);
+    }
+  }
+
+  /** 부모 → 자식 태스크 매핑 */
+  const childrenMap = new Map<string, KanbanTask[]>();
+  const hasParent = new Set<string>();
+
+  for (const task of tasks) {
+    if (task.baseBranch && branchToTask.has(task.baseBranch)) {
+      const parent = branchToTask.get(task.baseBranch)!;
+      if (parent.id === task.id) continue;
+      if (!childrenMap.has(parent.id)) childrenMap.set(parent.id, []);
+      childrenMap.get(parent.id)!.push(task);
+      hasParent.add(task.id);
+    }
+  }
+
+  /** 루트 노드: 부모가 없는 태스크 */
+  const roots = tasks.filter((t) => !hasParent.has(t.id));
+
+  /** DFS 순회로 정렬된 배열과 트리 메타정보 생성 */
+  const sorted: KanbanTask[] = [];
+
+  function traverse(task: KanbanTask, depth: number, isLast: boolean) {
+    const children = childrenMap.get(task.id) || [];
+    treeInfo.set(task.id, { depth, isLast, hasChildren: children.length > 0 });
+    sorted.push(task);
+    children.forEach((child, i) => {
+      traverse(child, depth + 1, i === children.length - 1);
+    });
+  }
+
+  roots.forEach((root, i) => {
+    traverse(root, 0, i === roots.length - 1);
+  });
+
+  return { sorted, treeInfo };
+}
+
+/** hex 색상에서 10% 밝기의 배경색을 생성한다 */
+function hexToBg(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const mix = (c: number) => Math.round(c + (255 - c) * 0.88);
+  return `#${mix(r).toString(16).padStart(2, "0")}${mix(g).toString(16).padStart(2, "0")}${mix(b).toString(16).padStart(2, "0")}`;
+}
+
+/** 프로젝트 그룹 래퍼: 파스텔 테두리 + 프로젝트명 라벨. 자식 전용 그룹은 점선 테두리 + 배경 없음 */
+export default function ProjectTaskGroup({ projectName, color, hasBranchRelations, isChildGroup, children }: ProjectTaskGroupProps) {
+  return (
+    <div
+      className={`rounded-lg mb-3 border-2 ${isChildGroup ? "border-dashed" : ""}`}
+      style={{
+        borderColor: color,
+        backgroundColor: isChildGroup ? undefined : hexToBg(color),
+      }}
+    >
+      {/* 프로젝트명 라벨 */}
+      <div className="px-3 py-1.5 flex items-center gap-1.5">
+        <span className="text-xs font-semibold text-text-secondary truncate">
+          {projectName}
+        </span>
+        {hasBranchRelations && (
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" className="text-text-muted shrink-0" aria-label="Branch flow">
+            <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.492 2.492 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25zM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5zM3.5 3.25a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0zm8 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0z"/>
+          </svg>
+        )}
+      </div>
+
+      {/* 태스크 카드 영역 */}
+      <div className="px-1 pb-1">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TaskDetailInfoCard.tsx
+++ b/src/components/TaskDetailInfoCard.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import type { KanbanTask } from "@/entities/KanbanTask";
 import PriorityEditor from "@/components/PriorityEditor";
+import ProjectColorEditor from "@/components/ProjectColorEditor";
 
 interface TaskDetailInfoCardProps {
   task: KanbanTask;
@@ -24,12 +25,23 @@ export default function TaskDetailInfoCard({
         </h3>
         <dl className="space-y-3">
           {task.project && (
-            <div className="flex items-center justify-between gap-2">
-              <dt className="text-xs text-text-muted">{t("project")}</dt>
-              <dd className="text-xs px-2 py-0.5 rounded-full font-medium bg-tag-project-bg text-tag-project-text truncate max-w-[160px]">
-                {task.project.name}
-              </dd>
-            </div>
+            <>
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-xs text-text-muted">{t("project")}</dt>
+                <dd className="text-xs px-2 py-0.5 rounded-full font-medium bg-tag-project-bg text-tag-project-text truncate max-w-[160px]">
+                  {task.project.name}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-xs text-text-muted">{t("projectColor")}</dt>
+                <dd>
+                  <ProjectColorEditor
+                    projectId={task.project.id}
+                    currentColor={task.project.color}
+                  />
+                </dd>
+              </div>
+            </>
           )}
           <div className="flex items-center justify-between gap-2">
             <dt className="text-xs text-text-muted">{t("priority")}</dt>

--- a/src/entities/Project.ts
+++ b/src/entities/Project.ts
@@ -30,6 +30,9 @@ export class Project {
   @Column({ name: "is_worktree", type: "boolean", default: false })
   isWorktree!: boolean;
 
+  @Column({ name: "color", type: "varchar", length: 7, nullable: true, default: null })
+  color!: string | null;
+
   @CreateDateColumn({ name: "created_at" })
   createdAt!: Date;
 }

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -13,6 +13,8 @@ import { AddAppSettings1771166907165 } from "@/migrations/1771166907165-AddAppSe
 import { AddPendingStatus1771171200000 } from "@/migrations/1771171200000-AddPendingStatus";
 import { RemoveBranchNameUnique1771257600000 } from "@/migrations/1771257600000-RemoveBranchNameUnique";
 import { AddPriorityToKanbanTasks1771344000000 } from "@/migrations/1771344000000-AddPriorityToKanbanTasks";
+import { AddColorIndexToProjects1771343199455 } from "@/migrations/1771343199455-AddColorIndexToProjects";
+import { ReplaceColorIndexWithColor1771388085809 } from "@/migrations/1771388085809-ReplaceColorIndexWithColor";
 
 /**
  * TypeORM DataSource 싱글턴.
@@ -34,7 +36,7 @@ function createDataSource(): DataSource {
     type: "postgres",
     url: process.env.DATABASE_URL ?? buildDatabaseUrl(),
     entities: [KanbanTask, Project, PaneLayoutConfig, AppSettings],
-    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785, AddAppSettings1771166907165, AddPendingStatus1771171200000, RemoveBranchNameUnique1771257600000, AddPriorityToKanbanTasks1771344000000],
+    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785, AddAppSettings1771166907165, AddPendingStatus1771171200000, RemoveBranchNameUnique1771257600000, AddPriorityToKanbanTasks1771344000000, AddColorIndexToProjects1771343199455, ReplaceColorIndexWithColor1771388085809],
     synchronize: false,
     logging: process.env.NODE_ENV !== "production",
   });

--- a/src/migrations/1771343199455-AddColorIndexToProjects.ts
+++ b/src/migrations/1771343199455-AddColorIndexToProjects.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddColorIndexToProjects1771343199455 implements MigrationInterface {
+    name = 'AddColorIndexToProjects1771343199455'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "projects" ADD "color_index" smallint`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "projects" DROP COLUMN "color_index"`);
+    }
+
+}

--- a/src/migrations/1771388085809-ReplaceColorIndexWithColor.ts
+++ b/src/migrations/1771388085809-ReplaceColorIndexWithColor.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ReplaceColorIndexWithColor1771388085809 implements MigrationInterface {
+    name = 'ReplaceColorIndexWithColor1771388085809'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "projects" RENAME COLUMN "color_index" TO "color"`);
+        await queryRunner.query(`ALTER TABLE "projects" DROP COLUMN "color"`);
+        await queryRunner.query(`ALTER TABLE "projects" ADD "color" character varying(7)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "projects" DROP COLUMN "color"`);
+        await queryRunner.query(`ALTER TABLE "projects" ADD "color" smallint`);
+        await queryRunner.query(`ALTER TABLE "projects" RENAME COLUMN "color" TO "color_index"`);
+    }
+
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획 - 그룹/플로우라인](.claude/plan/ui/2602/17-project-group-flow-line.plan.md)
- [작업 계획 - 색상 DB/편집기](.claude/plan/ui/2602/18-project-color-db-depth-opacity.plan.md)

## 어떤 작업인가요?
- 칸반 보드에서 같은 프로젝트의 태스크를 시각적으로 그룹핑하고, 브랜치 부모/자식 관계를 플로우 라인으로 표현하며, 프로젝트 색상을 DB에 저장하고 react-colorful 기반 색상 편집기를 추가하는 작업

## 어떻게 해결했나요?
**프로젝트별 태스크 그룹핑**
- 같은 프로젝트의 인접한 태스크를 파스텔 테두리 그룹으로 시각적 구분
- 자식 전용 그룹(기본 브랜치 태스크가 없는 그룹)은 점선 테두리 + 배경 없음으로 차별화

**브랜치 플로우 라인**
- baseBranch → branchName 관계를 분석하여 DFS 기반 트리 구조 생성
- 자식 브랜치 앞에 L자형 SVG 커넥터로 계층 관계 시각화
- 트리 깊이에 따른 들여쓰기 적용

**프로젝트 색상 DB 저장 및 편집기**
- Project 엔티티에 `color` (varchar 7, hex) 컬럼 추가
- react-colorful 기반 색상 편집기: HexColorPicker + HexColorInput + 8개 프리셋 스와치
- 색상 변경 시 같은 repo의 worktree 프로젝트에도 동기 반영

## 중요한 변경 사항은 무엇인가요?
### 프로젝트 태스크 그룹 시스템

**ProjectTaskGroup 컴포넌트 신규 추가**
- **변경 이유**: 같은 프로젝트의 태스크를 시각적으로 묶어 가독성 향상
- **수정 파일**: `src/components/ProjectTaskGroup.tsx` (신규), `src/components/Column.tsx`

**Column 그룹 렌더링 로직**
- **변경 이유**: DnD 인덱스 호환성을 유지하며 프로젝트별 연속 그룹 빌드
- **수정 파일**: `src/components/Column.tsx`, `src/components/Board.tsx`

### 색상 시스템

**Project 엔티티 color 컬럼 추가**
- **변경 이유**: 프로젝트 색상을 DB에 영속화하여 사용자 커스터마이즈 지원
- **수정 파일**: `src/entities/Project.ts`, `src/migrations/1771343199455-AddColorIndexToProjects.ts`, `src/migrations/1771388085809-ReplaceColorIndexWithColor.ts`, `src/lib/database.ts`

**react-colorful 기반 색상 편집기**
- **변경 이유**: hex 값 직접 입력과 스펙트럼 선택을 모두 지원하는 풍부한 색상 편집 UX
- **수정 파일**: `src/components/ProjectColorEditor.tsx` (신규), `src/components/TaskDetailInfoCard.tsx`, `package.json`

**inline hex 스타일 기반 그룹 색상**
- **변경 이유**: CSS 클래스 기반 8색 제한 대신 임의의 hex 색상 지원
- **수정 파일**: `src/components/ProjectTaskGroup.tsx`, `src/components/Board.tsx`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
