### PR TITLE
Fix OpenCode review transitions and notification filtering

### DIFF
--- a/src/components/NotificationListener.tsx
+++ b/src/components/NotificationListener.tsx
@@ -76,8 +76,9 @@ export default function NotificationListener({
           }
 
           if (data.type === "hook-status-target-missing") {
-            const { isNotificationEnabled: isEnabled } = settingsRef.current;
+            const { isNotificationEnabled: isEnabled, enabledStatuses: statuses } = settingsRef.current;
             if (!isEnabled) return;
+            if (!statuses.includes(data.requestedStatus)) return;
 
             const { projectName, branchName, requestedStatus, reason } = data;
             notifyHookStatusTargetMissing({

--- a/src/components/__tests__/NotificationListener.test.tsx
+++ b/src/components/__tests__/NotificationListener.test.tsx
@@ -222,7 +222,7 @@ describe("NotificationListener", () => {
     expect(mockNotifyTaskStatusChanged).not.toHaveBeenCalled();
   });
 
-  it("should notify missing target even when requestedStatus is not in enabledStatuses", async () => {
+  it("should not notify missing target when requestedStatus is not in enabledStatuses", async () => {
     // Given
     const { default: NotificationListener } = await import("@/components/NotificationListener");
     render(
@@ -244,13 +244,7 @@ describe("NotificationListener", () => {
     });
 
     // Then
-    expect(mockNotifyHookStatusTargetMissing).toHaveBeenCalledWith({
-      projectName: "case-study",
-      branchName: "feat/test",
-      requestedStatus: "pending",
-      reason: "project-not-found",
-      locale: "ko",
-    });
+    expect(mockNotifyHookStatusTargetMissing).not.toHaveBeenCalled();
   });
 
   it("should render nothing", async () => {

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -72,6 +72,7 @@ describe("openCodeHooksSetup", () => {
       const pluginContent = await readFile(pluginPath, "utf-8");
 
       expect(pluginContent).toMatch(/message\.updated[\s\S]*?role[\s\S]*?user[\s\S]*?progress/);
+      expect(pluginContent).toMatch(/message\.updated[\s\S]*?isAssistantMessageCompleted\(message\)[\s\S]*?review/);
       expect(pluginContent).toMatch(/question\.asked[\s\S]*?pending/);
       expect(pluginContent).toMatch(/question\.replied[\s\S]*?progress/);
       expect(pluginContent).toMatch(/session\.idle[\s\S]*?review/);
@@ -93,11 +94,36 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toContain("sessionCache.has(sessionID)");
       expect(pluginContent).toContain("sessionCache.set(sessionID, isMain)");
       expect(pluginContent).toContain("result.data?.parentID");
-      expect(pluginContent).toContain("properties?.info ?? (event as any).properties?.message");
-      expect(pluginContent).toMatch(/message\.updated[\s\S]*?isMainSession\(message\.sessionID\)/);
-      expect(pluginContent).toMatch(/question\.asked[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
-      expect(pluginContent).toMatch(/question\.replied[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
-      expect(pluginContent).toMatch(/session\.idle[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
+      expect(pluginContent).toContain("type OpenCodeEvent = {");
+      expect(pluginContent).toContain("type OpenCodeMessage = {");
+      expect(pluginContent).toContain("function getSessionID(event: OpenCodeEvent): string | undefined");
+      expect(pluginContent).toContain("function getMessage(event: OpenCodeEvent): OpenCodeMessage | undefined");
+      expect(pluginContent).toContain("event?.properties?.sessionId ??");
+      expect(pluginContent).toContain("event?.properties?.info?.sessionId");
+      expect(pluginContent).toContain("event?.properties?.info ?? event?.properties?.message");
+      expect(pluginContent).toContain("const eventPayload = event as OpenCodeEvent");
+      expect(pluginContent).toContain("const sessionID = getSessionID(eventPayload)");
+      expect(pluginContent).toContain("const message = getMessage(eventPayload)");
+      expect(pluginContent).toMatch(/if \(!\(await isMainSession\(sessionID\)\)\) \{/);
+    });
+
+    it("should generate assistant completion detection for review status", async () => {
+      // Given
+      const repoPath = tempDir;
+
+      // When
+      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+
+      // Then
+      const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
+      const pluginContent = await readFile(pluginPath, "utf-8");
+
+      expect(pluginContent).toContain("function isAssistantMessageCompleted(message: OpenCodeMessage | undefined): boolean");
+      expect(pluginContent).toContain('message?.stopReason ??');
+      expect(pluginContent).toContain('message?.stop_reason ??');
+      expect(pluginContent).toContain('message?.completedAt ??');
+      expect(pluginContent).toContain('message?.status === \"completed\"');
+      expect(pluginContent).toContain("if (isAssistantMessageCompleted(message)) {");
     });
 
     it("should not fail when called twice (overwrites existing plugin)", async () => {

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -4,7 +4,8 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 
 /**
  * OpenCode는 `.opencode/plugins/` 디렉토리에 TypeScript 플러그인을 배치하여 hooks를 등록한다.
- * message.updated(user) → progress, question.asked → pending, question.replied → progress, session.idle → review 상태를 전송한다.
+ * message.updated(user) → progress, question.asked → pending, question.replied → progress,
+ * assistant 완료 message.updated 또는 session.idle → review 상태를 전송한다.
  */
 
 const PLUGIN_FILE_NAME = "kanvibe-plugin.ts";
@@ -17,11 +18,65 @@ function generatePluginScript(kanvibeUrl: string, projectName: string): string {
 /**
  * KanVibe OpenCode Plugin
  * message.updated(user) → progress, question.asked → pending,
- * question.replied → progress, session.idle → review 상태 변경
+ * question.replied → progress, assistant 완료 message.updated 또는 session.idle → review 상태 변경
  */
 export const KanvibePlugin: Plugin = async ({ $, client }) => {
   const KANVIBE_URL = "${kanvibeUrl}";
   const PROJECT_NAME = "${projectName}";
+
+  type OpenCodeMessage = {
+    role?: string;
+    sessionID?: string;
+    sessionId?: string;
+    stopReason?: string | null;
+    stop_reason?: string | null;
+    completedAt?: string | number | null;
+    completed?: boolean;
+    isComplete?: boolean;
+    isCompleted?: boolean;
+    status?: string;
+  };
+
+  type OpenCodeEvent = {
+    type?: string;
+    properties?: {
+      sessionID?: string;
+      sessionId?: string;
+      message?: OpenCodeMessage;
+      info?: OpenCodeMessage;
+    };
+  };
+
+  function getSessionID(event: OpenCodeEvent): string | undefined {
+    return (
+      event?.properties?.sessionID ??
+      event?.properties?.sessionId ??
+      event?.properties?.message?.sessionID ??
+      event?.properties?.message?.sessionId ??
+      event?.properties?.info?.sessionID ??
+      event?.properties?.info?.sessionId
+    );
+  }
+
+  function getMessage(event: OpenCodeEvent): OpenCodeMessage | undefined {
+    return event?.properties?.info ?? event?.properties?.message;
+  }
+
+  function isAssistantMessageCompleted(message: OpenCodeMessage | undefined): boolean {
+    if (message?.role !== "assistant") {
+      return false;
+    }
+
+    return Boolean(
+      message?.stopReason ??
+        message?.stop_reason ??
+        message?.completedAt ??
+        message?.completed ??
+        message?.isComplete ??
+        message?.isCompleted ??
+        message?.status === "completed"
+    );
+  }
 
   async function getBranchName(): Promise<string | null> {
     try {
@@ -73,33 +128,38 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
 
   return {
     event: async ({ event }) => {
-      if (event.type === "message.updated") {
-        const message =
-          (event as any).properties?.info ?? (event as any).properties?.message;
+      const eventPayload = event as OpenCodeEvent;
+      const eventType = eventPayload.type;
+      const sessionID = getSessionID(eventPayload);
+      const message = getMessage(eventPayload);
 
-        if (message?.role === "user" && (await isMainSession(message.sessionID))) {
+      if (!(await isMainSession(sessionID))) {
+        return;
+      }
+
+      if (eventType === "message.updated") {
+        if (message?.role === "user") {
           await updateStatus("progress");
-        }
-      }
-      if (event.type === "question.asked") {
-        if (!(await isMainSession(event.properties.sessionID))) {
           return;
         }
 
+        if (isAssistantMessageCompleted(message)) {
+          await updateStatus("review");
+        }
+        return;
+      }
+
+      if (eventType === "question.asked") {
         await updateStatus("pending");
+        return;
       }
-      if (event.type === "question.replied") {
-        if (!(await isMainSession(event.properties.sessionID))) {
-          return;
-        }
 
+      if (eventType === "question.replied") {
         await updateStatus("progress");
+        return;
       }
-      if (event.type === "session.idle") {
-        if (!(await isMainSession(event.properties.sessionID))) {
-          return;
-        }
 
+      if (eventType === "session.idle") {
         await updateStatus("review");
       }
     },


### PR DESCRIPTION
## Related References
- None

## What is this PR?
- Fix two hook-notification edge cases before merging back into `dev`.

## How was it solved?
**Filter missing-target notifications by enabled status**
- Reuse `enabledStatuses` when handling `hook-status-target-missing` events.
- Update the listener test so disabled statuses stay silent.

**Move OpenCode sessions to review on assistant completion**
- Detect completed assistant `message.updated` payloads and map them to `review`.
- Normalize session and message extraction across event payload variants while keeping main-session filtering intact.
- Extend the generated plugin tests to cover the new completion detection logic.

## Important Changes
### Notification filtering

**Skip disabled missing-target alerts**
- **Why**: prevent notifications for statuses the user explicitly turned off.
- **Modified files**: `src/components/NotificationListener.tsx`, `src/components/__tests__/NotificationListener.test.tsx`

### OpenCode review transitions

**Treat completed assistant updates as review-ready**
- **Why**: move tasks into `review` as soon as the assistant finishes, without waiting for `session.idle`.
- **Modified files**: `src/lib/openCodeHooksSetup.ts`, `src/lib/__tests__/openCodeHooksSetup.test.ts`

**Support alternate OpenCode payload shapes**
- **Why**: handle both `sessionID`/`sessionId` and `info`/`message` payloads consistently during main-session checks.
- **Modified files**: `src/lib/openCodeHooksSetup.ts`, `src/lib/__tests__/openCodeHooksSetup.test.ts`