### PR TITLE
fix(hooks): OpenCode 플러그인의 잘못된 이벤트 hook 수정

### DIFF
--- a/.codex/hooks/kanvibe-notify-hook.sh
+++ b/.codex/hooks/kanvibe-notify-hook.sh
@@ -4,8 +4,8 @@
 # Codex 응답이 완료되면 현재 브랜치의 작업을 REVIEW로 변경한다.
 # Codex notify 스크립트는 첫 번째 인자로 JSON payload를 받는다.
 
-KANVIBE_URL="http://localhost:4885"
-PROJECT_NAME="kanvibe"
+KANVIBE_URL="http://localhost:7777"
+PROJECT_NAME="kanvibe_dev"
 
 JSON_PAYLOAD="$1"
 

--- a/README.md
+++ b/README.md
@@ -178,11 +178,13 @@ agent-turn-complete (agent done) → REVIEW
 
 #### OpenCode
 ```
-User sends message (chat.message) → PROGRESS
-Session idle (session.idle)       → REVIEW
+User sends message (message.updated, role=user) → PROGRESS
+AI asks a question (question.asked)             → PENDING
+User answers question (question.replied)        → PROGRESS
+Session idle (session.idle)                     → REVIEW
 ```
 
-OpenCode uses its own [plugin system](https://opencode.ai/docs/plugins/) instead of shell-script hooks. KanVibe generates a TypeScript plugin at `.opencode/plugins/kanvibe-plugin.ts` that subscribes to OpenCode's native event hooks (`chat.message` and `session.idle`) via the `@opencode-ai/plugin` SDK. This means status updates are handled in-process without spawning external shell commands.
+OpenCode uses its own [plugin system](https://opencode.ai/docs/plugins/) instead of shell-script hooks. KanVibe generates a TypeScript plugin at `.opencode/plugins/kanvibe-plugin.ts` that subscribes to OpenCode's native event hooks (`message.updated`, `question.asked`, `question.replied`, and `session.idle`) via the `@opencode-ai/plugin` SDK. This means status updates are handled in-process without spawning external shell commands.
 
 All agent hooks are **auto-installed** when you register a project through KanVibe's directory scan or create a task with a worktree. You can also install them individually from the task detail page.
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -178,11 +178,13 @@ agent-turn-complete (에이전트 완료) → REVIEW
 
 #### OpenCode
 ```
-사용자 메시지 전송 (chat.message) → PROGRESS
-세션 대기 (session.idle)         → REVIEW
+사용자 메시지 전송 (message.updated, role=user) → PROGRESS
+AI 질문 대기 (question.asked)                   → PENDING
+사용자 질문 답변 (question.replied)              → PROGRESS
+세션 대기 (session.idle)                        → REVIEW
 ```
 
-OpenCode는 셸 스크립트 hooks 대신 자체 [플러그인 시스템](https://opencode.ai/docs/plugins/)을 사용합니다. KanVibe는 `.opencode/plugins/kanvibe-plugin.ts`에 TypeScript 플러그인을 생성하여 `@opencode-ai/plugin` SDK를 통해 OpenCode의 네이티브 이벤트 hooks(`chat.message`, `session.idle`)를 구독합니다. 외부 셸 명령을 실행하지 않고 프로세스 내에서 상태 업데이트를 처리합니다.
+OpenCode는 셸 스크립트 hooks 대신 자체 [플러그인 시스템](https://opencode.ai/docs/plugins/)을 사용합니다. KanVibe는 `.opencode/plugins/kanvibe-plugin.ts`에 TypeScript 플러그인을 생성하여 `@opencode-ai/plugin` SDK를 통해 OpenCode의 네이티브 이벤트 hooks(`message.updated`, `question.asked`, `question.replied`, `session.idle`)를 구독합니다. 외부 셸 명령을 실행하지 않고 프로세스 내에서 상태 업데이트를 처리합니다.
 
 모든 에이전트 Hook은 KanVibe 디렉토리 스캔으로 프로젝트를 등록하거나 worktree와 함께 태스크를 생성하면 **자동 설치**됩니다. 태스크 상세 페이지에서 개별 설치도 가능합니다.
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -178,11 +178,13 @@ agent-turn-complete（代理完成） → REVIEW
 
 #### OpenCode
 ```
-用户发送消息 (chat.message)  → PROGRESS
-会话空闲 (session.idle)      → REVIEW
+用户发送消息 (message.updated, role=user) → PROGRESS
+AI 提问等待 (question.asked)              → PENDING
+用户回答问题 (question.replied)           → PROGRESS
+会话空闲 (session.idle)                   → REVIEW
 ```
 
-OpenCode 使用自己的[插件系统](https://opencode.ai/docs/plugins/)，而非 shell 脚本 hooks。KanVibe 在 `.opencode/plugins/kanvibe-plugin.ts` 生成 TypeScript 插件，通过 `@opencode-ai/plugin` SDK 订阅 OpenCode 的原生事件 hooks（`chat.message` 和 `session.idle`）。状态更新在进程内处理，无需启动外部 shell 命令。
+OpenCode 使用自己的[插件系统](https://opencode.ai/docs/plugins/)，而非 shell 脚本 hooks。KanVibe 在 `.opencode/plugins/kanvibe-plugin.ts` 生成 TypeScript 插件，通过 `@opencode-ai/plugin` SDK 订阅 OpenCode 的原生事件 hooks（`message.updated`、`question.asked`、`question.replied` 和 `session.idle`）。状态更新在进程内处理，无需启动外部 shell 命令。
 
 通过 KanVibe 目录扫描注册项目或创建带有 worktree 的任务时，所有代理 Hook 会**自动安装**。也可以在任务详情页面中单独安装。
 

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -43,6 +43,40 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toContain("/api/hooks/status");
     });
 
+    it("should generate plugin with all event handlers for status tracking", async () => {
+      // Given
+      const repoPath = tempDir;
+
+      // When
+      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+
+      // Then
+      const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
+      const pluginContent = await readFile(pluginPath, "utf-8");
+
+      expect(pluginContent).toContain('"message.updated"');
+      expect(pluginContent).toContain('"question.asked"');
+      expect(pluginContent).toContain('"question.replied"');
+      expect(pluginContent).toContain('"session.idle"');
+    });
+
+    it("should map event types to correct statuses", async () => {
+      // Given
+      const repoPath = tempDir;
+
+      // When
+      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+
+      // Then
+      const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
+      const pluginContent = await readFile(pluginPath, "utf-8");
+
+      expect(pluginContent).toMatch(/message\.updated[\s\S]*?role[\s\S]*?user[\s\S]*?progress/);
+      expect(pluginContent).toMatch(/question\.asked[\s\S]*?pending/);
+      expect(pluginContent).toMatch(/question\.replied[\s\S]*?progress/);
+      expect(pluginContent).toMatch(/session\.idle[\s\S]*?review/);
+    });
+
     it("should not fail when called twice (overwrites existing plugin)", async () => {
       // Given
       const repoPath = tempDir;


### PR DESCRIPTION
## 어떤 작업인가요?
- OpenCode 플러그인이 존재하지 않는 `chat.message` hook을 사용하여 PROGRESS 상태가 전송되지 않던 버그를 수정

## 어떻게 해결했나요?
**잘못된 hook을 유효한 OpenCode 이벤트로 교체**
- OpenCode 공식 플러그인 API에 `chat.message` hook이 존재하지 않아 PROGRESS 상태가 전혀 전송되지 않는 문제 발견
- `message.updated` 이벤트에서 `role === "user"` 체크로 변경하여 사용자 메시지 전송 시 PROGRESS 전송

**question 이벤트 핸들러 추가**
- `question.asked` → PENDING: AI가 사용자에게 질문할 때
- `question.replied` → PROGRESS: 사용자가 질문에 답변한 후

## 중요한 변경 사항은 무엇인가요?
### OpenCode 플러그인 이벤트 수정

**chat.message → message.updated 교체**
- **변경 이유**: `chat.message`는 OpenCode 플러그인 시스템에 존재하지 않는 hook으로, PROGRESS 상태가 전송되지 않았음
- **수정 파일**: `src/lib/openCodeHooksSetup.ts`, `.opencode/plugins/kanvibe-plugin.ts`

**question.asked/question.replied 이벤트 추가**
- **변경 이유**: Claude Code의 PENDING 상태 추적(PreToolUse/PostToolUse)에 대응하는 OpenCode 이벤트 추가
- **수정 파일**: `src/lib/openCodeHooksSetup.ts`

**이벤트-상태 매핑 테스트 추가**
- **변경 이유**: 생성된 플러그인에 모든 이벤트 핸들러가 올바르게 포함되는지 검증
- **수정 파일**: `src/lib/__tests__/openCodeHooksSetup.test.ts`

**README 문서 업데이트 (en, ko, zh)**
- **변경 이유**: OpenCode 이벤트 흐름 설명을 실제 구현과 일치하도록 수정
- **수정 파일**: `README.md`, `docs/README.ko.md`, `docs/README.zh.md`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
