### PR TITLE
style(board): 설정 버튼 아이콘 SVG 교체 및 크기 조정

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -471,10 +471,13 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
           </button>
           <button
             onClick={() => setIsSettingsOpen(true)}
-            className="px-3 py-1.5 text-sm text-text-muted hover:text-text-primary transition-colors"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-surface transition-colors"
             title={tc("settings")}
           >
-            &#9881;
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+              <circle cx="12" cy="12" r="3"/>
+            </svg>
           </button>
           <form action={logoutAction}>
             <button


### PR DESCRIPTION
## Summary
- 설정 버튼의 HTML entity(`&#9881;`) 아이콘을 인라인 SVG 기어 아이콘(20x20px)으로 교체
- 버튼 크기를 "New Task" 버튼과 동일한 높이(~32px)로 조정
- 호버 시 배경 효과(`hover:bg-bg-surface`) 및 `rounded-md` 추가

## Test plan
- [ ] 설정 버튼이 New Task 버튼과 유사한 크기로 렌더링되는지 확인
- [ ] 호버 시 배경색 변경 및 아이콘 색상 변경 동작 확인
- [ ] 설정 버튼 클릭 시 설정 패널이 정상적으로 열리는지 확인