### PR TITLE
fix(terminal): zellij 세션 생성 시 --new-session-with-layout 플래그로 변경

### DIFF
--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -1,15 +1,29 @@
 /**
  * @vitest-environment node
  */
+import path from "path";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SessionType } from "@/entities/KanbanTask";
 
 // --- Mocks ---
 
 const mockExecSync = vi.fn();
-vi.mock("child_process", () => ({
-  execSync: (...args: unknown[]) => mockExecSync(...args),
-}));
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return {
+    ...actual,
+    execSync: (...args: unknown[]) => mockExecSync(...args),
+  };
+});
+
+const mockExistsSync = vi.fn();
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  };
+});
 
 const mockPtyOnData = vi.fn();
 const mockPtyOnExit = vi.fn();
@@ -139,5 +153,143 @@ describe("attachLocalSession — tmux 세션 자동 생성", () => {
 
     // Then
     expect(ws.close).toHaveBeenCalledWith(1008, "tmux 세션 생성에 실패했습니다.");
+  });
+});
+
+describe("attachLocalSession — zellij 세션 생성 및 레이아웃 적용", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  /** zellij list-sessions 응답을 설정한다. 다른 execSync 호출은 빈 문자열을 반환한다 */
+  function mockZellijSessions(sessionListOutput: string) {
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("list-sessions")) {
+        return sessionListOutput;
+      }
+      return "";
+    });
+  }
+
+  it("should spawn new zellij session with --session flag when session does not exist", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
+    mockZellijSessions("other-session [Created 1h ago]\n");
+    mockExistsSync.mockReturnValue(false);
+
+    // When
+    await attachLocalSession(
+      "task-z1",
+      SessionType.ZELLIJ,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    expect(nodePty.spawn).toHaveBeenCalledWith(
+      "zellij",
+      ["--session", "feat-login"],
+      expect.objectContaining({ cwd: "/workspace" }),
+    );
+  });
+
+  it("should include --new-session-with-layout when KDL layout file exists", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
+    mockZellijSessions("");
+    mockExistsSync.mockReturnValue(true);
+
+    const expectedLayoutPath = path.join("/workspace", ".zellij-layout.kdl");
+
+    // When
+    await attachLocalSession(
+      "task-z2",
+      SessionType.ZELLIJ,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    expect(nodePty.spawn).toHaveBeenCalledWith(
+      "zellij",
+      ["--session", "feat-login", "--new-session-with-layout", expectedLayoutPath],
+      expect.objectContaining({ cwd: "/workspace" }),
+    );
+  });
+
+  it("should attach to existing zellij session without creating new one", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
+    mockZellijSessions("feat-login [Created 1h ago]\n");
+
+    // When
+    await attachLocalSession(
+      "task-z3",
+      SessionType.ZELLIJ,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    expect(nodePty.spawn).toHaveBeenCalledWith(
+      "zellij",
+      ["attach", "feat-login"],
+      expect.any(Object),
+    );
+  });
+
+  it("should not include layout flag when layout file does not exist", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
+    mockZellijSessions("");
+    mockExistsSync.mockReturnValue(false);
+
+    // When
+    await attachLocalSession(
+      "task-z4",
+      SessionType.ZELLIJ,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    expect(nodePty.spawn).toHaveBeenCalledWith(
+      "zellij",
+      ["--session", "feat-login"],
+      expect.objectContaining({ cwd: "/workspace" }),
+    );
+  });
+
+  it("should skip layout file check when cwd is not provided", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
+    mockZellijSessions("");
+
+    // When
+    await attachLocalSession(
+      "task-z5",
+      SessionType.ZELLIJ,
+      "feat-login",
+      createMockWs(),
+    );
+
+    // Then
+    /** existsSync가 호출되지 않아야 한다 (cwd가 없으므로 레이아웃 파일 체크 불필요) */
+    expect(mockExistsSync).not.toHaveBeenCalled();
+    expect(nodePty.spawn).toHaveBeenCalledWith(
+      "zellij",
+      ["--session", "feat-login"],
+      expect.any(Object),
+    );
   });
 });

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -1,22 +1,37 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PaneLayoutType, type PaneCommand } from "@/entities/PaneLayoutConfig";
 import { SessionType } from "@/entities/KanbanTask";
 
 // --- Mocks ---
 
