### PR TITLE
fix(terminal): 멀티 탭 터미널 PTY 공유 및 자동 포커스

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
+KANVIBE_USER=admin (require change)
+KANVIBE_PASSWORD=changeme (require change)
 PORT=4885
+WS_PORT=4887
 DB_PORT=4886
-KANVIBE_USER=admin
-KANVIBE_PASSWORD=changeme

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ cp .env.example .env
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `PORT` | Web server port | `4885` |
+| `WS_PORT` | WebSocket server port | `4887` (`PORT + 2`) |
 | `DB_PORT` | PostgreSQL port | `4886` |
 | `KANVIBE_USER` | Login username | `admin` |
 | `KANVIBE_PASSWORD` | Login password | `changeme` (change this!) |

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -56,6 +56,7 @@ cp .env.example .env
 | 변수 | 설명 | 기본값 |
 |------|------|--------|
 | `PORT` | 웹 서버 포트 | `4885` |
+| `WS_PORT` | WebSocket 서버 포트 | `4887` (`PORT + 2`) |
 | `DB_PORT` | PostgreSQL 포트 | `4886` |
 | `KANVIBE_USER` | 로그인 사용자명 | `admin` |
 | `KANVIBE_PASSWORD` | 로그인 비밀번호 | `changeme` (변경 필수!) |

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -56,6 +56,7 @@ cp .env.example .env
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
 | `PORT` | Web 服务器端口 | `4885` |
+| `WS_PORT` | WebSocket 服务器端口 | `4887` (`PORT + 2`) |
 | `DB_PORT` | PostgreSQL 端口 | `4886` |
 | `KANVIBE_USER` | 登录用户名 | `admin` |
 | `KANVIBE_PASSWORD` | 登录密码 | `changeme`（请修改！） |

--- a/server.ts
+++ b/server.ts
@@ -22,7 +22,7 @@ process.on("uncaughtException", (error) => {
 const dev = process.env.NODE_ENV !== "production";
 const hostname = "0.0.0.0";
 const port = parseInt(process.env.PORT || "4885", 10);
-const wsPort = port + 10000;
+const wsPort = parseInt(process.env.WS_PORT || String(port + 2), 10);
 
 /**
  * Next.js에 httpServer를 전달하여 HMR WebSocket 등 내부 기능이

--- a/src/app/actions/__tests__/scanAndRegisterProjects.test.ts
+++ b/src/app/actions/__tests__/scanAndRegisterProjects.test.ts
@@ -35,7 +35,7 @@ vi.mock("@/lib/gitOperations", () => ({
 vi.mock("@/lib/worktree", () => ({
   isWindowAlive: vi.fn().mockResolvedValue(false),
   formatWindowName: vi.fn((name: string) => name),
-  createSessionWithoutWorktree: vi.fn(),
+  createSessionWithoutWorktree: vi.fn().mockResolvedValue({ sessionName: "test-session" }),
 }));
 
 vi.mock("@/lib/claudeHooksSetup", () => ({

--- a/src/components/NotificationListener.tsx
+++ b/src/components/NotificationListener.tsx
@@ -56,7 +56,9 @@ export default function NotificationListener({
   useEffect(() => {
     function connect() {
       const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      const port = parseInt(window.location.port || "4885", 10) + 10000;
+      const port = process.env.NEXT_PUBLIC_WS_PORT
+        ? parseInt(process.env.NEXT_PUBLIC_WS_PORT, 10)
+        : parseInt(window.location.port || "4885", 10) + 2;
       const wsUrl = `${protocol}//${window.location.hostname}:${port}/api/board/events`;
 
       const ws = new WebSocket(wsUrl);

--- a/src/hooks/useAutoRefresh.ts
+++ b/src/hooks/useAutoRefresh.ts
@@ -28,7 +28,9 @@ export function useAutoRefresh() {
   useEffect(() => {
     function connect() {
       const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      const port = parseInt(window.location.port || "4885", 10) + 10000;
+      const port = process.env.NEXT_PUBLIC_WS_PORT
+        ? parseInt(process.env.NEXT_PUBLIC_WS_PORT, 10)
+        : parseInt(window.location.port || "4885", 10) + 2;
       const wsUrl = `${protocol}//${window.location.hostname}:${port}/api/board/events`;
 
       const ws = new WebSocket(wsUrl);


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/terminal/2602/18-multi-tab-terminal.plan.md)

## 어떤 작업인가요?
- 여러 브라우저 탭에서 동일 태스크의 터미널을 열었을 때 PTY 프로세스를 공유하고, 탭 전환 시 tmux/zellij 세션 포커스를 자동으로 이동하도록 개선

## 어떻게 해결했나요?
**멀티 탭 PTY 공유**
- 동일 taskId로 이미 활성 PTY가 있으면 새 WebSocket 클라이언트를 기존 PTY에 연결하여 공유
- 모든 클라이언트가 연결 해제되었을 때만 PTY 프로세스를 종료

**자동 포커스**
- 브라우저 탭 전환(visibilitychange) 시 해당 태스크의 tmux window / zellij tab으로 자동 포커스 이동
- WebSocket 제어 메시지(`focus` 타입)로 서버에 포커스 요청 전달

**WebSocket 포트 환경변수 분리**
- `WS_PORT` 환경변수 도입으로 WebSocket 포트를 독립적으로 설정 가능
- 기본값을 `PORT + 10000`에서 `PORT + 2`로 변경하여 방화벽 이슈 감소

## 중요한 변경 사항은 무엇인가요?
### 멀티 탭 PTY 공유

**TerminalEntry 구조 변경**
- **변경 이유**: 단일 WebSocket(`ws`) 대신 여러 클라이언트를 관리하기 위해 `clients: Set<WebSocket>`으로 변경
- **수정 파일**: `src/lib/terminal.ts`

**클라이언트 연결/해제 로직 변경**
- **변경 이유**: 기존에는 새 탭에서 터미널 열면 기존 PTY를 종료하고 재생성했으나, 이제 기존 PTY를 공유하고 마지막 클라이언트 해제 시에만 종료
- **수정 파일**: `src/lib/terminal.ts`

### 자동 포커스

**focusSession 함수 추가**
- **변경 이유**: 탭 전환 시 tmux/zellij의 올바른 window/tab으로 포커스를 이동하여 사용자 경험 개선
- **수정 파일**: `src/lib/terminal.ts`, `src/components/Terminal.tsx`

### WebSocket 포트 설정

**WS_PORT 환경변수 도입**
- **변경 이유**: `PORT + 10000`은 포트 범위를 크게 벗어날 수 있어 `PORT + 2`로 변경하고, 환경변수로 커스텀 설정 가능하도록 개선
- **수정 파일**: `.env.example`, `server.ts`, `src/components/NotificationListener.tsx`, `src/components/Terminal.tsx`, `src/hooks/useAutoRefresh.ts`, `README.md`, `docs/README.ko.md`, `docs/README.zh.md`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
