### PR TITLE
fix(terminal): 세션 이름에 프로젝트명 포함하도록 수정

### DIFF
--- a/src/app/actions/__tests__/scanAndRegisterProjects.test.ts
+++ b/src/app/actions/__tests__/scanAndRegisterProjects.test.ts
@@ -34,7 +34,7 @@ vi.mock("@/lib/gitOperations", () => ({
 
 vi.mock("@/lib/worktree", () => ({
   isSessionAlive: vi.fn().mockResolvedValue(false),
-  formatSessionName: vi.fn((name: string) => name.replace(/\//g, "-")),
+  formatSessionName: vi.fn((projectName: string, branchName: string) => `${projectName}-${branchName}`.replace(/\//g, "-")),
   createSessionWithoutWorktree: vi.fn().mockResolvedValue({ sessionName: "test-session" }),
 }));
 

--- a/src/app/actions/project.ts
+++ b/src/app/actions/project.ts
@@ -265,7 +265,7 @@ export async function scanAndRegisterProjects(
         }
 
         /** 브랜치명 기반 독립 세션이 존재하면 연결 정보를 설정한다 */
-        const sessionName = formatSessionName(wt.branch);
+        const sessionName = formatSessionName(path.basename(project.repoPath), wt.branch);
         const hasSession = await isSessionAlive(
           SessionType.TMUX,
           sessionName,
@@ -303,7 +303,7 @@ export async function scanAndRegisterProjects(
       });
 
       if (mainBranchTask && !mainBranchTask.sessionType) {
-        const sessionName = formatSessionName(project.defaultBranch);
+        const sessionName = formatSessionName(path.basename(project.repoPath), project.defaultBranch);
         const hasSession = await isSessionAlive(
           SessionType.TMUX,
           sessionName,

--- a/src/lib/__tests__/projectColor.test.ts
+++ b/src/lib/__tests__/projectColor.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { computeProjectColor } from "@/lib/projectColor";
+
+const PRESET_COLORS = [
+  "#F9A8D4", "#93C5FD", "#86EFAC", "#C4B5FD",
+  "#FDBA74", "#FDE047", "#5EEAD4", "#A5B4FC",
+];
+
+describe("computeProjectColor", () => {
+  it("should return a deterministic color for the same project name", () => {
+    // Given
+    const projectName = "kanvibe";
+
+    // When
+    const first = computeProjectColor(projectName);
+    const second = computeProjectColor(projectName);
+
+    // Then
+    expect(first).toBe(second);
+  });
+
+  it("should return a color from the preset palette", () => {
+    // Given
+    const projectNames = ["kanvibe", "my-app", "test-project", "dashboard"];
+
+    // When & Then
+    for (const name of projectNames) {
+      expect(PRESET_COLORS).toContain(computeProjectColor(name));
+    }
+  });
+
+  it("should return different colors for different project names", () => {
+    // Given
+    const names = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta"];
+
+    // When
+    const colors = names.map(computeProjectColor);
+    const uniqueColors = new Set(colors);
+
+    // Then
+    expect(uniqueColors.size).toBeGreaterThan(1);
+  });
+
+  it("should handle empty string without error", () => {
+    // Given & When
+    const result = computeProjectColor("");
+
+    // Then
+    expect(PRESET_COLORS).toContain(result);
+  });
+
+  it("should handle single character names", () => {
+    // Given & When
+    const result = computeProjectColor("a");
+
+    // Then
+    expect(PRESET_COLORS).toContain(result);
+  });
+});

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -19,49 +19,48 @@ vi.mock("@/app/actions/paneLayout", () => ({
 }));
 
 describe("formatSessionName", () => {
-  it("should replace slashes with hyphens", async () => {
+  it("should format as projectName-branchName with slashes replaced", async () => {
     // Given
     const { formatSessionName } = await import("@/lib/worktree");
 
     // When
-    const result = formatSessionName("feat/something");
+    const result = formatSessionName("kanvibe", "feat/something");
 
     // Then
-    expect(result).toBe("feat-something");
+    expect(result).toBe("kanvibe-feat-something");
   });
 
-  it("should handle multiple slashes", async () => {
+  it("should handle multiple slashes in branch name", async () => {
     // Given
     const { formatSessionName } = await import("@/lib/worktree");
 
     // When
-    const result = formatSessionName("feat/ui/button");
+    const result = formatSessionName("kanvibe", "feat/ui/button");
 
     // Then
-    expect(result).toBe("feat-ui-button");
+    expect(result).toBe("kanvibe-feat-ui-button");
   });
 
-  it("should return the same string when no slashes exist", async () => {
+  it("should handle branch name without slashes", async () => {
     // Given
     const { formatSessionName } = await import("@/lib/worktree");
 
     // When
-    const result = formatSessionName("main");
+    const result = formatSessionName("kanvibe", "main");
 
     // Then
-    expect(result).toBe("main");
+    expect(result).toBe("kanvibe-main");
   });
 
-  it("should not add leading space unlike the old formatWindowName", async () => {
+  it("should replace slashes in project name as well", async () => {
     // Given
     const { formatSessionName } = await import("@/lib/worktree");
 
     // When
-    const result = formatSessionName("feat/test");
+    const result = formatSessionName("parent/project", "feat/test");
 
     // Then
-    expect(result).not.toMatch(/^\s/);
-    expect(result).toBe("feat-test");
+    expect(result).toBe("parent-project-feat-test");
   });
 });
 
@@ -240,7 +239,7 @@ describe("createSessionWithoutWorktree", () => {
     );
 
     // Then
-    expect(result.sessionName).toBe("feat-my-feature");
+    expect(result.sessionName).toBe("path-feat-my-feature");
   });
 
   it("should create tmux session with working directory when session does not exist", async () => {
@@ -259,7 +258,7 @@ describe("createSessionWithoutWorktree", () => {
 
     // Then
     expect(mockExecGit).toHaveBeenCalledWith(
-      'tmux new-session -d -s "feat-test" -c "/custom/dir"',
+      'tmux new-session -d -s "path-feat-test" -c "/custom/dir"',
       null,
     );
   });
@@ -280,7 +279,7 @@ describe("createSessionWithoutWorktree", () => {
     /** isSessionAlive → has-session 호출 1회만 발생, new-session은 호출되지 않는다 */
     expect(mockExecGit).toHaveBeenCalledTimes(1);
     expect(mockExecGit).toHaveBeenCalledWith(
-      'tmux has-session -t "main" 2>/dev/null',
+      'tmux has-session -t "path-main" 2>/dev/null',
       undefined,
     );
   });

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -10,8 +10,8 @@ interface WorktreeSession {
 }
 
 /** branchName을 세션 이름으로 변환한다. `/`를 `-`로 치환한다 */
-export function formatSessionName(branchName: string): string {
-  return branchName.replace(/\//g, "-");
+export function formatSessionName(projectName: string, branchName: string): string {
+  return `${projectName}-${branchName}`.replace(/\//g, "-");
 }
 
 /** zellij 세션 이름을 소켓 경로 108바이트 제한에 맞게 truncate한다 */
@@ -121,7 +121,7 @@ export async function createWorktreeWithSession(
     worktreeBase,
     branchName.replace(/\//g, "-"),
   );
-  const sessionName = formatSessionName(branchName);
+  const sessionName = formatSessionName(projectName, branchName);
 
   await execGit(
     `git -C "${projectPath}" worktree add "${worktreePath}" -b "${branchName}" "${baseBranch}"`,
@@ -175,7 +175,8 @@ export async function createSessionWithoutWorktree(
   sshHost?: string | null,
   workingDir?: string,
 ): Promise<{ sessionName: string }> {
-  const sessionName = formatSessionName(branchName);
+  const projectName = path.basename(projectPath);
+  const sessionName = formatSessionName(projectName, branchName);
   const cwd = workingDir || projectPath;
 
   if (sessionType === SessionType.TMUX) {


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/terminal/2602/21-fix-session-name-format.plan.md)

## 어떤 작업인가요?
- tmux/zellij 세션 이름이 `branchName`만으로 생성되어 다중 프로젝트 환경에서 세션 구분이 불가능한 버그를 수정

## 어떻게 해결했나요?
**formatSessionName에 projectName 매개변수 추가**
- `formatSessionName(branchName)` → `formatSessionName(projectName, branchName)` 시그니처 변경
- 세션 이름을 `projectName-branchName` 형식으로 생성 (`/`는 전부 `-`로 치환)
- 프로젝트명은 `path.basename(projectPath)`로 결정하여 worktree 디렉토리 네이밍과 일관성 유지

## 중요한 변경 사항은 무엇인가요?
### 세션 이름 포맷 변경

**formatSessionName 시그니처 변경**
- **변경 이유**: 기존에는 브랜치명만 사용하여 `fix-tmux-session-name`처럼 생성됨 → `kanvibe-fix-tmux-session-name` 형식으로 변경
- **수정 파일**: `src/lib/worktree.ts`

**모든 호출부 업데이트**
- **변경 이유**: 새 시그니처에 맞게 projectName 전달
- **수정 파일**: `src/lib/worktree.ts` (createWorktreeWithSession, createSessionWithoutWorktree), `src/app/actions/project.ts` (scanAndRegisterProjects 2곳)

**테스트 수정**
- **변경 이유**: 새 시그니처 및 기대값 반영
- **수정 파일**: `src/lib/__tests__/worktree.test.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
