### PR TITLE
fix(filter): redirect 시 프로젝트 필터 유실 방지를 위한 sessionStorage 백업/복원

### DIFF
--- a/src/hooks/__tests__/useProjectFilterParams.test.ts
+++ b/src/hooks/__tests__/useProjectFilterParams.test.ts
@@ -15,6 +15,7 @@ const VALID_IDS = ["proj-1", "proj-2", "proj-3"];
 
 beforeEach(() => {
   mockGet.mockReset();
+  sessionStorage.clear();
   vi.stubGlobal("location", { href: "http://localhost:3000/ko" });
   vi.stubGlobal("queueMicrotask", (fn: () => void) => fn());
   vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
@@ -70,6 +71,114 @@ describe("useProjectFilterParams", () => {
       // Then
       expect(result.current[0]).toEqual([]);
     });
+
+    it("should sync valid URL filter to sessionStorage on mount", () => {
+      // Given
+      mockGet.mockReturnValue("proj-1,proj-2");
+
+      // When
+      renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // Then
+      expect(sessionStorage.getItem("kanvibe_project_filter")).toBe("proj-1,proj-2");
+    });
+  });
+
+  describe("sessionStorage restoration", () => {
+    it("should restore filter from sessionStorage when URL has no projects param", () => {
+      // Given
+      mockGet.mockReturnValue(null);
+      sessionStorage.setItem("kanvibe_project_filter", "proj-1,proj-3");
+
+      // When
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // Then
+      expect(result.current[0]).toEqual(["proj-1", "proj-3"]);
+    });
+
+    it("should update URL when restoring from sessionStorage", () => {
+      // Given
+      mockGet.mockReturnValue(null);
+      sessionStorage.setItem("kanvibe_project_filter", "proj-2");
+
+      // When
+      renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // Then
+      expect(window.history.replaceState).toHaveBeenCalledWith(
+        null,
+        "",
+        expect.stringContaining("projects=proj-2"),
+      );
+    });
+
+    it("should filter out invalid IDs from sessionStorage", () => {
+      // Given
+      mockGet.mockReturnValue(null);
+      sessionStorage.setItem("kanvibe_project_filter", "proj-1,deleted-proj,proj-2");
+
+      // When
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // Then
+      expect(result.current[0]).toEqual(["proj-1", "proj-2"]);
+    });
+
+    it("should return empty array when sessionStorage has only invalid IDs", () => {
+      // Given
+      mockGet.mockReturnValue(null);
+      sessionStorage.setItem("kanvibe_project_filter", "deleted-1,deleted-2");
+
+      // When
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // Then
+      expect(result.current[0]).toEqual([]);
+    });
+
+    it("should return empty array when sessionStorage has empty string", () => {
+      // Given
+      mockGet.mockReturnValue(null);
+      sessionStorage.setItem("kanvibe_project_filter", "");
+
+      // When
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // Then
+      expect(result.current[0]).toEqual([]);
+    });
+
+    it("should gracefully handle sessionStorage access error on restore", () => {
+      // Given
+      mockGet.mockReturnValue(null);
+      const originalGetItem = sessionStorage.getItem;
+      vi.spyOn(sessionStorage, "getItem").mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+
+      // When
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // Then
+      expect(result.current[0]).toEqual([]);
+      sessionStorage.getItem = originalGetItem;
+    });
+
+    it("should restore only once across re-renders", () => {
+      // Given
+      mockGet.mockReturnValue(null);
+      sessionStorage.setItem("kanvibe_project_filter", "proj-1");
+
+      // When
+      const { result, rerender } = renderHook(() => useProjectFilterParams(VALID_IDS));
+      (window.history.replaceState as ReturnType<typeof vi.fn>).mockClear();
+      rerender();
+
+      // Then
+      expect(result.current[0]).toEqual(["proj-1"]);
+      expect(window.history.replaceState).not.toHaveBeenCalled();
+    });
   });
 
   describe("URL synchronization on state change", () => {
@@ -120,6 +229,51 @@ describe("useProjectFilterParams", () => {
 
       // Then
       expect(result.current[0]).toEqual(["proj-1", "proj-2"]);
+    });
+
+    it("should sync to sessionStorage when setting IDs", () => {
+      // Given
+      mockGet.mockReturnValue(null);
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // When
+      act(() => {
+        result.current[1](["proj-1", "proj-3"]);
+      });
+
+      // Then
+      expect(sessionStorage.getItem("kanvibe_project_filter")).toBe("proj-1,proj-3");
+    });
+
+    it("should remove sessionStorage entry when setting empty array", () => {
+      // Given
+      mockGet.mockReturnValue("proj-1");
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+
+      // When
+      act(() => {
+        result.current[1]([]);
+      });
+
+      // Then
+      expect(sessionStorage.getItem("kanvibe_project_filter")).toBeNull();
+    });
+
+    it("should gracefully handle sessionStorage access error on sync", () => {
+      // Given
+      mockGet.mockReturnValue(null);
+      const { result } = renderHook(() => useProjectFilterParams(VALID_IDS));
+      vi.spyOn(sessionStorage, "setItem").mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+
+      // When & Then
+      expect(() => {
+        act(() => {
+          result.current[1](["proj-1"]);
+        });
+      }).not.toThrow();
+      expect(result.current[0]).toEqual(["proj-1"]);
     });
   });
 });

