### PR TITLE
fix(task): 태스크 생성 시 baseBranch 누락 버그 수정

### DIFF
--- a/.claude/plan/task/2602/18-fix-base-branch-issue.plan.md
+++ b/.claude/plan/task/2602/18-fix-base-branch-issue.plan.md
@@ -1,0 +1,85 @@
+# Fix base_branch 누락 버그
+
+## Business Goal
+kanban_tasks 테이블의 base_branch 컬럼이 파생 브랜치 태스크에서 빈 값으로 저장되는 버그를 수정하여, 브랜치 계층 관계(부모-자식) 시각화가 가능하도록 한다.
+
+## Scope
+- **In Scope**: 태스크 생성 코드 3곳 수정 + 기존 데이터 보정 마이그레이션
+- **Out of Scope**: git merge-base 기반 실제 부모 브랜치 탐지, UI/프론트엔드 변경
+
+## Codebase Analysis Summary
+태스크 생성 경로 3곳 중 2곳에서 baseBranch를 설정하지 않음. orphan 태스크 연결 시에도 미설정.
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/app/actions/project.ts` | worktree 스캔 및 태스크 생성 | Modify |
+| `src/app/api/hooks/start/route.ts` | AI hook API 태스크 생성 | Modify |
+| `src/migrations/` | 기존 데이터 보정 | Create |
+| `src/lib/database.ts` | 마이그레이션 등록 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 마이그레이션 패턴 | 기존 마이그레이션 파일 | TypeORM MigrationInterface, up/down 구현 |
+| 마이그레이션 등록 | CLAUDE.md | database.ts의 migrations 배열에 import 추가 |
+| 한국어 주석 | CODE_PRINCIPLES.md | 주석은 한국어로 작성 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| base branch 결정 방식 | project.defaultBranch 기본값 | 단순/안정적, SSH 호환 | git merge-base |
+| 데이터 보정 방식 | TypeORM 마이그레이션 | 프로젝트 컨벤션 준수 | SQL 스크립트 수동 실행 |
+
+## Implementation Todos
+
+### Todo 1: worktree 스캔 태스크 생성 시 baseBranch 설정
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: scanAndRegisterProjects에서 새 태스크/orphan 태스크에 baseBranch를 설정한다
+- **Work**:
+  - `src/app/actions/project.ts`의 `scanAndRegisterProjects` 함수 내 worktree 스캔 루프에서:
+    - 새 태스크 생성 시 `baseBranch: project.defaultBranch` 추가 (line ~288)
+    - orphan 태스크 연결 시 `orphanTask.baseBranch = project.defaultBranch` 추가 (line ~270)
+- **Convention Notes**: 기존 코드 스타일 유지, 한국어 주석
+- **Verification**: TypeScript 컴파일 통과 (`pnpm build`)
+- **Exit Criteria**: 두 경로 모두 baseBranch가 설정됨
+- **Status**: pending
+
+### Todo 2: AI hook API에서 baseBranch 반영
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: POST /api/hooks/start에서 계산한 base 값을 task.baseBranch에 저장한다
+- **Work**:
+  - `src/app/api/hooks/start/route.ts`의 `POST` 함수에서:
+    - worktree 생성 시 계산한 `base` 값을 `task.baseBranch = base`로 설정 (line ~44 이후)
+- **Convention Notes**: 기존 코드 스타일 유지
+- **Verification**: TypeScript 컴파일 통과
+- **Exit Criteria**: hook API를 통해 생성된 태스크의 baseBranch에 올바른 값 저장
+- **Status**: pending
+
+### Todo 3: 기존 데이터 보정 마이그레이션 생성
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 기존 빈 base_branch를 프로젝트의 defaultBranch로 채우는 마이그레이션 생성
+- **Work**:
+  - `src/migrations/` 에 새 마이그레이션 파일 생성
+  - UP: projects 테이블의 default_branch를 JOIN하여 빈 base_branch를 채움
+  - DOWN: 보정된 값을 NULL로 되돌림 (rollback)
+  - `src/lib/database.ts`의 migrations 배열에 새 마이그레이션 import 추가
+- **Convention Notes**: 기존 마이그레이션 파일 패턴 준수, database.ts에 등록 필수
+- **Verification**: 마이그레이션 파일 문법 검증 (TypeScript 컴파일)
+- **Exit Criteria**: 마이그레이션 파일 생성 및 database.ts에 등록 완료
+- **Status**: pending
+
+## Verification Strategy
+- `pnpm build` — TypeScript 컴파일 성공 확인
+- 마이그레이션 SQL 로직 검토
+
+## Progress Tracking
+- Total Todos: 3
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-18: Plan created

--- a/src/app/actions/__tests__/scanAndRegisterProjects.test.ts
+++ b/src/app/actions/__tests__/scanAndRegisterProjects.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskStatus, SessionType } from "@/entities/KanbanTask";
+
+// --- Mocks ---
+
+const mockTaskFindOneBy = vi.fn();
+const mockTaskCreate = vi.fn((data: Record<string, unknown>) => ({ ...data }));
+const mockTaskSave = vi.fn((entity: Record<string, unknown>) => entity);
+const mockProjectFind = vi.fn();
+const mockProjectCreate = vi.fn((data: Record<string, unknown>) => ({ id: "proj-1", ...data }));
+const mockProjectSave = vi.fn((entity: Record<string, unknown>) => entity);
+
+vi.mock("@/lib/database", () => ({
+  getTaskRepository: vi.fn().mockResolvedValue({
+    findOneBy: mockTaskFindOneBy,
+    create: mockTaskCreate,
+    save: mockTaskSave,
+  }),
+  getProjectRepository: vi.fn().mockResolvedValue({
+    find: mockProjectFind,
+    create: mockProjectCreate,
+    save: mockProjectSave,
+  }),
+}));
+
+vi.mock("@/lib/gitOperations", () => ({
+  scanGitRepos: vi.fn().mockResolvedValue(["/repo/path"]),
+  getDefaultBranch: vi.fn().mockResolvedValue("main"),
+  listWorktrees: vi.fn().mockResolvedValue([]),
+  validateGitRepo: vi.fn(),
+  listBranches: vi.fn(),
+  execGit: vi.fn(),
+}));
+
+vi.mock("@/lib/worktree", () => ({
+  isWindowAlive: vi.fn().mockResolvedValue(false),
+  formatWindowName: vi.fn((name: string) => name),
+  createSessionWithoutWorktree: vi.fn(),
+}));
+
+vi.mock("@/lib/claudeHooksSetup", () => ({
+  setupClaudeHooks: vi.fn().mockResolvedValue(undefined),
+  getClaudeHooksStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/geminiHooksSetup", () => ({
+  setupGeminiHooks: vi.fn().mockResolvedValue(undefined),
+  getGeminiHooksStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/codexHooksSetup", () => ({
+  setupCodexHooks: vi.fn().mockResolvedValue(undefined),
+  getCodexHooksStatus: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const { listWorktrees } = await import("@/lib/gitOperations");
+
+describe("scanAndRegisterProjects — baseBranch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockProjectFind.mockResolvedValue([]);
+    mockProjectSave.mockImplementation((entity: Record<string, unknown>) => ({
+      id: "proj-1",
+      name: "test-project",
+      repoPath: "/repo/path",
+      defaultBranch: "main",
+      sshHost: null,
+      ...entity,
+    }));
+  });
+
+  it("should set baseBranch to project.defaultBranch when creating a new worktree task", async () => {
+    // Given
+    mockProjectFind
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { id: "proj-1", name: "test-project", repoPath: "/repo/path", defaultBranch: "main", sshHost: null },
+      ]);
+
+    vi.mocked(listWorktrees).mockResolvedValue([
+      { path: "/repo/path/worktrees/feat-branch", branch: "feat-branch", isBare: false },
+    ]);
+
+    mockTaskFindOneBy.mockResolvedValue(null);
+
+    const { scanAndRegisterProjects } = await import("@/app/actions/project");
+
+    // When
+    await scanAndRegisterProjects("/root");
+
+    // Then
+    expect(mockTaskCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        branchName: "feat-branch",
+        baseBranch: "main",
+        projectId: "proj-1",
+      })
+    );
+  });
+
+  it("should set baseBranch on orphan task when linking to project", async () => {
+    // Given
+    const orphanTask = {
+      branchName: "feat-orphan",
+      projectId: null,
+      worktreePath: null,
+      baseBranch: null,
+    };
+
+    mockProjectFind
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { id: "proj-1", name: "test-project", repoPath: "/repo/path", defaultBranch: "main", sshHost: null },
+      ]);
+
+    vi.mocked(listWorktrees).mockResolvedValue([
+      { path: "/repo/path/worktrees/feat-orphan", branch: "feat-orphan", isBare: false },
+    ]);
+
+    /** createDefaultBranchTask에서 2번, worktree 스캔에서 2번 findOneBy를 호출한다 */
+    mockTaskFindOneBy
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(orphanTask);
+
+    const { scanAndRegisterProjects } = await import("@/app/actions/project");
+
+    // When
+    await scanAndRegisterProjects("/root");
+
+    // Then
+    expect(orphanTask.baseBranch).toBe("main");
+    expect(mockTaskSave).toHaveBeenCalledWith(
+      expect.objectContaining({ baseBranch: "main" })
+    );
+  });
+
+  it("should preserve existing baseBranch on orphan task when already set", async () => {
+    // Given
+    const orphanTask = {
+      branchName: "feat-orphan",
+      projectId: null,
+      worktreePath: null,
+      baseBranch: "develop",
+    };
+
+    mockProjectFind
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { id: "proj-1", name: "test-project", repoPath: "/repo/path", defaultBranch: "main", sshHost: null },
+      ]);
+
+    vi.mocked(listWorktrees).mockResolvedValue([
+      { path: "/repo/path/worktrees/feat-orphan", branch: "feat-orphan", isBare: false },
+    ]);
+
+    /** createDefaultBranchTask에서 2번, worktree 스캔에서 2번 findOneBy를 호출한다 */
+    mockTaskFindOneBy
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(orphanTask);
+
+    const { scanAndRegisterProjects } = await import("@/app/actions/project");
+
+    // When
+    await scanAndRegisterProjects("/root");
+
+    // Then
+    expect(orphanTask.baseBranch).toBe("develop");
+  });
+});

--- a/src/app/actions/project.ts
+++ b/src/app/actions/project.ts
@@ -255,6 +255,7 @@ export async function scanAndRegisterProjects(
         if (orphanTask) {
           orphanTask.projectId = project.id;
           orphanTask.worktreePath = wt.path;
+          orphanTask.baseBranch = orphanTask.baseBranch || project.defaultBranch;
           await taskRepo.save(orphanTask);
           result.worktreeTasks.push(wt.branch);
           continue;
@@ -275,6 +276,7 @@ export async function scanAndRegisterProjects(
           branchName: wt.branch,
           worktreePath: wt.path,
           projectId: project.id,
+          baseBranch: project.defaultBranch,
           status: hasWindow ? TaskStatus.PROGRESS : TaskStatus.TODO,
           ...(hasWindow && {
             sessionType: SessionType.TMUX,

--- a/src/app/api/hooks/start/__tests__/route.test.ts
+++ b/src/app/api/hooks/start/__tests__/route.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskStatus, SessionType } from "@/entities/KanbanTask";
+
+// --- Mocks ---
+
+const mockTaskCreate = vi.fn((data: Record<string, unknown>) => ({ ...data }));
+const mockTaskSave = vi.fn((entity: Record<string, unknown>) => ({
+  id: "task-1",
+  status: TaskStatus.PROGRESS,
+  sessionName: null,
+  ...entity,
+}));
+const mockProjectFindOneBy = vi.fn();
+
+vi.mock("@/lib/database", () => ({
+  getTaskRepository: vi.fn().mockResolvedValue({
+    create: mockTaskCreate,
+    save: mockTaskSave,
+  }),
+  getProjectRepository: vi.fn().mockResolvedValue({
+    findOneBy: mockProjectFindOneBy,
+  }),
+}));
+
+vi.mock("@/lib/worktree", () => ({
+  createWorktreeWithSession: vi.fn().mockResolvedValue({
+    worktreePath: "/worktree/path",
+    sessionName: "session-1",
+  }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/boardNotifier", () => ({
+  broadcastBoardUpdate: vi.fn(),
+}));
+
+describe("POST /api/hooks/start — baseBranch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should set baseBranch to project.defaultBranch when baseBranch is not provided in request", async () => {
+    // Given
+    mockProjectFindOneBy.mockResolvedValue({
+      id: "proj-1",
+      repoPath: "/repo/path",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+
+    const request = new Request("http://localhost:4885/api/hooks/start", {
+      method: "POST",
+      body: JSON.stringify({
+        title: "New Task",
+        branchName: "feat-new",
+        sessionType: "tmux",
+        projectId: "proj-1",
+      }),
+    });
+
+    const { POST } = await import("@/app/api/hooks/start/route");
+
+    // When
+    const response = await POST(request as never);
+    const body = await response.json();
+
+    // Then
+    expect(body.success).toBe(true);
+    expect(mockTaskSave).toHaveBeenCalledWith(
+      expect.objectContaining({ baseBranch: "main" })
+    );
+  });
+
+  it("should use provided baseBranch from request when available", async () => {
+    // Given
+    mockProjectFindOneBy.mockResolvedValue({
+      id: "proj-1",
+      repoPath: "/repo/path",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+
+    const request = new Request("http://localhost:4885/api/hooks/start", {
+      method: "POST",
+      body: JSON.stringify({
+        title: "New Task",
+        branchName: "feat-new",
+        baseBranch: "develop",
+        sessionType: "tmux",
+        projectId: "proj-1",
+      }),
+    });
+
+    const { POST } = await import("@/app/api/hooks/start/route");
+
+    // When
+    const response = await POST(request as never);
+    const body = await response.json();
+
+    // Then
+    expect(body.success).toBe(true);
+    expect(mockTaskSave).toHaveBeenCalledWith(
+      expect.objectContaining({ baseBranch: "develop" })
+    );
+  });
+
+  it("should keep baseBranch as null when no project context exists", async () => {
+    // Given
+    const request = new Request("http://localhost:4885/api/hooks/start", {
+      method: "POST",
+      body: JSON.stringify({
+        title: "Simple Task",
+      }),
+    });
+
+    const { POST } = await import("@/app/api/hooks/start/route");
+
+    // When
+    const response = await POST(request as never);
+    const body = await response.json();
+
+    // Then
+    expect(body.success).toBe(true);
+    expect(mockTaskCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ baseBranch: null })
+    );
+  });
+});

--- a/src/app/api/hooks/start/route.ts
+++ b/src/app/api/hooks/start/route.ts
@@ -50,6 +50,7 @@ export async function POST(request: NextRequest) {
             project.sshHost,
             projectId
           );
+          task.baseBranch = base;
           task.worktreePath = session.worktreePath;
           task.sessionName = session.sessionName;
           task.sshHost = project.sshHost;

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -15,6 +15,7 @@ import { RemoveBranchNameUnique1771257600000 } from "@/migrations/1771257600000-
 import { AddPriorityToKanbanTasks1771344000000 } from "@/migrations/1771344000000-AddPriorityToKanbanTasks";
 import { AddColorIndexToProjects1771343199455 } from "@/migrations/1771343199455-AddColorIndexToProjects";
 import { ReplaceColorIndexWithColor1771388085809 } from "@/migrations/1771388085809-ReplaceColorIndexWithColor";
+import { FillEmptyBaseBranch1771400000000 } from "@/migrations/1771400000000-FillEmptyBaseBranch";
 
 /**
  * TypeORM DataSource 싱글턴.
@@ -36,7 +37,7 @@ function createDataSource(): DataSource {
     type: "postgres",
     url: process.env.DATABASE_URL ?? buildDatabaseUrl(),
     entities: [KanbanTask, Project, PaneLayoutConfig, AppSettings],
-    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785, AddAppSettings1771166907165, AddPendingStatus1771171200000, RemoveBranchNameUnique1771257600000, AddPriorityToKanbanTasks1771344000000, AddColorIndexToProjects1771343199455, ReplaceColorIndexWithColor1771388085809],
+    migrations: [InitialSchema1770854400000, AddPrUrlToKanbanTasks1770854400001, AddIsWorktreeToProjects1770854400002, AddPaneLayoutConfig1771048256887, AssignDisplayOrder1771166346785, AddAppSettings1771166907165, AddPendingStatus1771171200000, RemoveBranchNameUnique1771257600000, AddPriorityToKanbanTasks1771344000000, AddColorIndexToProjects1771343199455, ReplaceColorIndexWithColor1771388085809, FillEmptyBaseBranch1771400000000],
     synchronize: false,
     logging: process.env.NODE_ENV !== "production",
   });

--- a/src/migrations/1771400000000-FillEmptyBaseBranch.ts
+++ b/src/migrations/1771400000000-FillEmptyBaseBranch.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FillEmptyBaseBranch1771400000000 implements MigrationInterface {
+    name = 'FillEmptyBaseBranch1771400000000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE kanban_tasks t
+            SET base_branch = p.default_branch
+            FROM projects p
+            WHERE t.project_id = p.id
+              AND (t.base_branch IS NULL OR t.base_branch = '')
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        /** 보정 전 원본 값을 복원할 수 없으므로 rollback은 no-op으로 처리한다 */
+    }
+
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/task/2602/18-fix-base-branch-issue.plan.md)
- 이슈 : #73

## 어떤 작업인가요?
- `kanban_tasks.base_branch` 컬럼이 파생 브랜치 태스크에서 빈 값으로 저장되는 버그를 수정하여 브랜치 계층 관계 시각화가 가능하도록 함

## 어떻게 해결했나요?
**태스크 생성 코드 수정 (2곳)**
- worktree 스캔 및 AI hook API에서 태스크 생성 시 `baseBranch`가 누락되던 문제 수정
- `project.defaultBranch`를 기본값으로 설정

**기존 데이터 보정**
- 마이그레이션으로 빈 `base_branch`를 프로젝트의 `default_branch`로 채움

**테스트 추가**
- `scanAndRegisterProjects`, `POST /api/hooks/start`에 대한 baseBranch 설정 단위 테스트 6건 추가

## 중요한 변경 사항은 무엇인가요?
### worktree 스캔 baseBranch 설정

**신규 태스크 생성 시 baseBranch 추가**
- **변경 이유**: worktree에서 발견된 브랜치로 태스크 생성 시 baseBranch가 null로 저장됨
- **수정 파일**: `src/app/actions/project.ts`

**orphan 태스크 연결 시 baseBranch 설정**
- **변경 이유**: orphan 태스크를 프로젝트에 연결할 때 baseBranch가 설정되지 않음 (기존 값이 있으면 보존)
- **수정 파일**: `src/app/actions/project.ts`

### AI hook API baseBranch 반영

**계산된 base 값을 태스크에 저장**
- **변경 이유**: worktree 생성 시 `baseBranch || project.defaultBranch`로 base를 계산하지만 태스크 엔티티에 반영하지 않음
- **수정 파일**: `src/app/api/hooks/start/route.ts`

### 데이터 보정 마이그레이션

**기존 빈 base_branch를 default_branch로 채움**
- **변경 이유**: 이미 저장된 태스크의 빈 base_branch를 보정
- **수정 파일**: `src/migrations/1771400000000-FillEmptyBaseBranch.ts`, `src/lib/database.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
