### PR TITLE
fix(hooks): Claude Code hook 명령어를 절대 경로 기반으로 변경

### DIFF
--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -147,7 +147,7 @@ export async function setupClaudeHooks(
       hooks: [
         {
           type: "command",
-          command: ".claude/hooks/kanvibe-prompt-hook.sh",
+          command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh',
           timeout: 10,
         },
       ],
@@ -163,7 +163,7 @@ export async function setupClaudeHooks(
       hooks: [
         {
           type: "command",
-          command: ".claude/hooks/kanvibe-question-hook.sh",
+          command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-question-hook.sh',
           timeout: 10,
         },
       ],
@@ -179,7 +179,7 @@ export async function setupClaudeHooks(
       hooks: [
         {
           type: "command",
-          command: ".claude/hooks/kanvibe-prompt-hook.sh",
+          command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh',
           timeout: 10,
         },
       ],
@@ -194,7 +194,7 @@ export async function setupClaudeHooks(
       hooks: [
         {
           type: "command",
-          command: ".claude/hooks/kanvibe-stop-hook.sh",
+          command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-stop-hook.sh',
           timeout: 10,
         },
       ],


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- Claude Code hook 설정 시 상대 경로 대신 `$CLAUDE_PROJECT_DIR` 환경변수 기반 절대 경로를 사용하도록 변경

## 어떻게 해결했나요?
**hook command 경로를 절대 경로로 변경**
- `setupClaudeHooks` 함수에서 생성하는 4개의 hook command 경로를 `$CLAUDE_PROJECT_DIR` 기반으로 수정
- worktree 등 작업 디렉토리가 프로젝트 루트와 다른 환경에서도 hook이 안정적으로 실행되도록 개선

## 중요한 변경 사항은 무엇인가요?
### Claude Code hook 경로 변경

**상대 경로 → 절대 경로**
- **변경 이유**: 상대 경로(`.claude/hooks/...`)는 working directory에 따라 해석이 달라질 수 있음. Claude Code 공식 문서에서 `$CLAUDE_PROJECT_DIR` 사용을 권장
- **수정 파일**: `src/lib/claudeHooksSetup.ts`

| hook 이벤트 | 변경 전 | 변경 후 |
|------------|---------|---------|
| UserPromptSubmit | `.claude/hooks/kanvibe-prompt-hook.sh` | `"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh` |
| PreToolUse | `.claude/hooks/kanvibe-question-hook.sh` | `"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-question-hook.sh` |
| PostToolUse | `.claude/hooks/kanvibe-prompt-hook.sh` | `"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh` |
| Stop | `.claude/hooks/kanvibe-stop-hook.sh` | `"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-stop-hook.sh` |

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
