### PR TITLE
feat(ui): 태스크 상세 페이지 description 인라인 수정 기능

### DIFF
--- a/.claude/plan/ui/2602/20-edit-description.plan.md
+++ b/.claude/plan/ui/2602/20-edit-description.plan.md
@@ -1,0 +1,88 @@
+# Edit Description on Task Detail Page
+
+## Business Goal
+게시물 상세 페이지에서 작업 설명(description)을 인라인으로 수정할 수 있도록 하여, 사용자가 별도 폼 없이 빠르게 설명을 추가/변경할 수 있게 한다.
+
+## Scope
+- **In Scope**: description 클릭 시 textarea 전환, 저장/취소 버튼, Ctrl+Enter 저장, Escape 취소, 설명 없을 때 "설명 추가" 플레이스홀더, i18n 3개 언어 번역 키
+- **Out of Scope**: 마크다운 렌더링, 리치 텍스트 에디터, title 수정
+
+## Codebase Analysis Summary
+- `TaskDetailTitleCard.tsx`: 현재 description을 읽기 전용 `<p>`로 표시. `"use client"` 이미 적용된 클라이언트 컴포넌트.
+- `src/app/actions/kanban.ts`: `updateTask(taskId, { description })` 함수 존재.
+- `PriorityEditor.tsx`: `useTransition` + `updateTask` + `router.refresh()` 인라인 수정 패턴.
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/components/TaskDetailTitleCard.tsx` | description 표시 및 수정 UI | Modify |
+| `messages/ko.json` | 한국어 번역 | Modify |
+| `messages/en.json` | 영어 번역 | Modify |
+| `messages/zh.json` | 중국어 번역 | Modify |
+| `src/app/actions/kanban.ts` | `updateTask` server action | Reference |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 인라인 수정 패턴 | `PriorityEditor.tsx` | `useTransition` + `updateTask` + `router.refresh()` |
+| 디자인 토큰 | `globals.css` | Tailwind CSS 변수 사용 (`bg-bg-surface`, `text-text-secondary` 등) |
+| i18n | CLAUDE.md | 3개 언어 동시 추가, `useTranslations` 사용 |
+
+## Implementation Todos
+
+### Todo 1: i18n 번역 키 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: description 수정 UI에 필요한 번역 키를 3개 언어 파일에 추가
+- **Work**:
+  - `messages/ko.json`의 `taskDetail` 네임스페이스에 추가: `editDescription`, `addDescription`, `save`, `cancel`
+  - `messages/en.json`의 `taskDetail` 네임스페이스에 동일 키 추가
+  - `messages/zh.json`의 `taskDetail` 네임스페이스에 동일 키 추가
+- **Convention Notes**: 기존 `taskDetail` 네임스페이스 내 키 위치에 알파벳순 삽입
+- **Verification**: JSON 파싱 에러 없음 확인
+- **Exit Criteria**: 3개 언어 파일에 동일 키가 존재
+- **Status**: pending
+
+### Todo 2: TaskDetailTitleCard에 description 인라인 수정 기능 구현
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: description 클릭 시 textarea로 전환되는 인라인 수정 UI 구현
+- **Work**:
+  - `TaskDetailTitleCard.tsx`에 `isEditing` 상태 추가
+  - `updateTask` import, `useRouter`, `useTransition`, `useTranslations` 사용
+  - description `<p>` 클릭 시 `isEditing: true` 전환
+  - 편집 모드: `<textarea>` + 저장/취소 버튼 렌더링
+  - 저장: `updateTask(taskId, { description })` 호출 후 `router.refresh()`
+  - 취소: `isEditing: false`로 복원
+  - Ctrl+Enter로 저장, Escape로 취소 키보드 핸들링
+  - description이 없을 때 "설명 추가" 클릭 가능한 플레이스홀더 표시
+  - `isPending` 상태에서 opacity 처리 (PriorityEditor 패턴)
+  - Props에 `taskId: string` 추가 필요
+- **Convention Notes**: 디자인 토큰 CSS 변수 사용, 한국어 주석
+- **Verification**: 클릭 → textarea 전환, 저장/취소 동작, 키보드 단축키 확인
+- **Exit Criteria**: description 수정 후 페이지 새로고침 시 변경된 내용 유지
+- **Status**: pending
+
+### Todo 3: TaskDetailPage에서 taskId prop 전달
+- **Priority**: 2
+- **Dependencies**: Todo 2
+- **Goal**: TaskDetailTitleCard에 taskId를 전달하여 updateTask 호출 가능하게 함
+- **Work**:
+  - `src/app/[locale]/task/[id]/page.tsx`에서 `<TaskDetailTitleCard task={task} />` → `<TaskDetailTitleCard task={task} taskId={task.id} />` 변경
+- **Convention Notes**: 기존 page.tsx 패턴 유지
+- **Verification**: TypeScript 타입 에러 없음
+- **Exit Criteria**: TaskDetailTitleCard에 taskId prop이 정상 전달됨
+- **Status**: pending
+
+## Verification Strategy
+- `pnpm build`로 타입 에러 및 빌드 에러 없음 확인
+- 브라우저에서 수동 테스트: description 클릭 → 수정 → 저장 → 새로고침 후 반영 확인
+
+## Progress Tracking
+- Total Todos: 3
+- Completed: 3
+- Status: Execution complete
+
+## Change Log
+- 2026-02-20: Plan created
+- 2026-02-20: All todos completed, TypeScript type check passed

--- a/messages/en.json
+++ b/messages/en.json
@@ -188,6 +188,7 @@
     "project": "Project",
     "baseProject": "Base",
     "projectColor": "Project Color",
+    "addDescription": "Add description",
     "actions": "Change Status",
     "deleteConfirm": "Are you sure you want to delete this task?",
     "hooksStatus": "Hooks Status",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -188,6 +188,7 @@
     "project": "프로젝트",
     "baseProject": "Base",
     "projectColor": "프로젝트 색상",
+    "addDescription": "설명 추가",
     "actions": "상태 변경",
     "deleteConfirm": "이 작업을 삭제하시겠습니까?",
     "hooksStatus": "Hooks 상태",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -188,6 +188,7 @@
     "project": "项目",
     "baseProject": "Base",
     "projectColor": "项目颜色",
+    "addDescription": "添加描述",
     "actions": "状态变更",
     "deleteConfirm": "确定要删除此任务吗？",
     "hooksStatus": "Hooks 状态",

--- a/src/app/[locale]/task/[id]/page.tsx
+++ b/src/app/[locale]/task/[id]/page.tsx
@@ -132,7 +132,7 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
           {t("backToBoard")}
         </Link>
 
-        <TaskDetailTitleCard task={task} />
+        <TaskDetailTitleCard task={task} taskId={task.id} />
 
         <TaskDetailInfoCard task={task} agentTagStyle={agentTagStyle} baseBranchTaskId={baseBranchTaskId} />
 

--- a/src/components/TaskDetailTitleCard.tsx
+++ b/src/components/TaskDetailTitleCard.tsx
@@ -1,16 +1,71 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect, useTransition } from "react";
+import { useRouter } from "@/i18n/navigation";
+import { useTranslations } from "next-intl";
 import type { KanbanTask } from "@/entities/KanbanTask";
+import { updateTask } from "@/app/actions/kanban";
 import TaskStatusBadge from "@/components/TaskStatusBadge";
 import ProjectBranchTasksModal from "@/components/ProjectBranchTasksModal";
 
 interface TaskDetailTitleCardProps {
   task: KanbanTask;
+  taskId: string;
 }
 
-export default function TaskDetailTitleCard({ task }: TaskDetailTitleCardProps) {
+export default function TaskDetailTitleCard({ task, taskId }: TaskDetailTitleCardProps) {
   const [showBranchTasksModal, setShowBranchTasksModal] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(task.description ?? "");
+  const [isPending, startTransition] = useTransition();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const router = useRouter();
+  const t = useTranslations("taskDetail");
+  const tc = useTranslations("common");
+
+  /** 편집 모드 진입 시 textarea에 포커스하고 커서를 끝으로 이동 */
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.selectionStart = textareaRef.current.value.length;
+    }
+  }, [isEditing]);
+
+  function handleStartEditing() {
+    setDraft(task.description ?? "");
+    setIsEditing(true);
+  }
+
+  function handleCancel() {
+    setIsEditing(false);
+    setDraft(task.description ?? "");
+  }
+
+  function handleSave() {
+    const trimmed = draft.trim();
+    const newDescription = trimmed || null;
+
+    if (newDescription === task.description) {
+      setIsEditing(false);
+      return;
+    }
+
+    startTransition(async () => {
+      await updateTask(taskId, { description: newDescription });
+      setIsEditing(false);
+      router.refresh();
+    });
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Escape") {
+      handleCancel();
+    }
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+  }
 
   return (
     <>
@@ -46,11 +101,54 @@ export default function TaskDetailTitleCard({ task }: TaskDetailTitleCardProps) 
             </button>
           )}
         </div>
-        {task.description && (
-          <p className="text-sm text-text-secondary mt-3 leading-relaxed">
-            {task.description}
-          </p>
-        )}
+
+        {/* description 인라인 수정 영역 */}
+        <div className={isPending ? "opacity-50 pointer-events-none mt-3" : "mt-3"}>
+          {isEditing ? (
+            <div>
+              <textarea
+                ref={textareaRef}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={handleKeyDown}
+                rows={4}
+                className="w-full text-sm text-text-primary bg-bg-page border border-border-default rounded-md p-2 leading-relaxed resize-y focus:outline-none focus:border-brand-primary"
+              />
+              <div className="flex justify-end gap-2 mt-2">
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="px-3 py-1.5 text-xs text-text-secondary bg-bg-page border border-border-default rounded-md hover:border-border-strong transition-colors"
+                >
+                  {tc("cancel")}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  className="px-3 py-1.5 text-xs text-white bg-brand-primary rounded-md hover:opacity-90 transition-opacity"
+                >
+                  {tc("save")}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={handleStartEditing}
+              className="w-full text-left cursor-pointer group"
+            >
+              {task.description ? (
+                <p className="text-sm text-text-secondary leading-relaxed group-hover:text-text-primary transition-colors">
+                  {task.description}
+                </p>
+              ) : (
+                <p className="text-sm text-text-muted italic group-hover:text-text-secondary transition-colors">
+                  {t("addDescription")}
+                </p>
+              )}
+            </button>
+          )}
+        </div>
       </div>
 
       {/* 모달 */}

--- a/src/components/__tests__/TaskDetailTitleCard.test.tsx
+++ b/src/components/__tests__/TaskDetailTitleCard.test.tsx
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TaskDetailTitleCard from "../TaskDetailTitleCard";
+import { TaskStatus } from "@/entities/KanbanTask";
+import type { KanbanTask } from "@/entities/KanbanTask";
+
+const mockRefresh = vi.fn();
+const mockUpdateTask = vi.fn().mockResolvedValue({});
+
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({
+    refresh: mockRefresh,
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace: string) => (key: string) => {
+    const messages: Record<string, Record<string, string>> = {
+      taskDetail: {
+        addDescription: "설명 추가",
+      },
+      common: {
+        cancel: "취소",
+        save: "저장",
+      },
+    };
+    return messages[namespace]?.[key] ?? key;
+  },
+}));
+
+vi.mock("@/app/actions/kanban", () => ({
+  updateTask: (...args: unknown[]) => mockUpdateTask(...args),
+}));
+
+vi.mock("@/components/TaskStatusBadge", () => ({
+  default: ({ status }: { status: string }) => (
+    <span data-testid="status-badge">{status}</span>
+  ),
+}));
+
+vi.mock("@/components/ProjectBranchTasksModal", () => ({
+  default: () => <div data-testid="branch-tasks-modal" />,
+}));
+
+function createTask(overrides: Partial<KanbanTask> = {}): KanbanTask {
+  return {
+    id: "task-1",
+    title: "Test Task",
+    description: null,
+    status: TaskStatus.TODO,
+    branchName: "feat/test-branch",
+    worktreePath: null,
+    sessionType: null,
+    sessionName: null,
+    sshHost: null,
+    agentType: null,
+    project: {
+      id: "project-1",
+      name: "kanvibe",
+      repoPath: "/path/to/repo",
+      defaultBranch: "main",
+      sshHost: null,
+      isWorktree: false,
+      color: null,
+      createdAt: new Date(),
+    },
+    projectId: "project-1",
+    baseBranch: "main",
+    prUrl: null,
+    priority: null,
+    displayOrder: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("TaskDetailTitleCard - Description Editing", () => {
+  beforeEach(() => {
+    mockRefresh.mockClear();
+    mockUpdateTask.mockClear();
+  });
+
+  it("should show 'addDescription' placeholder when description is null", () => {
+    // Given
+    const task = createTask({ description: null });
+
+    // When
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+
+    // Then
+    expect(screen.getByText("설명 추가")).toBeDefined();
+  });
+
+  it("should show description text when description exists", () => {
+    // Given
+    const task = createTask({ description: "기존 설명" });
+
+    // When
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+
+    // Then
+    expect(screen.getByText("기존 설명")).toBeDefined();
+  });
+
+  it("should enter edit mode when description area is clicked", async () => {
+    // Given
+    const task = createTask({ description: "기존 설명" });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+
+    // When
+    fireEvent.click(screen.getByText("기존 설명"));
+
+    // Then
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toBeDefined();
+    expect((textarea as HTMLTextAreaElement).value).toBe("기존 설명");
+  });
+
+  it("should enter edit mode with empty draft when placeholder is clicked", async () => {
+    // Given
+    const task = createTask({ description: null });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+
+    // When
+    fireEvent.click(screen.getByText("설명 추가"));
+
+    // Then
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toBeDefined();
+    expect((textarea as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("should show cancel and save buttons in edit mode", () => {
+    // Given
+    const task = createTask({ description: "기존 설명" });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+
+    // When
+    fireEvent.click(screen.getByText("기존 설명"));
+
+    // Then
+    expect(screen.getByText("취소")).toBeDefined();
+    expect(screen.getByText("저장")).toBeDefined();
+  });
+
+  it("should exit edit mode and reset draft when cancel is clicked", async () => {
+    // Given
+    const user = userEvent.setup();
+    const task = createTask({ description: "기존 설명" });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+    fireEvent.click(screen.getByText("기존 설명"));
+
+    // When - 텍스트 수정 후 취소
+    const textarea = screen.getByRole("textbox");
+    await user.clear(textarea);
+    await user.type(textarea, "수정된 설명");
+    fireEvent.click(screen.getByText("취소"));
+
+    // Then - 편집 모드 종료, 원래 설명 표시
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.getByText("기존 설명")).toBeDefined();
+  });
+
+  it("should exit edit mode when Escape key is pressed", () => {
+    // Given
+    const task = createTask({ description: "기존 설명" });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+    fireEvent.click(screen.getByText("기존 설명"));
+
+    // When
+    const textarea = screen.getByRole("textbox");
+    fireEvent.keyDown(textarea, { key: "Escape" });
+
+    // Then
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.getByText("기존 설명")).toBeDefined();
+  });
+
+  it("should call updateTask when save button is clicked with changed description", async () => {
+    // Given
+    const user = userEvent.setup();
+    const task = createTask({ description: "기존 설명" });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+    fireEvent.click(screen.getByText("기존 설명"));
+
+    // When
+    const textarea = screen.getByRole("textbox");
+    await user.clear(textarea);
+    await user.type(textarea, "새로운 설명");
+    await act(async () => {
+      fireEvent.click(screen.getByText("저장"));
+    });
+
+    // Then
+    expect(mockUpdateTask).toHaveBeenCalledWith("task-1", { description: "새로운 설명" });
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("should call updateTask via Cmd+Enter shortcut", async () => {
+    // Given
+    const user = userEvent.setup();
+    const task = createTask({ description: "기존 설명" });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+    fireEvent.click(screen.getByText("기존 설명"));
+
+    // When
+    const textarea = screen.getByRole("textbox");
+    await user.clear(textarea);
+    await user.type(textarea, "단축키 저장");
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    });
+
+    // Then
+    expect(mockUpdateTask).toHaveBeenCalledWith("task-1", { description: "단축키 저장" });
+  });
+
+  it("should call updateTask via Ctrl+Enter shortcut", async () => {
+    // Given
+    const user = userEvent.setup();
+    const task = createTask({ description: "기존 설명" });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+    fireEvent.click(screen.getByText("기존 설명"));
+
+    // When
+    const textarea = screen.getByRole("textbox");
+    await user.clear(textarea);
+    await user.type(textarea, "컨트롤 저장");
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
+    });
+
+    // Then
+    expect(mockUpdateTask).toHaveBeenCalledWith("task-1", { description: "컨트롤 저장" });
+  });
+
+  it("should not call updateTask when description is unchanged", async () => {
+    // Given
+    const task = createTask({ description: "기존 설명" });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+    fireEvent.click(screen.getByText("기존 설명"));
+
+    // When - 수정하지 않고 저장
+    await act(async () => {
+      fireEvent.click(screen.getByText("저장"));
+    });
+
+    // Then
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("should save null when draft is empty (whitespace only)", async () => {
+    // Given
+    const user = userEvent.setup();
+    const task = createTask({ description: "기존 설명" });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+    fireEvent.click(screen.getByText("기존 설명"));
+
+    // When - 빈 값으로 저장
+    const textarea = screen.getByRole("textbox");
+    await user.clear(textarea);
+    await user.type(textarea, "   ");
+    await act(async () => {
+      fireEvent.click(screen.getByText("저장"));
+    });
+
+    // Then - 빈 문자열이 아닌 null로 저장
+    expect(mockUpdateTask).toHaveBeenCalledWith("task-1", { description: null });
+  });
+
+  it("should save new description when task originally had no description", async () => {
+    // Given
+    const user = userEvent.setup();
+    const task = createTask({ description: null });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+    fireEvent.click(screen.getByText("설명 추가"));
+
+    // When
+    const textarea = screen.getByRole("textbox");
+    await user.type(textarea, "새 설명 추가");
+    await act(async () => {
+      fireEvent.click(screen.getByText("저장"));
+    });
+
+    // Then
+    expect(mockUpdateTask).toHaveBeenCalledWith("task-1", { description: "새 설명 추가" });
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/ui/2602/20-edit-description.plan.md)

## 어떤 작업인가요?
- 태스크 상세 페이지에서 description(설명)을 인라인으로 수정할 수 있는 기능 추가

## 어떻게 해결했나요?
**인라인 description 수정 UI 구현**
- TaskDetailTitleCard 컴포넌트에 클릭 → textarea 전환 방식의 인라인 편집 기능 추가
- 기존 `updateTask` server action을 활용하여 DB에 반영

**i18n 번역 키 추가**
- 3개 언어(ko, en, zh) 파일에 `addDescription` 번역 키 추가

## 중요한 변경 사항은 무엇인가요?
### 인라인 description 수정 기능

**TaskDetailTitleCard에 편집 모드 추가**
- **변경 이유**: 별도 폼 없이 빠르게 설명을 추가/수정할 수 있도록
- **수정 파일**: `src/components/TaskDetailTitleCard.tsx`

**주요 동작:**
- description 텍스트 클릭 시 textarea로 전환
- 저장/취소 버튼 + `Ctrl+Enter`(저장), `Escape`(취소) 키보드 단축키
- description이 없을 때 "설명 추가" 플레이스홀더 표시
- 저장 중 opacity 처리 (기존 PriorityEditor 패턴 준수)

**TaskDetailPage에서 taskId prop 전달**
- **변경 이유**: TaskDetailTitleCard에서 updateTask 호출에 필요
- **수정 파일**: `src/app/[locale]/task/[id]/page.tsx`

**i18n 번역 키 추가**
- **변경 이유**: "설명 추가" 플레이스홀더의 다국어 지원
- **수정 파일**: `messages/ko.json`, `messages/en.json`, `messages/zh.json`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
