### PR TITLE
fix: skip subagent sessions in generated OpenCode hooks

### DIFF
--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -77,6 +77,25 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toMatch(/session\.idle[\s\S]*?review/);
     });
 
+    it("should filter subagent sessions before updating statuses", async () => {
+      // Given
+      const repoPath = tempDir;
+
+      // When
+      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+
+      // Then
+      const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
+      const pluginContent = await readFile(pluginPath, "utf-8");
+
+      expect(pluginContent).toContain("client.session.get");
+      expect(pluginContent).toContain("result.data.parentID");
+      expect(pluginContent).toContain("properties?.info ?? (event as any).properties?.message");
+      expect(pluginContent).toMatch(/question\.asked[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
+      expect(pluginContent).toMatch(/question\.replied[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
+      expect(pluginContent).toMatch(/session\.idle[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
+    });
+
     it("should not fail when called twice (overwrites existing plugin)", async () => {
       // Given
       const repoPath = tempDir;

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -88,9 +88,13 @@ describe("openCodeHooksSetup", () => {
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
       const pluginContent = await readFile(pluginPath, "utf-8");
 
+      expect(pluginContent).toContain("const sessionCache = new Map<string, boolean>()");
       expect(pluginContent).toContain("client.session.get");
-      expect(pluginContent).toContain("result.data.parentID");
+      expect(pluginContent).toContain("sessionCache.has(sessionID)");
+      expect(pluginContent).toContain("sessionCache.set(sessionID, isMain)");
+      expect(pluginContent).toContain("result.data?.parentID");
       expect(pluginContent).toContain("properties?.info ?? (event as any).properties?.message");
+      expect(pluginContent).toMatch(/message\.updated[\s\S]*?isMainSession\(message\.sessionID\)/);
       expect(pluginContent).toMatch(/question\.asked[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
       expect(pluginContent).toMatch(/question\.replied[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
       expect(pluginContent).toMatch(/session\.idle[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -19,7 +19,7 @@ function generatePluginScript(kanvibeUrl: string, projectName: string): string {
  * message.updated(user) → progress, question.asked → pending,
  * question.replied → progress, session.idle → review 상태 변경
  */
-export const KanvibePlugin: Plugin = async ({ $ }) => {
+export const KanvibePlugin: Plugin = async ({ $, client }) => {
   const KANVIBE_URL = "${kanvibeUrl}";
   const PROJECT_NAME = "${projectName}";
 
@@ -49,21 +49,51 @@ export const KanvibePlugin: Plugin = async ({ $ }) => {
     }
   }
 
+  async function isMainSession(sessionID: string | undefined): Promise<boolean> {
+    if (!sessionID) return false;
+
+    try {
+      const result = await client.session.get({
+        path: { id: sessionID },
+      });
+
+      if (result.error) return false;
+
+      return !result.data.parentID;
+    } catch {
+      return false;
+    }
+  }
+
   return {
     event: async ({ event }) => {
       if (event.type === "message.updated") {
-        const message = (event as any).properties?.message;
-        if (message?.role === "user") {
+        const message =
+          (event as any).properties?.info ?? (event as any).properties?.message;
+
+        if (message?.role === "user" && (await isMainSession(message.sessionID))) {
           await updateStatus("progress");
         }
       }
       if (event.type === "question.asked") {
+        if (!(await isMainSession(event.properties.sessionID))) {
+          return;
+        }
+
         await updateStatus("pending");
       }
       if (event.type === "question.replied") {
+        if (!(await isMainSession(event.properties.sessionID))) {
+          return;
+        }
+
         await updateStatus("progress");
       }
       if (event.type === "session.idle") {
+        if (!(await isMainSession(event.properties.sessionID))) {
+          return;
+        }
+
         await updateStatus("review");
       }
     },

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -49,8 +49,11 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
     }
   }
 
+  const sessionCache = new Map<string, boolean>();
+
   async function isMainSession(sessionID: string | undefined): Promise<boolean> {
     if (!sessionID) return false;
+    if (sessionCache.has(sessionID)) return sessionCache.get(sessionID)!;
 
     try {
       const result = await client.session.get({
@@ -59,7 +62,10 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
 
       if (result.error) return false;
 
-      return !result.data.parentID;
+      const isMain = !result.data?.parentID;
+      sessionCache.set(sessionID, isMain);
+
+      return isMain;
     } catch {
       return false;
     }


### PR DESCRIPTION
## Summary
- skip status updates for generated OpenCode hook events when the session is a subagent
- use `client.session.get()` and the current `message.updated` payload shape in the generated plugin
- add coverage for subagent filtering in `src/lib/__tests__/openCodeHooksSetup.test.ts`

## Testing
- `NODE_ENV=test pnpm test src/lib/__tests__/openCodeHooksSetup.test.ts`
- `pnpm check`