### PR TITLE
feat(desktop): add multi-window support and board drag fixes

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,7 +1,7 @@
 const http = require("node:http");
 const path = require("node:path");
 const process = require("node:process");
-const { app, BrowserWindow, session } = require("electron");
+const { app, BrowserWindow, session, shell } = require("electron");
 
 const PORT = process.env.PORT || "4885";
 const DEFAULT_LOCALE = process.env.KANVIBE_LOCALE || "ko";
@@ -17,6 +17,67 @@ if (process.platform === "linux") {
 
 let mainWindow = null;
 let serverBootstrapped = false;
+
+function getTitleBarOptions() {
+  if (process.platform === "darwin") {
+    return {
+      titleBarStyle: "hiddenInset",
+    };
+  }
+
+  return {
+    titleBarStyle: "hidden",
+    titleBarOverlay: {
+      color: "#ffffff",
+      symbolColor: "#111827",
+      height: 40,
+    },
+  };
+}
+
+function createBrowserWindowOptions() {
+  return {
+    width: 1600,
+    height: 1000,
+    minWidth: 1200,
+    minHeight: 800,
+    backgroundColor: "#ffffff",
+    autoHideMenuBar: true,
+    ...getTitleBarOptions(),
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  };
+}
+
+function isKanvibeUrl(targetUrl) {
+  try {
+    const parsedUrl = new URL(targetUrl);
+    return parsedUrl.origin === `http://127.0.0.1:${PORT}`;
+  } catch {
+    return false;
+  }
+}
+
+function attachWindowHandlers(browserWindow) {
+  browserWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (isKanvibeUrl(url)) {
+      return {
+        action: "allow",
+        overrideBrowserWindowOptions: createBrowserWindowOptions(),
+      };
+    }
+
+    void shell.openExternal(url);
+    return { action: "deny" };
+  });
+
+  browserWindow.webContents.on("did-create-window", (childWindow) => {
+    attachWindowHandlers(childWindow);
+  });
+}
 
 async function waitForServer(url, retries = 80) {
   for (let attempt = 0; attempt < retries; attempt += 1) {
@@ -72,19 +133,8 @@ async function createMainWindow() {
   const startUrl = `http://127.0.0.1:${PORT}/${DEFAULT_LOCALE}/login`;
   await waitForServer(startUrl);
 
-  mainWindow = new BrowserWindow({
-    width: 1600,
-    height: 1000,
-    minWidth: 1200,
-    minHeight: 800,
-    backgroundColor: "#ffffff",
-    autoHideMenuBar: true,
-    webPreferences: {
-      preload: path.join(__dirname, "preload.js"),
-      contextIsolation: true,
-      nodeIntegration: false,
-    },
-  });
+  mainWindow = new BrowserWindow(createBrowserWindowOptions());
+  attachWindowHandlers(mainWindow);
 
   await mainWindow.loadURL(startUrl);
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -18,6 +18,10 @@ if (process.platform === "linux") {
 let mainWindow = null;
 let serverBootstrapped = false;
 
+function getDefaultUrl() {
+  return `http://127.0.0.1:${PORT}/${DEFAULT_LOCALE}/login`;
+}
+
 function getTitleBarOptions() {
   if (process.platform === "darwin") {
     return {
@@ -77,6 +81,24 @@ function attachWindowHandlers(browserWindow) {
   browserWindow.webContents.on("did-create-window", (childWindow) => {
     attachWindowHandlers(childWindow);
   });
+
+  browserWindow.webContents.on("before-input-event", (event, input) => {
+    const isNewWindowShortcut =
+      input.type === "keyDown" &&
+      !input.isAutoRepeat &&
+      !input.alt &&
+      (input.control || input.meta) &&
+      input.key.toLowerCase() === "n";
+
+    if (!isNewWindowShortcut) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const currentUrl = browserWindow.webContents.getURL() || getDefaultUrl();
+    void createAppWindow(currentUrl);
+  });
 }
 
 async function waitForServer(url, retries = 80) {
@@ -127,20 +149,28 @@ function bootstrapInternalServer() {
   serverBootstrapped = true;
 }
 
-async function createMainWindow() {
+async function createAppWindow(targetUrl = getDefaultUrl()) {
   bootstrapInternalServer();
 
-  const startUrl = `http://127.0.0.1:${PORT}/${DEFAULT_LOCALE}/login`;
-  await waitForServer(startUrl);
+  await waitForServer(targetUrl);
 
-  mainWindow = new BrowserWindow(createBrowserWindowOptions());
-  attachWindowHandlers(mainWindow);
+  const browserWindow = new BrowserWindow(createBrowserWindowOptions());
+  mainWindow = browserWindow;
+  attachWindowHandlers(browserWindow);
 
-  await mainWindow.loadURL(startUrl);
+  await browserWindow.loadURL(targetUrl);
 
-  mainWindow.on("closed", () => {
-    mainWindow = null;
+  browserWindow.on("closed", () => {
+    if (mainWindow === browserWindow) {
+      mainWindow = null;
+    }
   });
+
+  return browserWindow;
+}
+
+async function createMainWindow() {
+  return createAppWindow();
 }
 
 app.whenReady().then(async () => {

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, useTransition } from "react";
 import { useTranslations } from "next-intl";
 import { DragDropContext, type DropResult } from "@hello-pangea/dnd";
 import Column from "./Column";
@@ -88,6 +88,95 @@ function insertAtFilteredIndex(
   return arr;
 }
 
+interface DragMovePlan {
+  updatedTasks: TasksByStatus;
+  doneTotalDelta: number;
+  doneOffsetDelta: number;
+  persistence:
+    | { type: "reorder"; status: TaskStatus; orderedIds: string[] }
+    | { type: "move"; taskId: string; status: TaskStatus; orderedIds: string[] };
+}
+
+function buildDragMovePlan(
+  currentTasks: TasksByStatus,
+  result: DropResult,
+  projectFilterSet: Set<string> | null,
+): DragMovePlan | null {
+  const { source, destination, draggableId } = result;
+  if (!destination) return null;
+
+  const sourceStatus = source.droppableId as TaskStatus;
+  const destStatus = destination.droppableId as TaskStatus;
+  const updated: TasksByStatus = { ...currentTasks };
+
+  const taskIndex = updated[sourceStatus].findIndex((task) => task.id === draggableId);
+  if (taskIndex === -1) return null;
+
+  const movedTask = updated[sourceStatus][taskIndex];
+  const newSource = updated[sourceStatus].filter((task) => task.id !== draggableId);
+
+  if (sourceStatus === destStatus) {
+    updated[sourceStatus] = insertAtFilteredIndex(
+      newSource,
+      movedTask,
+      destination.index,
+      projectFilterSet,
+    );
+
+    const orderedIds = (
+      projectFilterSet
+        ? updated[sourceStatus].filter(
+            (task) => task.projectId && projectFilterSet.has(task.projectId),
+          )
+        : updated[sourceStatus]
+    ).map((task) => task.id);
+
+    return {
+      updatedTasks: updated,
+      doneTotalDelta: 0,
+      doneOffsetDelta: 0,
+      persistence: {
+        type: "reorder",
+        status: sourceStatus,
+        orderedIds,
+      },
+    };
+  }
+
+  updated[sourceStatus] = newSource;
+  const updatedTask: KanbanTask = { ...movedTask, status: destStatus };
+  updated[destStatus] = insertAtFilteredIndex(
+    updated[destStatus],
+    updatedTask,
+    destination.index,
+    projectFilterSet,
+  );
+
+  const orderedIds = (
+    projectFilterSet
+      ? updated[destStatus].filter(
+          (task) => task.projectId && projectFilterSet.has(task.projectId),
+        )
+      : updated[destStatus]
+  ).map((task) => task.id);
+
+  return {
+    updatedTasks: updated,
+    doneTotalDelta:
+      (destStatus === TaskStatus.DONE ? 1 : 0) -
+      (sourceStatus === TaskStatus.DONE ? 1 : 0),
+    doneOffsetDelta:
+      (destStatus === TaskStatus.DONE ? 1 : 0) -
+      (sourceStatus === TaskStatus.DONE ? 1 : 0),
+    persistence: {
+      type: "move",
+      taskId: draggableId,
+      status: destStatus,
+      orderedIds,
+    },
+  };
+}
+
 export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings, defaultSessionType }: BoardProps) {
   useAutoRefresh();
   const t = useTranslations("board");
@@ -111,6 +200,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const [isDoneAlertDismissed, setIsDoneAlertDismissed] = useState(doneAlertDismissed);
   const [pendingDoneResult, setPendingDoneResult] = useState<DropResult | null>(null);
   const [currentDefaultSessionType, setCurrentDefaultSessionType] = useState<SessionType>(defaultSessionType);
+  const [, startDragPersistenceTransition] = useTransition();
 
   /** projectId → 표시할 프로젝트 이름 매핑. worktree 프로젝트는 메인 프로젝트 이름으로 resolve한다 */
   const projectNameMap = useMemo(() => {
@@ -268,79 +358,33 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   /** 드래그 결과를 받아 state 업데이트 + DB 반영을 수행한다 */
   const executeDragMove = useCallback(
     (result: DropResult) => {
-      const { source, destination, draggableId } = result;
-      if (!destination) return;
+      const plan = buildDragMovePlan(tasks, result, projectFilterSet);
+      if (!plan) return;
 
-      const sourceStatus = source.droppableId as TaskStatus;
-      const destStatus = destination.droppableId as TaskStatus;
+      setTasks(plan.updatedTasks);
 
-      setTasks((prev) => {
-        const updated = { ...prev };
+      if (plan.doneTotalDelta !== 0) {
+        setDoneTotal((prev) => prev + plan.doneTotalDelta);
+      }
 
-        const taskIndex = updated[sourceStatus].findIndex(
-          (task) => task.id === draggableId
-        );
-        if (taskIndex === -1) return prev;
+      if (plan.doneOffsetDelta !== 0) {
+        setDoneOffset((prev) => prev + plan.doneOffsetDelta);
+      }
 
-        const movedTask = updated[sourceStatus][taskIndex];
-        const newSource = updated[sourceStatus].filter(
-          (task) => task.id !== draggableId
-        );
-
-        if (sourceStatus === destStatus) {
-          updated[sourceStatus] = insertAtFilteredIndex(
-            newSource,
-            movedTask,
-            destination.index,
-            projectFilterSet
-          );
-
-          const reorderIds = (
-            projectFilterSet
-              ? updated[sourceStatus].filter(
-                  (task) =>
-                    task.projectId && projectFilterSet.has(task.projectId)
-                )
-              : updated[sourceStatus]
-          ).map((task) => task.id);
-
-          reorderTasks(sourceStatus, reorderIds);
-        } else {
-          updated[sourceStatus] = newSource;
-          const updatedTask: KanbanTask = { ...movedTask, status: destStatus };
-          updated[destStatus] = insertAtFilteredIndex(
-            updated[destStatus],
-            updatedTask,
-            destination.index,
-            projectFilterSet
-          );
-
-          if (destStatus === TaskStatus.DONE) {
-            setDoneTotal((prev) => prev + 1);
-            setDoneOffset((prev) => prev + 1);
-          }
-          if (sourceStatus === TaskStatus.DONE) {
-            setDoneTotal((prev) => prev - 1);
-            setDoneOffset((prev) => prev - 1);
-          }
-
-          /** 상태 변경 + 목적지 컬럼 순서를 한 번에 DB에 반영한다 (revalidation 없음) */
-          const destReorderIds = (
-            projectFilterSet
-              ? updated[destStatus].filter(
-                  (task) =>
-                    task.projectId && projectFilterSet.has(task.projectId)
-                )
-              : updated[destStatus]
-          ).map((task) => task.id);
-
-          moveTaskToColumn(draggableId, destStatus, destReorderIds);
+      startDragPersistenceTransition(async () => {
+        if (plan.persistence.type === "reorder") {
+          await reorderTasks(plan.persistence.status, plan.persistence.orderedIds);
+          return;
         }
 
-        return updated;
+        await moveTaskToColumn(
+          plan.persistence.taskId,
+          plan.persistence.status,
+          plan.persistence.orderedIds,
+        );
       });
     },
-    [projectFilterSet]
+    [projectFilterSet, startDragPersistenceTransition, tasks]
   );
 
   const handleDragEnd = useCallback(

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Draggable } from "@hello-pangea/dnd";
+import { useLocale } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import type { KanbanTask } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
@@ -26,10 +28,27 @@ const priorityConfig: Record<TaskPriority, { label: string; colorClass: string }
 };
 
 export default function TaskCard({ task, index, onContextMenu, projectName, isBaseProject }: TaskCardProps) {
+  const locale = useLocale();
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    setIsDesktop(Boolean(window.kanvibeDesktop?.isDesktop));
+  }, []);
+
+  const taskDetailPath = `/${locale}/task/${task.id}`;
+
   return (
     <Draggable draggableId={task.id} index={index}>
       {(provided, snapshot) => (
-        <Link href={`/task/${task.id}`}>
+        <Link
+          href={`/task/${task.id}`}
+          onClick={(event) => {
+            if (!isDesktop) return;
+
+            event.preventDefault();
+            window.open(taskDetailPath, "_blank", "noopener");
+          }}
+        >
           <div
             ref={provided.innerRef}
             {...provided.draggableProps}

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import Board from "../Board";
+import { reorderTasks } from "@/app/actions/kanban";
 import { SessionType, TaskStatus } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import type { TasksByStatus } from "@/app/actions/kanban";
@@ -10,7 +11,23 @@ vi.mock("next-intl", () => ({
 }));
 
 vi.mock("@hello-pangea/dnd", () => ({
-  DragDropContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DragDropContext: ({ children, onDragEnd }: { children: React.ReactNode; onDragEnd?: (result: unknown) => void }) => (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          onDragEnd?.({
+            draggableId: "task-1",
+            source: { droppableId: TaskStatus.TODO, index: 0 },
+            destination: { droppableId: TaskStatus.TODO, index: 0 },
+          })
+        }
+      >
+        trigger-drag-end
+      </button>
+      {children}
+    </div>
+  ),
 }));
 
 vi.mock("@/app/actions/kanban", () => ({
@@ -96,6 +113,37 @@ function createEmptyTasks(): TasksByStatus {
   };
 }
 
+function createTasksWithTodo(): TasksByStatus {
+  return {
+    [TaskStatus.TODO]: [
+      {
+        id: "task-1",
+        title: "Test Task",
+        description: null,
+        status: TaskStatus.TODO,
+        branchName: null,
+        worktreePath: null,
+        sessionType: null,
+        sessionName: null,
+        sshHost: null,
+        agentType: null,
+        project: null,
+        projectId: "project-1",
+        baseBranch: null,
+        prUrl: null,
+        priority: null,
+        displayOrder: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+    [TaskStatus.PROGRESS]: [],
+    [TaskStatus.PENDING]: [],
+    [TaskStatus.REVIEW]: [],
+    [TaskStatus.DONE]: [],
+  };
+}
+
 describe("Board defaultSessionType sync", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -148,6 +196,28 @@ describe("Board defaultSessionType sync", () => {
     // Then
     await waitFor(() => {
       expect(screen.getByTestId("create-task-default-session").textContent).toBe(SessionType.ZELLIJ);
+    });
+  });
+
+  it("드래그 종료 시 reorder action을 이벤트 이후에 호출한다", async () => {
+    render(
+      <Board
+        initialTasks={createTasksWithTodo()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "trigger-drag-end" }));
+
+    await waitFor(() => {
+      expect(reorderTasks).toHaveBeenCalledWith(TaskStatus.TODO, ["task-1"]);
     });
   });
 });

--- a/src/components/__tests__/TaskCard.test.tsx
+++ b/src/components/__tests__/TaskCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import TaskCard from "../TaskCard";
 import { TaskPriority } from "@/entities/TaskPriority";
 import { TaskStatus } from "@/entities/KanbanTask";
@@ -21,6 +21,10 @@ vi.mock("@/i18n/navigation", () => ({
   Link: ({ children, ...props }: { children: React.ReactNode; href: string }) => (
     <a {...props}>{children}</a>
   ),
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "ko",
 }));
 
 function createTask(overrides: Partial<KanbanTask> = {}): KanbanTask {
@@ -115,5 +119,21 @@ describe("TaskCard - Priority Badge", () => {
     // Then
     const badge = screen.getByText("!!!");
     expect(badge.className).toContain("ml-auto");
+  });
+
+  it("should open task detail in a new window on desktop", async () => {
+    const task = createTask();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    window.kanvibeDesktop = { isDesktop: true };
+
+    render(<TaskCard task={task} index={0} onContextMenu={onContextMenu} />);
+
+    fireEvent.click(screen.getByRole("link"));
+
+    expect(openSpy).toHaveBeenCalledWith("/ko/task/task-1", "_blank", "noopener");
+
+    openSpy.mockRestore();
+    delete window.kanvibeDesktop;
   });
 });

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+  kanvibeDesktop?: {
+    isDesktop?: boolean;
+  };
+}


### PR DESCRIPTION
## Summary
- open task detail views in separate Electron windows and support desktop keyboard shortcuts for creating new windows
- keep the Electron title bar light and route external links to the system browser
- move board drag persistence out of React state updaters to avoid router update warnings during render
- add regression coverage for desktop window opening and board drag reorder behavior

## Testing
- not run (`node_modules` is missing in this worktree, so local typecheck and Vitest could not start)