### PR TITLE
feat(git): remote origin fetch 및 remote-only 브랜치 목록 지원

### DIFF
--- a/.codex/hooks/kanvibe-notify-hook.sh
+++ b/.codex/hooks/kanvibe-notify-hook.sh
@@ -4,8 +4,8 @@
 # Codex 응답이 완료되면 현재 브랜치의 작업을 REVIEW로 변경한다.
 # Codex notify 스크립트는 첫 번째 인자로 JSON payload를 받는다.
 
-KANVIBE_URL="http://localhost:4885"
-PROJECT_NAME="kanvibe"
+KANVIBE_URL="http://localhost:9736"
+PROJECT_NAME="kanvibe_dev"
 
 JSON_PAYLOAD="$1"
 


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/git/2602/22-remote-origin-branch-search.plan.md)

## 어떤 작업인가요?
- 브랜치 목록 조회 시 remote origin을 fetch하여 최신 브랜치 정보를 반영하고, 로컬에 없는 remote-only 브랜치도 표시되도록 개선

## 어떻게 해결했나요?
**remote origin fetch 및 브랜치 목록 개선**
- `listBranches` 호출 시 `fetchOrigin`으로 최신 remote 정보를 먼저 가져옴
- 로컬에 없는 remote-only 브랜치는 `origin/` prefix를 유지하여 git ref resolution이 정확히 동작하도록 처리

**codex hook 설정 변경**
- URL 포트와 프로젝트명을 현재 개발 환경에 맞게 변경

## 중요한 변경 사항은 무엇인가요?
### remote origin fetch 및 브랜치 분류

**fetchOrigin 함수 추가**
- **변경 이유**: 브랜치 목록을 조회하기 전에 remote의 최신 상태를 반영해야 신규 브랜치나 삭제된 브랜치가 정확히 표시됨
- **수정 파일**: `src/lib/gitOperations.ts`

**listBranches에서 로컬/remote-only 브랜치 구분**
- **변경 이유**: 로컬에 체크아웃하지 않은 remote 브랜치도 목록에 표시하되, `origin/` prefix로 구분하여 git ref가 정확히 해석되도록 함
- **수정 파일**: `src/lib/gitOperations.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
