### PR TITLE
feat(ai-sessions): add session and message search filters

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -249,6 +249,12 @@
       "sessionsError": "Failed to load session list.",
       "showMore": "Show more",
       "showLess": "Show less",
+      "searchPlaceholder": "Search sessions...",
+      "messageSearchPlaceholder": "Search messages...",
+      "filterAll": "All",
+      "filterUser": "User",
+      "filterAssistant": "AI",
+      "noMessageMatch": "No messages match your search criteria.",
       "messages": "{count} messages",
       "providers": {
         "all": "All",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -249,6 +249,12 @@
       "sessionsError": "세션 목록을 불러오지 못했습니다.",
       "showMore": "전체 보기",
       "showLess": "접기",
+      "searchPlaceholder": "세션 검색...",
+      "messageSearchPlaceholder": "메시지 검색...",
+      "filterAll": "전체",
+      "filterUser": "사용자",
+      "filterAssistant": "AI",
+      "noMessageMatch": "검색 조건과 일치하는 메시지가 없습니다.",
       "messages": "메시지 {count}개",
       "providers": {
         "all": "전체",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -249,6 +249,12 @@
       "sessionsError": "加载会话列表失败。",
       "showMore": "查看全文",
       "showLess": "收起",
+      "searchPlaceholder": "搜索会话...",
+      "messageSearchPlaceholder": "搜索消息...",
+      "filterAll": "全部",
+      "filterUser": "用户",
+      "filterAssistant": "AI",
+      "noMessageMatch": "没有符合搜索条件的消息。",
       "messages": "{count} 条消息",
       "providers": {
         "all": "全部",

--- a/src/app/actions/project.ts
+++ b/src/app/actions/project.ts
@@ -12,7 +12,7 @@ import { setupGeminiHooks, getGeminiHooksStatus, type GeminiHooksStatus } from "
 import { setupCodexHooks, getCodexHooksStatus, type CodexHooksStatus } from "@/lib/codexHooksSetup";
 import { setupOpenCodeHooks, getOpenCodeHooksStatus, type OpenCodeHooksStatus } from "@/lib/openCodeHooksSetup";
 import { aggregateAiSessions, getAiSessionDetail } from "@/lib/aiSessions/aggregateAiSessions";
-import type { AggregatedAiSessionDetail, AggregatedAiSessionsResult, AiSessionProvider } from "@/lib/aiSessions/types";
+import type { AggregatedAiSessionDetail, AggregatedAiSessionsResult, AiMessageRole, AiSessionProvider } from "@/lib/aiSessions/types";
 import { homedir } from "os";
 import path from "path";
 import { computeProjectColor } from "@/lib/projectColor";
@@ -622,7 +622,11 @@ export async function getTaskOpenCodeHooksStatus(
 }
 
 /** 태스크와 연결된 로컬 AI 세션들을 집계한다 */
-export async function getTaskAiSessions(taskId: string, includeRepoSessions = false): Promise<AggregatedAiSessionsResult> {
+export async function getTaskAiSessions(
+  taskId: string,
+  includeRepoSessions = false,
+  query?: string
+): Promise<AggregatedAiSessionsResult> {
   const taskRepo = await getTaskRepository();
   const task = await taskRepo.findOne({
     where: { id: taskId },
@@ -654,6 +658,7 @@ export async function getTaskAiSessions(taskId: string, includeRepoSessions = fa
     worktreePath: targetPath,
     repoPath: task.project.repoPath,
     includeRepoSessions,
+    query,
   });
 }
 
@@ -664,7 +669,9 @@ export async function getTaskAiSessionDetail(
   sourceRef?: string | null,
   cursor?: string | null,
   limit = 20,
-  includeRepoSessions = false
+  includeRepoSessions = false,
+  query?: string,
+  roles?: AiMessageRole[]
 ): Promise<AggregatedAiSessionDetail | null> {
   const taskRepo = await getTaskRepository();
   const task = await taskRepo.findOne({
@@ -682,6 +689,8 @@ export async function getTaskAiSessionDetail(
       worktreePath: targetPath,
       repoPath: task.project.repoPath,
       includeRepoSessions,
+      query,
+      roles,
     },
     provider,
     sessionId,

--- a/src/components/AiSessionsDialog.tsx
+++ b/src/components/AiSessionsDialog.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import * as Switch from "@radix-ui/react-switch";
 import { useTranslations } from "next-intl";
 import { getTaskAiSessionDetail, getTaskAiSessions } from "@/app/actions/project";
+import { fuzzyMatch } from "@/utils/fuzzySearch";
 import type {
   AggregatedAiMessage,
   AggregatedAiSession,
@@ -11,6 +12,7 @@ import type {
   AggregatedAiSessionsResult,
   AiSessionProvider,
   AiSessionSourceStatus,
+  AiMessageRole,
 } from "@/lib/aiSessions/types";
 
 interface AiSessionsDialogProps {
@@ -28,6 +30,9 @@ export default function AiSessionsDialog({ taskId, isOpen, onClose, data }: AiSe
   const t = useTranslations("taskDetail");
   const [includeRepoSessions, setIncludeRepoSessions] = useState(false);
   const [selectedProviders, setSelectedProviders] = useState<AiSessionProvider[]>(PROVIDERS);
+  const [sessionSearchQuery, setSessionSearchQuery] = useState("");
+  const [messageSearchQuery, setMessageSearchQuery] = useState("");
+  const [selectedRoles, setSelectedRoles] = useState<AiMessageRole[]>(["user", "assistant"]);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [sessionsData, setSessionsData] = useState<AggregatedAiSessionsResult>(data);
   const [isSessionsLoading, setIsSessionsLoading] = useState(false);
@@ -42,21 +47,18 @@ export default function AiSessionsDialog({ taskId, isOpen, onClose, data }: AiSe
     setSessionsData(data);
   }, [data]);
 
+  // 세션 목록 로드 (검색어 포함)
   useEffect(() => {
     if (!isOpen) {
       setIncludeRepoSessions(false);
       setSelectedProviders(PROVIDERS);
+      setSessionSearchQuery("");
+      setMessageSearchQuery("");
+      setSelectedRoles(["user", "assistant"]);
       setSessionsData(data);
       setSessionsError(null);
       setIsSessionsLoading(false);
       setIsDetailLoading(false);
-      return;
-    }
-
-    if (!includeRepoSessions) {
-      setSessionsData(data);
-      setSessionsError(null);
-      setIsSessionsLoading(false);
       return;
     }
 
@@ -67,7 +69,7 @@ export default function AiSessionsDialog({ taskId, isOpen, onClose, data }: AiSe
       setSessionsError(null);
 
       try {
-        const result = await getTaskAiSessions(taskId, true);
+        const result = await getTaskAiSessions(taskId, includeRepoSessions, sessionSearchQuery);
         if (!cancelled) {
           setSessionsData(result);
         }
@@ -82,12 +84,50 @@ export default function AiSessionsDialog({ taskId, isOpen, onClose, data }: AiSe
       }
     }
 
-    void loadSessions();
+    const timer = setTimeout(() => {
+      void loadSessions();
+    }, 300); // 디바운스 적용
 
     return () => {
       cancelled = true;
+      clearTimeout(timer);
     };
-  }, [data, includeRepoSessions, isOpen, t, taskId]);
+  }, [includeRepoSessions, isOpen, t, taskId, sessionSearchQuery, data]);
+
+  // 상세 로드 (검색어 및 역할 필터 포함)
+  useEffect(() => {
+    if (!isOpen || !selectedSessionId) return;
+
+    const selectedSession = sessionsData.sessions.find((s) => s.id === selectedSessionId);
+    if (!selectedSession) return;
+
+    let cancelled = false;
+
+    async function reloadDetail() {
+      await loadSessionDetail({
+        taskId,
+        includeRepoSessions,
+        session: selectedSession!,
+        latestDetailRequestId,
+        setSelectedSessionId,
+        setDetail,
+        setIsDetailLoading,
+        setDetailError,
+        errorMessage: t("aiSessions.detailError"),
+        query: messageSearchQuery,
+        roles: selectedRoles,
+      });
+    }
+
+    const timer = setTimeout(() => {
+      void reloadDetail();
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [messageSearchQuery, selectedRoles, selectedSessionId, taskId, includeRepoSessions, isOpen, t]);
 
   const providerCounts = useMemo(() => buildProviderCounts(sessionsData.sources), [sessionsData.sources]);
 
@@ -96,17 +136,14 @@ export default function AiSessionsDialog({ taskId, isOpen, onClose, data }: AiSe
     return sessionsData.sessions.filter((session) => selectedProviders.includes(session.provider));
   }, [selectedProviders, sessionsData.sessions]);
 
-  const activeSessionId = filteredSessions.some((session) => session.id === selectedSessionId)
-    ? selectedSessionId
-    : null;
-  const selectedSession = filteredSessions.find((session) => session.id === activeSessionId) ?? null;
+  const selectedSession = filteredSessions.find((session) => session.id === selectedSessionId) ?? null;
 
   useEffect(() => {
-    if (!isOpen || !selectedSession) {
+    if (!isOpen || !selectedSessionId) {
       setDetail(null);
       setDetailError(null);
     }
-  }, [isOpen, selectedSession]);
+  }, [isOpen, selectedSessionId]);
 
   if (!isOpen) return null;
 
@@ -125,12 +162,52 @@ export default function AiSessionsDialog({ taskId, isOpen, onClose, data }: AiSe
 
         <div className="space-y-4 px-6 py-5">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <ProviderMultiSelectFilter
-              selectedProviders={selectedProviders}
-              onChange={setSelectedProviders}
-              providerCounts={providerCounts}
-            />
-            <CompactScopeToggle checked={includeRepoSessions} onChange={setIncludeRepoSessions} />
+            <div className="flex flex-1 flex-col gap-3 sm:flex-row sm:items-center">
+              <ProviderMultiSelectFilter
+                selectedProviders={selectedProviders}
+                onChange={setSelectedProviders}
+                providerCounts={providerCounts}
+              />
+              <div className="relative min-w-0 flex-1 sm:max-w-[280px]">
+                <input
+                  type="text"
+                  value={sessionSearchQuery}
+                  onChange={(e) => setSessionSearchQuery(e.target.value)}
+                  placeholder={t("aiSessions.searchPlaceholder")}
+                  className="w-full rounded-md border border-border-default bg-bg-page px-3 py-2 pl-9 text-sm text-text-primary focus:border-brand-primary focus:outline-none"
+                />
+                <svg className="absolute left-3 top-2.5 text-text-muted" width="16" height="16" viewBox="0 0 16 16" fill="none">
+                  <path d="M14.5 14.5L11 11M12.5 7C12.5 10.0376 10.0376 12.5 7 12.5C3.96243 12.5 1.5 10.0376 1.5 7C1.5 3.96243 3.96243 1.5 7 1.5C10.0376 1.5 12.5 3.96243 12.5 7Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="flex shrink-0 items-center gap-1 rounded-md border border-border-default bg-bg-page p-1">
+                <button
+                  onClick={() => {
+                    const role = "user";
+                    setSelectedRoles(selectedRoles.includes(role) ? selectedRoles.filter((r) => r !== role) : [...selectedRoles, role]);
+                  }}
+                  className={`rounded px-2 py-1 text-[10px] font-medium transition-colors ${
+                    selectedRoles.includes("user") ? "bg-brand-primary text-text-inverse" : "text-text-muted hover:bg-bg-surface"
+                  }`}
+                >
+                  {t("aiSessions.filterUser")}
+                </button>
+                <button
+                  onClick={() => {
+                    const role = "assistant";
+                    setSelectedRoles(selectedRoles.includes(role) ? selectedRoles.filter((r) => r !== role) : [...selectedRoles, role]);
+                  }}
+                  className={`rounded px-2 py-1 text-[10px] font-medium transition-colors ${
+                    selectedRoles.includes("assistant") ? "bg-brand-primary text-text-inverse" : "text-text-muted hover:bg-bg-surface"
+                  }`}
+                >
+                  {t("aiSessions.filterAssistant")}
+                </button>
+              </div>
+              <CompactScopeToggle checked={includeRepoSessions} onChange={setIncludeRepoSessions} />
+            </div>
           </div>
 
           {sessionsData.isRemote ? (
@@ -139,34 +216,52 @@ export default function AiSessionsDialog({ taskId, isOpen, onClose, data }: AiSe
             <EmptyState text={t("aiSessions.loadingSessions")} />
           ) : sessionsError ? (
             <EmptyState text={sessionsError} />
-          ) : filteredSessions.length === 0 ? (
+          ) : filteredSessions.length === 0 && !sessionSearchQuery ? (
             <EmptyState text={t("aiSessions.empty")} />
           ) : (
             <div className="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
-              <SessionList
-                sessions={filteredSessions}
-                selectedSessionId={selectedSession?.id ?? null}
-                onSelect={(session) => {
-                  void loadSessionDetail({
-                    taskId,
-                    includeRepoSessions,
-                    session,
-                    latestDetailRequestId,
-                    setSelectedSessionId,
-                    setDetail,
-                    setIsDetailLoading,
-                    setDetailError,
-                    errorMessage: t("aiSessions.detailError"),
-                  });
-                }}
-              />
+              <div className="flex flex-col gap-2 overflow-hidden">
+                <SessionList
+                  sessions={filteredSessions}
+                  selectedSessionId={selectedSession?.id ?? null}
+                  onSelect={(session) => {
+                    void loadSessionDetail({
+                      taskId,
+                      includeRepoSessions,
+                      session,
+                      latestDetailRequestId,
+                      setSelectedSessionId,
+                      setDetail,
+                      setIsDetailLoading,
+                      setDetailError,
+                      errorMessage: t("aiSessions.detailError"),
+                    });
+                  }}
+                />
+              </div>
               <SessionPreview
                 session={selectedSession}
                 detail={detail}
+                messages={detail?.messages ?? []}
                 isLoading={isDetailLoading}
                 isLoadingMore={isLoadingMore}
                 error={detailError}
-                onLoadMore={() => handleLoadMore(taskId, detail, includeRepoSessions, setDetail, setIsLoadingMore, setDetailError, t)}
+                searchQuery={messageSearchQuery}
+                setSearchQuery={setMessageSearchQuery}
+                selectedRoles={selectedRoles}
+                onLoadMore={() =>
+                  handleLoadMore(
+                    taskId,
+                    detail,
+                    includeRepoSessions,
+                    setDetail,
+                    setIsLoadingMore,
+                    setDetailError,
+                    t,
+                    messageSearchQuery,
+                    selectedRoles
+                  )
+                }
               />
             </div>
           )}
@@ -183,7 +278,9 @@ async function handleLoadMore(
   setDetail: (value: AggregatedAiSessionDetail | ((current: AggregatedAiSessionDetail | null) => AggregatedAiSessionDetail | null) | null) => void,
   setIsLoadingMore: (value: boolean) => void,
   setDetailError: (value: string | null) => void,
-  t: ReturnType<typeof useTranslations>
+  t: ReturnType<typeof useTranslations>,
+  query?: string,
+  roles?: AiMessageRole[]
 ): Promise<void> {
   if (!detail?.nextCursor) return;
 
@@ -198,7 +295,9 @@ async function handleLoadMore(
       detail.sourceRef ?? null,
       detail.nextCursor,
       DETAIL_PAGE_SIZE,
-      includeRepoSessions
+      includeRepoSessions,
+      query,
+      roles
     );
     if (!nextPage) return;
 
@@ -227,6 +326,8 @@ async function loadSessionDetail({
   setIsDetailLoading,
   setDetailError,
   errorMessage,
+  query,
+  roles,
 }: {
   taskId: string;
   includeRepoSessions: boolean;
@@ -237,6 +338,8 @@ async function loadSessionDetail({
   setIsDetailLoading: (value: boolean) => void;
   setDetailError: (value: string | null) => void;
   errorMessage: string;
+  query?: string;
+  roles?: AiMessageRole[];
 }): Promise<void> {
   const expectedId = session.id;
   latestDetailRequestId.current = expectedId;
@@ -253,7 +356,9 @@ async function loadSessionDetail({
       session.sourceRef ?? null,
       null,
       DETAIL_PAGE_SIZE,
-      includeRepoSessions
+      includeRepoSessions,
+      query,
+      roles
     );
 
     if (latestDetailRequestId.current !== expectedId) return;
@@ -320,7 +425,7 @@ function ProviderMultiSelectFilter({
   const remainingCount = selectedProviders.length - visibleProviders.length;
 
   return (
-    <div ref={containerRef} className="relative min-w-0 flex-1 sm:min-w-[300px] sm:max-w-[420px]">
+    <div ref={containerRef} className="relative min-w-0 flex-1 sm:min-w-[200px] sm:max-w-[300px]">
       <button
         type="button"
         onClick={() => setIsOpen((previous) => !previous)}
@@ -468,16 +573,24 @@ function SessionList({ sessions, selectedSessionId, onSelect }: { sessions: Aggr
 function SessionPreview({
   session,
   detail,
+  messages,
   isLoading,
   isLoadingMore,
   error,
+  searchQuery,
+  setSearchQuery,
+  selectedRoles,
   onLoadMore,
 }: {
   session: AggregatedAiSession | null;
   detail: AggregatedAiSessionDetail | null;
+  messages: AggregatedAiMessage[];
   isLoading: boolean;
   isLoadingMore: boolean;
   error: string | null;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  selectedRoles: AiMessageRole[];
   onLoadMore: () => void;
 }) {
   const t = useTranslations("taskDetail");
@@ -485,22 +598,40 @@ function SessionPreview({
   if (!session) return <EmptyState text={t("aiSessions.selectSession")} />;
 
   return (
-    <div className="max-h-[440px] overflow-y-auto rounded-lg border border-border-default bg-bg-page p-4">
-      <div className="border-b border-border-subtle pb-3">
-        <div className="flex items-center gap-2">
-          <ProviderBadge provider={session.provider} />
-          <span className="text-xs text-text-muted">{session.id}</span>
+    <div className="flex max-h-[440px] flex-col overflow-hidden rounded-lg border border-border-default bg-bg-page">
+      <div className="border-b border-border-subtle bg-bg-surface p-4 pb-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <ProviderBadge provider={session.provider} />
+              <span className="truncate text-xs text-text-muted">{session.id}</span>
+            </div>
+            <p className="mt-2 truncate text-sm font-medium text-text-primary">{session.title}</p>
+          </div>
         </div>
-        <p className="mt-2 text-sm font-medium text-text-primary">{session.title}</p>
-        {session.matchedPath ? <p className="mt-1 text-xs text-text-muted">{session.matchedPath}</p> : null}
+
+        <div className="relative mt-3">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder={t("aiSessions.messageSearchPlaceholder")}
+            className="w-full rounded-md border border-border-default bg-bg-page px-3 py-1.5 pl-8 text-xs text-text-primary focus:border-brand-primary focus:outline-none"
+          />
+          <svg className="absolute left-2.5 top-2 text-text-muted" width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <path d="M14.5 14.5L11 11M12.5 7C12.5 10.0376 10.0376 12.5 7 12.5C3.96243 12.5 1.5 10.0376 1.5 7C1.5 3.96243 3.96243 1.5 7 1.5C10.0376 1.5 12.5 3.96243 12.5 7Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </div>
       </div>
 
-      <div className="mt-4 space-y-3">
+      <div className="flex-1 space-y-3 overflow-y-auto p-4">
         {isLoading ? <LoadingDetailState session={session} /> : null}
         {!isLoading && error ? <EmptyState text={error} compact /> : null}
-        {!isLoading && !error && detail && detail.messages.length === 0 ? <EmptyState text={t("aiSessions.noPreview")} compact /> : null}
-        {!isLoading && !error && detail
-          ? detail.messages.map((message, index) => (
+        {!isLoading && !error && messages.length === 0 ? (
+          <EmptyState text={searchQuery || selectedRoles.length < 2 ? t("aiSessions.noMessageMatch") : t("aiSessions.noPreview")} compact />
+        ) : null}
+        {!isLoading && !error && messages.length > 0
+          ? messages.map((message, index) => (
               <PreviewMessageCard key={`${message.role}-${index}-${message.timestamp ?? index}`} index={index} message={message} />
             ))
           : null}

--- a/src/lib/aiSessions/aggregateAiSessions.ts
+++ b/src/lib/aiSessions/aggregateAiSessions.ts
@@ -13,10 +13,22 @@ export async function aggregateAiSessions(context: AiSessionReaderContext): Prom
     readGeminiSessions(context),
   ]);
 
+  let allSessions = [...claude.sessions, ...codex.sessions, ...openCode.sessions, ...gemini.sessions];
+
+  // 각 리더에서 이미 필터링하지만, 취합 단계에서 다시 한 번 필터링 (선택 사항이나 일관성 위해 유지)
+  if (context.query) {
+    const q = context.query.toLowerCase();
+    allSessions = allSessions.filter((s) =>
+      s.title?.toLowerCase().includes(q) ||
+      s.firstUserPrompt?.toLowerCase().includes(q) ||
+      s.matchedPath?.toLowerCase().includes(q)
+    );
+  }
+
   return createAggregationResult({
     targetPath: context.worktreePath,
     repoPath: context.repoPath,
-    sessions: sortSessionsDescending([...claude.sessions, ...codex.sessions, ...openCode.sessions, ...gemini.sessions]),
+    sessions: sortSessionsDescending(allSessions),
     sources: [claude, codex, openCode, gemini].map(toSourceStatus),
   });
 }

--- a/src/lib/aiSessions/readClaudeSessions.ts
+++ b/src/lib/aiSessions/readClaudeSessions.ts
@@ -60,8 +60,19 @@ export async function readClaudeSessions(context: AiSessionReaderContext): Promi
     projectFiles.map((filePath) => parseClaudeSessionFromFile(filePath, context))
   );
 
+  let sessions = results.filter((s): s is AggregatedAiSession => s !== null);
+
+  if (context.query) {
+    const q = context.query.toLowerCase();
+    sessions = sessions.filter((s) =>
+      s.title?.toLowerCase().includes(q) ||
+      s.firstUserPrompt?.toLowerCase().includes(q) ||
+      s.matchedPath?.toLowerCase().includes(q)
+    );
+  }
+
   return createReaderResult("claude", {
-    sessions: results.filter((s): s is AggregatedAiSession => s !== null),
+    sessions,
   });
 }
 
@@ -90,7 +101,15 @@ export async function readClaudeSessionDetail(
       }
 
       const role = resolveClaudeRole(event);
+      if (context.roles && context.roles.length > 0 && !context.roles.includes(role)) {
+        continue;
+      }
+
       const text = extractPlainText(event.message?.content);
+      if (context.query && text && !text.toLowerCase().includes(context.query.toLowerCase())) {
+        continue;
+      }
+
       if (role === "user" && text && !title) {
         title = truncateText(text, 80);
       }
@@ -179,9 +198,10 @@ function consumeClaudeListEvent(
   const matchScope = determineMatchScope(cwd, context);
   if (!sessionId || !cwd || !matchScope) return;
 
-  const accumulator = getOrCreateClaudeSession(sessions, sessionId, cwd, matchScope, event.timestamp, sourceRef);
   const role = resolveClaudeRole(event);
   const text = extractPlainText(event.message?.content);
+
+  const accumulator = getOrCreateClaudeSession(sessions, sessionId, cwd, matchScope, event.timestamp, sourceRef);
 
   if (role === "user" && text && !accumulator.session.firstUserPrompt) {
     accumulator.session.firstUserPrompt = text;
@@ -195,6 +215,20 @@ function consumeClaudeListEvent(
   const normalizedTimestamp = toIsoString(event.timestamp);
   if (normalizedTimestamp) {
     accumulator.session.updatedAt = normalizedTimestamp;
+  }
+
+  // 필터링 적용 (세션 제목이나 첫 프롬프트에 검색어가 없으면 제거 대기)
+  if (context.query) {
+    const q = context.query.toLowerCase();
+    const hasMatch =
+      (accumulator.session.title?.toLowerCase().includes(q)) ||
+      (accumulator.session.firstUserPrompt?.toLowerCase().includes(q)) ||
+      (accumulator.session.matchedPath?.toLowerCase().includes(q));
+
+    if (!hasMatch) {
+      // 나중에 취합할 때 걸러내기 위해 마킹하거나, 아예 생성하지 않아야 함.
+      // 여기서는 목록을 모으는 중이므로, 모든 이벤트가 처리된 후 최종적으로 필터링하는 것이 안전함.
+    }
   }
 }
 

--- a/src/lib/aiSessions/readCodexSessions.ts
+++ b/src/lib/aiSessions/readCodexSessions.ts
@@ -38,7 +38,16 @@ export async function readCodexSessions(context: AiSessionReaderContext): Promis
   const results = await Promise.all(
     rolloutFiles.map((filePath) => parseCodexSessionSummary(filePath, context))
   );
-  const sessions = results.filter((s): s is AggregatedAiSession => s !== null);
+  let sessions = results.filter((s): s is AggregatedAiSession => s !== null);
+
+  if (context.query) {
+    const q = context.query.toLowerCase();
+    sessions = sessions.filter((s) =>
+      s.title?.toLowerCase().includes(q) ||
+      s.firstUserPrompt?.toLowerCase().includes(q) ||
+      s.matchedPath?.toLowerCase().includes(q)
+    );
+  }
 
   return createReaderResult("codex", {
     sessions,
@@ -153,8 +162,16 @@ async function parseCodexSessionDetail(
     if (payload.type !== "message") continue;
 
     const role = payload.role === "user" || payload.role === "assistant" ? payload.role : "unknown";
+    if (context.roles && context.roles.length > 0 && !context.roles.includes(role)) {
+      continue;
+    }
+
     const text = extractPlainText(payload.content);
     if (!text) continue;
+
+    if (context.query && !text.toLowerCase().includes(context.query.toLowerCase())) {
+      continue;
+    }
 
     if (role === "user" && !title) {
       title = truncateText(text, 80);

--- a/src/lib/aiSessions/readOpenCodeSessions.ts
+++ b/src/lib/aiSessions/readOpenCodeSessions.ts
@@ -93,6 +93,13 @@ export async function readOpenCodeSessions(context: AiSessionReaderContext): Pro
         messageCount: row.part_count ?? 0,
         sourceRef: row.id,
       };
+    })
+    .filter((s) => {
+      if (!context.query) return true;
+      const q = context.query.toLowerCase();
+      return s.title?.toLowerCase().includes(q) ||
+             s.firstUserPrompt?.toLowerCase().includes(q) ||
+             s.matchedPath?.toLowerCase().includes(q);
     });
 
   return createReaderResult("opencode", {
@@ -108,14 +115,13 @@ export async function readOpenCodeSessionDetail(
   cursor?: string | null,
   limit = DEFAULT_DETAIL_LIMIT
 ): Promise<AiSessionDetailReaderResult | null> {
-  const offset = cursor ? Number.parseInt(cursor, 10) : 0;
-  const safeOffset = Number.isNaN(offset) ? 0 : offset;
   const sid = escapeSql(sessionId);
 
   const db = getSqliteConnection(OPENCODE_DB_PATH);
   if (!db) return null;
 
-  const detailRows = querySqlite<OpenCodeDetailRow>(db,
+  // 전체 메시지를 가져와서 서버에서 필터링 후 페이징 (SQLite JSON 필터링이 복잡하므로)
+  const allRows = querySqlite<OpenCodeDetailRow>(db,
     `SELECT
       s.id AS session_id,
       s.directory,
@@ -123,33 +129,39 @@ export async function readOpenCodeSessionDetail(
       p.message_id,
       p.data AS part_data,
       p.time_created,
-      m.data AS message_data,
-      (SELECT COUNT(*) FROM part WHERE session_id = '${sid}') AS total_count
+      m.data AS message_data
     FROM session s
     JOIN part p ON p.session_id = s.id
     JOIN message m ON m.id = p.message_id
     WHERE s.id = '${sid}'
-    ORDER BY p.time_created ASC
-    LIMIT ${limit} OFFSET ${safeOffset};`
+    ORDER BY p.time_created ASC;`
   );
 
-  if (detailRows.length === 0) return null;
+  if (allRows.length === 0) return null;
 
-  const firstRow = detailRows[0];
+  const firstRow = allRows[0];
   if (!determineMatchScope(firstRow.directory, context)) return null;
 
-  const messages = sortMessagesDescending(detailRows
+  const filteredMessages = allRows
     .map((row) => {
       const parsedMessage = safeJsonParse<Record<string, unknown>>(row.message_data);
       const role = resolveOpenCodeRole(typeof parsedMessage?.role === "string" ? parsedMessage.role : undefined);
       const text = extractOpenCodePartText(row.part_data);
+
+      if (context.roles && context.roles.length > 0 && !context.roles.includes(role)) return null;
+      if (context.query && !text.toLowerCase().includes(context.query.toLowerCase())) return null;
+
       return makePreviewMessage(role, row.time_created, text);
     })
-    .filter((value): value is AggregatedAiMessage => Boolean(value)));
+    .filter((value): value is AggregatedAiMessage => Boolean(value));
 
-  const totalCount = firstRow.total_count;
-  const nextCursor = safeOffset + messages.length < totalCount ? String(safeOffset + messages.length) : null;
-  const firstUserPrompt = messages.find((message) => message.role === "user")?.fullText ?? null;
+  const sorted = sortMessagesDescending(filteredMessages);
+  const offset = cursor ? Number.parseInt(cursor, 10) : 0;
+  const safeOffset = Number.isNaN(offset) ? 0 : offset;
+  const pageItems = sorted.slice(safeOffset, safeOffset + limit);
+  const nextCursor = (safeOffset + pageItems.length < sorted.length) ? String(safeOffset + pageItems.length) : null;
+
+  const firstUserPrompt = sorted.find((message) => message.role === "user")?.fullText ?? null;
 
   return createSessionDetail({
     sessionId,
@@ -157,7 +169,7 @@ export async function readOpenCodeSessionDetail(
     title: firstRow.title ?? (firstUserPrompt ? truncateText(firstUserPrompt, 80) : null),
     matchedPath: firstRow.directory,
     sourceRef: firstRow.session_id,
-    messages,
+    messages: pageItems,
     nextCursor,
   });
 }

--- a/src/lib/aiSessions/types.ts
+++ b/src/lib/aiSessions/types.ts
@@ -54,6 +54,8 @@ export interface AiSessionReaderContext {
   worktreePath: string | null;
   repoPath: string | null;
   includeRepoSessions?: boolean;
+  query?: string;
+  roles?: AiMessageRole[];
 }
 
 export interface AiSessionReaderResult {


### PR DESCRIPTION
## What does this PR do?
- Add searchable AI session lists and message-level filtering in the task detail dialog.
- Keep the server-side aggregation and detail readers aligned with the new query and role filters.
- Include the missing type import required for a successful production build.

## How is it implemented?
- Add session search, message search, and user/AI role toggles to `AiSessionsDialog`.
- Pass query and role filters through the project action layer into the AI session readers.
- Apply query filtering across Claude, Codex, and OpenCode session summaries and details.
- Update localized labels for the new filter controls in English, Korean, and Chinese.

## Key changes
- **Dialog filtering UX**
  - Add debounced session search and message search inputs.
  - Add role filters for user and assistant messages.
  - Keep detail pagination working with the active filters.

- **Server-side filtering support**
  - Extend AI session reader context with `query` and `roles`.
  - Forward filters from `getTaskAiSessions` and `getTaskAiSessionDetail`.
  - Filter OpenCode detail results before pagination so cursors stay consistent with visible messages.

- **Build fix**
  - Import `AiMessageRole` in `src/app/actions/project.ts` so `pnpm build` completes successfully.