### PR TITLE
fix: 프로젝트 색상 통일 및 태스크 상세 페이지 개선

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,9 @@ Tailwind 클래스에서 CSS 변수 토큰을 직접 사용한다:
 
 Google 브랜드 컬러 (#4285F4, #EA4335, #FBBC05, #34A853) 기반 + 블랙&화이트 라이트 테마.
 
-### 네비게이션 원형 버튼 색상 규칙
+### 네비게이션 원형 버튼 및 프로젝트 배지 색상 규칙
 
-태스크 상세 페이지의 원형(>) 네비게이션 버튼은 항상 **Primary Color**(`bg-brand-primary`)를 사용한다. 프로젝트 색상으로 변경하지 않는다. 해당 버튼: `TaskDetailTitleCard`의 "다른 작업 보기" 버튼, `ProjectBranchTasksModal`의 작업 이동 버튼.
+태스크 상세 페이지의 원형(>) 네비게이션 버튼과 프로젝트 배지는 항상 **Project Tag Color**(`bg-tag-project-bg`, #202632)를 사용한다. 프로젝트별 동적 색상으로 변경하지 않는다. 해당 요소: `TaskDetailTitleCard`의 "다른 작업 보기" 버튼, `ProjectBranchTasksModal`의 작업 이동 버튼, `TaskDetailInfoCard`의 프로젝트 배지 및 이동 버튼.
 
 ### 새 토큰 추가 시
 

--- a/src/components/ProjectBranchTasksModal.tsx
+++ b/src/components/ProjectBranchTasksModal.tsx
@@ -153,7 +153,7 @@ export default function ProjectBranchTasksModal({
                           </button>
                           <button
                             onClick={() => handleTaskClick(task.id)}
-                            className="flex-shrink-0 w-6 h-6 rounded-full bg-brand-primary hover:opacity-80 text-white flex items-center justify-center transition-opacity"
+                            className="flex-shrink-0 w-6 h-6 rounded-full bg-tag-project-bg hover:opacity-80 text-white flex items-center justify-center transition-opacity"
                             aria-label="Open task"
                             title={task.title}
                           >

--- a/src/components/TaskDetailInfoCard.tsx
+++ b/src/components/TaskDetailInfoCard.tsx
@@ -5,7 +5,6 @@ import type { KanbanTask } from "@/entities/KanbanTask";
 import PriorityEditor from "@/components/PriorityEditor";
 import { Link } from "@/i18n/navigation";
 import ProjectColorEditor from "@/components/ProjectColorEditor";
-import { computeProjectColor } from "@/lib/projectColor";
 
 interface TaskDetailInfoCardProps {
   task: KanbanTask;
@@ -34,14 +33,13 @@ export default function TaskDetailInfoCard({
                 <dt className="text-xs text-text-muted">{t("project")}</dt>
                 <dd className="flex items-center gap-1">
                   <span
-                    className="text-xs px-2 py-0.5 rounded-full font-medium text-white truncate max-w-[140px]"
-                    style={{ backgroundColor: task.project.color || computeProjectColor(task.project.name) }}
+                    className="text-xs px-2 py-0.5 rounded-full font-medium text-white truncate max-w-[140px] bg-tag-project-bg"
                   >
                     {task.project.name}
                   </span>
                   <Link
                     href={baseBranchTaskId ? `/task/${baseBranchTaskId}` : "/"}
-                    className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-muted transition-colors"
+                    className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-tag-project-bg hover:opacity-80 text-white transition-opacity"
                     title={task.baseBranch ?? task.project.name}
                   >
                     <svg

--- a/src/components/TaskDetailTitleCard.tsx
+++ b/src/components/TaskDetailTitleCard.tsx
@@ -80,7 +80,7 @@ export default function TaskDetailTitleCard({ task, taskId }: TaskDetailTitleCar
           {task.branchName && task.projectId && (
             <button
               onClick={() => setShowBranchTasksModal(true)}
-              className="flex-shrink-0 w-6 h-6 rounded-full bg-brand-primary hover:opacity-80 text-white flex items-center justify-center transition-opacity"
+              className="flex-shrink-0 w-6 h-6 rounded-full bg-tag-project-bg hover:opacity-80 text-white flex items-center justify-center transition-opacity"
               aria-label="View other tasks in this project"
               title="다른 작업 보기"
             >

--- a/src/components/__tests__/TaskDetailInfoCard.test.tsx
+++ b/src/components/__tests__/TaskDetailInfoCard.test.tsx
@@ -144,3 +144,53 @@ describe("TaskDetailInfoCard - Project Shortcut Navigation", () => {
     expect(screen.queryByTestId("shortcut-link")).toBeNull();
   });
 });
+
+describe("TaskDetailInfoCard - Project Badge Color", () => {
+  it("should use fixed bg-tag-project-bg class instead of inline backgroundColor", () => {
+    // Given
+    const task = createTask({
+      project: {
+        id: "project-1",
+        name: "kanvibe",
+        repoPath: "/path/to/repo",
+        defaultBranch: "main",
+        sshHost: null,
+        isWorktree: false,
+        color: "#FF0000",
+        createdAt: new Date(),
+      },
+    });
+
+    // When
+    render(
+      <TaskDetailInfoCard
+        task={task}
+        agentTagStyle={null}
+        baseBranchTaskId={null}
+      />
+    );
+
+    // Then - 프로젝트 배지가 인라인 스타일 없이 고정 클래스를 사용해야 한다
+    const badge = screen.getByText("kanvibe");
+    expect(badge.className).toContain("bg-tag-project-bg");
+    expect(badge.getAttribute("style")).toBeNull();
+  });
+
+  it("should render shortcut link with bg-tag-project-bg class", () => {
+    // Given
+    const task = createTask();
+
+    // When
+    render(
+      <TaskDetailInfoCard
+        task={task}
+        agentTagStyle={null}
+        baseBranchTaskId="main-task-123"
+      />
+    );
+
+    // Then
+    const shortcutLink = screen.getByTestId("shortcut-link");
+    expect(shortcutLink.className).toContain("bg-tag-project-bg");
+  });
+});

--- a/src/lib/__tests__/projectColor.test.ts
+++ b/src/lib/__tests__/projectColor.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { computeProjectColor } from "@/lib/projectColor";
+
+describe("computeProjectColor", () => {
+  it("should return a valid hex color string", () => {
+    // Given
+    const projectName = "kanvibe";
+
+    // When
+    const color = computeProjectColor(projectName);
+
+    // Then
+    expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+  });
+
+  it("should return the same color for the same project name (deterministic)", () => {
+    // Given
+    const projectName = "kanvibe";
+
+    // When
+    const color1 = computeProjectColor(projectName);
+    const color2 = computeProjectColor(projectName);
+
+    // Then
+    expect(color1).toBe(color2);
+  });
+
+  it("should return different colors for different project names", () => {
+    // Given
+    const names = ["kanvibe", "my-app", "backend", "frontend", "docs"];
+
+    // When
+    const colors = names.map(computeProjectColor);
+
+    // Then - 최소 2가지 이상 다른 색상이 나와야 한다
+    const uniqueColors = new Set(colors);
+    expect(uniqueColors.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("should return one of the preset colors", () => {
+    // Given
+    const presetColors = [
+      "#F9A8D4", "#93C5FD", "#86EFAC", "#C4B5FD",
+      "#FDBA74", "#FDE047", "#5EEAD4", "#A5B4FC",
+    ];
+
+    // When
+    const color = computeProjectColor("test-project");
+
+    // Then
+    expect(presetColors).toContain(color);
+  });
+
+  it("should handle empty string without throwing", () => {
+    // Given / When
+    const color = computeProjectColor("");
+
+    // Then
+    expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+  });
+
+  it("should handle long project names without throwing", () => {
+    // Given
+    const longName = "a".repeat(1000);
+
+    // When
+    const color = computeProjectColor(longName);
+
+    // Then
+    expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+  });
+});


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/ui/2602/20-edit-description.plan.md)

## 어떤 작업인가요?
- 태스크 상세 페이지의 프로젝트 배지와 네비게이션 버튼 색상을 디자인 토큰 `#202632`로 통일하고, description 인라인 수정 기능 추가 및 터미널 세션 모델을 브랜치별 독립 구조로 리팩토링

## 어떻게 해결했나요?

**프로젝트 색상 시스템 개선**
- 프로젝트명 기반 결정론적 해시 색상 유틸리티(`computeProjectColor`) 추출
- 태스크 상세 페이지의 프로젝트 배지·네비게이션 버튼 색상을 `bg-tag-project-bg`(#202632)로 고정

**태스크 description 인라인 수정**
- TaskDetailTitleCard에 description 인라인 편집 기능 추가 (Cmd/Ctrl+Enter 저장, Escape 취소)

**터미널 세션 모델 리팩토링**
- tmux/zellij 독립 세션 기반으로 변경하여 브랜치별 독립 세션 관리
- 레거시 형식 세션 연결 시 window 자동 생성 복원

## 중요한 변경 사항은 무엇인가요?

### 프로젝트 배지·버튼 색상 #202632 고정

**프로젝트 배지 인라인 스타일 제거**
- **변경 이유**: 동적 프로젝트 색상 대신 디자인 토큰 `#202632`로 통일하기로 결정
- **수정 파일**: `src/components/TaskDetailInfoCard.tsx`, `src/components/TaskDetailTitleCard.tsx`, `src/components/ProjectBranchTasksModal.tsx`

**프로젝트 색상 유틸리티 추출**
- **변경 이유**: Board 컴포넌트에 인라인으로 있던 해시 계산 로직을 재사용 가능한 유틸리티로 분리
- **수정 파일**: `src/lib/projectColor.ts`, `src/components/Board.tsx`, `src/components/ProjectColorEditor.tsx`

### 터미널 브랜치별 독립 세션

**tmux/zellij 세션 모델 변경**
- **변경 이유**: 기존 공유 세션 방식에서 브랜치별 독립 세션으로 전환하여 작업 격리 강화
- **수정 파일**: `src/lib/terminal.ts`, `src/lib/worktree.ts`, `server.ts`
