### PR TITLE
프로젝트 필터를 URL query string으로 전환하여 탭 간 독립성 보장

### DIFF
--- a/.claude/plan/ui/2602/21-project-filter-query-string.plan.md
+++ b/.claude/plan/ui/2602/21-project-filter-query-string.plan.md
@@ -1,0 +1,77 @@
+# 프로젝트 필터 Query String 전환
+
+## Business Goal
+프로젝트 필터를 localStorage 대신 URL query string으로 관리하여, 브라우저 탭마다 독립적인 필터 상태를 유지한다. 사용자가 여러 탭을 열어 서로 다른 프로젝트를 필터링하면서 작업할 수 있도록 한다.
+
+## Scope
+- **In Scope**: Board.tsx의 필터 상태를 query string(`?projects=id1,id2`)으로 전환, localStorage 관련 코드 제거
+- **Out of Scope**: 다른 상태(정렬, 검색어 등)의 query string 전환
+
+## Codebase Analysis Summary
+- `Board.tsx:104` — `useState<string[]>([])` 로 `selectedProjectIds` 관리
+- `Board.tsx:255-273` — `localStorage` 읽기(mount시) / 쓰기(변경시) useEffect 2개
+- `Board.tsx:38` — `FILTER_STORAGE_KEY = "kanvibe:projectFilter"` 상수
+- `ProjectSelector.tsx` — Board로부터 `selectedProjectIds`와 `onSelectionChange`를 props로 받음 (변경 불필요)
+- `src/app/[locale]/page.tsx` — 서버 컴포넌트, Board를 렌더링
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/components/Board.tsx` | 메인 보드 컴포넌트, 필터 상태 관리 | Modify |
+| `src/components/ProjectSelector.tsx` | 프로젝트 셀렉터 UI | Reference (변경 없음) |
+| `src/app/[locale]/page.tsx` | 홈페이지 서버 컴포넌트 | Reference (변경 없음) |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 한국어 주석 | CODE_PRINCIPLES.md | JSDoc 주석은 한국어로 작성 |
+| useMemo/useCallback | Board.tsx 기존 패턴 | 메모이제이션 패턴 유지 |
+| "use client" | Board.tsx | 클라이언트 컴포넌트 유지 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| Query param format | `?projects=id1,id2` | 간결하고 URL 가독성 좋음 | `?projects=id1&projects=id2` |
+| URL 업데이트 방식 | `window.history.replaceState` | 리렌더/스크롤 없이 URL만 변경 | `router.replace` (전체 리렌더 유발) |
+| 초기값 읽기 | `useSearchParams()` | Next.js 표준 방식 | URL 직접 파싱 |
+| 빈 필터 처리 | query param 제거 | 깔끔한 기본 URL | `?projects=` 빈 값 유지 |
+
+## Implementation Todos
+
+### Todo 1: Board.tsx 필터 상태를 query string 기반으로 전환
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: `selectedProjectIds` 상태를 URL query string에서 읽고, 변경 시 URL을 업데이트하도록 전환
+- **Work**:
+  - `next/navigation`에서 `useSearchParams` import 추가
+  - `FILTER_STORAGE_KEY` 상수 제거
+  - `selectedProjectIds` 초기값을 `useSearchParams()`에서 `projects` param 파싱하여 설정
+  - `setSelectedProjectIds` 를 래핑하여 state 변경 시 `window.history.replaceState`로 URL도 업데이트
+  - localStorage 읽기 useEffect (L255-265 영역) 제거
+  - localStorage 쓰기 useEffect (L267-273 영역) 제거
+  - `useSearchParams`는 `Suspense` 바운더리가 필요하므로, 필요시 page.tsx에 Suspense 래핑 추가
+- **Convention Notes**: 기존 useMemo/useCallback 패턴 유지, 한국어 주석
+- **Verification**: `pnpm build` 성공, 브라우저에서 필터 선택 시 URL 변경 확인
+- **Exit Criteria**:
+  - 필터 선택 시 URL에 `?projects=id1,id2` 반영
+  - 필터 해제 시 query param 제거
+  - URL에 projects param이 있는 상태로 페이지 로드 시 필터 복원
+  - 서로 다른 탭에서 독립적인 필터 유지
+- **Status**: completed
+
+## Verification Strategy
+- `pnpm build` 성공
+- 브라우저에서 다음 시나리오 확인:
+  1. 필터 선택 → URL에 `?projects=...` 반영
+  2. 필터 해제 → URL에서 param 제거
+  3. URL 직접 입력 → 해당 필터 적용
+  4. 두 탭에서 서로 다른 필터 독립 동작
+
+## Progress Tracking
+- Total Todos: 1
+- Completed: 1
+- Status: Execution complete
+
+## Change Log
+- 2026-02-21: Plan created
+- 2026-02-21: Todo 1 completed — Build, lint, tests all pass

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -16,6 +16,7 @@ import { TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import { logoutAction } from "@/app/actions/auth";
 import { useAutoRefresh } from "@/hooks/useAutoRefresh";
+import { useProjectFilterParams } from "@/hooks/useProjectFilterParams";
 
 interface BoardProps {
   initialTasks: TasksByStatus;
@@ -35,8 +36,6 @@ const COLUMNS: { status: TaskStatus; labelKey: string; colorClass: string }[] = 
   { status: TaskStatus.REVIEW, labelKey: "review", colorClass: "bg-status-review" },
   { status: TaskStatus.DONE, labelKey: "done", colorClass: "bg-status-done" },
 ];
-
-const FILTER_STORAGE_KEY = "kanvibe:projectFilter";
 
 interface ContextMenuState {
   isOpen: boolean;
@@ -101,7 +100,9 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
     projectId: string;
   } | null>(null);
   const [isMounted, setIsMounted] = useState(false);
-  const [selectedProjectIds, setSelectedProjectIds] = useState<string[]>([]);
+  const [selectedProjectIds, setSelectedProjectIds] = useProjectFilterParams(
+    projects.map((p) => p.id),
+  );
   const [doneTotal, setDoneTotal] = useState(initialDoneTotal);
   const [doneOffset, setDoneOffset] = useState(initialDoneLimit);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -241,36 +242,6 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   useEffect(() => {
     setIsMounted(true);
   }, []);
-
-  /** localStorage에서 저장된 필터를 복원한다 */
-  useEffect(() => {
-    const stored = localStorage.getItem(FILTER_STORAGE_KEY);
-    if (!stored) return;
-
-    try {
-      const parsed = JSON.parse(stored);
-      if (Array.isArray(parsed)) {
-        const validIds = parsed.filter((id: string) =>
-          projects.some((p) => p.id === id)
-        );
-        if (validIds.length > 0) setSelectedProjectIds(validIds);
-      }
-    } catch {
-      /** 이전 단일 선택 포맷 호환: plain string */
-      if (projects.some((p) => p.id === stored)) {
-        setSelectedProjectIds([stored]);
-      }
-    }
-  }, [projects]);
-
-  /** 필터 변경 시 localStorage에 저장한다 */
-  useEffect(() => {
-    if (selectedProjectIds.length > 0) {
-      localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify(selectedProjectIds));
-    } else {
-      localStorage.removeItem(FILTER_STORAGE_KEY);
-    }
-  }, [selectedProjectIds]);
 
   /** 서버 revalidation 후 initialTasks가 변경되면 로컬 state에 반영한다 */
   useEffect(() => {

--- a/src/hooks/__tests__/useProjectFilterParams.test.ts
+++ b/src/hooks/__tests__/useProjectFilterParams.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+
+const mockGet = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({
+    get: mockGet,
+  }),
+}));
+
+import { useProjectFilterParams } from "../useProjectFilterParams";
+
+const VALID_IDS = ["proj-1", "proj-2", "proj-3"];
+
+beforeEach(() => {
+  mockGet.mockReset();
+  vi.stubGlobal("location", { href: "http://localhost:3000/ko" });
+  vi.stubGlobal("queueMicrotask", (fn: () => void) => fn());
+  vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useProjectFilterParams", () => {
+  describe("initialization from URL", () => {
+    it("should return empty array when no projects param exists", () => {
+      // Given
+      mockGet.mockReturnValue(null);
+
+      // When
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // Then
+      expect(result.current[0]).toEqual([]);
+    });
+
+    it("should parse comma-separated project IDs from URL", () => {
+      // Given
+      mockGet.mockReturnValue("proj-1,proj-3");
+
+      // When
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // Then
+      expect(result.current[0]).toEqual(["proj-1", "proj-3"]);
+    });
+
+    it("should filter out invalid project IDs", () => {
+      // Given
+      mockGet.mockReturnValue("proj-1,invalid-id,proj-2");
+
+      // When
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // Then
+      expect(result.current[0]).toEqual(["proj-1", "proj-2"]);
+    });
+
+    it("should return empty array when all IDs are invalid", () => {
+      // Given
+      mockGet.mockReturnValue("invalid-1,invalid-2");
+
+      // When
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // Then
+      expect(result.current[0]).toEqual([]);
+    });
+  });
+
+  describe("URL synchronization on state change", () => {
+    it("should update URL with projects param when setting IDs", () => {
+      // Given
+      mockGet.mockReturnValue(null);
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // When
+      act(() => {
+        result.current[1](["proj-1", "proj-2"]);
+      });
+
+      // Then
+      expect(result.current[0]).toEqual(["proj-1", "proj-2"]);
+      expect(window.history.replaceState).toHaveBeenCalledWith(
+        null,
+        "",
+        expect.stringContaining("projects=proj-1%2Cproj-2"),
+      );
+    });
+
+    it("should remove projects param from URL when setting empty array", () => {
+      // Given
+      mockGet.mockReturnValue("proj-1");
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // When
+      act(() => {
+        result.current[1]([]);
+      });
+
+      // Then
+      expect(result.current[0]).toEqual([]);
+      const calledUrl = (window.history.replaceState as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[2] as string;
+      expect(new URL(calledUrl).searchParams.has("projects")).toBe(false);
+    });
+
+    it("should support updater function pattern", () => {
+      // Given
+      mockGet.mockReturnValue("proj-1");
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // When
+      act(() => {
+        result.current[1]((prev) => [...prev, "proj-2"]);
+      });
+
+      // Then
+      expect(result.current[0]).toEqual(["proj-1", "proj-2"]);
+    });
+  });
+});

--- a/src/hooks/useProjectFilterParams.ts
+++ b/src/hooks/useProjectFilterParams.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+
+const QUERY_PARAM_KEY = "projects";
+
+/**
+ * URL query string 기반 프로젝트 필터 상태를 관리한다.
+ * 탭마다 독립적인 필터를 유지하기 위해 localStorage 대신 URL을 사용한다.
+ * @param validProjectIds 유효한 프로젝트 ID 목록 (존재하지 않는 ID를 걸러내기 위해 사용)
+ */
+export function useProjectFilterParams(validProjectIds: string[]) {
+  const searchParams = useSearchParams();
+  const validIdSet = new Set(validProjectIds);
+
+  const [selectedProjectIds, setSelectedProjectIdsState] = useState<string[]>(() => {
+    const param = searchParams.get(QUERY_PARAM_KEY);
+    if (!param) return [];
+    return param.split(",").filter((id) => validIdSet.has(id));
+  });
+
+  const isUpdatingUrl = useRef(false);
+  const setSelectedProjectIds = useCallback(
+    (idsOrUpdater: string[] | ((prev: string[]) => string[])) => {
+      setSelectedProjectIdsState((prev) => {
+        const nextIds = typeof idsOrUpdater === "function" ? idsOrUpdater(prev) : idsOrUpdater;
+
+        if (!isUpdatingUrl.current) {
+          isUpdatingUrl.current = true;
+          queueMicrotask(() => {
+            const url = new URL(window.location.href);
+            if (nextIds.length > 0) {
+              url.searchParams.set(QUERY_PARAM_KEY, nextIds.join(","));
+            } else {
+              url.searchParams.delete(QUERY_PARAM_KEY);
+            }
+            window.history.replaceState(null, "", url.toString());
+            isUpdatingUrl.current = false;
+          });
+        }
+
+        return nextIds;
+      });
+    },
+    [],
+  );
+
+  return [selectedProjectIds, setSelectedProjectIds] as const;
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/ui/2602/21-project-filter-query-string.plan.md)

## 어떤 작업인가요?
- 프로젝트 필터를 localStorage 대신 URL query string으로 관리하여, 브라우저 탭마다 독립적인 필터 상태를 유지하도록 개선

## 어떻게 해결했나요?
**useProjectFilterParams 커스텀 훅 추출**
- URL query string(`?projects=id1,id2`)에서 필터 초기값을 파싱하고, 변경 시 `window.history.replaceState`로 URL을 동기화하는 훅을 분리
- Board 컴포넌트의 필터 관련 코드를 단순화

**localStorage 기반 필터 제거**
- `FILTER_STORAGE_KEY` 상수 및 localStorage 읽기/쓰기 useEffect 2개를 제거
- 탭 간 필터 간섭 문제 해소

## 중요한 변경 사항은 무엇인가요?
### useProjectFilterParams 훅 생성

**URL query string 기반 필터 상태 관리**
- **변경 이유**: 여러 탭에서 같은 localStorage를 공유하여 필터가 간섭되는 문제 해결
- **수정 파일**: `src/hooks/useProjectFilterParams.ts` (신규)

**테스트 추가**
- **변경 이유**: 초기화 파싱, 유효하지 않은 ID 필터링, URL 동기화 로직 검증
- **수정 파일**: `src/hooks/__tests__/useProjectFilterParams.test.ts` (신규, 7 tests)

### Board 컴포넌트 리팩토링

**localStorage → useProjectFilterParams 전환**
- **변경 이유**: 인라인 필터 로직을 훅으로 대체하여 Board 컴포넌트 단순화
- **수정 파일**: `src/components/Board.tsx`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
