### PR TITLE
fix(terminal): 레거시 형식 세션 연결 시 window 자동 생성 복원

### DIFF
--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SessionType } from "@/entities/KanbanTask";
+
+// --- Mocks ---
+
+const mockExecSync = vi.fn();
+vi.mock("child_process", () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+const mockPtyOnData = vi.fn();
+const mockPtyOnExit = vi.fn();
+vi.mock("node-pty", () => ({
+  spawn: vi.fn(() => ({
+    write: vi.fn(),
+    resize: vi.fn(),
+    onData: mockPtyOnData,
+    onExit: mockPtyOnExit,
+    kill: vi.fn(),
+    pid: 12345,
+  })),
+}));
+
+function createMockWs() {
+  return {
+    readyState: 1,
+    OPEN: 1,
+    send: vi.fn(),
+    close: vi.fn(),
+    on: vi.fn(),
+  } as unknown as import("ws").WebSocket;
+}
+
+/** execSync 호출 중 특정 패턴이 포함된 명령어를 찾아 반환한다 */
+function findExecSyncCall(pattern: string): string | undefined {
+  return mockExecSync.mock.calls
+    .map((call) => call[0] as string)
+    .find((cmd) => cmd.includes(pattern));
+}
+
+describe("attachLocalSession — tmux 자동 생성 분기", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("should create session with named window when legacy session does not exist", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) {
+        throw new Error("session not found");
+      }
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-1",
+      SessionType.TMUX,
+      "kanvibe",
+      " main",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    const newSessionCmd = findExecSyncCall("new-session");
+    expect(newSessionCmd).toBeDefined();
+    expect(newSessionCmd).toContain('-s "kanvibe"');
+    expect(newSessionCmd).toContain('-n " main"');
+    expect(newSessionCmd).toContain('-c "/workspace"');
+  });
+
+  it("should create window only when legacy session exists but window does not", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) return "";
+      if (typeof cmd === "string" && cmd.includes("list-windows")) return "other-window\n";
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-2",
+      SessionType.TMUX,
+      "kanvibe",
+      " main",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    const newWindowCmd = findExecSyncCall("new-window");
+    expect(newWindowCmd).toBeDefined();
+    expect(newWindowCmd).toContain('-t "kanvibe"');
+    expect(newWindowCmd).toContain('-n " main"');
+    expect(findExecSyncCall("new-session")).toBeUndefined();
+  });
+
+  it("should skip creation when legacy session and window both exist", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) return "";
+      if (typeof cmd === "string" && cmd.includes("list-windows")) return " main\n";
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-3",
+      SessionType.TMUX,
+      "kanvibe",
+      " main",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    expect(findExecSyncCall("new-session")).toBeUndefined();
+    expect(findExecSyncCall("new-window")).toBeUndefined();
+  });
+
+  it("should create independent session without window for new format", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) {
+        throw new Error("session not found");
+      }
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-4",
+      SessionType.TMUX,
+      "kanvibe/feat-login",
+      " feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    const newSessionCmd = findExecSyncCall("new-session");
+    expect(newSessionCmd).toBeDefined();
+    expect(newSessionCmd).toContain('-s "kanvibe/feat-login"');
+    expect(newSessionCmd).not.toContain("-n ");
+  });
+
+  it("should close ws when legacy session creation fails", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    const ws = createMockWs();
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) {
+        throw new Error("session not found");
+      }
+      if (typeof cmd === "string" && cmd.includes("new-session")) {
+        throw new Error("tmux creation failed");
+      }
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-5",
+      SessionType.TMUX,
+      "kanvibe",
+      " main",
+      ws,
+      "/workspace",
+    );
+
+    // Then
+    expect(ws.close).toHaveBeenCalledWith(1008, "tmux 세션 생성에 실패했습니다.");
+  });
+});


### PR DESCRIPTION
## 관련 자료
- 이슈 : 독립 세션 기반 리팩토링(#83) 이후 터미널 연결 실패

## 어떤 작업인가요?
- 커밋 b39f954(tmux/zellij 독립 세션 기반 리팩토링) 이후 레거시 형식 세션에서 "can't find window" 에러가 발생하는 문제를 수정한다.

## 어떻게 해결했나요?
**레거시 형식 tmux window 자동 생성 로직 복원**
- 독립 세션 리팩토링에서 `isTmuxWindowAlive` 함수와 window 자동 생성 로직이 제거되어, 레거시 형식(공유 세션 + window) 연결 시 window가 없으면 "can't find window" 에러가 발생했다.
- `isTmuxWindowAlive` 함수를 복원하고, 레거시/신규 형식에 따라 세션과 window를 올바르게 자동 생성하도록 분기 처리했다.

**테스트 추가**
- `attachLocalSession`의 레거시/신규 형식별 자동 생성 분기 로직을 검증하는 유닛 테스트를 추가했다.

## 중요한 변경 사항은 무엇인가요?
### attachLocalSession 자동 생성 로직 수정

**isTmuxWindowAlive 함수 복원**
- **변경 이유**: 레거시 형식에서 window 존재 여부를 확인하기 위해 필수
- **수정 파일**: `src/lib/terminal.ts`

**레거시/신규 분기 자동 생성**
- **변경 이유**: 레거시(세션 없으면 session+window 동시 생성, 세션만 있으면 window 추가)와 신규(독립 세션만 생성)를 분리
- **수정 파일**: `src/lib/terminal.ts`

### attachRemoteSession 자동 생성 로직 추가

**SSH 환경 레거시 세션/window 자동 생성**
- **변경 이유**: SSH 원격 환경에서도 동일한 "can't find window" 문제가 발생할 수 있으므로, 명령어 체인으로 세션/window 자동 생성 후 attach하도록 수정
- **수정 파일**: `src/lib/terminal.ts`

### 테스트 추가

**attachLocalSession 자동 생성 분기 테스트**
- **변경 이유**: 레거시 세션만/window만/둘 다 없는 케이스와 신규 형식 케이스를 검증
- **수정 파일**: `src/lib/__tests__/terminal.test.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
