### PR TITLE
fix(kanban): 신규 태스크 생성 시 TODO 상태 유지

### DIFF
--- a/src/app/actions/__tests__/createTask.test.ts
+++ b/src/app/actions/__tests__/createTask.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskStatus, SessionType } from "@/entities/KanbanTask";
+
+// --- Mocks ---
+
+const mockTaskCreate = vi.fn((data: Record<string, unknown>) => ({ ...data }));
+const mockTaskSave = vi.fn((entity: Record<string, unknown>) => ({
+  id: "task-1",
+  ...entity,
+}));
+const mockCreateQueryBuilder = vi.fn().mockReturnValue({
+  select: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  getRawOne: vi.fn().mockResolvedValue({ max: 0 }),
+});
+
+const mockProjectFindOneBy = vi.fn();
+
+vi.mock("@/lib/database", () => ({
+  getTaskRepository: vi.fn().mockResolvedValue({
+    create: mockTaskCreate,
+    save: mockTaskSave,
+    createQueryBuilder: mockCreateQueryBuilder,
+  }),
+  getProjectRepository: vi.fn().mockResolvedValue({
+    findOneBy: mockProjectFindOneBy,
+  }),
+}));
+
+const mockCreateWorktreeWithSession = vi.fn();
+
+vi.mock("@/lib/worktree", () => ({
+  createWorktreeWithSession: mockCreateWorktreeWithSession,
+  removeWorktreeAndSession: vi.fn(),
+  removeWorktreeAndBranch: vi.fn(),
+  createSessionWithoutWorktree: vi.fn(),
+  removeSessionOnly: vi.fn(),
+}));
+
+vi.mock("@/lib/claudeHooksSetup", () => ({
+  setupClaudeHooks: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+describe("createTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should create task with TODO status when no worktree session is needed", async () => {
+    // Given
+    const { createTask } = await import("@/app/actions/kanban");
+
+    // When
+    const result = await createTask({ title: "simple task" });
+
+    // Then
+    expect(mockTaskCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: TaskStatus.TODO })
+    );
+    expect(result.status).toBe(TaskStatus.TODO);
+  });
+
+  it("should keep TODO status even when worktree session is created successfully", async () => {
+    // Given
+    const project = {
+      id: "proj-1",
+      name: "test-project",
+      repoPath: "/repo/path",
+      defaultBranch: "main",
+      sshHost: null,
+    };
+    mockProjectFindOneBy.mockResolvedValue(project);
+    mockCreateWorktreeWithSession.mockResolvedValue({
+      worktreePath: "/repo/path/worktrees/feat-branch",
+      sessionName: "feat-branch-session",
+    });
+
+    const { createTask } = await import("@/app/actions/kanban");
+
+    // When
+    const result = await createTask({
+      title: "worktree task",
+      branchName: "feat-branch",
+      sessionType: SessionType.TMUX,
+      projectId: "proj-1",
+    });
+
+    // Then
+    expect(result.status).toBe(TaskStatus.TODO);
+    expect(result.worktreePath).toBe("/repo/path/worktrees/feat-branch");
+    expect(result.sessionName).toBe("feat-branch-session");
+  });
+});

--- a/src/app/actions/kanban.ts
+++ b/src/app/actions/kanban.ts
@@ -145,7 +145,6 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
         task.worktreePath = session.worktreePath;
         task.sessionName = session.sessionName;
         task.sshHost = project.sshHost;
-        task.status = TaskStatus.PROGRESS;
 
         /** 로컬 worktree에 Claude Code hooks를 자동 설정한다 */
         if (!project.sshHost && session.worktreePath) {


### PR DESCRIPTION
## Summary
- worktree/세션 생성 성공 시 태스크 상태를 PROGRESS로 자동 변경하던 로직 제거
- 신규 태스크는 항상 TODO 상태로 생성되도록 수정

## Changes
- `src/app/actions/kanban.ts`: `createTask` 함수에서 `task.status = TaskStatus.PROGRESS` 라인 제거

## Test plan
- [ ] 프로젝트/브랜치를 지정하여 새 태스크 생성 → TODO 상태로 생성되는지 확인
- [ ] worktree/세션이 정상적으로 생성되는지 확인 (상태 변경만 제거, 세션 생성 로직은 유지)