### PR TITLE
docs: add English-only git convention rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,14 @@ next-intl 기반. 지원 언어: 한국어(ko), 영어(en), 중국어(zh). 기�
 2. `messages/en.json`, `messages/zh.json`에 동일 키로 번역 추가
 3. 컴포넌트에서 `t("key")` 또는 `t("namespace.key")`로 사용
 
+## Git Convention
+
+All git-related text must be written in **English**:
+- Commit messages
+- PR titles and descriptions
+- Issue titles and descriptions
+- Branch names
+
 ## 문서 업데이트 규칙
 
 사용자 대면 동작에 영향을 주는 변경 시 아래 문서를 함께 업데이트한다. 세 언어 버전은 항상 동시에 수정한다.


### PR DESCRIPTION
## 어떤 작업인가요?
- CLAUDE.md에 Git Convention 섹션을 추가하여 커밋 메시지, PR, 이슈, 브랜치명을 영어로 작성하도록 규칙을 명시

## 어떻게 해결했나요?
**Git Convention 규칙 추가**
- CLAUDE.md의 문서 업데이트 규칙 섹션 앞에 Git Convention 섹션 추가
- Commit messages, PR titles/descriptions, Issue titles/descriptions, Branch names를 영어로 작성하는 규칙 명시

## 중요한 변경 사항은 무엇인가요?
### Git Convention 섹션 추가

**영어 작성 규칙 명시**
- **변경 이유**: git 관련 텍스트(커밋, PR, 이슈, 브랜치명)를 영어로 통일하기 위한 규칙 필요
- **수정 파일**: `CLAUDE.md`
