### PR TITLE
refactor(terminal): tmux/zellij 독립 세션 기반으로 변경

### DIFF
--- a/.claude/plan/terminal/2602/20-session-per-branch.plan.md
+++ b/.claude/plan/terminal/2602/20-session-per-branch.plan.md
@@ -1,0 +1,171 @@
+# Session-per-Branch: tmux/zellij 세션 기반 전환
+
+## Business Goal
+현재 프로젝트 단위로 하나의 tmux 세션(또는 zellij 세션)을 공유하고 브랜치별 window/tab을 생성하는 방식을, 각 브랜치마다 독립적인 세션을 생성하는 방식으로 전환한다. 이를 통해 브랜치 간 전환이 `tmux switch-client` / `zellij attach`로 단순해지고, 세션 격리로 안정성이 향상된다.
+
+## Scope
+- **In Scope**: tmux/zellij 모두 세션 기반으로 전환, 세션 이름 형식 변경(`projectName/branchName`), zellij 세션 이름 길이 안전장치
+- **Out of Scope**: DB 마이그레이션 (기존 task의 session_name 업데이트), 기존 tmux 세션 정리 스크립트, PTY 공유 방식 변경
+
+## Codebase Analysis Summary
+현재 시스템은 프로젝트 이름으로 하나의 공유 세션을 생성하고, 각 브랜치를 tmux window / zellij tab으로 추가하는 구조이다. `sessionName = path.basename(projectPath)`로 프로젝트 단위, `windowName = formatWindowName(branchName)`로 브랜치를 식별한다.
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/lib/worktree.ts` | worktree + tmux/zellij 세션 생성/삭제 핵심 로직 | Modify |
+| `src/lib/terminal.ts` | PTY 생성 및 tmux/zellij attach 로직 | Modify |
+| `src/app/actions/project.ts` | 프로젝트 스캔 시 세션 감지 및 메인 브랜치 태스크 생성 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 주석 언어 | CODE_PRINCIPLES.md | 한국어로 작성 |
+| 함수 주석 | 기존 코드 | JSDoc 스타일, `/** ... */` |
+| 세션 명령어 패턴 | worktree.ts | `execGit()` 래퍼로 실행, sshHost 분기 지원 |
+| 에러 처리 | 기존 코드 | try-catch로 감싸고 실패 시 무시 또는 에러 로깅 |
+| 네이밍 | CODE_PRINCIPLES.md | 동사 기반, 비즈니스 역할 명시 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 세션 이름 형식 | `projectName/branchName` (sanitized) | `tmux ls` 시 프로젝트별 그룹핑, uniqueness 보장 | branchName만 (프로젝트 간 충돌), projectName_branchName (가독성 낮음) |
+| tmux 세션 이름 제한 | 검증 불필요 | 메인테이너 "no defined limit" 확인 | truncation 추가 |
+| zellij 세션 이름 제한 | 소켓 경로 108바이트 기준 truncation | macOS 기준 ~62자 제한 | 무제한 (macOS에서 오류 발생) |
+| focusSession tmux 동작 | no-op | 세션 기반에서는 각 PTY가 독립 세션이므로 window 전환 불필요 | switch-client (PTY에서는 의미 없음) |
+| formatWindowName 유지 | 제거하고 formatSessionName으로 대체 | window 개념이 사라지므로 혼란 방지 | 이름만 변경 |
+
+## Implementation Todos
+
+### Todo 1: formatSessionName 헬퍼 함수 추가 및 formatWindowName 교체
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 세션 이름 생성 로직을 `projectName/branchName` 형식으로 변경하고, zellij용 길이 안전장치를 추가한다
+- **Work**:
+  - `src/lib/worktree.ts`의 `formatWindowName` 함수를 `formatSessionName(projectName: string, branchName: string): string`으로 교체
+  - 형식: `${projectName}/${branchName.replace(/\//g, "-")}` (leading space 제거)
+  - `sanitizeZellijSessionName(sessionName: string): string` 헬퍼 추가: 소켓 경로 길이 기반 truncation (최대 60자로 안전하게 제한)
+  - `formatWindowName` 참조를 모두 `formatSessionName`으로 변경
+  - `WorktreeSession` 인터페이스는 유지 (sessionName 필드 의미만 변경)
+- **Convention Notes**: 함수명은 동사 기반이 아닌 formatter이므로 `format` 접두사 유지. JSDoc 주석 한국어.
+- **Verification**: TypeScript 컴파일 성공 (`npx tsc --noEmit`)
+- **Exit Criteria**: `formatSessionName` 함수가 존재하고, `formatWindowName` 참조가 0개
+- **Status**: pending
+
+### Todo 2: createWorktreeWithSession 세션 기반 전환
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: worktree 생성 시 공유 세션의 window 대신 독립 세션을 생성하도록 변경한다
+- **Work**:
+  - `src/lib/worktree.ts`의 `createWorktreeWithSession()` 수정
+  - tmux 경로:
+    - `sessionName = formatSessionName(projectName, branchName)` (기존: `projectName`)
+    - `tmux has-session` 체크 → 있으면 재사용, 없으면 `tmux new-session -d -s "sessionName" -c "worktreePath"`
+    - `tmux new-window` 호출 제거
+    - `isWindowAlive` → `isSessionAlive`로 교체 (Todo 4에서 구현, 여기서는 `tmux has-session` 직접 사용)
+  - zellij 경로:
+    - `sessionName = sanitizeZellijSessionName(formatSessionName(projectName, branchName))`
+    - `zellij --session "sessionName" --cwd "worktreePath" &` 로 독립 세션 생성
+    - `zellij action new-tab` 호출 제거
+  - pane 레이아웃: `applyPaneLayoutAsync`의 `windowName` 대신 세션의 기본 window(첫 번째 window) 사용
+- **Convention Notes**: `execGit()` 래퍼 유지, sshHost 분기 유지
+- **Verification**: TypeScript 컴파일 성공
+- **Exit Criteria**: `tmux new-window` / `zellij action new-tab` 호출이 이 함수에서 제거됨
+- **Status**: pending
+
+### Todo 3: createSessionWithoutWorktree 세션 기반 전환
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: worktree 없이 세션을 생성하는 함수도 독립 세션 방식으로 변경한다
+- **Work**:
+  - `src/lib/worktree.ts`의 `createSessionWithoutWorktree()` 수정
+  - tmux: `tmux new-session -d -s "sessionName" -c "cwd"` (has-session 체크 후)
+  - zellij: `zellij --session "sessionName" --cwd "cwd" &`
+  - window/tab 생성 코드 제거
+  - `sessionName` 생성에 `formatSessionName` 사용
+- **Convention Notes**: 기존 함수 시그니처 유지 (하위 호환)
+- **Verification**: TypeScript 컴파일 성공
+- **Exit Criteria**: window/tab 생성 코드가 제거되고 독립 세션 생성으로 대체됨
+- **Status**: pending
+
+### Todo 4: removeSessionOnly 및 유틸리티 함수 전환
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 세션 삭제, 생존 확인, 목록 조회 함수를 세션 기반으로 변경한다
+- **Work**:
+  - `removeSessionOnly()`: tmux `kill-window` → `kill-session`, zellij `close-tab` → `kill-session`
+  - `isWindowAlive()` → `isSessionAlive()`로 rename 및 로직 변경: tmux `has-session -t`, zellij `list-sessions | grep`
+  - `listActiveWindows()` → `listActiveSessions()`로 rename: tmux `list-sessions -F '#{session_name}'`, zellij `list-sessions`
+  - `applyPaneLayout()`: target을 `"sessionName":"windowName"` → `"sessionName"` (기본 window 사용)
+- **Convention Notes**: 함수 rename 시 참조하는 모든 곳 업데이트. `find_referencing_symbols`로 확인.
+- **Verification**: TypeScript 컴파일 성공, `isWindowAlive` / `listActiveWindows` 참조 0개
+- **Exit Criteria**: window 기반 유틸리티가 모두 session 기반으로 전환됨
+- **Status**: pending
+
+### Todo 5: terminal.ts attachLocalSession 세션 기반 전환
+- **Priority**: 3
+- **Dependencies**: Todo 1, Todo 4
+- **Goal**: 로컬 터미널 연결 시 세션에 직접 attach하도록 변경한다
+- **Work**:
+  - `src/lib/terminal.ts`의 `attachLocalSession()` 수정
+  - `isTmuxWindowAlive()` → `isTmuxSessionAlive(sessionName)`: `tmux has-session -t "sessionName"` 사용
+  - 자동 생성 로직: `tmux new-session -d -s "sessionName" -c "dir"` (window 생성 제거)
+  - attach args: `["attach-session", "-t", sessionName]` (windowIndex 불필요)
+  - `getTmuxWindowIndex()` 함수 제거 (더 이상 사용 안 함)
+  - zellij: `["attach", sessionName]` (go-to-tab-name 호출 제거)
+- **Convention Notes**: `activeTerminals` Map의 `TerminalEntry`에서 `windowName` 필드는 호환성을 위해 유지하되 tmux에서는 사용하지 않음
+- **Verification**: TypeScript 컴파일 성공
+- **Exit Criteria**: `tmux attach-session -t session:windowIndex` 패턴이 `tmux attach-session -t sessionName`으로 변경됨
+- **Status**: pending
+
+### Todo 6: terminal.ts focusSession 및 attachRemoteSession 전환
+- **Priority**: 3
+- **Dependencies**: Todo 1, Todo 4
+- **Goal**: 포커스 전환 및 원격 연결도 세션 기반으로 변경한다
+- **Work**:
+  - `focusSession()`: tmux 분기를 no-op으로 변경 (세션 기반에서는 window 전환이 불필요). zellij도 독립 세션이므로 no-op.
+  - `attachRemoteSession()`: tmux `attach-session -t "sessionName"` (`:windowName` 제거), zellij `attach "sessionName"` (go-to-tab-name 제거)
+- **Convention Notes**: no-op 처리 시 주석으로 사유 명시
+- **Verification**: TypeScript 컴파일 성공
+- **Exit Criteria**: `select-window` / `go-to-tab-name` 호출이 제거됨
+- **Status**: pending
+
+### Todo 7: project.ts scanAndRegisterProjects 세션 감지 로직 변경
+- **Priority**: 4
+- **Dependencies**: Todo 1, Todo 4
+- **Goal**: 프로젝트 스캔 시 세션 감지 로직을 새 세션 이름 형식에 맞게 변경한다
+- **Work**:
+  - `src/app/actions/project.ts`의 `scanAndRegisterProjects()` 수정
+  - worktree 스캔 블록: `sessionName = formatSessionName(projectName, branchName)`, `isSessionAlive()` 사용
+  - 메인 브랜치 세션 감지 블록: 동일하게 `formatSessionName` + `isSessionAlive` 사용
+  - `formatWindowName` import 제거, `formatSessionName` import 추가
+- **Convention Notes**: `isWindowAlive` → `isSessionAlive` rename에 맞춤
+- **Verification**: TypeScript 컴파일 성공
+- **Exit Criteria**: `scanAndRegisterProjects`에서 `formatWindowName` / `isWindowAlive` 참조 0개
+- **Status**: pending
+
+### Todo 8: 최종 빌드 검증 및 정리
+- **Priority**: 5
+- **Dependencies**: Todo 2, Todo 3, Todo 4, Todo 5, Todo 6, Todo 7
+- **Goal**: 전체 빌드 성공 확인 및 미사용 코드 정리
+- **Work**:
+  - `npx tsc --noEmit`으로 타입 검증
+  - `formatWindowName`, `isTmuxWindowAlive`, `getTmuxWindowIndex`, `isWindowAlive`, `listActiveWindows` 등 미사용 함수/import 완전 제거 확인
+  - 기존 테스트 파일(`src/app/api/hooks/start/__tests__/route.test.ts`)에서 sessionName 관련 테스트 데이터가 있으면 새 형식에 맞게 업데이트
+- **Convention Notes**: 미사용 코드는 주석 처리 없이 완전 삭제
+- **Verification**: `pnpm build` 또는 `npx tsc --noEmit` 성공
+- **Exit Criteria**: 빌드 성공, window 기반 코드 잔여물 0개
+- **Status**: pending
+
+## Verification Strategy
+- TypeScript 컴파일: `npx tsc --noEmit`
+- 기존 테스트: `pnpm test` (있는 경우)
+- grep 검증: `grep -r "new-window\|kill-window\|list-windows\|select-window\|formatWindowName\|isWindowAlive\|listActiveWindows" src/lib/ src/app/` → 0 결과
+
+## Progress Tracking
+- Total Todos: 8
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-20: Plan created

--- a/server.ts
+++ b/server.ts
@@ -6,7 +6,6 @@ import { WebSocketServer, type WebSocket } from "ws";
 import { validateSessionFromCookie } from "@/lib/auth";
 import { getTaskRepository } from "@/lib/database";
 import { attachLocalSession, attachRemoteSession } from "@/lib/terminal";
-import { formatWindowName } from "@/lib/worktree";
 import { parseSSHConfig } from "@/lib/sshConfig";
 import { addBoardClient, removeBoardClient, getBoardClients } from "@/lib/boardNotifier";
 
@@ -110,9 +109,9 @@ app.prepare().then(() => {
         return;
       }
 
-      /** branchName 또는 baseBranch에서 window/tab 이름을 파생한다 */
+      /** 구 형식 sessionName("/"없음)에서는 branchName으로 window를 특정해야 한다 */
       const derivedBranch = task.branchName || task.baseBranch;
-      const windowName = derivedBranch ? formatWindowName(derivedBranch) : "";
+      const windowName = derivedBranch ? ` ${derivedBranch.replace(/\//g, "-")}` : "";
 
       if (task.sshHost) {
         const sshHosts = await parseSSHConfig();

--- a/src/app/actions/__tests__/scanAndRegisterProjects.test.ts
+++ b/src/app/actions/__tests__/scanAndRegisterProjects.test.ts
@@ -33,8 +33,8 @@ vi.mock("@/lib/gitOperations", () => ({
 }));
 
 vi.mock("@/lib/worktree", () => ({
-  isWindowAlive: vi.fn().mockResolvedValue(false),
-  formatWindowName: vi.fn((name: string) => name),
+  isSessionAlive: vi.fn().mockResolvedValue(false),
+  formatSessionName: vi.fn((projectName: string, branchName: string) => `${projectName}/${branchName}`),
   createSessionWithoutWorktree: vi.fn().mockResolvedValue({ sessionName: "test-session" }),
 }));
 

--- a/src/app/actions/project.ts
+++ b/src/app/actions/project.ts
@@ -6,7 +6,7 @@ import { Project } from "@/entities/Project";
 import { validateGitRepo, getDefaultBranch, listBranches, scanGitRepos, listWorktrees, execGit } from "@/lib/gitOperations";
 import { TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { IsNull } from "typeorm";
-import { isWindowAlive, formatWindowName, createSessionWithoutWorktree } from "@/lib/worktree";
+import { isSessionAlive, formatSessionName, createSessionWithoutWorktree } from "@/lib/worktree";
 import { setupClaudeHooks, getClaudeHooksStatus, type ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
 import { setupGeminiHooks, getGeminiHooksStatus, type GeminiHooksStatus } from "@/lib/geminiHooksSetup";
 import { setupCodexHooks, getCodexHooksStatus, type CodexHooksStatus } from "@/lib/codexHooksSetup";
@@ -261,13 +261,12 @@ export async function scanAndRegisterProjects(
           continue;
         }
 
-        /** tmux 세션에 동일한 session-window가 있으면 연결 정보를 설정한다 */
-        const sessionName = path.basename(project.repoPath);
-        const windowName = formatWindowName(wt.branch);
-        const hasWindow = await isWindowAlive(
+        /** 해당 브랜치의 독립 tmux 세션이 활성 상태이면 연결 정보를 설정한다 */
+        const projectName = path.basename(project.repoPath);
+        const sessionName = formatSessionName(projectName, wt.branch);
+        const hasSession = await isSessionAlive(
           SessionType.TMUX,
           sessionName,
-          windowName,
           project.sshHost
         );
 
@@ -277,8 +276,8 @@ export async function scanAndRegisterProjects(
           worktreePath: wt.path,
           projectId: project.id,
           baseBranch: project.defaultBranch,
-          status: hasWindow ? TaskStatus.PROGRESS : TaskStatus.TODO,
-          ...(hasWindow && {
+          status: hasSession ? TaskStatus.PROGRESS : TaskStatus.TODO,
+          ...(hasSession && {
             sessionType: SessionType.TMUX,
             sessionName,
             sshHost: project.sshHost,
@@ -302,16 +301,15 @@ export async function scanAndRegisterProjects(
       });
 
       if (mainBranchTask && !mainBranchTask.sessionType) {
-        const sessionName = path.basename(project.repoPath);
-        const windowName = formatWindowName(project.defaultBranch);
-        const hasWindow = await isWindowAlive(
+        const projectName = path.basename(project.repoPath);
+        const sessionName = formatSessionName(projectName, project.defaultBranch);
+        const hasSession = await isSessionAlive(
           SessionType.TMUX,
           sessionName,
-          windowName,
           project.sshHost,
         );
 
-        if (hasWindow) {
+        if (hasSession) {
           mainBranchTask.sessionType = SessionType.TMUX;
           mainBranchTask.sessionName = sessionName;
           mainBranchTask.worktreePath = project.repoPath;

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -1,0 +1,276 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SessionType } from "@/entities/KanbanTask";
+
+// --- Mocks ---
+
+const mockExecGit = vi.fn();
+
+vi.mock("@/lib/gitOperations", () => ({
+  execGit: (...args: unknown[]) => mockExecGit(...args),
+}));
+
+vi.mock("@/app/actions/paneLayout", () => ({
+  getEffectivePaneLayout: vi.fn().mockResolvedValue(null),
+}));
+
+describe("formatSessionName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should combine projectName and branchName with slash separator", async () => {
+    // Given
+    const { formatSessionName } = await import("@/lib/worktree");
+
+    // When
+    const result = formatSessionName("kanvibe", "feat-login");
+
+    // Then
+    expect(result).toBe("kanvibe/feat-login");
+  });
+
+  it("should replace slashes in branchName with hyphens", async () => {
+    // Given
+    const { formatSessionName } = await import("@/lib/worktree");
+
+    // When
+    const result = formatSessionName("kanvibe", "feat/user/auth");
+
+    // Then
+    expect(result).toBe("kanvibe/feat-user-auth");
+  });
+
+  it("should handle branchName without slashes unchanged", async () => {
+    // Given
+    const { formatSessionName } = await import("@/lib/worktree");
+
+    // When
+    const result = formatSessionName("my-project", "main");
+
+    // Then
+    expect(result).toBe("my-project/main");
+  });
+});
+
+describe("sanitizeZellijSessionName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return sessionName unchanged when within length limit", async () => {
+    // Given
+    const { sanitizeZellijSessionName } = await import("@/lib/worktree");
+    const shortName = "kanvibe/feat-login";
+
+    // When
+    const result = sanitizeZellijSessionName(shortName);
+
+    // Then
+    expect(result).toBe(shortName);
+  });
+
+  it("should truncate sessionName exceeding 60 characters", async () => {
+    // Given
+    const { sanitizeZellijSessionName } = await import("@/lib/worktree");
+    const longName = "a".repeat(80);
+
+    // When
+    const result = sanitizeZellijSessionName(longName);
+
+    // Then
+    expect(result).toHaveLength(60);
+    expect(result).toBe("a".repeat(60));
+  });
+
+  it("should return exact 60-char sessionName unchanged", async () => {
+    // Given
+    const { sanitizeZellijSessionName } = await import("@/lib/worktree");
+    const exactName = "x".repeat(60);
+
+    // When
+    const result = sanitizeZellijSessionName(exactName);
+
+    // Then
+    expect(result).toBe(exactName);
+  });
+});
+
+describe("removeSessionOnly", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should kill tmux session for new format sessionName with slash", async () => {
+    // Given
+    const { removeSessionOnly } = await import("@/lib/worktree");
+    mockExecGit.mockResolvedValue("");
+
+    // When
+    await removeSessionOnly(SessionType.TMUX, "kanvibe/feat-login", "feat-login");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledWith(
+      `tmux kill-session -t "kanvibe/feat-login"`,
+      undefined,
+    );
+  });
+
+  it("should kill tmux window for legacy sessionName without slash", async () => {
+    // Given
+    const { removeSessionOnly } = await import("@/lib/worktree");
+    mockExecGit.mockResolvedValue("");
+
+    // When
+    await removeSessionOnly(SessionType.TMUX, "kanvibe", "feat-login");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledWith(
+      `tmux kill-window -t "kanvibe: feat-login"`,
+      undefined,
+    );
+  });
+
+  it("should kill zellij session for new format sessionName with slash", async () => {
+    // Given
+    const { removeSessionOnly } = await import("@/lib/worktree");
+    mockExecGit.mockResolvedValue("");
+
+    // When
+    await removeSessionOnly(SessionType.ZELLIJ, "kanvibe/feat-login", "feat-login");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledWith(
+      `zellij kill-session "kanvibe/feat-login"`,
+      undefined,
+    );
+  });
+
+  it("should close zellij tab for legacy sessionName without slash", async () => {
+    // Given
+    const { removeSessionOnly } = await import("@/lib/worktree");
+    mockExecGit.mockResolvedValue("");
+
+    // When
+    await removeSessionOnly(SessionType.ZELLIJ, "kanvibe", "feat/login");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledWith(
+      `zellij action --session "kanvibe" go-to-tab-name " feat-login" && zellij action --session "kanvibe" close-tab`,
+      undefined,
+    );
+  });
+
+  it("should pass sshHost to execGit for remote session removal", async () => {
+    // Given
+    const { removeSessionOnly } = await import("@/lib/worktree");
+    mockExecGit.mockResolvedValue("");
+
+    // When
+    await removeSessionOnly(SessionType.TMUX, "kanvibe/feat-login", "feat-login", "my-server");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledWith(
+      `tmux kill-session -t "kanvibe/feat-login"`,
+      "my-server",
+    );
+  });
+
+  it("should silently catch errors when session is already terminated", async () => {
+    // Given
+    const { removeSessionOnly } = await import("@/lib/worktree");
+    mockExecGit.mockRejectedValue(new Error("session not found"));
+
+    // When & Then
+    await expect(
+      removeSessionOnly(SessionType.TMUX, "kanvibe/feat-login", "feat-login"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("isSessionAlive", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return true when tmux session exists", async () => {
+    // Given
+    const { isSessionAlive } = await import("@/lib/worktree");
+    mockExecGit.mockResolvedValue("");
+
+    // When
+    const result = await isSessionAlive(SessionType.TMUX, "kanvibe/feat-login");
+
+    // Then
+    expect(result).toBe(true);
+    expect(mockExecGit).toHaveBeenCalledWith(
+      `tmux has-session -t "kanvibe/feat-login" 2>/dev/null`,
+      undefined,
+    );
+  });
+
+  it("should return false when tmux session does not exist", async () => {
+    // Given
+    const { isSessionAlive } = await import("@/lib/worktree");
+    mockExecGit.mockRejectedValue(new Error("session not found"));
+
+    // When
+    const result = await isSessionAlive(SessionType.TMUX, "kanvibe/nonexistent");
+
+    // Then
+    expect(result).toBe(false);
+  });
+
+  it("should return true when zellij session exists in list", async () => {
+    // Given
+    const { isSessionAlive } = await import("@/lib/worktree");
+    mockExecGit.mockResolvedValue("kanvibe/feat-login\nother-session\n");
+
+    // When
+    const result = await isSessionAlive(SessionType.ZELLIJ, "kanvibe/feat-login");
+
+    // Then
+    expect(result).toBe(true);
+  });
+
+  it("should return false when zellij session is not in list", async () => {
+    // Given
+    const { isSessionAlive } = await import("@/lib/worktree");
+    mockExecGit.mockResolvedValue("other-session\nanother-session\n");
+
+    // When
+    const result = await isSessionAlive(SessionType.ZELLIJ, "kanvibe/feat-login");
+
+    // Then
+    expect(result).toBe(false);
+  });
+
+  it("should return false when zellij list-sessions command fails", async () => {
+    // Given
+    const { isSessionAlive } = await import("@/lib/worktree");
+    mockExecGit.mockRejectedValue(new Error("zellij not installed"));
+
+    // When
+    const result = await isSessionAlive(SessionType.ZELLIJ, "kanvibe/feat-login");
+
+    // Then
+    expect(result).toBe(false);
+  });
+
+  it("should pass sshHost for remote session check", async () => {
+    // Given
+    const { isSessionAlive } = await import("@/lib/worktree");
+    mockExecGit.mockResolvedValue("");
+
+    // When
+    await isSessionAlive(SessionType.TMUX, "kanvibe/feat-login", "my-server");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledWith(
+      `tmux has-session -t "kanvibe/feat-login" 2>/dev/null`,
+      "my-server",
+    );
+  });
+});

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -1,6 +1,6 @@
-import type { WebSocket } from "ws";
-import { execSync } from "child_process";
 import { SessionType } from "@/entities/KanbanTask";
+import { execSync } from "child_process";
+import type { WebSocket } from "ws";
 
 /**
  * 활성 터미널 세션을 관리하는 레지스트리.
@@ -16,33 +16,15 @@ interface TerminalEntry {
 
 const activeTerminals = new Map<string, TerminalEntry>();
 
-/** tmux 세션에 해당 window가 존재하는지 확인한다 */
-function isTmuxWindowAlive(sessionName: string, windowName: string): boolean {
+/** tmux 세션이 존재하는지 확인한다 */
+function isTmuxSessionAlive(sessionName: string): boolean {
   try {
-    const output = execSync(
-      `tmux list-windows -t "${sessionName}" -F "#{window_name}"`,
-      { encoding: "utf-8", timeout: 5000 },
-    );
-    return output.split("\n").some((w) => w.trimEnd() === windowName);
+    execSync(`tmux has-session -t "${sessionName}" 2>/dev/null`, {
+      timeout: 5000,
+    });
+    return true;
   } catch {
     return false;
-  }
-}
-
-/** tmux window의 이름으로 인덱스를 조회한다. 중복 이름이 있어도 첫 번째 매치를 반환한다 */
-function getTmuxWindowIndex(sessionName: string, windowName: string): string | null {
-  try {
-    const output = execSync(
-      `tmux list-windows -t "${sessionName}" -F "#{window_name}\t#{window_index}"`,
-      { encoding: "utf-8", timeout: 5000 },
-    );
-    for (const line of output.split("\n")) {
-      const [name, index] = line.split("\t");
-      if (name?.trimEnd() === windowName && index) return index;
-    }
-    return null;
-  } catch {
-    return null;
   }
 }
 
@@ -85,8 +67,6 @@ export async function attachLocalSession(
           const parsed = JSON.parse(data.slice(1));
           if (parsed.type === "resize" && parsed.cols && parsed.rows) {
             existing.pty.resize(parsed.cols, parsed.rows);
-          } else if (parsed.type === "focus") {
-            focusSession(taskId);
           }
         } catch {
           existing.pty.write(data);
@@ -106,24 +86,22 @@ export async function attachLocalSession(
     return;
   }
 
-  /** tmux window가 없으면 세션과 window를 자동 생성한다 */
+  /**
+   * sessionName에 "/"가 포함되면 신규 독립 세션 형식(projectName/branchName),
+   * 없으면 구 형식(공유 세션 + window)이다.
+   */
+  const isLegacySharedSession = !sessionName.includes("/");
+
+  /** 세션이 없으면 자동 생성한다 */
   if (sessionType === SessionType.TMUX) {
-    if (!isTmuxWindowAlive(sessionName, windowName)) {
+    if (!isTmuxSessionAlive(sessionName)) {
       try {
         const dir = cwd || process.env.HOME || "/";
-        execSync(
-          `tmux has-session -t "${sessionName}" 2>/dev/null || tmux new-session -d -s "${sessionName}"`,
-          { timeout: 5000 },
-        );
-        /** 중복 방지: 다시 확인 후 없을 때만 생성한다 */
-        if (!isTmuxWindowAlive(sessionName, windowName)) {
-          execSync(
-            `tmux new-window -t "${sessionName}" -n "${windowName}" -c "${dir}"`,
-            { timeout: 5000 },
-          );
-        }
+        execSync(`tmux new-session -d -s "${sessionName}" -c "${dir}"`, {
+          timeout: 5000,
+        });
       } catch (error) {
-        console.error(`[터미널] tmux 세션/window 자동 생성 실패:`, error);
+        console.error(`[터미널] tmux 세션 자동 생성 실패:`, error);
         ws.close(1008, "tmux 세션 생성에 실패했습니다.");
         return;
       }
@@ -145,35 +123,21 @@ export async function attachLocalSession(
 
   const pty = await import("node-pty");
 
-  const shell =
-    sessionType === SessionType.TMUX
-      ? "tmux"
-      : "zellij";
-
-  /** tmux는 session:windowIndex 형식으로 특정 window에 직접 연결한다. 이름 중복 시에도 안전하도록 인덱스를 사용한다 */
-  let args: string[];
-  if (sessionType === SessionType.TMUX) {
-    const windowIndex = getTmuxWindowIndex(sessionName, windowName);
-    const target = windowIndex ? `${sessionName}:${windowIndex}` : `${sessionName}:${windowName}`;
-    args = ["attach-session", "-t", target];
-  } else {
-    args = ["attach", sessionName];
-  }
+  const shell = sessionType === SessionType.TMUX ? "tmux" : "zellij";
 
   /**
-   * zellij는 attach 전에 해당 tab으로 이동해야 한다.
-   * go-to-tab-name 액션으로 대상 tab을 선택한다.
+   * 구 형식(공유 세션)이면 특정 window를 타겟으로 attach하고,
+   * 신규 형식(독립 세션)이면 세션 전체에 직접 attach한다.
    */
-  if (sessionType === SessionType.ZELLIJ) {
-    const { exec } = await import("child_process");
-    const { promisify } = await import("util");
-    const execAsync = promisify(exec);
-    try {
-      await execAsync(`zellij action --session "${sessionName}" go-to-tab-name "${windowName}"`);
-    } catch {
-      // tab 이동 실패 시 기본 탭으로 attach
-    }
-  }
+  const tmuxTarget =
+    isLegacySharedSession && windowName
+      ? `${sessionName}:${windowName}`
+      : sessionName;
+
+  const args: string[] =
+    sessionType === SessionType.TMUX
+      ? ["attach-session", "-t", tmuxTarget]
+      : ["attach", sessionName];
 
   let ptyProcess: import("node-pty").IPty;
   try {
@@ -194,7 +158,13 @@ export async function attachLocalSession(
     return;
   }
 
-  const entry: TerminalEntry = { pty: ptyProcess, clients: new Set([ws]), sessionType, sessionName, windowName };
+  const entry: TerminalEntry = {
+    pty: ptyProcess,
+    clients: new Set([ws]),
+    sessionType,
+    sessionName,
+    windowName,
+  };
   activeTerminals.set(taskId, entry);
 
   ptyProcess.onData((data) => {
@@ -217,11 +187,8 @@ export async function attachLocalSession(
         const parsed = JSON.parse(data.slice(1));
         if (parsed.type === "resize" && parsed.cols && parsed.rows) {
           ptyProcess.resize(parsed.cols, parsed.rows);
-        } else if (parsed.type === "focus") {
-          focusSession(taskId);
         }
       } catch {
-        // 파싱 실패 시 일반 입력으로 처리
         ptyProcess.write(data);
       }
       return;
@@ -246,7 +213,12 @@ export async function attachRemoteSession(
   sessionName: string,
   windowName: string,
   ws: WebSocket,
-  sshConfig: { hostname: string; port: number; username: string; privateKeyPath: string },
+  sshConfig: {
+    hostname: string;
+    port: number;
+    username: string;
+    privateKeyPath: string;
+  },
   cols?: number,
   rows?: number,
 ): Promise<void> {
@@ -259,57 +231,69 @@ export async function attachRemoteSession(
   const conn = new Client();
 
   conn.on("ready", () => {
-    /** tmux는 session:window 타겟으로, zellij는 tab 이동 후 attach한다 */
+    /**
+     * 구 형식(공유 세션)이면 특정 window를 타겟으로 attach하고,
+     * 신규 형식(독립 세션)이면 세션 전체에 직접 attach한다.
+     */
+    const isLegacySharedSession = !sessionName.includes("/");
+    const tmuxTarget =
+      isLegacySharedSession && windowName
+        ? `${sessionName}:${windowName}`
+        : sessionName;
+
     const command =
       sessionType === SessionType.TMUX
-        ? `tmux attach-session -t "${sessionName}:${windowName}"`
-        : `zellij action --session "${sessionName}" go-to-tab-name "${windowName}" 2>/dev/null; zellij attach "${sessionName}"`;
+        ? `tmux attach-session -t "${tmuxTarget}"`
+        : `zellij attach "${sessionName}"`;
 
-    conn.shell({ term: "xterm-256color", cols: initialCols, rows: initialRows }, (err, stream) => {
-      if (err) {
-        ws.close(1011, "SSH shell 오류");
-        conn.end();
-        return;
-      }
-
-      stream.write(command + "\n");
-
-      stream.on("data", (data: Buffer) => {
-        if (ws.readyState === ws.OPEN) {
-          ws.send(data);
-        }
-      });
-
-      stream.on("close", () => {
-        ws.close();
-        conn.end();
-        activeTerminals.delete(taskId);
-      });
-
-      ws.on("message", (message) => {
-        const data = message.toString();
-
-        if (data.startsWith("\x01")) {
-          try {
-            const parsed = JSON.parse(data.slice(1));
-            if (parsed.type === "resize" && parsed.cols && parsed.rows) {
-              stream.setWindow(parsed.rows, parsed.cols, 0, 0);
-            }
-          } catch {
-            stream.write(data);
-          }
+    conn.shell(
+      { term: "xterm-256color", cols: initialCols, rows: initialRows },
+      (err, stream) => {
+        if (err) {
+          ws.close(1011, "SSH shell 오류");
+          conn.end();
           return;
         }
 
-        stream.write(data);
-      });
+        stream.write(command + "\n");
 
-      ws.on("close", () => {
-        stream.close();
-        conn.end();
-        activeTerminals.delete(taskId);
-      });
-    });
+        stream.on("data", (data: Buffer) => {
+          if (ws.readyState === ws.OPEN) {
+            ws.send(data);
+          }
+        });
+
+        stream.on("close", () => {
+          ws.close();
+          conn.end();
+          activeTerminals.delete(taskId);
+        });
+
+        ws.on("message", (message) => {
+          const data = message.toString();
+
+          if (data.startsWith("\x01")) {
+            try {
+              const parsed = JSON.parse(data.slice(1));
+              if (parsed.type === "resize" && parsed.cols && parsed.rows) {
+                stream.setWindow(parsed.rows, parsed.cols, 0, 0);
+              }
+            } catch {
+              stream.write(data);
+            }
+            return;
+          }
+
+          stream.write(data);
+        });
+
+        ws.on("close", () => {
+          stream.close();
+          conn.end();
+          activeTerminals.delete(taskId);
+        });
+      },
+    );
   });
 
   conn.on("error", (err) => {
@@ -323,29 +307,6 @@ export async function attachRemoteSession(
     username: sshConfig.username,
     privateKey: fs.readFileSync(sshConfig.privateKeyPath),
   });
-}
-
-/** 탭 전환 시 해당 태스크의 tmux window / zellij tab으로 포커스를 이동한다 */
-export function focusSession(taskId: string): void {
-  const entry = activeTerminals.get(taskId);
-  if (!entry) return;
-
-  try {
-    if (entry.sessionType === SessionType.TMUX) {
-      const windowIndex = getTmuxWindowIndex(entry.sessionName, entry.windowName);
-      const target = windowIndex
-        ? `${entry.sessionName}:${windowIndex}`
-        : `${entry.sessionName}:${entry.windowName}`;
-      execSync(`tmux select-window -t "${target}"`, { timeout: 3000, stdio: "ignore" });
-    } else {
-      execSync(
-        `zellij action --session "${entry.sessionName}" go-to-tab-name "${entry.windowName}"`,
-        { timeout: 3000, stdio: "ignore" },
-      );
-    }
-  } catch {
-    // focus 실패 시 무시 (세션이 종료되었을 수 있음)
-  }
 }
 
 /** 터미널 세션을 분리하고 PTY 프로세스를 종료한다. 모든 연결된 클라이언트를 닫는다 */

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -9,10 +9,18 @@ interface WorktreeSession {
   sessionName: string;
 }
 
-/** branchName을 tmux window / zellij tab 이름으로 변환한다 */
-export function formatWindowName(branchName: string): string {
-  return ` ${branchName.replace(/\//g, "-")}`;
+/** projectName과 branchName을 조합하여 독립 세션 이름을 생성한다 */
+export function formatSessionName(projectName: string, branchName: string): string {
+  return `${projectName}/${branchName.replace(/\//g, "-")}`;
 }
+
+/** zellij 세션 이름을 소켓 경로 108바이트 제한에 맞게 truncate한다 */
+const ZELLIJ_SESSION_NAME_MAX_LENGTH = 60;
+export function sanitizeZellijSessionName(sessionName: string): string {
+  if (sessionName.length <= ZELLIJ_SESSION_NAME_MAX_LENGTH) return sessionName;
+  return sessionName.slice(0, ZELLIJ_SESSION_NAME_MAX_LENGTH);
+}
+
 
 /**
  * tmux window에 pane 레이아웃을 적용하고 각 pane에 시작 명령어를 실행한다.
@@ -20,12 +28,11 @@ export function formatWindowName(branchName: string): string {
  */
 async function applyPaneLayout(
   sessionName: string,
-  windowName: string,
   layoutType: PaneLayoutType,
   panes: PaneCommand[],
   worktreePath: string,
 ): Promise<void> {
-  const target = `"${sessionName}":"${windowName}"`;
+  const target = `"${sessionName}"`;
 
   /** 레이아웃 타입에 따른 tmux split 명령어 시퀀스 */
   const splitCommands: Record<PaneLayoutType, string[]> = {
@@ -72,7 +79,6 @@ async function applyPaneLayout(
  */
 function applyPaneLayoutAsync(
   sessionName: string,
-  windowName: string,
   worktreePath: string,
   projectId?: string,
 ): void {
@@ -82,7 +88,6 @@ function applyPaneLayoutAsync(
       if (layoutConfig && layoutConfig.layoutType !== PaneLayoutType.SINGLE) {
         await applyPaneLayout(
           sessionName,
-          windowName,
           layoutConfig.layoutType as PaneLayoutType,
           layoutConfig.panes,
           worktreePath,
@@ -116,8 +121,7 @@ export async function createWorktreeWithSession(
     worktreeBase,
     branchName.replace(/\//g, "-"),
   );
-  const sessionName = projectName;
-  const windowName = formatWindowName(branchName);
+  const rawSessionName = formatSessionName(projectName, branchName);
 
   await execGit(
     `git -C "${projectPath}" worktree add "${worktreePath}" -b "${branchName}" "${baseBranch}"`,
@@ -125,17 +129,13 @@ export async function createWorktreeWithSession(
   );
 
   if (sessionType === SessionType.TMUX) {
-    /** 메인 tmux 세션이 없으면 자동 생성한다 */
-    await execGit(
-      `tmux has-session -t "${sessionName}" 2>/dev/null || tmux new-session -d -s "${sessionName}"`,
-      sshHost,
-    );
+    const sessionName = rawSessionName;
 
-    /** 동일 이름의 window가 이미 존재하면 중복 생성하지 않는다 (tmux는 이름 중복 시 select 불가) */
-    const hasWindow = await isWindowAlive(sessionType, sessionName, windowName, sshHost);
-    if (!hasWindow) {
+    /** 동일 이름의 세션이 이미 존재하면 중복 생성하지 않는다 */
+    const hasSession = await isSessionAlive(sessionType, sessionName, sshHost);
+    if (!hasSession) {
       await execGit(
-        `tmux new-window -t "${sessionName}" -n "${windowName}" -c "${worktreePath}"`,
+        `tmux new-session -d -s "${sessionName}" -c "${worktreePath}"`,
         sshHost,
       );
     }
@@ -144,33 +144,27 @@ export async function createWorktreeWithSession(
     if (!sshHost) {
       applyPaneLayoutAsync(
         sessionName,
-        windowName,
         worktreePath,
         projectId ?? undefined,
       );
     }
+
+    return { worktreePath, sessionName };
   } else {
-    /** 메인 zellij 세션이 없으면 백그라운드로 생성한다 */
-    try {
-      await execGit(
-        `zellij list-sessions 2>/dev/null | grep -q "^${sessionName}$"`,
-        sshHost,
-      );
-    } catch {
+    const sessionName = sanitizeZellijSessionName(rawSessionName);
+
+    /** 동일 이름의 세션이 이미 존재하면 중복 생성하지 않는다 */
+    const hasSession = await isSessionAlive(sessionType, sessionName, sshHost);
+    if (!hasSession) {
       await execGit(
         `cd "${worktreePath}" && zellij --session "${sessionName}" &`,
         sshHost,
       );
       await new Promise((resolve) => setTimeout(resolve, 2000));
     }
-    /** 메인 세션에 worktree 디렉토리의 tab을 추가한다 */
-    await execGit(
-      `zellij action --session "${sessionName}" new-tab --name "${windowName}" --cwd "${worktreePath}"`,
-      sshHost,
-    );
-  }
 
-  return { worktreePath, sessionName };
+    return { worktreePath, sessionName };
+  }
 }
 
 /**
@@ -184,44 +178,38 @@ export async function createSessionWithoutWorktree(
   sshHost?: string | null,
   workingDir?: string,
 ): Promise<{ sessionName: string }> {
-  const sessionName = path.basename(projectPath);
-  const windowName = formatWindowName(branchName);
+  const projectName = path.basename(projectPath);
+  const rawSessionName = formatSessionName(projectName, branchName);
   const cwd = workingDir || projectPath;
 
   if (sessionType === SessionType.TMUX) {
-    await execGit(
-      `tmux has-session -t "${sessionName}" 2>/dev/null || tmux new-session -d -s "${sessionName}"`,
-      sshHost,
-    );
+    const sessionName = rawSessionName;
 
-    /** 동일 이름의 window가 이미 존재하면 중복 생성하지 않는다 (tmux는 이름 중복 시 select 불가) */
-    const hasWindow = await isWindowAlive(sessionType, sessionName, windowName, sshHost);
-    if (!hasWindow) {
+    /** 동일 이름의 세션이 이미 존재하면 중복 생성하지 않는다 */
+    const hasSession = await isSessionAlive(sessionType, sessionName, sshHost);
+    if (!hasSession) {
       await execGit(
-        `tmux new-window -t "${sessionName}" -n "${windowName}" -c "${cwd}"`,
+        `tmux new-session -d -s "${sessionName}" -c "${cwd}"`,
         sshHost,
       );
     }
+
+    return { sessionName };
   } else {
-    try {
-      await execGit(
-        `zellij list-sessions 2>/dev/null | grep -q "^${sessionName}$"`,
-        sshHost,
-      );
-    } catch {
+    const sessionName = sanitizeZellijSessionName(rawSessionName);
+
+    /** 동일 이름의 세션이 이미 존재하면 중복 생성하지 않는다 */
+    const hasSession = await isSessionAlive(sessionType, sessionName, sshHost);
+    if (!hasSession) {
       await execGit(
         `cd "${cwd}" && zellij --session "${sessionName}" &`,
         sshHost,
       );
       await new Promise((resolve) => setTimeout(resolve, 2000));
     }
-    await execGit(
-      `zellij action --session "${sessionName}" new-tab --name "${windowName}" --cwd "${cwd}"`,
-      sshHost,
-    );
-  }
 
-  return { sessionName };
+    return { sessionName };
+  }
 }
 
 /** worktree와 브랜치를 삭제한다. 세션은 건드리지 않는다 */
@@ -255,34 +243,53 @@ export async function removeWorktreeAndBranch(
   }
 }
 
-/** tmux window / zellij tab만 제거한다. worktree와 브랜치는 삭제하지 않는다 */
+/** tmux 세션 / zellij 세션을 제거한다. worktree와 브랜치는 삭제하지 않는다 */
 export async function removeSessionOnly(
   sessionType: SessionType,
   sessionName: string,
   branchName: string,
   sshHost?: string | null,
 ): Promise<void> {
-  const windowName = formatWindowName(branchName);
-
   try {
+    /**
+     * sessionName에 "/"가 포함되면 신규 독립 세션 형식(projectName/branchName)이므로 세션을 삭제한다.
+     * "/"가 없으면 구 형식(공유 세션)이므로 해당 window/tab만 삭제하여 다른 브랜치에 영향을 주지 않는다.
+     */
+    const isLegacySharedSession = !sessionName.includes("/");
+
     if (sessionType === SessionType.TMUX) {
-      await execGit(
-        `tmux kill-window -t "${sessionName}:${windowName}"`,
-        sshHost,
-      );
+      if (isLegacySharedSession) {
+        const windowName = ` ${branchName.replace(/\//g, "-")}`;
+        await execGit(
+          `tmux kill-window -t "${sessionName}:${windowName}"`,
+          sshHost,
+        );
+      } else {
+        await execGit(
+          `tmux kill-session -t "${sessionName}"`,
+          sshHost,
+        );
+      }
     } else {
-      await execGit(
-        `zellij action --session "${sessionName}" go-to-tab-name "${windowName}" && zellij action --session "${sessionName}" close-tab`,
-        sshHost,
-      );
+      if (isLegacySharedSession) {
+        await execGit(
+          `zellij action --session "${sessionName}" go-to-tab-name " ${branchName.replace(/\//g, "-")}" && zellij action --session "${sessionName}" close-tab`,
+          sshHost,
+        );
+      } else {
+        await execGit(
+          `zellij kill-session "${sessionName}"`,
+          sshHost,
+        );
+      }
     }
   } catch {
-    // window/tab이 이미 종료된 경우 무시
+    // 세션/window가 이미 종료된 경우 무시
   }
 }
 
 /**
- * worktree와 메인 세션의 tmux window / zellij tab을 삭제한다.
+ * worktree와 tmux/zellij 세션을 삭제한다.
  * sshHost가 지정되면 원격에서 실행한다.
  */
 export async function removeWorktreeAndSession(
@@ -296,21 +303,19 @@ export async function removeWorktreeAndSession(
   await removeWorktreeAndBranch(projectPath, branchName, sshHost);
 }
 
-/** 메인 세션 내의 활성 window/tab 목록을 반환한다 */
-export async function listActiveWindows(
+/** 활성 tmux/zellij 세션 이름 목록을 반환한다 */
+export async function listActiveSessions(
   sessionType: SessionType,
-  mainSession: string,
   sshHost?: string | null,
 ): Promise<string[]> {
   try {
     if (sessionType === SessionType.TMUX) {
       const output = await execGit(
-        `tmux list-windows -t "${mainSession}" -F '#{window_name}'`,
+        `tmux list-sessions -F '#{session_name}'`,
         sshHost,
       );
       return output.split("\n").filter(Boolean);
     } else {
-      /** zellij는 외부에서 탭 목록을 조회할 수 없으므로 세션 목록을 반환한다 */
       const output = await execGit("zellij list-sessions", sshHost);
       return output.split("\n").filter(Boolean);
     }
@@ -319,13 +324,24 @@ export async function listActiveWindows(
   }
 }
 
-/** window/tab이 활성 상태인지 확인한다 */
-export async function isWindowAlive(
+/** tmux/zellij 세션이 활성 상태인지 확인한다 */
+export async function isSessionAlive(
   sessionType: SessionType,
-  mainSession: string,
-  windowName: string,
+  sessionName: string,
   sshHost?: string | null,
 ): Promise<boolean> {
-  const windows = await listActiveWindows(sessionType, mainSession, sshHost);
-  return windows.some((w) => w.trimEnd() === windowName);
+  try {
+    if (sessionType === SessionType.TMUX) {
+      await execGit(
+        `tmux has-session -t "${sessionName}" 2>/dev/null`,
+        sshHost,
+      );
+      return true;
+    } else {
+      const output = await execGit("zellij list-sessions", sshHost);
+      return output.split("\n").some((s) => s.trim() === sessionName);
+    }
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/terminal/2602/20-session-per-branch.plan.md)

## 어떤 작업인가요?
- tmux/zellij 터미널 멀티플렉서의 브랜치 관리 방식을 공유 세션의 window/tab 기반에서 브랜치별 독립 세션 기반으로 변경한다. 브라우저 멀티 탭에서 서로 다른 브랜치를 동시에 열 때 window 전환 충돌 없이 독립적으로 사용할 수 있다.

## 어떻게 해결했나요?
**세션 생성/삭제 아키텍처 변경**
- 기존: 프로젝트당 하나의 tmux session, 브랜치마다 window 추가 (`tmux new-window`)
- 변경: 브랜치마다 독립적인 tmux session 생성 (`tmux new-session -d -s "project/branch"`)
- zellij도 동일하게 독립 세션 방식으로 통일

**하위 호환성 유지**
- 기존 task의 `sessionName`에 `/`가 없으면 레거시(공유 세션) 형식으로 판단
- 레거시 형식: `kill-window`, window 타겟 attach 유지
- 신규 형식: `kill-session`, 세션 직접 attach

**테스트 추가**
- `formatSessionName`, `sanitizeZellijSessionName`, `removeSessionOnly`, `isSessionAlive` 유닛 테스트 18건

## 중요한 변경 사항은 무엇인가요?
### 세션 네이밍 규칙 변경

**`formatWindowName` → `formatSessionName`**
- **변경 이유**: window 이름이 아닌 독립 세션 이름을 생성해야 하므로 `projectName/branchName` 형식으로 변경
- **수정 파일**: `src/lib/worktree.ts`, `src/app/actions/project.ts`

**`sanitizeZellijSessionName` 추가**
- **변경 이유**: zellij 세션 이름이 Unix 소켓 경로 108바이트 제한에 걸릴 수 있어 60자로 truncate
- **수정 파일**: `src/lib/worktree.ts`

### 세션 생성/삭제 로직 변경

**`createWorktreeWithSession` / `createSessionWithoutWorktree`**
- **변경 이유**: `new-window` → `new-session`으로 변경하여 브랜치별 독립 세션 생성
- **수정 파일**: `src/lib/worktree.ts`

**`removeSessionOnly` 하위 호환 분기**
- **변경 이유**: 기존 task(레거시 sessionName)와 신규 task를 안전하게 처리
- **수정 파일**: `src/lib/worktree.ts`

### PTY 연결 로직 변경

**`attachLocalSession` / `attachRemoteSession`**
- **변경 이유**: 독립 세션에 직접 attach하되, 레거시 형식은 window 타겟으로 attach하여 하위 호환 유지
- **수정 파일**: `src/lib/terminal.ts`

**`focusSession` 제거**
- **변경 이유**: 독립 세션에서는 window/tab 전환이 불필요하므로 no-op으로 변경
- **수정 파일**: `src/lib/terminal.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
