### PR TITLE
fix(ui): 프로젝트 필터 3개 이상 선택 시 헤더 높이 증가 방지

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -110,3 +110,7 @@ default_modes:
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
+
+# override of the corresponding setting in serena_config.yml, see the documentation there.
+# If null or missing, the value from the global config is used.
+symbol_info_budget:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,8 @@ Vitest + @testing-library/react 기반. Given-When-Then 패턴을 사용한다.
 ### 테스트 실행
 
 ```bash
-pnpm test          # 전체 테스트 실행
-pnpm test:watch    # watch 모드
+NODE_ENV=test pnpm test          # 전체 테스트 실행
+NODE_ENV=test pnpm test:watch    # watch 모드
 ```
 
 ### 테스트 작성 규칙

--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import type { Project } from "@/entities/Project";
 
+const MAX_VISIBLE_CHIPS = 2;
+
 type BaseProps = {
   projects: Project[];
   placeholder?: string;
@@ -207,31 +209,38 @@ export default function ProjectSelector(props: ProjectSelectorProps) {
         className="relative"
         onKeyDown={handleMultiKeyDown}
       >
-        {/* 트리거: 선택된 프로젝트 칩 또는 placeholder */}
+        {/* 트리거: 선택된 프로젝트 칩 또는 placeholder. 칩은 최대 2개까지 표시하고 나머지는 "+N" 배지로 축약한다 */}
         <div
           onClick={() => setIsOpen(!isOpen)}
-          className={`w-full px-2 bg-bg-page border rounded-md text-text-primary cursor-pointer flex items-center gap-1 flex-wrap ${
+          className={`w-full px-2 bg-bg-page border rounded-md text-text-primary cursor-pointer flex items-center gap-1 overflow-hidden ${
             compact ? "py-1 min-h-[34px]" : "py-1.5 min-h-[38px]"
           } ${isOpen ? "border-brand-primary" : "border-border-default"}`}
         >
           {selectedProjects.length === 0 ? (
             <span className="text-text-muted text-sm px-1">{placeholder}</span>
           ) : (
-            selectedProjects.map((p) => (
-              <span
-                key={p.id}
-                className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs bg-brand-primary/10 text-brand-primary rounded font-medium max-w-[120px]"
-              >
-                <span className="truncate">{p.name}</span>
-                <button
-                  type="button"
-                  onMouseDown={(e) => removeChip(p.id, e)}
-                  className="ml-0.5 hover:text-status-error flex-shrink-0 leading-none"
+            <>
+              {selectedProjects.slice(0, MAX_VISIBLE_CHIPS).map((p) => (
+                <span
+                  key={p.id}
+                  className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs bg-brand-primary/10 text-brand-primary rounded font-medium max-w-[120px] flex-shrink-0"
                 >
-                  &times;
-                </button>
-              </span>
-            ))
+                  <span className="truncate">{p.name}</span>
+                  <button
+                    type="button"
+                    onMouseDown={(e) => removeChip(p.id, e)}
+                    className="ml-0.5 hover:text-status-error flex-shrink-0 leading-none"
+                  >
+                    &times;
+                  </button>
+                </span>
+              ))}
+              {selectedProjects.length > MAX_VISIBLE_CHIPS && (
+                <span className="inline-flex items-center px-1.5 py-0.5 text-xs bg-brand-primary/10 text-brand-primary rounded font-medium flex-shrink-0">
+                  +{selectedProjects.length - MAX_VISIBLE_CHIPS}
+                </span>
+              )}
+            </>
           )}
           <svg
             className="ml-auto flex-shrink-0 text-text-muted"

--- a/src/components/__tests__/ProjectSelector.test.tsx
+++ b/src/components/__tests__/ProjectSelector.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { Project } from "@/entities/Project";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import ProjectSelector from "../ProjectSelector";
+
+function createProject(id: string, name: string): Project {
+  return {
+    id,
+    name,
+    repoPath: `/repo/${id}`,
+    defaultBranch: "main",
+    sshHost: null,
+    isWorktree: false,
+    color: null,
+    createdAt: new Date(),
+  };
+}
+
+const projects = [
+  createProject("1", "Alpha"),
+  createProject("2", "Beta"),
+  createProject("3", "Gamma"),
+  createProject("4", "Delta"),
+  createProject("5", "Epsilon"),
+];
+
+describe("ProjectSelector chip truncation", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("should show all chips when 2 or fewer projects are selected", () => {
+    // Given
+    const selectedIds = ["1", "2"];
+
+    // When
+    render(
+      <ProjectSelector
+        multiple
+        projects={projects}
+        selectedProjectIds={selectedIds}
+        onSelectionChange={vi.fn()}
+      />,
+    );
+
+    // Then
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    expect(screen.getByText("Beta")).toBeTruthy();
+    expect(screen.queryByText(/^\+\d+$/)).toBeNull();
+  });
+
+  it("should show only 2 chips and a +N badge when 3 or more projects are selected", () => {
+    // Given
+    const selectedIds = ["1", "2", "3", "4", "5"];
+
+    // When
+    render(
+      <ProjectSelector
+        multiple
+        projects={projects}
+        selectedProjectIds={selectedIds}
+        onSelectionChange={vi.fn()}
+      />,
+    );
+
+    // Then
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    expect(screen.getByText("Beta")).toBeTruthy();
+    expect(screen.queryByText("Gamma")).toBeNull();
+    expect(screen.queryByText("Delta")).toBeNull();
+    expect(screen.queryByText("Epsilon")).toBeNull();
+    expect(screen.getByText("+3")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- 프로젝트 필터에서 3개 이상 선택 시 헤더 영역 높이가 증가하는 문제를 수정하고, 관련 테스트를 추가했습니다.

## 어떻게 해결했나요?
**칩 축약 렌더링 적용**
- 선택된 프로젝트 칩을 최대 2개까지만 표시하고, 초과분은 `+N` 배지로 축약
- `flex-wrap`을 `overflow-hidden`으로 변경하여 헤더 높이 고정

**테스트 추가**
- 칩 축약 렌더링 동작을 검증하는 단위 테스트 작성

## 중요한 변경 사항은 무엇인가요?
### 칩 축약 렌더링

**MAX_VISIBLE_CHIPS 상수 도입 및 slice 적용**
- **변경 이유**: 프로젝트 3개 이상 선택 시 칩이 줄바꿈되며 헤더 높이가 증가하는 문제 해결
- **수정 파일**: `src/components/ProjectSelector.tsx`

**칩 축약 테스트 추가**
- **변경 이유**: 2개 이하/3개 이상 선택 시 렌더링 동작 검증
- **수정 파일**: `src/components/__tests__/ProjectSelector.test.tsx`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
