### PR TITLE
feat(settings): 기본 세션 타입(tmux/zellij) 설정 기능 추가

### DIFF
--- a/.claude/plan/settings/2602/22-default-session-type.plan.md
+++ b/.claude/plan/settings/2602/22-default-session-type.plan.md
@@ -1,0 +1,117 @@
+# 기본 세션 타입 설정 기능
+
+## Business Goal
+새 작업 생성 시 세션 타입이 항상 tmux로 고정되어 있어 zellij 사용자가 매번 수동으로 변경해야 한다. 설정에서 기본 세션 타입을 선택할 수 있게 하여 사용자 편의성을 높인다.
+
+## Scope
+- **In Scope**: appSettings에 기본 세션 타입 설정 추가, ProjectSettings UI, CreateTaskModal/BranchTaskModal 기본값 반영, i18n 번역
+- **Out of Scope**: hooks API(`/api/hooks/start`)의 기본 세션 타입 (외부에서 직접 전달하므로 제어 불가)
+
+## Codebase Analysis Summary
+- `appSettings.ts`에 KV 스토어 기반 설정 getter/setter 패턴이 존재 (`getAppSetting`/`setAppSetting`)
+- `ProjectSettings.tsx`에 사이드바, 알림 등 설정 UI가 섹션별로 구성됨
+- `CreateTaskModal`의 세션 타입 `<select>`는 tmux가 첫 번째 option으로 하드코딩
+- `BranchTaskModal`은 `useState<SessionType>(SessionType.TMUX)`로 초기화
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/app/actions/appSettings.ts` | 설정 getter/setter | Modify |
+| `src/components/ProjectSettings.tsx` | 설정 패널 UI | Modify |
+| `src/components/CreateTaskModal.tsx` | 작업 생성 모달 | Modify |
+| `src/components/BranchTaskModal.tsx` | 브랜치 분기 모달 | Modify |
+| `src/components/Board.tsx` | Board 컴포넌트 (props 전달) | Modify |
+| `src/app/[locale]/page.tsx` | 메인 페이지 (설정 로딩) | Modify |
+| `messages/ko.json` | 한국어 번역 | Modify |
+| `messages/en.json` | 영어 번역 | Modify |
+| `messages/zh.json` | 중국어 번역 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 설정 키 상수 | appSettings.ts | `UPPER_SNAKE_CASE` + `_KEY` 접미사 |
+| getter/setter 네이밍 | appSettings.ts | `get{Setting}` / `set{Setting}` 패턴 |
+| 번역 키 | messages/*.json | `settings` 네임스페이스 하위 |
+| 주석 언어 | CODE_PRINCIPLES.md | 한국어 |
+
+## Implementation Todos
+
+### Todo 1: appSettings에 기본 세션 타입 getter/setter 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: DB에 기본 세션 타입을 저장/조회하는 함수 추가
+- **Work**:
+  - `src/app/actions/appSettings.ts`에 `DEFAULT_SESSION_TYPE_KEY` 상수 추가
+  - `getDefaultSessionType()` 함수 추가 — `SessionType`을 반환, 미설정 시 `SessionType.TMUX` 반환
+  - `setDefaultSessionType(sessionType: SessionType)` 함수 추가
+- **Convention Notes**: 기존 `getSidebarDefaultCollapsed`/`setSidebarDefaultCollapsed` 패턴 따름
+- **Verification**: TypeScript 컴파일 확인
+- **Exit Criteria**: getter/setter가 올바르게 export됨
+- **Status**: pending
+
+### Todo 2: i18n 번역 키 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 3개 언어 파일에 기본 세션 타입 설정 관련 번역 추가
+- **Work**:
+  - `messages/ko.json`의 `settings` 네임스페이스에 추가:
+    - `defaultSessionTypeSection`: "작업 생성"
+    - `defaultSessionType`: "기본 세션 타입"
+    - `defaultSessionTypeDescription`: "새 작업 생성 시 기본으로 선택되는 세션 타입입니다."
+  - `messages/en.json`, `messages/zh.json`에 동일 키로 번역 추가
+- **Convention Notes**: 기존 번역 키 네이밍 패턴 따름
+- **Verification**: JSON 파싱 가능 여부 확인
+- **Exit Criteria**: 3개 언어 파일에 동일 키 존재
+- **Status**: pending
+
+### Todo 3: ProjectSettings에 기본 세션 타입 선택 UI 추가
+- **Priority**: 2
+- **Dependencies**: Todo 1, Todo 2
+- **Goal**: 설정 패널에서 기본 세션 타입을 선택할 수 있는 UI 추가
+- **Work**:
+  - `ProjectSettingsProps`에 `defaultSessionType: SessionType` 추가
+  - 알림 섹션 위에 "작업 생성" 섹션 추가
+  - `<select>` 드롭다운으로 tmux/zellij 선택 가능하게 구현
+  - `setDefaultSessionType()` 호출하여 변경 저장
+- **Convention Notes**: 기존 사이드바 접기 토글 UI 패턴 참고
+- **Verification**: UI 렌더링 확인
+- **Exit Criteria**: 설정에서 세션 타입 변경 시 DB에 저장
+- **Status**: pending
+
+### Todo 4: Board/page.tsx에서 기본 세션 타입 전달
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 메인 페이지에서 기본 세션 타입을 로딩하여 Board → CreateTaskModal/BranchTaskModal로 전달
+- **Work**:
+  - `src/app/[locale]/page.tsx`에서 `getDefaultSessionType()` 호출 추가
+  - `Board` props에 전달
+  - `BoardProps`에 `defaultSessionType: SessionType` 추가
+  - `Board`에서 `CreateTaskModal`, `BranchTaskModal`, `ProjectSettings`에 prop 전달
+- **Convention Notes**: 기존 `sidebarDefaultCollapsed` 전달 패턴 따름
+- **Verification**: TypeScript 컴파일 확인
+- **Exit Criteria**: 설정값이 모달까지 전달됨
+- **Status**: pending
+
+### Todo 5: CreateTaskModal/BranchTaskModal에서 기본값 반영
+- **Priority**: 3
+- **Dependencies**: Todo 4
+- **Goal**: 세션 타입 선택의 기본값을 설정에서 가져온 값으로 적용
+- **Work**:
+  - `CreateTaskModal`: props에 `defaultSessionType` 추가, `<select>` 기본값으로 사용
+  - `BranchTaskModal`: props에 `defaultSessionType` 추가, `useState` 초기값으로 사용
+- **Convention Notes**: CreateTaskModal은 uncontrolled select, BranchTaskModal은 controlled state
+- **Verification**: TypeScript 컴파일 확인
+- **Exit Criteria**: 모달 열 때 설정된 기본값이 선택되어 있음
+- **Status**: pending
+
+## Verification Strategy
+- TypeScript 빌드 성공 확인
+- 3개 언어 JSON 파일 파싱 확인
+
+## Progress Tracking
+- Total Todos: 5
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-22: Plan created

--- a/messages/en.json
+++ b/messages/en.json
@@ -127,7 +127,10 @@
     "notificationEnabled": "Browser notifications",
     "notificationEnabledDescription": "Receive browser notifications when task status changes.",
     "notificationStatusFilter": "Notify for statuses",
-    "notificationStatusFilterDescription": "Only receive notifications when tasks change to selected statuses."
+    "notificationStatusFilterDescription": "Only receive notifications when tasks change to selected statuses.",
+    "taskCreationSection": "Task Creation",
+    "defaultSessionType": "Default session type",
+    "defaultSessionTypeDescription": "The default session type selected when creating a new task."
   },
   "paneLayout": {
     "title": "Pane Layout Settings",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -127,7 +127,10 @@
     "notificationEnabled": "브라우저 알림",
     "notificationEnabledDescription": "작업 상태 변경 시 브라우저 알림을 받습니다.",
     "notificationStatusFilter": "알림 받을 상태",
-    "notificationStatusFilterDescription": "선택한 상태로 변경될 때만 알림을 받습니다."
+    "notificationStatusFilterDescription": "선택한 상태로 변경될 때만 알림을 받습니다.",
+    "taskCreationSection": "작업 생성",
+    "defaultSessionType": "기본 세션 타입",
+    "defaultSessionTypeDescription": "새 작업 생성 시 기본으로 선택되는 세션 타입입니다."
   },
   "paneLayout": {
     "title": "Pane 레이아웃 설정",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -127,7 +127,10 @@
     "notificationEnabled": "浏览器通知",
     "notificationEnabledDescription": "任务状态变更时接收浏览器通知。",
     "notificationStatusFilter": "通知状态",
-    "notificationStatusFilterDescription": "仅在任务变更为所选状态时接收通知。"
+    "notificationStatusFilterDescription": "仅在任务变更为所选状态时接收通知。",
+    "taskCreationSection": "任务创建",
+    "defaultSessionType": "默认会话类型",
+    "defaultSessionTypeDescription": "创建新任务时默认选择的会话类型。"
   },
   "paneLayout": {
     "title": "面板布局设置",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,13 +1,13 @@
 import Board from "@/components/Board";
 import { getTasksByStatus } from "@/app/actions/kanban";
 import { getAllProjects } from "@/app/actions/project";
-import { getSidebarDefaultCollapsed, getDoneAlertDismissed, getNotificationSettings } from "@/app/actions/appSettings";
+import { getSidebarDefaultCollapsed, getDoneAlertDismissed, getNotificationSettings, getDefaultSessionType } from "@/app/actions/appSettings";
 import { getAvailableHosts } from "@/lib/sshConfig";
 
 export const dynamic = "force-dynamic";
 
 export default async function HomePage() {
-  const [{ tasks, doneTotal, doneLimit }, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings] =
+  const [{ tasks, doneTotal, doneLimit }, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings, defaultSessionType] =
     await Promise.all([
       getTasksByStatus(),
       getAvailableHosts(),
@@ -15,6 +15,7 @@ export default async function HomePage() {
       getSidebarDefaultCollapsed(),
       getDoneAlertDismissed(),
       getNotificationSettings(),
+      getDefaultSessionType(),
     ]);
 
   return (
@@ -27,6 +28,7 @@ export default async function HomePage() {
       sidebarDefaultCollapsed={sidebarDefaultCollapsed}
       doneAlertDismissed={doneAlertDismissed}
       notificationSettings={notificationSettings}
+      defaultSessionType={defaultSessionType}
     />
   );
 }

--- a/src/app/actions/__tests__/appSettings.test.ts
+++ b/src/app/actions/__tests__/appSettings.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionType } from "@/entities/KanbanTask";
+
+const mockFindOne = vi.fn();
+const mockSave = vi.fn();
+const mockCreate = vi.fn((value: Record<string, unknown>) => value);
+const mockRevalidatePath = vi.fn();
+
+vi.mock("@/lib/database", () => ({
+  getAppSettingsRepository: vi.fn().mockResolvedValue({
+    findOne: mockFindOne,
+    save: mockSave,
+    create: mockCreate,
+  }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mockRevalidatePath,
+}));
+
+describe("appSettings default session type", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("기본 세션 타입 설정이 없으면 tmux를 반환한다", async () => {
+    // Given
+    mockFindOne.mockResolvedValue(null);
+    const { getDefaultSessionType } = await import("@/app/actions/appSettings");
+
+    // When
+    const result = await getDefaultSessionType();
+
+    // Then
+    expect(result).toBe(SessionType.TMUX);
+  });
+
+  it("저장된 값이 zellij면 zellij를 반환한다", async () => {
+    // Given
+    mockFindOne.mockResolvedValue({ key: "default_session_type", value: SessionType.ZELLIJ });
+    const { getDefaultSessionType } = await import("@/app/actions/appSettings");
+
+    // When
+    const result = await getDefaultSessionType();
+
+    // Then
+    expect(result).toBe(SessionType.ZELLIJ);
+  });
+
+  it("저장된 값이 예상 범위를 벗어나면 tmux로 폴백한다", async () => {
+    // Given
+    mockFindOne.mockResolvedValue({ key: "default_session_type", value: "invalid" });
+    const { getDefaultSessionType } = await import("@/app/actions/appSettings");
+
+    // When
+    const result = await getDefaultSessionType();
+
+    // Then
+    expect(result).toBe(SessionType.TMUX);
+  });
+
+  it("기본 세션 타입 저장 시 값을 저장하고 경로를 갱신한다", async () => {
+    // Given
+    mockFindOne.mockResolvedValue(null);
+    const { setDefaultSessionType } = await import("@/app/actions/appSettings");
+
+    // When
+    await setDefaultSessionType(SessionType.ZELLIJ);
+
+    // Then
+    expect(mockCreate).toHaveBeenCalledWith({
+      key: "default_session_type",
+      value: SessionType.ZELLIJ,
+    });
+    expect(mockSave).toHaveBeenCalledWith({
+      key: "default_session_type",
+      value: SessionType.ZELLIJ,
+    });
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/");
+  });
+});

--- a/src/app/actions/appSettings.ts
+++ b/src/app/actions/appSettings.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { getAppSettingsRepository } from "@/lib/database";
+import { SessionType } from "@/entities/KanbanTask";
 
 const SIDEBAR_COLLAPSED_KEY = "sidebar_default_collapsed";
 const SIDEBAR_HINT_DISMISSED_KEY = "sidebar_hint_dismissed";
@@ -114,13 +115,13 @@ export async function setNotificationStatuses(statuses: string[]): Promise<void>
 const DEFAULT_SESSION_TYPE_KEY = "default_session_type";
 
 /** 기본 세션 타입을 조회한다. 미설정 시 "tmux"를 반환한다 */
-export async function getDefaultSessionType(): Promise<string> {
+export async function getDefaultSessionType(): Promise<SessionType> {
   const value = await getAppSetting(DEFAULT_SESSION_TYPE_KEY);
-  return value || "tmux";
+  return value === SessionType.ZELLIJ ? SessionType.ZELLIJ : SessionType.TMUX;
 }
 
 /** 기본 세션 타입을 저장한다 */
-export async function setDefaultSessionType(sessionType: string): Promise<void> {
+export async function setDefaultSessionType(sessionType: SessionType): Promise<void> {
   await setAppSetting(DEFAULT_SESSION_TYPE_KEY, sessionType);
   revalidatePath("/");
 }

--- a/src/app/actions/appSettings.ts
+++ b/src/app/actions/appSettings.ts
@@ -110,3 +110,17 @@ export async function setNotificationStatuses(statuses: string[]): Promise<void>
   await setAppSetting(NOTIFICATION_STATUSES_KEY, JSON.stringify(statuses));
   revalidatePath("/");
 }
+
+const DEFAULT_SESSION_TYPE_KEY = "default_session_type";
+
+/** 기본 세션 타입을 조회한다. 미설정 시 "tmux"를 반환한다 */
+export async function getDefaultSessionType(): Promise<string> {
+  const value = await getAppSetting(DEFAULT_SESSION_TYPE_KEY);
+  return value || "tmux";
+}
+
+/** 기본 세션 타입을 저장한다 */
+export async function setDefaultSessionType(sessionType: string): Promise<void> {
+  await setAppSetting(DEFAULT_SESSION_TYPE_KEY, sessionType);
+  revalidatePath("/");
+}

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -28,6 +28,7 @@ interface BoardProps {
   sidebarDefaultCollapsed: boolean;
   doneAlertDismissed: boolean;
   notificationSettings: { isEnabled: boolean; enabledStatuses: string[] };
+  defaultSessionType: string;
 }
 
 const COLUMNS: { status: TaskStatus; labelKey: string; colorClass: string }[] = [
@@ -87,7 +88,7 @@ function insertAtFilteredIndex(
   return arr;
 }
 
-export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings }: BoardProps) {
+export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings, defaultSessionType }: BoardProps) {
   useAutoRefresh();
   const t = useTranslations("board");
   const tt = useTranslations("task");
@@ -506,6 +507,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         projects={projects}
         defaultProjectId={branchTodoDefaults?.projectId || (selectedProjectIds.length === 1 ? selectedProjectIds[0] : "")}
         defaultBaseBranch={branchTodoDefaults?.baseBranch}
+        defaultSessionType={defaultSessionType}
       />
 
       <ProjectSettings
@@ -514,6 +516,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         projects={projects}
         sshHosts={sshHosts}
         sidebarDefaultCollapsed={sidebarDefaultCollapsed}
+        defaultSessionType={defaultSessionType}
         notificationSettings={notificationSettings}
       />
 
@@ -533,6 +536,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         <BranchTaskModal
           task={contextMenu.task}
           projects={projects}
+          defaultSessionType={defaultSessionType}
           onClose={() => {
             setIsBranchModalOpen(false);
             handleCloseContextMenu();

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -12,7 +12,7 @@ import BranchTaskModal from "./BranchTaskModal";
 import DoneConfirmDialog from "./DoneConfirmDialog";
 import { reorderTasks, deleteTask, getMoreDoneTasks, moveTaskToColumn } from "@/app/actions/kanban";
 import type { TasksByStatus } from "@/app/actions/kanban";
-import { TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
+import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import { logoutAction } from "@/app/actions/auth";
 import { useAutoRefresh } from "@/hooks/useAutoRefresh";
@@ -28,7 +28,7 @@ interface BoardProps {
   sidebarDefaultCollapsed: boolean;
   doneAlertDismissed: boolean;
   notificationSettings: { isEnabled: boolean; enabledStatuses: string[] };
-  defaultSessionType: string;
+  defaultSessionType: SessionType;
 }
 
 const COLUMNS: { status: TaskStatus; labelKey: string; colorClass: string }[] = [
@@ -110,6 +110,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isDoneAlertDismissed, setIsDoneAlertDismissed] = useState(doneAlertDismissed);
   const [pendingDoneResult, setPendingDoneResult] = useState<DropResult | null>(null);
+  const [currentDefaultSessionType, setCurrentDefaultSessionType] = useState<SessionType>(defaultSessionType);
 
   /** projectId → 표시할 프로젝트 이름 매핑. worktree 프로젝트는 메인 프로젝트 이름으로 resolve한다 */
   const projectNameMap = useMemo(() => {
@@ -243,6 +244,10 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
     setDoneTotal(initialDoneTotal);
     setDoneOffset(initialDoneLimit);
   }, [initialTasks, initialDoneTotal, initialDoneLimit]);
+
+  useEffect(() => {
+    setCurrentDefaultSessionType(defaultSessionType);
+  }, [defaultSessionType]);
 
   const handleLoadMoreDone = useCallback(async () => {
     if (isLoadingMore) return;
@@ -507,7 +512,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         projects={projects}
         defaultProjectId={branchTodoDefaults?.projectId || (selectedProjectIds.length === 1 ? selectedProjectIds[0] : "")}
         defaultBaseBranch={branchTodoDefaults?.baseBranch}
-        defaultSessionType={defaultSessionType}
+        defaultSessionType={currentDefaultSessionType}
       />
 
       <ProjectSettings
@@ -516,7 +521,10 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         projects={projects}
         sshHosts={sshHosts}
         sidebarDefaultCollapsed={sidebarDefaultCollapsed}
-        defaultSessionType={defaultSessionType}
+        defaultSessionType={currentDefaultSessionType}
+        onDefaultSessionTypeChange={(sessionType) => {
+          setCurrentDefaultSessionType(sessionType);
+        }}
         notificationSettings={notificationSettings}
       />
 
@@ -536,7 +544,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         <BranchTaskModal
           task={contextMenu.task}
           projects={projects}
-          defaultSessionType={defaultSessionType}
+          defaultSessionType={currentDefaultSessionType}
           onClose={() => {
             setIsBranchModalOpen(false);
             handleCloseContextMenu();

--- a/src/components/BranchTaskModal.tsx
+++ b/src/components/BranchTaskModal.tsx
@@ -11,6 +11,7 @@ import BranchSearchInput from "./BranchSearchInput";
 interface BranchTaskModalProps {
   task: KanbanTask;
   projects: Project[];
+  defaultSessionType?: string;
   onClose: () => void;
 }
 
@@ -18,6 +19,7 @@ interface BranchTaskModalProps {
 export default function BranchTaskModal({
   task,
   projects,
+  defaultSessionType,
   onClose,
 }: BranchTaskModalProps) {
   const t = useTranslations("branch");
@@ -30,7 +32,7 @@ export default function BranchTaskModal({
   const [baseBranch, setBaseBranch] = useState("");
   const [branchName, setBranchName] = useState("");
   const [sessionType, setSessionType] = useState<SessionType>(
-    SessionType.TMUX
+    (defaultSessionType as SessionType) || SessionType.TMUX
   );
   const [error, setError] = useState<string | null>(null);
 

--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -19,6 +19,7 @@ interface CreateTaskModalProps {
   projects: Project[];
   defaultProjectId?: string;
   defaultBaseBranch?: string;
+  defaultSessionType?: string;
 }
 
 export default function CreateTaskModal({
@@ -28,6 +29,7 @@ export default function CreateTaskModal({
   projects,
   defaultProjectId,
   defaultBaseBranch,
+  defaultSessionType,
 }: CreateTaskModalProps) {
   const t = useTranslations("task");
   const tc = useTranslations("common");
@@ -162,6 +164,7 @@ export default function CreateTaskModal({
             </label>
             <select
               name="sessionType"
+              defaultValue={defaultSessionType || "tmux"}
               className="w-full px-3 py-2 bg-bg-page border border-border-default rounded-md text-text-primary focus:outline-none focus:border-brand-primary transition-colors"
             >
               <option value="tmux">tmux</option>

--- a/src/components/ProjectSettings.tsx
+++ b/src/components/ProjectSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useTranslations } from "next-intl";
 import {
   deleteProject,
@@ -32,6 +32,7 @@ interface ProjectSettingsProps {
   sshHosts: string[];
   sidebarDefaultCollapsed: boolean;
   defaultSessionType: SessionType;
+  onDefaultSessionTypeChange?: (sessionType: SessionType) => void;
   notificationSettings: { isEnabled: boolean; enabledStatuses: string[] };
 }
 
@@ -42,6 +43,7 @@ export default function ProjectSettings({
   sshHosts,
   sidebarDefaultCollapsed,
   defaultSessionType,
+  onDefaultSessionTypeChange,
   notificationSettings,
 }: ProjectSettingsProps) {
   const t = useTranslations("settings");
@@ -53,6 +55,12 @@ export default function ProjectSettings({
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
   const [scanSshHost, setScanSshHost] = useState("");
+  const [selectedDefaultSessionType, setSelectedDefaultSessionType] = useState(defaultSessionType);
+
+  useEffect(() => {
+    setSelectedDefaultSessionType(defaultSessionType);
+  }, [defaultSessionType]);
+
   if (!isOpen) return null;
 
   function handleScan(formData: FormData) {
@@ -170,10 +178,13 @@ export default function ProjectSettings({
               <p className="text-xs text-text-muted mt-0.5">{t("defaultSessionTypeDescription")}</p>
             </div>
             <select
-              value={defaultSessionType}
+              value={selectedDefaultSessionType}
               onChange={(e) => {
+                const nextSessionType = e.target.value as SessionType;
+                setSelectedDefaultSessionType(nextSessionType);
                 startTransition(async () => {
-                  await setDefaultSessionType(e.target.value);
+                  await setDefaultSessionType(nextSessionType);
+                  onDefaultSessionTypeChange?.(nextSessionType);
                 });
               }}
               disabled={isPending}

--- a/src/components/ProjectSettings.tsx
+++ b/src/components/ProjectSettings.tsx
@@ -11,7 +11,9 @@ import {
   setSidebarDefaultCollapsed,
   setNotificationEnabled,
   setNotificationStatuses,
+  setDefaultSessionType,
 } from "@/app/actions/appSettings";
+import { SessionType } from "@/entities/KanbanTask";
 import { Link } from "@/i18n/navigation";
 import type { Project } from "@/entities/Project";
 import FolderSearchInput from "@/components/FolderSearchInput";
@@ -29,6 +31,7 @@ interface ProjectSettingsProps {
   projects: Project[];
   sshHosts: string[];
   sidebarDefaultCollapsed: boolean;
+  defaultSessionType: SessionType;
   notificationSettings: { isEnabled: boolean; enabledStatuses: string[] };
 }
 
@@ -38,6 +41,7 @@ export default function ProjectSettings({
   projects,
   sshHosts,
   sidebarDefaultCollapsed,
+  defaultSessionType,
   notificationSettings,
 }: ProjectSettingsProps) {
   const t = useTranslations("settings");
@@ -153,6 +157,32 @@ export default function ProjectSettings({
               />
             </button>
           </label>
+        </div>
+
+        {/* 작업 생성 설정 */}
+        <div className="p-4 border-b border-border-default">
+          <h3 className="text-xs text-text-muted uppercase tracking-wide mb-3">
+            {t("taskCreationSection")}
+          </h3>
+          <div className="flex items-center justify-between">
+            <div>
+              <span className="text-sm text-text-primary">{t("defaultSessionType")}</span>
+              <p className="text-xs text-text-muted mt-0.5">{t("defaultSessionTypeDescription")}</p>
+            </div>
+            <select
+              value={defaultSessionType}
+              onChange={(e) => {
+                startTransition(async () => {
+                  await setDefaultSessionType(e.target.value);
+                });
+              }}
+              disabled={isPending}
+              className="px-2 py-1 text-sm bg-bg-page border border-border-default rounded-md text-text-primary focus:outline-none focus:border-brand-primary transition-colors"
+            >
+              <option value="tmux">tmux</option>
+              <option value="zellij">zellij</option>
+            </select>
+          </div>
         </div>
 
         {/* 알림 설정 */}

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import Board from "../Board";
+import { SessionType, TaskStatus } from "@/entities/KanbanTask";
+import type { Project } from "@/entities/Project";
+import type { TasksByStatus } from "@/app/actions/kanban";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@hello-pangea/dnd", () => ({
+  DragDropContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/app/actions/kanban", () => ({
+  reorderTasks: vi.fn(),
+  deleteTask: vi.fn(),
+  getMoreDoneTasks: vi.fn().mockResolvedValue({ tasks: [], doneTotal: 0 }),
+  moveTaskToColumn: vi.fn(),
+}));
+
+vi.mock("@/app/actions/auth", () => ({
+  logoutAction: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAutoRefresh", () => ({
+  useAutoRefresh: vi.fn(),
+}));
+
+vi.mock("@/hooks/useProjectFilterParams", () => ({
+  useProjectFilterParams: vi.fn().mockReturnValue([[], vi.fn()]),
+}));
+
+vi.mock("../Column", () => ({
+  default: () => <div data-testid="column" />,
+}));
+
+vi.mock("../ProjectSelector", () => ({
+  default: () => <div data-testid="project-selector" />,
+}));
+
+vi.mock("../TaskContextMenu", () => ({
+  default: () => <div data-testid="task-context-menu" />,
+}));
+
+vi.mock("../DoneConfirmDialog", () => ({
+  default: () => <div data-testid="done-confirm-dialog" />,
+}));
+
+vi.mock("../BranchTaskModal", () => ({
+  default: () => <div data-testid="branch-task-modal" />,
+}));
+
+vi.mock("../CreateTaskModal", () => ({
+  default: ({ defaultSessionType }: { defaultSessionType: SessionType }) => (
+    <div data-testid="create-task-default-session">{defaultSessionType}</div>
+  ),
+}));
+
+vi.mock("../ProjectSettings", () => ({
+  default: ({
+    defaultSessionType,
+    onDefaultSessionTypeChange,
+  }: {
+    defaultSessionType: SessionType;
+    onDefaultSessionTypeChange?: (sessionType: SessionType) => void;
+  }) => (
+    <div>
+      <div data-testid="project-settings-default-session">{defaultSessionType}</div>
+      <button onClick={() => onDefaultSessionTypeChange?.(SessionType.ZELLIJ)}>change-default-session</button>
+    </div>
+  ),
+}));
+
+function createProject(): Project {
+  return {
+    id: "project-1",
+    name: "kanvibe",
+    repoPath: "/repo/kanvibe",
+    defaultBranch: "main",
+    sshHost: null,
+    isWorktree: false,
+    color: null,
+    createdAt: new Date(),
+  };
+}
+
+function createEmptyTasks(): TasksByStatus {
+  return {
+    [TaskStatus.TODO]: [],
+    [TaskStatus.PROGRESS]: [],
+    [TaskStatus.PENDING]: [],
+    [TaskStatus.REVIEW]: [],
+    [TaskStatus.DONE]: [],
+  };
+}
+
+describe("Board defaultSessionType sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defaultSessionType prop이 변경되면 내부 상태와 하위 컴포넌트가 동기화된다", async () => {
+    // Given
+    const baseProps = {
+      initialTasks: createEmptyTasks(),
+      initialDoneTotal: 0,
+      initialDoneLimit: 20,
+      sshHosts: [],
+      projects: [createProject()],
+      sidebarDefaultCollapsed: false,
+      doneAlertDismissed: false,
+      notificationSettings: { isEnabled: true, enabledStatuses: ["progress", "pending", "review"] },
+    };
+
+    const { rerender } = render(<Board {...baseProps} defaultSessionType={SessionType.TMUX} />);
+
+    // When
+    rerender(<Board {...baseProps} defaultSessionType={SessionType.ZELLIJ} />);
+
+    // Then
+    await waitFor(() => {
+      expect(screen.getByTestId("create-task-default-session").textContent).toBe(SessionType.ZELLIJ);
+      expect(screen.getByTestId("project-settings-default-session").textContent).toBe(SessionType.ZELLIJ);
+    });
+  });
+
+  it("ProjectSettings에서 변경 콜백을 호출하면 Board 상태가 즉시 반영된다", async () => {
+    // Given
+    render(
+      <Board
+        initialTasks={createEmptyTasks()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+      />,
+    );
+
+    // When
+    fireEvent.click(screen.getByRole("button", { name: "change-default-session" }));
+
+    // Then
+    await waitFor(() => {
+      expect(screen.getByTestId("create-task-default-session").textContent).toBe(SessionType.ZELLIJ);
+    });
+  });
+});

--- a/src/components/__tests__/ProjectSettings.test.tsx
+++ b/src/components/__tests__/ProjectSettings.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ProjectSettings from "../ProjectSettings";
+import { SessionType } from "@/entities/KanbanTask";
+import type { Project } from "@/entities/Project";
+
+const mockSetDefaultSessionType = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({
+    children,
+    href,
+    prefetch: _prefetch,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    prefetch?: boolean;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/FolderSearchInput", () => ({
+  default: () => <div data-testid="folder-search-input" />,
+}));
+
+vi.mock("@/app/actions/project", () => ({
+  deleteProject: vi.fn().mockResolvedValue(undefined),
+  scanAndRegisterProjects: vi.fn().mockResolvedValue({ registered: [], skipped: [], errors: [], worktreeTasks: [] }),
+}));
+
+vi.mock("@/app/actions/appSettings", () => ({
+  setSidebarDefaultCollapsed: vi.fn().mockResolvedValue(undefined),
+  setNotificationEnabled: vi.fn().mockResolvedValue(undefined),
+  setNotificationStatuses: vi.fn().mockResolvedValue(undefined),
+  setDefaultSessionType: (...args: unknown[]) => mockSetDefaultSessionType(...args),
+}));
+
+function createProject(): Project {
+  return {
+    id: "project-1",
+    name: "kanvibe",
+    repoPath: "/repo/kanvibe",
+    defaultBranch: "main",
+    sshHost: null,
+    isWorktree: false,
+    color: null,
+    createdAt: new Date(),
+  };
+}
+
+describe("ProjectSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("기본 세션 타입을 변경하면 onDefaultSessionTypeChange를 호출한다", async () => {
+    // Given
+    const onDefaultSessionTypeChange = vi.fn();
+
+    render(
+      <ProjectSettings
+        isOpen
+        onClose={vi.fn()}
+        projects={[createProject()]}
+        sshHosts={[]}
+        sidebarDefaultCollapsed={false}
+        defaultSessionType={SessionType.TMUX}
+        onDefaultSessionTypeChange={onDefaultSessionTypeChange}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+      />,
+    );
+
+    // When
+    const sessionTypeSelect = screen.getByDisplayValue(SessionType.TMUX);
+    fireEvent.change(sessionTypeSelect, { target: { value: SessionType.ZELLIJ } });
+
+    // Then
+    await waitFor(() => {
+      expect(mockSetDefaultSessionType).toHaveBeenCalledWith(SessionType.ZELLIJ);
+      expect(onDefaultSessionTypeChange).toHaveBeenCalledWith(SessionType.ZELLIJ);
+    });
+  });
+});


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/settings/2602/22-default-session-type.plan.md)

## 어떤 작업인가요?
- 설정에서 기본 세션 타입(tmux/zellij)을 선택할 수 있게 하여, 새 작업 생성 시 매번 수동 변경할 필요 없이 원하는 세션 타입이 기본 선택되도록 한다.

## 어떻게 해결했나요?
**기본 세션 타입 설정 저장/조회**
- `appSettings`의 KV 스토어 패턴을 활용하여 `getDefaultSessionType()` / `setDefaultSessionType()` 추가
- 미설정 시 기존 동작과 동일하게 tmux를 기본값으로 반환

**설정 UI 추가**
- `ProjectSettings` 패널에 "작업 생성" 섹션을 추가하여 tmux/zellij 선택 드롭다운 제공
- 변경 즉시 DB에 저장

**모달 기본값 반영**
- `CreateTaskModal`과 `BranchTaskModal`에서 설정값을 `defaultValue` / `useState` 초기값으로 사용

## 중요한 변경 사항은 무엇인가요?
### 설정 저장 로직

**`appSettings.ts`에 기본 세션 타입 getter/setter 추가**
- **변경 이유**: DB에 기본 세션 타입 설정을 영속화하기 위함
- **수정 파일**: `src/app/actions/appSettings.ts`

### 설정 UI

**`ProjectSettings`에 작업 생성 섹션 추가**
- **변경 이유**: 사용자가 기본 세션 타입을 변경할 수 있는 UI 필요
- **수정 파일**: `src/components/ProjectSettings.tsx`

### 데이터 흐름

**page.tsx → Board → 모달 컴포넌트로 설정값 전달**
- **변경 이유**: 서버에서 조회한 설정값을 클라이언트 모달까지 props로 전달
- **수정 파일**: `src/app/[locale]/page.tsx`, `src/components/Board.tsx`, `src/components/CreateTaskModal.tsx`, `src/components/BranchTaskModal.tsx`

### i18n

**3개 언어 번역 키 추가**
- **변경 이유**: 새 UI 요소에 대한 다국어 지원
- **수정 파일**: `messages/ko.json`, `messages/en.json`, `messages/zh.json`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
