### PR TITLE
fix: 프로젝트 초기 색상 해시 기반 결정 및 네비게이션 버튼 색상 통일

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ Tailwind 클래스에서 CSS 변수 토큰을 직접 사용한다:
 
 Google 브랜드 컬러 (#4285F4, #EA4335, #FBBC05, #34A853) 기반 + 블랙&화이트 라이트 테마.
 
+### 네비게이션 원형 버튼 색상 규칙
+
+태스크 상세 페이지의 원형(>) 네비게이션 버튼은 항상 **Primary Color**(`bg-brand-primary`)를 사용한다. 프로젝트 색상으로 변경하지 않는다. 해당 버튼: `TaskDetailTitleCard`의 "다른 작업 보기" 버튼, `ProjectBranchTasksModal`의 작업 이동 버튼.
+
 ### 새 토큰 추가 시
 
 1. `prd/design-system.json`에 토큰 정의

--- a/src/app/actions/project.ts
+++ b/src/app/actions/project.ts
@@ -12,6 +12,7 @@ import { setupGeminiHooks, getGeminiHooksStatus, type GeminiHooksStatus } from "
 import { setupCodexHooks, getCodexHooksStatus, type CodexHooksStatus } from "@/lib/codexHooksSetup";
 import { homedir } from "os";
 import path from "path";
+import { computeProjectColor } from "@/lib/projectColor";
 
 /** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
 function serialize<T>(data: T): T {
@@ -109,6 +110,7 @@ export async function registerProject(
     repoPath,
     defaultBranch,
     sshHost: sshHost || null,
+    color: computeProjectColor(name),
   });
 
   const saved = await repo.save(project);
@@ -198,6 +200,7 @@ export async function scanAndRegisterProjects(
         repoPath,
         defaultBranch,
         sshHost: sshHost || null,
+        color: computeProjectColor(projectName),
       });
 
       const saved = await repo.save(project);

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -16,6 +16,7 @@ import { TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import { logoutAction } from "@/app/actions/auth";
 import { useAutoRefresh } from "@/hooks/useAutoRefresh";
+import { computeProjectColor } from "@/lib/projectColor";
 
 interface BoardProps {
   initialTasks: TasksByStatus;
@@ -137,10 +138,6 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
 
   /** 프로젝트명 → hex 색상 매핑. DB color 우선, 없으면 해시 기반 프리셋 할당 */
   const projectColorMap = useMemo(() => {
-    const PRESET_COLORS = [
-      "#F9A8D4", "#93C5FD", "#86EFAC", "#C4B5FD",
-      "#FDBA74", "#FDE047", "#5EEAD4", "#A5B4FC",
-    ];
     const colorMap: Record<string, string> = {};
 
     const uniqueNames = new Set(Object.values(projectNameMap));
@@ -151,11 +148,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
       if (mainProject?.color) {
         colorMap[name] = mainProject.color;
       } else {
-        let hash = 0;
-        for (let i = 0; i < name.length; i++) {
-          hash = (hash * 31 + name.charCodeAt(i)) | 0;
-        }
-        colorMap[name] = PRESET_COLORS[((hash % 8) + 8) % 8];
+        colorMap[name] = computeProjectColor(name);
       }
     }
     return colorMap;

--- a/src/components/ProjectBranchTasksModal.tsx
+++ b/src/components/ProjectBranchTasksModal.tsx
@@ -153,7 +153,7 @@ export default function ProjectBranchTasksModal({
                           </button>
                           <button
                             onClick={() => handleTaskClick(task.id)}
-                            className="flex-shrink-0 w-6 h-6 rounded-full bg-tag-project-bg hover:opacity-80 text-tag-project-text flex items-center justify-center transition-opacity"
+                            className="flex-shrink-0 w-6 h-6 rounded-full bg-brand-primary hover:opacity-80 text-white flex items-center justify-center transition-opacity"
                             aria-label="Open task"
                             title={task.title}
                           >

--- a/src/components/ProjectColorEditor.tsx
+++ b/src/components/ProjectColorEditor.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "@/i18n/navigation";
 import { HexColorPicker, HexColorInput } from "react-colorful";
 import { updateProjectColor } from "@/app/actions/kanban";
+import { computeProjectColor } from "@/lib/projectColor";
 
 const PRESET_COLORS = [
   "#F9A8D4", "#93C5FD", "#86EFAC", "#C4B5FD",
@@ -12,18 +13,20 @@ const PRESET_COLORS = [
 
 interface ProjectColorEditorProps {
   projectId: string;
+  projectName: string;
   currentColor: string | null;
 }
 
-export default function ProjectColorEditor({ projectId, currentColor }: ProjectColorEditorProps) {
+export default function ProjectColorEditor({ projectId, projectName, currentColor }: ProjectColorEditorProps) {
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
-  const [color, setColor] = useState(currentColor || PRESET_COLORS[0]);
+  const fallbackColor = currentColor || computeProjectColor(projectName);
+  const [color, setColor] = useState(fallbackColor);
 
   function handleOpen() {
     /** 팝오버를 열 때 최신 prop 값으로 동기화한다 */
-    setColor(currentColor || PRESET_COLORS[0]);
+    setColor(currentColor || computeProjectColor(projectName));
     setIsOpen(true);
   }
 

--- a/src/components/TaskDetailInfoCard.tsx
+++ b/src/components/TaskDetailInfoCard.tsx
@@ -5,6 +5,7 @@ import type { KanbanTask } from "@/entities/KanbanTask";
 import PriorityEditor from "@/components/PriorityEditor";
 import { Link } from "@/i18n/navigation";
 import ProjectColorEditor from "@/components/ProjectColorEditor";
+import { computeProjectColor } from "@/lib/projectColor";
 
 interface TaskDetailInfoCardProps {
   task: KanbanTask;
@@ -32,7 +33,10 @@ export default function TaskDetailInfoCard({
               <div className="flex items-center justify-between gap-2">
                 <dt className="text-xs text-text-muted">{t("project")}</dt>
                 <dd className="flex items-center gap-1">
-                  <span className="text-xs px-2 py-0.5 rounded-full font-medium bg-tag-project-bg text-tag-project-text truncate max-w-[140px]">
+                  <span
+                    className="text-xs px-2 py-0.5 rounded-full font-medium text-white truncate max-w-[140px]"
+                    style={{ backgroundColor: task.project.color || computeProjectColor(task.project.name) }}
+                  >
                     {task.project.name}
                   </span>
                   <Link
@@ -62,6 +66,7 @@ export default function TaskDetailInfoCard({
                 <dd>
                   <ProjectColorEditor
                     projectId={task.project.id}
+                    projectName={task.project.name}
                     currentColor={task.project.color}
                   />
                 </dd>

--- a/src/components/TaskDetailTitleCard.tsx
+++ b/src/components/TaskDetailTitleCard.tsx
@@ -25,7 +25,7 @@ export default function TaskDetailTitleCard({ task }: TaskDetailTitleCardProps) 
           {task.branchName && task.projectId && (
             <button
               onClick={() => setShowBranchTasksModal(true)}
-              className="flex-shrink-0 w-6 h-6 rounded-full bg-tag-project-bg hover:opacity-80 text-tag-project-text flex items-center justify-center transition-opacity"
+              className="flex-shrink-0 w-6 h-6 rounded-full bg-brand-primary hover:opacity-80 text-white flex items-center justify-center transition-opacity"
               aria-label="View other tasks in this project"
               title="다른 작업 보기"
             >

--- a/src/lib/projectColor.ts
+++ b/src/lib/projectColor.ts
@@ -1,0 +1,15 @@
+/** 프로젝트 색상 관련 유틸리티 */
+
+const PRESET_COLORS = [
+  "#F9A8D4", "#93C5FD", "#86EFAC", "#C4B5FD",
+  "#FDBA74", "#FDE047", "#5EEAD4", "#A5B4FC",
+];
+
+/** 프로젝트명을 기반으로 결정론적 해시 색상을 계산한다 */
+export function computeProjectColor(projectName: string): string {
+  let hash = 0;
+  for (let i = 0; i < projectName.length; i++) {
+    hash = (hash * 31 + projectName.charCodeAt(i)) | 0;
+  }
+  return PRESET_COLORS[((hash % 8) + 8) % 8];
+}


### PR DESCRIPTION
## Summary
- 프로젝트 색상 해시 계산 로직을 `computeProjectColor` 유틸리티로 추출하여 서버/클라이언트 간 일관된 초기 색상 할당
- 프로젝트 등록 시 DB에 해시 기반 초기 색상을 저장하여 색상 미지정 프로젝트에서도 일관된 색상 표시
- 태스크 상세 페이지의 네비게이션 원형 버튼을 `brand-primary` 색상으로 통일
- 프로젝트 태그가 실제 프로젝트 색상을 반영하도록 `TaskDetailInfoCard` 수정

## Test plan
- [ ] 신규 프로젝트 등록 시 초기 색상이 해시 기반으로 할당되는지 확인
- [ ] 기존 색상 미지정 프로젝트에서도 태그 색상이 일관되게 표시되는지 확인
- [ ] 컬러 피커의 기본 색상이 프로젝트명 기반 해시 색상으로 표시되는지 확인
- [ ] 네비게이션 원형 버튼이 프로젝트 색상이 아닌 brand-primary로 표시되는지 확인