-const mockExecGit = vi.fn();
+const mockExecGit = vi.fn().mockResolvedValue("");
 
 vi.mock("@/lib/gitOperations", () => ({
   execGit: (...args: unknown[]) => mockExecGit(...args),
 }));
 
-vi.mock("@/entities/PaneLayoutConfig", () => ({
-  PaneLayoutType: { SINGLE: "single" },
-}));
+const mockGetEffectivePaneLayout = vi.fn();
 
 vi.mock("@/app/actions/paneLayout", () => ({
-  getEffectivePaneLayout: vi.fn().mockResolvedValue(null),
+  getEffectivePaneLayout: (...args: unknown[]) =>
+    mockGetEffectivePaneLayout(...args),
 }));
+
+const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("fs/promises", () => ({
+  writeFile: (...args: unknown[]) => mockWriteFile(...args),
+}));
+
+/** execGit 호출 중 특정 패턴을 포함하는 명령어만 필터링한다 */
+function filterCalls(pattern: string | RegExp): string[] {
+  return mockExecGit.mock.calls
+    .map((call) => call[0] as string)
+    .filter((cmd) =>
+      typeof pattern === "string" ? cmd.includes(pattern) : pattern.test(cmd),
+    );
+}
 
 describe("formatSessionName", () => {
   it("should format as projectName-branchName with slashes replaced", async () => {
@@ -282,5 +297,393 @@ describe("createSessionWithoutWorktree", () => {
       'tmux has-session -t "path-main" 2>/dev/null',
       undefined,
     );
+  });
+});
+
+describe("generateZellijLayoutKdl", () => {
+  const worktreePath = "/home/user/kanvibe__worktrees/feat-branch";
+
+  async function importGenerateZellijLayoutKdl() {
+    const mod = await import("@/lib/worktree");
+    return mod.generateZellijLayoutKdl;
+  }
+
+  it("should generate single pane layout with command", async () => {
+    // Given
+    const panes: PaneCommand[] = [{ position: 0, command: "echo hello" }];
+    const generateZellijLayoutKdl = await importGenerateZellijLayoutKdl();
+
+    // When
+    const kdl = generateZellijLayoutKdl(PaneLayoutType.SINGLE, panes, worktreePath);
+
+    // Then
+    expect(kdl).toContain("layout {");
+    expect(kdl).toContain('command="bash"');
+    expect(kdl).toContain('"echo hello"');
+    /** KDL child-brace 내부에서는 cwd "path" 형태를 사용한다 */
+    expect(kdl).toContain(`cwd "${worktreePath}"`);
+    expect(kdl).not.toContain("split_direction");
+  });
+
+  it("should generate single pane layout without command", async () => {
+    // Given
+    const panes: PaneCommand[] = [{ position: 0, command: "" }];
+    const generateZellijLayoutKdl = await importGenerateZellijLayoutKdl();
+
+    // When
+    const kdl = generateZellijLayoutKdl(PaneLayoutType.SINGLE, panes, worktreePath);
+
+    // Then
+    expect(kdl).toContain(`pane cwd="${worktreePath}"`);
+    expect(kdl).not.toContain('command="bash"');
+  });
+
+  it("should generate horizontal 2-pane layout (top/bottom)", async () => {
+    // Given
+    const panes: PaneCommand[] = [
+      { position: 0, command: "pnpm dev" },
+      { position: 1, command: "pnpm test" },
+    ];
+    const generateZellijLayoutKdl = await importGenerateZellijLayoutKdl();
+
+    // When
+    const kdl = generateZellijLayoutKdl(PaneLayoutType.HORIZONTAL_2, panes, worktreePath);
+
+    // Then
+    expect(kdl).toContain('"pnpm dev"');
+    expect(kdl).toContain('"pnpm test"');
+    /** 수평 2분할은 split_direction 없이 기본 horizontal 사용 */
+    expect(kdl).not.toContain("split_direction");
+  });
+
+  it("should generate vertical 2-pane layout (left/right)", async () => {
+    // Given
+    const panes: PaneCommand[] = [
+      { position: 0, command: "pnpm dev" },
+      { position: 1, command: "pnpm test" },
+    ];
+    const generateZellijLayoutKdl = await importGenerateZellijLayoutKdl();
+
+    // When
+    const kdl = generateZellijLayoutKdl(PaneLayoutType.VERTICAL_2, panes, worktreePath);
+
+    // Then
+    expect(kdl).toContain('split_direction="vertical"');
+    expect(kdl).toContain('"pnpm dev"');
+    expect(kdl).toContain('"pnpm test"');
+  });
+
+  it("should generate LEFT_RIGHT_TB layout (left + right-top/bottom)", async () => {
+    // Given
+    const panes: PaneCommand[] = [
+      { position: 0, command: "claude --dangerously-skip-permissions" },
+      { position: 1, command: "pnpm dev" },
+      { position: 2, command: "pnpm test:watch" },
+    ];
+    const generateZellijLayoutKdl = await importGenerateZellijLayoutKdl();
+
+    // When
+    const kdl = generateZellijLayoutKdl(PaneLayoutType.LEFT_RIGHT_TB, panes, worktreePath);
+
+    // Then
+    expect(kdl).toContain('split_direction="vertical"');
+    expect(kdl).toContain('"claude --dangerously-skip-permissions"');
+    expect(kdl).toContain('"pnpm dev"');
+    expect(kdl).toContain('"pnpm test:watch"');
+    /** position 0은 좌측 단독, position 1/2는 우측 상하 분할 */
+    const lines = kdl.split("\n");
+    const verticalContainerIdx = lines.findIndex((l) => l.includes('split_direction="vertical"'));
+    expect(verticalContainerIdx).toBeGreaterThan(-1);
+  });
+
+  it("should generate LEFT_TB_RIGHT layout (left-top/bottom + right)", async () => {
+    // Given
+    const panes: PaneCommand[] = [
+      { position: 0, command: "pnpm dev" },
+      { position: 1, command: "pnpm test" },
+      { position: 2, command: "claude" },
+    ];
+    const generateZellijLayoutKdl = await importGenerateZellijLayoutKdl();
+
+    // When
+    const kdl = generateZellijLayoutKdl(PaneLayoutType.LEFT_TB_RIGHT, panes, worktreePath);
+
+    // Then
+    expect(kdl).toContain('split_direction="vertical"');
+    expect(kdl).toContain('"pnpm dev"');
+    expect(kdl).toContain('"pnpm test"');
+    expect(kdl).toContain('"claude"');
+  });
+
+  it("should generate QUAD layout (2x2 grid)", async () => {
+    // Given
+    const panes: PaneCommand[] = [
+      { position: 0, command: "cmd0" },
+      { position: 1, command: "cmd1" },
+      { position: 2, command: "cmd2" },
+      { position: 3, command: "cmd3" },
+    ];
+    const generateZellijLayoutKdl = await importGenerateZellijLayoutKdl();
+
+    // When
+    const kdl = generateZellijLayoutKdl(PaneLayoutType.QUAD, panes, worktreePath);
+
+    // Then
+    expect(kdl).toContain('split_direction="vertical"');
+    expect(kdl).toContain('"cmd0"');
+    expect(kdl).toContain('"cmd1"');
+    expect(kdl).toContain('"cmd2"');
+    expect(kdl).toContain('"cmd3"');
+  });
+
+  it("should skip command for panes with empty command string", async () => {
+    // Given
+    const panes: PaneCommand[] = [
+      { position: 0, command: "pnpm dev" },
+      { position: 1, command: "" },
+    ];
+    const generateZellijLayoutKdl = await importGenerateZellijLayoutKdl();
+
+    // When
+    const kdl = generateZellijLayoutKdl(PaneLayoutType.VERTICAL_2, panes, worktreePath);
+
+    // Then
+    /** position 0은 command가 있고, position 1은 기본 shell pane이다 */
+    expect(kdl).toContain('"pnpm dev"');
+    const paneLines = kdl.split("\n").filter((l) => l.trim().startsWith("pane"));
+    const plainPanes = paneLines.filter(
+      (l) => l.includes("cwd=") && !l.includes("command=") && !l.includes("split_direction"),
+    );
+    expect(plainPanes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should escape special characters in paths and commands", async () => {
+    // Given
+    const panes: PaneCommand[] = [
+      { position: 0, command: 'echo "hello world"' },
+    ];
+    const pathWithBackslash = "/home/user/my\\project";
+    const generateZellijLayoutKdl = await importGenerateZellijLayoutKdl();
+
+    // When
+    const kdl = generateZellijLayoutKdl(PaneLayoutType.SINGLE, panes, pathWithBackslash);
+
+    // Then
+    expect(kdl).toContain("my\\\\project");
+    expect(kdl).toContain('\\"hello world\\"');
+  });
+
+  it("should set cwd on all panes", async () => {
+    // Given
+    const panes: PaneCommand[] = [
+      { position: 0, command: "cmd0" },
+      { position: 1, command: "" },
+      { position: 2, command: "cmd2" },
+    ];
+    const generateZellijLayoutKdl = await importGenerateZellijLayoutKdl();
+
+    // When
+    const kdl = generateZellijLayoutKdl(PaneLayoutType.LEFT_RIGHT_TB, panes, worktreePath);
+
+    // Then
+    const cwdCount = (kdl.match(new RegExp(worktreePath, "g")) || []).length;
+    expect(cwdCount).toBe(3);
+  });
+});
+
+describe("createWorktreeWithSession — Zellij KDL layout file persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should write layout file to worktree directory without starting zellij", async () => {
+    // Given
+    mockGetEffectivePaneLayout.mockResolvedValue({
+      layoutType: PaneLayoutType.VERTICAL_2,
+      panes: [
+        { position: 0, command: "pnpm dev" },
+        { position: 1, command: "pnpm test" },
+      ],
+    });
+
+    const { createWorktreeWithSession } = await import("@/lib/worktree");
+
+    // When
+    await createWorktreeWithSession(
+      "/home/user/kanvibe",
+      "feat-new",
+      "main",
+      SessionType.ZELLIJ,
+      null,
+      "project-1",
+    );
+
+    // Then
+    /** writeFile이 worktree 디렉토리에 .zellij-layout.kdl로 호출되어야 한다 */
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    const [writtenPath, writtenContent] = mockWriteFile.mock.calls[0];
+    expect(writtenPath).toContain("kanvibe__worktrees/feat-new");
+    expect(writtenPath).toContain(".zellij-layout.kdl");
+    expect(writtenContent).toContain('split_direction="vertical"');
+    expect(writtenContent).toContain('"pnpm dev"');
+
+    /** zellij를 서버에서 직접 시작하지 않아야 한다 (TTY 없이 실행 불가) */
+    const zellijCalls = filterCalls("zellij");
+    expect(zellijCalls).toHaveLength(0);
+  });
+
+  it("should not write layout file for SINGLE layout type", async () => {
+    // Given
+    mockGetEffectivePaneLayout.mockResolvedValue({
+      layoutType: PaneLayoutType.SINGLE,
+      panes: [{ position: 0, command: "echo hello" }],
+    });
+
+    const { createWorktreeWithSession } = await import("@/lib/worktree");
+
+    // When
+    await createWorktreeWithSession(
+      "/home/user/kanvibe",
+      "feat-new",
+      "main",
+      SessionType.ZELLIJ,
+      null,
+      "project-1",
+    );
+
+    // Then
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("should not write layout file for remote Zellij sessions", async () => {
+    // Given
+    mockGetEffectivePaneLayout.mockResolvedValue({
+      layoutType: PaneLayoutType.VERTICAL_2,
+      panes: [
+        { position: 0, command: "pnpm dev" },
+        { position: 1, command: "pnpm test" },
+      ],
+    });
+
+    const { createWorktreeWithSession } = await import("@/lib/worktree");
+
+    // When
+    await createWorktreeWithSession(
+      "/home/user/kanvibe",
+      "feat-new",
+      "main",
+      SessionType.ZELLIJ,
+      "remote-host",
+      "project-1",
+    );
+
+    // Then
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockGetEffectivePaneLayout).not.toHaveBeenCalled();
+  });
+
+  it("should fallback gracefully when getEffectivePaneLayout fails", async () => {
+    // Given
+    mockGetEffectivePaneLayout.mockRejectedValue(new Error("DB error"));
+
+    const { createWorktreeWithSession } = await import("@/lib/worktree");
+
+    // When & Then
+    await expect(
+      createWorktreeWithSession(
+        "/home/user/kanvibe",
+        "feat-new",
+        "main",
+        SessionType.ZELLIJ,
+        null,
+        "project-1",
+      ),
+    ).resolves.not.toThrow();
+
+    /** 레이아웃 파일 없이 세션 이름만 반환되어야 한다 */
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("should write KDL layout with 3-pane configuration to worktree", async () => {
+    // Given
+    mockGetEffectivePaneLayout.mockResolvedValue({
+      layoutType: PaneLayoutType.LEFT_RIGHT_TB,
+      panes: [
+        { position: 0, command: "claude --dangerously-skip-permissions" },
+        { position: 1, command: "pnpm dev" },
+        { position: 2, command: "pnpm test:watch" },
+      ],
+    });
+
+    const { createWorktreeWithSession } = await import("@/lib/worktree");
+
+    // When
+    await createWorktreeWithSession(
+      "/home/user/kanvibe",
+      "feat-new",
+      "main",
+      SessionType.ZELLIJ,
+      null,
+      "project-1",
+    );
+
+    // Then
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    const [, writtenContent] = mockWriteFile.mock.calls[0];
+    expect(writtenContent).toContain('"claude --dangerously-skip-permissions"');
+    expect(writtenContent).toContain('"pnpm dev"');
+    expect(writtenContent).toContain('"pnpm test:watch"');
+  });
+
+  it("should write KDL layout with 4-pane QUAD configuration to worktree", async () => {
+    // Given
+    mockGetEffectivePaneLayout.mockResolvedValue({
+      layoutType: PaneLayoutType.QUAD,
+      panes: [
+        { position: 0, command: "cmd0" },
+        { position: 1, command: "cmd1" },
+        { position: 2, command: "cmd2" },
+        { position: 3, command: "cmd3" },
+      ],
+    });
+
+    const { createWorktreeWithSession } = await import("@/lib/worktree");
+
+    // When
+    await createWorktreeWithSession(
+      "/home/user/kanvibe",
+      "feat-new",
+      "main",
+      SessionType.ZELLIJ,
+      null,
+      "project-1",
+    );
+
+    // Then
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    const [, writtenContent] = mockWriteFile.mock.calls[0];
+    expect(writtenContent).toContain('"cmd0"');
+    expect(writtenContent).toContain('"cmd1"');
+    expect(writtenContent).toContain('"cmd2"');
+    expect(writtenContent).toContain('"cmd3"');
+    expect(writtenContent).toContain('split_direction="vertical"');
+  });
+
+  it("should not start zellij from server for createSessionWithoutWorktree", async () => {
+    // Given
+    const { createSessionWithoutWorktree } = await import("@/lib/worktree");
+
+    // When
+    const result = await createSessionWithoutWorktree(
+      "/repo/path",
+      "feat/test",
+      SessionType.ZELLIJ,
+    );
+
+    // Then
+    expect(result.sessionName).toBe("path-feat-test");
+    /** zellij를 서버에서 직접 시작하지 않아야 한다 */
+    const zellijCalls = filterCalls("zellij");
+    expect(zellijCalls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## 관련 자료
- 이슈 : zellij --layout + --session 조합 시 "Session not found" 에러

## 어떤 작업인가요?
- zellij pane 레이아웃 설정이 적용되지 않고 "Session not found" 에러가 발생하는 버그를 수정

## 어떻게 해결했나요?
**zellij CLI 플래그 변경**
- zellij 0.43에서 `--layout`을 `--session`과 함께 사용하면 기존 세션에 탭을 추가하려 시도하여 세션이 없을 때 에러 발생
- `--new-session-with-layout` 플래그로 변경하여 새 세션 생성과 레이아웃 적용을 동시 처리

**테스트 보강**
- zellij 세션 생성/attach/레이아웃 적용 경로에 대한 테스트 5건 추가
- `child_process` mock 불완전으로 인한 기존 테스트 실패 수정

## 중요한 변경 사항은 무엇인가요?
### zellij --new-session-with-layout 플래그 적용

**`--layout` → `--new-session-with-layout` 변경**
- **변경 이유**: zellij 0.43에서 `--layout`과 `--session`을 함께 사용하면 기존 세션에 탭을 추가하려 시도하므로, 새 세션을 생성하는 `--new-session-with-layout` 플래그를 사용해야 함
- **수정 파일**: `src/lib/terminal.ts`

### 테스트 커버리지 확보

**zellij 세션 경로 테스트 추가**
- **변경 이유**: terminal.ts의 zellij 세션 생성/attach/레이아웃 적용 로직에 테스트가 없었음
- **수정 파일**: `src/lib/__tests__/terminal.test.ts`

**child_process mock 수정**
- **변경 이유**: terminal.ts → worktree.ts → gitOperations.ts 의존 체인에서 `exec` export 누락으로 4건 실패
- **수정 파일**: `src/lib/__tests__/terminal.test.ts`