--- a/src/hooks/useProjectFilterParams.ts
+++ b/src/hooks/useProjectFilterParams.ts
@@ -1,13 +1,15 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 
 const QUERY_PARAM_KEY = "projects";
+const SESSION_STORAGE_KEY = "kanvibe_project_filter";
 
 /**
  * URL query string 기반 프로젝트 필터 상태를 관리한다.
  * 탭마다 독립적인 필터를 유지하기 위해 localStorage 대신 URL을 사용한다.
+ * redirect 등으로 URL query가 유실될 경우 sessionStorage에서 복원한다.
  * @param validProjectIds 유효한 프로젝트 ID 목록 (존재하지 않는 ID를 걸러내기 위해 사용)
  */
 export function useProjectFilterParams(validProjectIds: string[]) {
@@ -20,11 +22,41 @@ export function useProjectFilterParams(validProjectIds: string[]) {
     return param.split(",").filter((id) => validIdSet.has(id));
   });
 
+  /**
+   * 클라이언트 하이드레이션 후 sessionStorage에서 필터를 복원한다.
+   * SSR에서는 sessionStorage에 접근할 수 없으므로 useEffect에서 처리한다.
+   */
+  const hasRestoredRef = useRef(false);
+  useEffect(() => {
+    if (hasRestoredRef.current) return;
+    hasRestoredRef.current = true;
+
+    const param = searchParams.get(QUERY_PARAM_KEY);
+    if (param) {
+      /** URL에 필터가 이미 있으면 sessionStorage에 동기화만 수행 */
+      const ids = param.split(",").filter((id) => validIdSet.has(id));
+      syncToSessionStorage(ids);
+      return;
+    }
+
+    /** URL에 필터가 없으면 sessionStorage에서 복원 */
+    const restored = restoreFromSessionStorage(validIdSet);
+    if (restored.length > 0) {
+      setSelectedProjectIdsState(restored);
+      const url = new URL(window.location.href);
+      url.searchParams.set(QUERY_PARAM_KEY, restored.join(","));
+      window.history.replaceState(null, "", url.toString());
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const isUpdatingUrl = useRef(false);
   const setSelectedProjectIds = useCallback(
     (idsOrUpdater: string[] | ((prev: string[]) => string[])) => {
       setSelectedProjectIdsState((prev) => {
         const nextIds = typeof idsOrUpdater === "function" ? idsOrUpdater(prev) : idsOrUpdater;
+
+        syncToSessionStorage(nextIds);
 
         if (!isUpdatingUrl.current) {
           isUpdatingUrl.current = true;
@@ -47,4 +79,26 @@ export function useProjectFilterParams(validProjectIds: string[]) {
   );
 
   return [selectedProjectIds, setSelectedProjectIds] as const;
+}
+
+function syncToSessionStorage(ids: string[]) {
+  try {
+    if (ids.length > 0) {
+      sessionStorage.setItem(SESSION_STORAGE_KEY, ids.join(","));
+    } else {
+      sessionStorage.removeItem(SESSION_STORAGE_KEY);
+    }
+  } catch {
+    /* SSR 또는 sessionStorage 접근 불가 환경에서는 무시 */
+  }
+}
+
+function restoreFromSessionStorage(validIdSet: Set<string>): string[] {
+  try {
+    const stored = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (!stored) return [];
+    return stored.split(",").filter((id) => validIdSet.has(id));
+  } catch {
+    return [];
+  }
 }


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- Next.js redirect 등으로 URL query string이 유실될 때 프로젝트 필터가 초기화되는 문제를 sessionStorage 백업/복원으로 해결

## 어떻게 해결했나요?
**sessionStorage 기반 프로젝트 필터 백업/복원**
- 프로젝트 필터 변경 시 sessionStorage에 동기화하여 URL query 유실에 대비
- 마운트 시 URL에 필터가 없으면 sessionStorage에서 복원하여 상태 유지

**엣지 케이스 테스트 추가**
- sessionStorage 동기화/복원, invalid ID 필터링, 에러 핸들링, 중복 복원 방지 테스트

## 중요한 변경 사항은 무엇인가요?
### sessionStorage 백업/복원 로직

**`useProjectFilterParams` 훅에 sessionStorage 연동 추가**
- **변경 이유**: redirect 시 URL query string(`?projects=...`)이 유실되면 사용자의 프로젝트 필터 선택이 초기화되는 문제
- **수정 파일**: `src/hooks/useProjectFilterParams.ts`

**테스트 커버리지 확장 (7 → 18 케이스)**
- **변경 이유**: sessionStorage 동기화, 복원, 에러 처리 등 새로운 로직에 대한 테스트 보장
- **수정 파일**: `src/hooks/__tests__/useProjectFilterParams.test.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
