### PR TITLE
브랜치 연결 화살표 및 depth 들여쓰기 제거

### DIFF
--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -6,7 +6,6 @@ import { Droppable } from "@hello-pangea/dnd";
 import TaskCard from "./TaskCard";
 import ProjectTaskGroup, {
   buildBranchTree,
-  type BranchTreeNode,
 } from "./ProjectTaskGroup";
 import type { KanbanTask, TaskStatus } from "@/entities/KanbanTask";
 
@@ -28,7 +27,6 @@ interface ColumnProps {
 interface TaskGroup {
   projectName: string | null;
   tasks: KanbanTask[];
-  treeInfo: Map<string, BranchTreeNode>;
   hasBranchRelations: boolean;
   /** 그룹 내 기본 브랜치(defaultBranch) 태스크가 없으면 true → 자식 전용 그룹 */
   isChildGroup: boolean;
@@ -68,7 +66,6 @@ function finalizeGroup(
     return {
       projectName: null,
       tasks: raw.tasks,
-      treeInfo: new Map(),
       hasBranchRelations: false,
       isChildGroup: false,
     };
@@ -91,46 +88,11 @@ function finalizeGroup(
   return {
     projectName: raw.name,
     tasks: raw.tasks,
-    treeInfo,
     hasBranchRelations,
     isChildGroup: !hasDefaultBranch,
   };
 }
 
-/** 브랜치 연결 화살표: 자식 태스크 앞에 표시되는 L자형 커넥터 */
-function BranchConnector({ depth }: { depth: number }) {
-  return (
-    <div
-      className="flex items-center gap-1 py-0.5 pointer-events-none"
-      style={{ paddingLeft: `${(depth - 1) * 16 + 8}px` }}
-    >
-      <svg
-        width="16"
-        height="12"
-        viewBox="0 0 16 12"
-        className="text-group-line shrink-0"
-        aria-hidden="true"
-      >
-        <path
-          d="M2 0 V8 H12"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M10 5 L13 8 L10 11"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-    </div>
-  );
-}
 
 export default function Column({
   status,
@@ -221,36 +183,19 @@ export default function Column({
                   hasBranchRelations={group.hasBranchRelations}
                   isChildGroup={group.isChildGroup}
                 >
-                  {group.tasks.map((task, localIdx) => {
-                    const treeNode = group.treeInfo.get(task.id);
-                    const isTreeChild = treeNode && treeNode.depth > 0;
-
-                    return (
-                      <div key={task.id}>
-                        {isTreeChild && (
-                          <BranchConnector depth={treeNode!.depth} />
-                        )}
-                        <div
-                          style={
-                            isTreeChild
-                              ? { paddingLeft: `${treeNode!.depth * 16}px` }
-                              : undefined
-                          }
-                        >
-                          <TaskCard
-                            task={task}
-                            index={startIndex + localIdx}
-                            onContextMenu={onContextMenu}
-                            projectName={undefined}
-                            isBaseProject={
-                              !!task.worktreePath &&
-                              !task.worktreePath.includes("__worktrees")
-                            }
-                          />
-                        </div>
-                      </div>
-                    );
-                  })}
+                  {group.tasks.map((task, localIdx) => (
+                    <TaskCard
+                      key={task.id}
+                      task={task}
+                      index={startIndex + localIdx}
+                      onContextMenu={onContextMenu}
+                      projectName={undefined}
+                      isBaseProject={
+                        !!task.worktreePath &&
+                        !task.worktreePath.includes("__worktrees")
+                      }
+                    />
+                  ))}
                 </ProjectTaskGroup>
               );
             })}


### PR DESCRIPTION
## 어떤 작업인가요?
- 프로젝트 그룹 내 자식 태스크 간 L자형 화살표 커넥터와 depth 기반 들여쓰기를 제거하여 점선 테두리로만 그룹을 구분하도록 단순화

## 어떻게 해결했나요?
**BranchConnector 컴포넌트 및 depth 들여쓰기 제거**
- BranchConnector SVG 컴포넌트 삭제
- treeInfo 기반 depth padding 로직 제거
- TaskGroup 인터페이스에서 treeInfo 필드 제거
- 미사용 BranchTreeNode 타입 import 정리

## 중요한 변경 사항은 무엇인가요?
### 프로젝트 그룹 내 태스크 렌더링 단순화

**BranchConnector 컴포넌트 삭제**
- **변경 이유**: 화살표 커넥터 대신 점선 테두리만으로 그룹 구분이 충분
- **수정 파일**: `src/components/Column.tsx`

**treeInfo 필드 및 depth padding 제거**
- **변경 이유**: 렌더링에서 더 이상 사용하지 않는 데이터 정리
- **수정 파일**: `src/components/Column.tsx`

## 스크린샷 및 시연 영상

### Before
![before](https://github.com/user-attachments/assets/placeholder-before)
`└→` 화살표와 들여쓰기로 자식 태스크 표시

### After
자식 태스크가 동일 레벨로 표시되고 점선 테두리로만 그룹 구분

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
