### PR TITLE
modify(auth): 쿠키 secure 플래그를 실제 요청 프로토콜 기반으로 변경

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { createHmac, randomUUID, timingSafeEqual } from "crypto";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 
 const SESSION_COOKIE = "kanvibe_session";
 
@@ -50,15 +50,23 @@ export function validateCredentials(
   );
 }
 
+/** 요청 프로토콜이 HTTPS인지 확인한다 (리버스 프록시 헤더도 고려) */
+async function isSecureRequest(): Promise<boolean> {
+  const headerStore = await headers();
+  const proto = headerStore.get("x-forwarded-proto");
+  return proto === "https";
+}
+
 /** 새 세션 토큰을 생성하고 서명된 쿠키에 설정한다 */
 export async function createSession(): Promise<string> {
   const token = randomUUID();
   const signed = signToken(token);
 
+  const useSecure = await isSecureRequest();
   const cookieStore = await cookies();
   cookieStore.set(SESSION_COOKIE, signed, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    secure: useSecure,
     sameSite: "lax",
     path: "/",
     maxAge: 60 * 60 * 24 * 7,


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- 쿠키의 `secure` 플래그를 `NODE_ENV` 환경변수 기반에서 실제 요청 프로토콜 기반으로 변경하여, 리버스 프록시 환경에서도 올바르게 동작하도록 개선

## 어떻게 해결했나요?
**쿠키 secure 플래그 결정 로직 변경**
- 기존: `process.env.NODE_ENV === "production"`으로 판단
- 변경: `x-forwarded-proto` 헤더를 확인하여 실제 HTTPS 요청 여부로 판단

## 중요한 변경 사항은 무엇인가요?
### 쿠키 secure 플래그 로직 변경

**`isSecureRequest()` 함수 추가**
- **변경 이유**: 리버스 프록시(Nginx, Cloudflare 등) 뒤에서 실행될 때 `NODE_ENV`만으로는 실제 HTTPS 여부를 판단할 수 없음
- **수정 파일**: `src/lib/auth.ts`

**`createSession()`에서 동적 secure 플래그 적용**
- **변경 이유**: `isSecureRequest()` 결과에 따라 쿠키 secure 속성을 동적으로 설정
- **수정 파일**: `src/lib/auth.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
