### PR TITLE
feat(cli): start 커맨드에 --fg/--bg 플래그 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ cp .env.example .env
 ### 2. Run
 
 ```bash
-bash kanvibe.sh start
+bash kanvibe.sh start          # Interactive mode selection (foreground/background)
+bash kanvibe.sh start --fg     # Foreground (output to terminal, Ctrl+C to stop)
+bash kanvibe.sh start --bg     # Background (server keeps running after terminal closes)
 ```
 
 This command checks dependencies (with i18n install prompts), installs packages, starts PostgreSQL, runs migrations, builds, and launches the server.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -69,7 +69,9 @@ cp .env.example .env
 ### 2. 실행
 
 ```bash
-bash kanvibe.sh start
+bash kanvibe.sh start          # 인터랙티브 모드 선택 (포그라운드/백그라운드)
+bash kanvibe.sh start --fg     # 포그라운드 (터미널에 직접 출력, Ctrl+C로 종료)
+bash kanvibe.sh start --bg     # 백그라운드 (터미널 닫아도 서버 유지)
 ```
 
 의존성 체크(i18n 설치 프롬프트 포함), 패키지 설치, PostgreSQL 시작, 마이그레이션, 빌드, 서버 실행까지 모두 처리됩니다.

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -69,7 +69,9 @@ cp .env.example .env
 ### 2. 运行
 
 ```bash
-bash kanvibe.sh start
+bash kanvibe.sh start          # 交互式模式选择（前台/后台）
+bash kanvibe.sh start --fg     # 前台运行（输出到终端，Ctrl+C 停止）
+bash kanvibe.sh start --bg     # 后台运行（关闭终端后服务器继续运行）
 ```
 
 此命令会检查依赖项（带有 i18n 安装提示）、安装包、启动 PostgreSQL、运行迁移、构建并启动服务器。

--- a/kanvibe.sh
+++ b/kanvibe.sh
@@ -67,9 +67,9 @@ msg() {
     en:title)           text="KanVibe" ;;
     zh:title)           text="KanVibe" ;;
 
-    ko:usage)           text="사용법: bash kanvibe.sh {start|stop}" ;;
-    en:usage)           text="Usage: bash kanvibe.sh {start|stop}" ;;
-    zh:usage)           text="用法: bash kanvibe.sh {start|stop}" ;;
+    ko:usage)           text="사용법: bash kanvibe.sh {start [--fg|--bg]|stop}" ;;
+    en:usage)           text="Usage: bash kanvibe.sh {start [--fg|--bg]|stop}" ;;
+    zh:usage)           text="用法: bash kanvibe.sh {start [--fg|--bg]|stop}" ;;
 
     ko:unknown_cmd)     text="알 수 없는 명령: $1" ;;
     en:unknown_cmd)     text="Unknown command: $1" ;;
@@ -850,6 +850,7 @@ setup_tmux_conf() {
 
 # ── start 커맨드 ─────────────────────────────────────────────
 cmd_start() {
+  local mode_flag="${1:-}"
   print_header
   load_env
 
@@ -939,12 +940,20 @@ cmd_start() {
 
   # 6. 서버 시작 — 실행 모드 선택
   step 6 $total "$(msg step_server)"
-  echo ""
-  printf "  $(msg run_mode_prompt)\n"
-  printf "    ${BOLD}1)${NC} $(msg run_fg)\n"
-  printf "    ${BOLD}2)${NC} $(msg run_bg)\n"
-  printf "  ${ARROW} [1/2] "
-  read -r run_mode
+
+  local run_mode=""
+  case "$mode_flag" in
+    --fg) run_mode="1" ;;
+    --bg) run_mode="2" ;;
+    *)
+      echo ""
+      printf "  $(msg run_mode_prompt)\n"
+      printf "    ${BOLD}1)${NC} $(msg run_fg)\n"
+      printf "    ${BOLD}2)${NC} $(msg run_bg)\n"
+      printf "  ${ARROW} [1/2] "
+      read -r run_mode
+      ;;
+  esac
 
   local LOG_FILE="$SCRIPT_DIR/logs/kanvibe.log"
   local app_port="${PORT:-3000}"
@@ -1018,13 +1027,15 @@ cmd_stop() {
 
 # ── 메인 ─────────────────────────────────────────────────────
 case "${1:-}" in
-  start) cmd_start ;;
+  start) cmd_start "${2:-}" ;;
   stop)  cmd_stop ;;
   *)
     print_header
     printf "  $(msg usage)\n\n"
-    printf "  ${BOLD}start${NC}   $(msg starting)\n"
-    printf "  ${BOLD}stop${NC}    $(msg stopping)\n\n"
+    printf "  ${BOLD}start${NC}          $(msg starting)\n"
+    printf "  ${BOLD}start --fg${NC}    $(msg run_fg)\n"
+    printf "  ${BOLD}start --bg${NC}    $(msg run_bg)\n"
+    printf "  ${BOLD}stop${NC}           $(msg stopping)\n\n"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- `kanvibe.sh start` 실행 시 `--fg`/`--bg` 플래그로 실행 모드를 미리 지정하여 인터랙티브 프롬프트(1/2 선택)를 건너뛸 수 있도록 개선

## 어떻게 해결했나요?
**start 커맨드에 --fg/--bg 플래그 지원 추가**
- `cmd_start()` 함수가 두 번째 인자를 받아 `--fg`이면 포그라운드, `--bg`이면 백그라운드로 바로 실행
- 플래그 없이 `bash kanvibe.sh start`로 실행하면 기존처럼 인터랙티브 프롬프트 표시 (하위 호환성 유지)

**README 및 usage 메시지 업데이트**
- 3개 언어(en, ko, zh)의 README와 스크립트 내 usage/i18n 메시지에 플래그 사용법 반영

## 중요한 변경 사항은 무엇인가요?
### start 커맨드 플래그 지원

**cmd_start() 함수에 mode_flag 파라미터 추가**
- **변경 이유**: 자동화 스크립트나 반복 실행 시 매번 1/2를 입력하는 불편함 해소
- **수정 파일**: `kanvibe.sh`

**usage 도움말 및 README 업데이트**
- **변경 이유**: 새 플래그 사용법 문서화
- **수정 파일**: `kanvibe.sh`, `README.md`, `docs/README.ko.md`, `docs/README.zh.md`
