### PR TITLE
fix(desktop): deliver native alerts and document --aiauthor option

### DIFF
--- a/.claude/skills/commit-skill/SKILL.md
+++ b/.claude/skills/commit-skill/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: commit-skill
+description: Conventional Commit Messages. 커밋 메시지 작성 및 PR 생성 지원. --only-commit 플래그로 커밋만 수행, --aiauthor 플래그로 AI 작성자 표기를 포함할 수 있으며, 플래그가 없으면 커밋 후 Push 및 PR 생성까지 진행.
+---
+
+## Flags
+
+- `--only-commit`: 커밋만 수행 (Push/PR 생성 없음)
+- `--aiauthor`: 커밋과 PR 본문에 AI 작성자 표기를 포함
+- (기본): 커밋 → Push → PR 생성까지 **확인 없이 자동 진행** → [references/pr-guide.md](references/pr-guide.md) 참조
+
+> **주의**: `--only-commit` 플래그가 없으면 사용자에게 PR 생성 여부를 묻지 않고 즉시 커밋 → Push → PR 생성을 순차 실행한다.
+
+---
+
+## AI 작성자 표기
+
+기본 동작에서는 AI 작성자 표기를 추가하지 않는다.
+
+`--aiauthor` 플래그가 있으면 커밋 메시지 footer와 PR 본문 마지막에 AI 작성자 표기를 포함한다.
+
+커밋 시 HEREDOC 형식을 사용하고, `--aiauthor`가 있으면 아래처럼 footer를 추가한다:
+```bash
+git commit -m "$(cat <<'EOF'
+feat: 커밋 메시지 내용
+
+Co-Authored-By: <AI name> <noreply@example.com>
+EOF
+)"
+```
+
+---
+
+## 커밋 워크플로우
+
+### 1단계: Base 브랜치 감지
+
+커밋 전 현재 브랜치의 base 브랜치를 감지하여 변경 범위를 파악한다.
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+REPO_ROOT=$(git rev-parse --show-toplevel)
+BASE_BRANCH=$(bash "$REPO_ROOT/.claude/scripts/find_base_branch.sh") || exit 1
+echo "Current: $CURRENT_BRANCH / Base: $BASE_BRANCH"
+```
+
+### 2단계: 변경 사항 분석
+
+base 브랜치 기준으로 변경 사항을 분석하여 커밋 단위를 결정한다.
+
+```bash
+# base 브랜치 대비 변경된 파일 목록
+git diff origin/${BASE_BRANCH}...HEAD --name-status
+
+# 아직 커밋되지 않은 변경 사항
+git diff --name-status
+git diff --cached --name-status
+```
+
+### 3단계: 커밋 단위 결정
+
+- base 브랜치 대비 전체 변경 사항을 파악한 뒤, 논리적으로 관련된 변경끼리 그룹핑
+- 각 커밋은 하나의 의미 있는 변경 단위로 구성
+- 이미 커밋된 내용과 중복되지 않도록 `git log origin/${BASE_BRANCH}..HEAD --oneline`으로 기존 커밋 확인
+
+### 4단계: 커밋 실행
+
+```bash
+git add <관련 파일들>
+git commit -m "$(cat <<'EOF'
+<type>(<optional scope>): <한국어 설명>
+EOF
+)"
+```
+
+---
+
+## Commit Message Formats
+
+### Default
+
+<pre>
+<b>&lt;type&gt;</b>(<b>&lt;optional scope&gt;</b>): <b>&lt;description&gt;</b>
+<sub>empty separator line</sub>
+<b>&lt;optional body&gt;</b>
+<sub>empty separator line</sub>
+<b>&lt;optional footer&gt;</b>
+</pre>
+
+### Merge Commit
+
+<pre>
+Merge branch '<b>&lt;branch name&gt;</b>'
+</pre>
+
+### Revert Commit
+
+<pre>
+Revert "<b>&lt;reverted commit subject line&gt;</b>"
+</pre>
+
+### Initial Commit
+
+```
+chore: init
+```
+
+### Types
+
+* API or UI relevant changes
+  * "feat" Commits, that add or remove a new feature to the API or UI
+  * "fix" Commits, that fix an API or UI bug of a preceded "feat" commit
+  * "modify" Commits, that change existing functionality or behavior
+* "refactor" Commits, that rewrite/restructure your code, however do not change any API or UI behaviour
+  * "perf" Commits are special "refactor" commits, that improve performance
+* "style" Commits, that do not affect the meaning (white-space, formatting, missing semi-colons, etc)
+* "test" Commits, that add missing tests or correcting existing tests
+* "docs" Commits, that affect documentation only
+* "build" Commits, that affect build components like build tool, ci pipeline, dependencies, project version, ...
+* "ops" Commits, that affect operational components like infrastructure, deployment, backup, recovery, ...
+* "chore" Miscellaneous commits e.g. modifying ".gitignore"
+
+### Scopes
+
+The "scope" provides additional contextual information.
+
+* Is an **optional** part of the format
+* Allowed Scopes depend on the specific project
+* Don't use issue identifiers as scopes
+
+### Breaking Changes Indicator
+
+Breaking changes should be indicated by adding "!" before ":" in the subject line e.g. "feat(api)!: remove status endpoint"
+
+* Is an **optional** part of the format
+* Breaking changes **must** be described in the commit footer section
+
+### Description
+
+* It is a **mandatory** part of the format
+* Use the imperative, present tense: "change" not "changed" nor "changes"
+* Don't capitalize the first letter
+* No dot (".") at the end
+
+### Body
+
+* Is an **optional** part of the format
+* Use the imperative, present tense
+* This is the place to mention issue identifiers and their relations
+
+### Footer
+
+* Is an **optional** part of the format
+* **optionally** reference an issue by its id.
+* **Breaking Changes** should start with the word "BREAKING CHANGE:" followed by space or two newlines.
+
+### Examples
+
+```
+feat: 이메일 알림 기능 추가
+```
+
+```
+feat(shopping cart): 장바구니에 즉시구매 버튼 추가
+```
+
+```
+feat!: 티켓 목록 엔드포인트 제거
+
+refers to JIRA-1337
+
+BREAKING CHANGE: ticket endpoints no longer supports list all entities.
+```
+
+```
+fix(api): 요청 body checksum 계산 오류 수정
+```
+
+```
+perf: HyperLogLog 적용으로 고유 방문자 집계 메모리 사용량 감소
+```
+
+```
+refactor: 피보나치 수열 계산을 재귀 방식으로 변경
+```
+
+---
+
+## 커밋 작성 지침
+
+### 중요 사항
+
+* **모든 커밋 메시지는 한국어로 작성**
+* **`--aiauthor` 사용 시 AI 작성자 표기를 커밋 footer와 PR 본문에 함께 반영**
+* git diff를 통해 변경 사항을 충분히 분석하고, 논리적으로 커밋을 분리
+* 각 커밋은 하나의 의미 있는 변경 단위로 구성
+
+### 커밋 전 체크리스트
+
+1. `git diff`로 모든 변경 사항 확인
+2. **절대 커밋하지 말아야 할 파일 확인**
+   * `.claude/`, `.gemini/`, `.opencode/`, hooks 등 AI 에이전트 관련 설정 파일은 커밋 금지
+   * `CLAUDE.local.md`, `GEMINI.md`, `AGENTS.md` 등 AI 설정 문서도 커밋 금지
+   * **예외**: `.claude/plan/` 폴더는 커밋 가능
+   * 위 파일들이 staging area에 포함되어 있다면 반드시 제거
+3. **Serena 관련 파일은 반드시 커밋**
+   * `.serena/` 폴더 내 변경 사항이 있으면 누락 없이 커밋에 포함
+   * `git diff --name-only`와 `git status`로 `.serena/` 변경 파일을 확인하고, 있으면 반드시 staging에 추가
+4. 관련된 변경 사항끼리 그룹핑하여 커밋 단위 결정
+5. **문서 변경사항 확인** → `docs:` 접두어 사용
+6. 커밋 메시지는 변경의 "이유"와 "무엇"을 명확히 설명
+7. `--aiauthor` 사용 여부에 맞게 AI 작성자 표기가 포함되었는지 최종 확인

--- a/.claude/skills/commit-skill/references/pr-guide.md
+++ b/.claude/skills/commit-skill/references/pr-guide.md
@@ -1,0 +1,168 @@
+# PR 생성 및 관리 가이드
+
+**--only-commit 플래그가 없을 때 이 가이드를 따른다.**
+
+---
+
+## AI 작성자 표기
+
+기본 동작에서는 PR 제목과 PR 본문에 AI 작성자 표기를 추가하지 않는다.
+
+`--aiauthor` 플래그가 있으면 PR 본문 마지막에만 AI 작성자 표기를 추가한다.
+
+```markdown
+Co-Authored-By: <AI name> <noreply@example.com>
+```
+
+---
+
+## GitHub CLI 사용
+
+* **GH 사용 필수**: PR 생성 및 수정 시에는 GitHub CLI(`gh`)를 사용
+
+---
+
+## 작업 순서
+
+### 0. GitHub CLI 권한 확인
+
+```bash
+command -v gh
+gh auth status
+gh repo view
+```
+
+설치되어 있지 않다면: `brew install gh`
+인증이 필요하다면: `gh auth login`
+
+### 1. Base 브랜치 자동 감지
+
+**Git / Base branch 규칙:**
+- 아래 스크립트로 현재 브랜치가 어떤 브랜치로부터 분기되었는지 찾는다.
+- 스크립트로 계산된 결과 base 브랜치가 항상 develop인 것은 아니다.
+- 감지된 base 브랜치를 신뢰하고 PR 작성 과정에도 그대로 사용한다.
+- 작업자의 요청이 있기 전까지는 base 브랜치를 다시 추론하거나 develop/main/master 등의 브랜치로 교체하지 않는다.
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+echo "Current branch: $CURRENT_BRANCH"
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+BASE_BRANCH=$(bash "$REPO_ROOT/.claude/scripts/find_base_branch.sh") || exit 1
+echo "Detected base branch: $BASE_BRANCH"
+```
+
+### 2. 변경 사항 분석
+
+base 브랜치와의 차이를 확인하여 PR 본문을 작성할 정보를 수집한다.
+
+```bash
+# 변경된 파일 목록 확인
+git diff origin/${BASE_BRANCH}...HEAD --name-status
+
+# 변경 통계 확인
+git diff origin/${BASE_BRANCH}...HEAD --stat
+
+# 커밋 히스토리 확인
+git log origin/${BASE_BRANCH}..HEAD --oneline
+```
+
+### 3. PR 본문 작성
+
+아래 템플릿을 기반으로 변경 사항을 분석하여 PR 본문을 작성한다.
+**최종적으로 해당 PR에 포함된 실제 변경 사항**에 대한 내용만 작성한다.
+없는 내용이나 코드를 추측해서 만들어내지 않는다.
+
+### 4. PR 생성
+
+```bash
+# PR 본문을 임시 파일로 저장
+cat > /tmp/pr_body.md <<'EOF'
+(아래 템플릿 기반으로 작성한 PR 본문)
+EOF
+
+# 감지한 base 브랜치를 향해 PR 생성
+gh pr create --base "$BASE_BRANCH" --title "PR 제목" --body-file /tmp/pr_body.md
+
+# 임시 파일 정리
+rm /tmp/pr_body.md
+```
+
+---
+
+## PR 작성 원칙
+
+* **한국어 작성**: 모든 PR 제목과 본문은 한국어로 작성
+* **`--aiauthor` 사용 시 PR 본문 마지막에 AI 작성자 표기를 추가**
+* **테스트 가이드 제외**: PR 본문에 테스트 가이드나 테스트 계획은 포함하지 않음
+
+---
+
+## PR 업데이트 시
+
+* 기존 PR 본문을 적절하게 수정하여 최신 내용을 업데이트
+
+---
+
+## 완료 확인
+
+* PR 생성 또는 업데이트 후 반드시 `git push`가 완료되었는지 확인
+
+---
+
+## PR 본문 템플릿
+
+```markdown
+## 관련 자료
+- [슬랙 스레드]()
+- [노션 업무 티켓]()
+- [작업 계획](.claude/plan/...) // .claude/plan/...에 브랜치 명과 동일한 파일이 존재하면 첨부, 아니면 제외
+- 이슈 : #
+
+## 어떤 작업인가요?
+- 리뷰어를 위한 PR 한 줄 설명 (PR 개요, 목적 등 '작업 배경' 설명)
+
+## 어떻게 해결했나요?
+**주요 작업 1**
+- 작업 목적
+- 작업 내용 요약
+
+**주요 작업 2**
+- 작업 목적
+- 작업 내용 요약
+
+...
+
+
+## 중요한 변경 사항은 무엇인가요?
+### 주요 작업 제목 1
+
+**해당 작업의 핵심 변경사항 1**
+- **변경 이유**: ...
+- **수정 파일**: ...
+
+**해당 작업의 핵심 변경사항 2**
+- **변경 이유**: ...
+- **수정 파일**: ...
+
+### 주요 작업 제목 2
+
+**해당 작업의 핵심 변경사항 1**
+- **변경 이유**: ...
+- **수정 파일**: ...
+
+**해당 작업의 핵심 변경사항 2**
+- **변경 이유**: ...
+- **수정 파일**: ...
+
+...
+
+
+## 스크린샷 및 시연 영상 (optional)
+
+### 코드 리뷰 RCA 룰
+리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
+- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
+- **C**(Comment): 가능한 반영해 주세요.
+- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
+```

--- a/.opencode/skills/commit-skill/SKILL.md
+++ b/.opencode/skills/commit-skill/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: commit-skill
+description: Conventional Commit Messages. 커밋 메시지 작성 및 PR 생성 지원. --only-commit 플래그로 커밋만 수행, --aiauthor 플래그로 AI 작성자 표기를 포함할 수 있으며, 플래그가 없으면 커밋 후 Push 및 PR 생성까지 진행.
+---
+
+## Flags
+
+- `--only-commit`: 커밋만 수행 (Push/PR 생성 없음)
+- `--aiauthor`: 커밋과 PR 본문에 AI 작성자 표기를 포함
+- (기본): 커밋 → Push → PR 생성까지 **확인 없이 자동 진행** → [references/pr-guide.md](references/pr-guide.md) 참조
+
+> **주의**: `--only-commit` 플래그가 없으면 사용자에게 PR 생성 여부를 묻지 않고 즉시 커밋 → Push → PR 생성을 순차 실행한다.
+
+---
+
+## AI 작성자 표기
+
+기본 동작에서는 AI 작성자 표기를 추가하지 않는다.
+
+`--aiauthor` 플래그가 있으면 커밋 메시지 footer와 PR 본문 마지막에 AI 작성자 표기를 포함한다.
+
+커밋 시 HEREDOC 형식을 사용하고, `--aiauthor`가 있으면 아래처럼 footer를 추가한다:
+```bash
+git commit -m "$(cat <<'EOF'
+feat: 커밋 메시지 내용
+
+Co-Authored-By: <AI name> <noreply@example.com>
+EOF
+)"
+```
+
+---
+
+## 커밋 워크플로우
+
+### 1단계: Base 브랜치 감지
+
+커밋 전 현재 브랜치의 base 브랜치를 감지하여 변경 범위를 파악한다.
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+REPO_ROOT=$(git rev-parse --show-toplevel)
+BASE_BRANCH=$(bash "$REPO_ROOT/.claude/scripts/find_base_branch.sh") || exit 1
+echo "Current: $CURRENT_BRANCH / Base: $BASE_BRANCH"
+```
+
+### 2단계: 변경 사항 분석
+
+base 브랜치 기준으로 변경 사항을 분석하여 커밋 단위를 결정한다.
+
+```bash
+# base 브랜치 대비 변경된 파일 목록
+git diff origin/${BASE_BRANCH}...HEAD --name-status
+
+# 아직 커밋되지 않은 변경 사항
+git diff --name-status
+git diff --cached --name-status
+```
+
+### 3단계: 커밋 단위 결정
+
+- base 브랜치 대비 전체 변경 사항을 파악한 뒤, 논리적으로 관련된 변경끼리 그룹핑
+- 각 커밋은 하나의 의미 있는 변경 단위로 구성
+- 이미 커밋된 내용과 중복되지 않도록 `git log origin/${BASE_BRANCH}..HEAD --oneline`으로 기존 커밋 확인
+
+### 4단계: 커밋 실행
+
+```bash
+git add <관련 파일들>
+git commit -m "$(cat <<'EOF'
+<type>(<optional scope>): <한국어 설명>
+EOF
+)"
+```
+
+---
+
+## Commit Message Formats
+
+### Default
+
+<pre>
+<b>&lt;type&gt;</b>(<b>&lt;optional scope&gt;</b>): <b>&lt;description&gt;</b>
+<sub>empty separator line</sub>
+<b>&lt;optional body&gt;</b>
+<sub>empty separator line</sub>
+<b>&lt;optional footer&gt;</b>
+</pre>
+
+### Merge Commit
+
+<pre>
+Merge branch '<b>&lt;branch name&gt;</b>'
+</pre>
+
+### Revert Commit
+
+<pre>
+Revert "<b>&lt;reverted commit subject line&gt;</b>"
+</pre>
+
+### Initial Commit
+
+```
+chore: init
+```
+
+### Types
+
+* API or UI relevant changes
+  * "feat" Commits, that add or remove a new feature to the API or UI
+  * "fix" Commits, that fix an API or UI bug of a preceded "feat" commit
+  * "modify" Commits, that change existing functionality or behavior
+* "refactor" Commits, that rewrite/restructure your code, however do not change any API or UI behaviour
+  * "perf" Commits are special "refactor" commits, that improve performance
+* "style" Commits, that do not affect the meaning (white-space, formatting, missing semi-colons, etc)
+* "test" Commits, that add missing tests or correcting existing tests
+* "docs" Commits, that affect documentation only
+* "build" Commits, that affect build components like build tool, ci pipeline, dependencies, project version, ...
+* "ops" Commits, that affect operational components like infrastructure, deployment, backup, recovery, ...
+* "chore" Miscellaneous commits e.g. modifying ".gitignore"
+
+### Scopes
+
+The "scope" provides additional contextual information.
+
+* Is an **optional** part of the format
+* Allowed Scopes depend on the specific project
+* Don't use issue identifiers as scopes
+
+### Breaking Changes Indicator
+
+Breaking changes should be indicated by adding "!" before ":" in the subject line e.g. "feat(api)!: remove status endpoint"
+
+* Is an **optional** part of the format
+* Breaking changes **must** be described in the commit footer section
+
+### Description
+
+* It is a **mandatory** part of the format
+* Use the imperative, present tense: "change" not "changed" nor "changes"
+* Don't capitalize the first letter
+* No dot (".") at the end
+
+### Body
+
+* Is an **optional** part of the format
+* Use the imperative, present tense
+* This is the place to mention issue identifiers and their relations
+
+### Footer
+
+* Is an **optional** part of the format
+* **optionally** reference an issue by its id.
+* **Breaking Changes** should start with the word "BREAKING CHANGE:" followed by space or two newlines.
+
+### Examples
+
+```
+feat: 이메일 알림 기능 추가
+```
+
+```
+feat(shopping cart): 장바구니에 즉시구매 버튼 추가
+```
+
+```
+feat!: 티켓 목록 엔드포인트 제거
+
+refers to JIRA-1337
+
+BREAKING CHANGE: ticket endpoints no longer supports list all entities.
+```
+
+```
+fix(api): 요청 body checksum 계산 오류 수정
+```
+
+```
+perf: HyperLogLog 적용으로 고유 방문자 집계 메모리 사용량 감소
+```
+
+```
+refactor: 피보나치 수열 계산을 재귀 방식으로 변경
+```
+
+---
+
+## 커밋 작성 지침
+
+### 중요 사항
+
+* **모든 커밋 메시지는 한국어로 작성**
+* **`--aiauthor` 사용 시 AI 작성자 표기를 커밋 footer와 PR 본문에 함께 반영**
+* git diff를 통해 변경 사항을 충분히 분석하고, 논리적으로 커밋을 분리
+* 각 커밋은 하나의 의미 있는 변경 단위로 구성
+
+### 커밋 전 체크리스트
+
+1. `git diff`로 모든 변경 사항 확인
+2. **절대 커밋하지 말아야 할 파일 확인**
+   * `.claude/`, `.gemini/`, `.opencode/`, hooks 등 AI 에이전트 관련 설정 파일은 커밋 금지
+   * `CLAUDE.local.md`, `GEMINI.md`, `AGENTS.md` 등 AI 설정 문서도 커밋 금지
+   * **예외**: `.claude/plan/` 폴더는 커밋 가능
+   * 위 파일들이 staging area에 포함되어 있다면 반드시 제거
+3. **Serena 관련 파일은 반드시 커밋**
+   * `.serena/` 폴더 내 변경 사항이 있으면 누락 없이 커밋에 포함
+   * `git diff --name-only`와 `git status`로 `.serena/` 변경 파일을 확인하고, 있으면 반드시 staging에 추가
+4. 관련된 변경 사항끼리 그룹핑하여 커밋 단위 결정
+5. **문서 변경사항 확인** → `docs:` 접두어 사용
+6. 커밋 메시지는 변경의 "이유"와 "무엇"을 명확히 설명
+7. `--aiauthor` 사용 여부에 맞게 AI 작성자 표기가 포함되었는지 최종 확인

--- a/.opencode/skills/commit-skill/references/pr-guide.md
+++ b/.opencode/skills/commit-skill/references/pr-guide.md
@@ -1,0 +1,168 @@
+# PR 생성 및 관리 가이드
+
+**--only-commit 플래그가 없을 때 이 가이드를 따른다.**
+
+---
+
+## AI 작성자 표기
+
+기본 동작에서는 PR 제목과 PR 본문에 AI 작성자 표기를 추가하지 않는다.
+
+`--aiauthor` 플래그가 있으면 PR 본문 마지막에만 AI 작성자 표기를 추가한다.
+
+```markdown
+Co-Authored-By: <AI name> <noreply@example.com>
+```
+
+---
+
+## GitHub CLI 사용
+
+* **GH 사용 필수**: PR 생성 및 수정 시에는 GitHub CLI(`gh`)를 사용
+
+---
+
+## 작업 순서
+
+### 0. GitHub CLI 권한 확인
+
+```bash
+command -v gh
+gh auth status
+gh repo view
+```
+
+설치되어 있지 않다면: `brew install gh`
+인증이 필요하다면: `gh auth login`
+
+### 1. Base 브랜치 자동 감지
+
+**Git / Base branch 규칙:**
+- 아래 스크립트로 현재 브랜치가 어떤 브랜치로부터 분기되었는지 찾는다.
+- 스크립트로 계산된 결과 base 브랜치가 항상 develop인 것은 아니다.
+- 감지된 base 브랜치를 신뢰하고 PR 작성 과정에도 그대로 사용한다.
+- 작업자의 요청이 있기 전까지는 base 브랜치를 다시 추론하거나 develop/main/master 등의 브랜치로 교체하지 않는다.
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+echo "Current branch: $CURRENT_BRANCH"
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+BASE_BRANCH=$(bash "$REPO_ROOT/.claude/scripts/find_base_branch.sh") || exit 1
+echo "Detected base branch: $BASE_BRANCH"
+```
+
+### 2. 변경 사항 분석
+
+base 브랜치와의 차이를 확인하여 PR 본문을 작성할 정보를 수집한다.
+
+```bash
+# 변경된 파일 목록 확인
+git diff origin/${BASE_BRANCH}...HEAD --name-status
+
+# 변경 통계 확인
+git diff origin/${BASE_BRANCH}...HEAD --stat
+
+# 커밋 히스토리 확인
+git log origin/${BASE_BRANCH}..HEAD --oneline
+```
+
+### 3. PR 본문 작성
+
+아래 템플릿을 기반으로 변경 사항을 분석하여 PR 본문을 작성한다.
+**최종적으로 해당 PR에 포함된 실제 변경 사항**에 대한 내용만 작성한다.
+없는 내용이나 코드를 추측해서 만들어내지 않는다.
+
+### 4. PR 생성
+
+```bash
+# PR 본문을 임시 파일로 저장
+cat > /tmp/pr_body.md <<'EOF'
+(아래 템플릿 기반으로 작성한 PR 본문)
+EOF
+
+# 감지한 base 브랜치를 향해 PR 생성
+gh pr create --base "$BASE_BRANCH" --title "PR 제목" --body-file /tmp/pr_body.md
+
+# 임시 파일 정리
+rm /tmp/pr_body.md
+```
+
+---
+
+## PR 작성 원칙
+
+* **한국어 작성**: 모든 PR 제목과 본문은 한국어로 작성
+* **`--aiauthor` 사용 시 PR 본문 마지막에 AI 작성자 표기를 추가**
+* **테스트 가이드 제외**: PR 본문에 테스트 가이드나 테스트 계획은 포함하지 않음
+
+---
+
+## PR 업데이트 시
+
+* 기존 PR 본문을 적절하게 수정하여 최신 내용을 업데이트
+
+---
+
+## 완료 확인
+
+* PR 생성 또는 업데이트 후 반드시 `git push`가 완료되었는지 확인
+
+---
+
+## PR 본문 템플릿
+
+```markdown
+## 관련 자료
+- [슬랙 스레드]()
+- [노션 업무 티켓]()
+- [작업 계획](.claude/plan/...) // .claude/plan/...에 브랜치 명과 동일한 파일이 존재하면 첨부, 아니면 제외
+- 이슈 : #
+
+## 어떤 작업인가요?
+- 리뷰어를 위한 PR 한 줄 설명 (PR 개요, 목적 등 '작업 배경' 설명)
+
+## 어떻게 해결했나요?
+**주요 작업 1**
+- 작업 목적
+- 작업 내용 요약
+
+**주요 작업 2**
+- 작업 목적
+- 작업 내용 요약
+
+...
+
+
+## 중요한 변경 사항은 무엇인가요?
+### 주요 작업 제목 1
+
+**해당 작업의 핵심 변경사항 1**
+- **변경 이유**: ...
+- **수정 파일**: ...
+
+**해당 작업의 핵심 변경사항 2**
+- **변경 이유**: ...
+- **수정 파일**: ...
+
+### 주요 작업 제목 2
+
+**해당 작업의 핵심 변경사항 1**
+- **변경 이유**: ...
+- **수정 파일**: ...
+
+**해당 작업의 핵심 변경사항 2**
+- **변경 이유**: ...
+- **수정 파일**: ...
+
+...
+
+
+## 스크린샷 및 시연 영상 (optional)
+
+### 코드 리뷰 RCA 룰
+리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
+- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
+- **C**(Comment): 가능한 반영해 주세요.
+- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
+```

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,7 +1,7 @@
 const http = require("node:http");
 const path = require("node:path");
 const process = require("node:process");
-const { app, BrowserWindow, session, shell } = require("electron");
+const { app, BrowserWindow, ipcMain, Notification, session, shell } = require("electron");
 
 const PORT = process.env.PORT || "4885";
 const DEFAULT_LOCALE = process.env.KANVIBE_LOCALE || "ko";
@@ -18,8 +18,12 @@ if (process.platform === "linux") {
 let mainWindow = null;
 let serverBootstrapped = false;
 
+function getServerBaseUrl() {
+  return `http://127.0.0.1:${PORT}`;
+}
+
 function getDefaultUrl() {
-  return `http://127.0.0.1:${PORT}/${DEFAULT_LOCALE}/login`;
+  return `${getServerBaseUrl()}/${DEFAULT_LOCALE}/login`;
 }
 
 function getTitleBarOptions() {
@@ -59,10 +63,65 @@ function createBrowserWindowOptions() {
 function isKanvibeUrl(targetUrl) {
   try {
     const parsedUrl = new URL(targetUrl);
-    return parsedUrl.origin === `http://127.0.0.1:${PORT}`;
+    return parsedUrl.origin === getServerBaseUrl();
   } catch {
     return false;
   }
+}
+
+function getNotificationIconPath() {
+  return path.join(app.getAppPath(), "public", "icons", "icon-192x192.png");
+}
+
+async function focusMainWindow(relativePath) {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    await createMainWindow();
+  }
+
+  if (!mainWindow) {
+    return;
+  }
+
+  if (mainWindow.isMinimized()) {
+    mainWindow.restore();
+  }
+
+  mainWindow.show();
+  mainWindow.focus();
+
+  if (!relativePath) {
+    return;
+  }
+
+  const targetUrl = new URL(relativePath, getServerBaseUrl()).href;
+  if (mainWindow.webContents.getURL() !== targetUrl) {
+    await mainWindow.loadURL(targetUrl);
+  }
+}
+
+function registerNotificationHandlers() {
+  ipcMain.handle("kanvibe:show-notification", async (_event, payload) => {
+    if (!Notification.isSupported()) {
+      return false;
+    }
+
+    const notification = new Notification({
+      title: payload.title,
+      body: payload.body,
+      icon: getNotificationIconPath(),
+    });
+
+    notification.on("click", () => {
+      const relativePath = payload.taskId
+        ? `/${payload.locale || DEFAULT_LOCALE}/task/${payload.taskId}`
+        : `/${payload.locale || DEFAULT_LOCALE}`;
+
+      void focusMainWindow(relativePath);
+    });
+
+    notification.show();
+    return true;
+  });
 }
 
 function attachWindowHandlers(browserWindow) {
@@ -177,6 +236,8 @@ app.whenReady().then(async () => {
   session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
     callback(permission === "notifications");
   });
+
+  registerNotificationHandlers();
 
   await createMainWindow();
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,5 +1,8 @@
-const { contextBridge } = require("electron");
+const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("kanvibeDesktop", {
   isDesktop: true,
+  showNotification(payload) {
+    return ipcRenderer.invoke("kanvibe:show-notification", payload);
+  },
 });

--- a/src/components/NotificationListener.tsx
+++ b/src/components/NotificationListener.tsx
@@ -27,6 +27,10 @@ export default function NotificationListener({
 
   // Service Worker 등록
   useEffect(() => {
+    if (window.kanvibeDesktop?.isDesktop) {
+      return;
+    }
+
     if ("serviceWorker" in navigator && typeof window !== "undefined") {
       navigator.serviceWorker
         .register("/sw.js", { scope: "/" })

--- a/src/components/__tests__/NotificationListener.test.tsx
+++ b/src/components/__tests__/NotificationListener.test.tsx
@@ -257,4 +257,26 @@ describe("NotificationListener", () => {
     // Then
     expect(container.innerHTML).toBe("");
   });
+
+  it("should skip service worker registration on desktop", async () => {
+    const registerSpy = vi.fn().mockResolvedValue({});
+    Object.defineProperty(global.navigator, "serviceWorker", {
+      value: {
+        register: registerSpy,
+      },
+      configurable: true,
+    });
+
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      showNotification: vi.fn().mockResolvedValue(true),
+    };
+
+    const { default: NotificationListener } = await import("@/components/NotificationListener");
+    render(<NotificationListener {...defaultProps} />);
+
+    expect(registerSpy).not.toHaveBeenCalled();
+
+    delete window.kanvibeDesktop;
+  });
 });

--- a/src/hooks/__tests__/useTaskNotification.test.ts
+++ b/src/hooks/__tests__/useTaskNotification.test.ts
@@ -15,6 +15,7 @@ const mockServiceWorkerRegistration = {
 };
 
 const mockGetRegistration = vi.fn().mockResolvedValue(mockServiceWorkerRegistration);
+const mockDesktopShowNotification = vi.fn().mockResolvedValue(true);
 
 // Notification 글로벌 설정
 const mockRequestPermission = vi.fn().mockResolvedValue("granted");
@@ -40,6 +41,9 @@ describe("useTaskNotification", () => {
     mockShowNotification.mockClear();
     mockGetRegistration.mockClear();
     mockRequestPermission.mockClear();
+    mockDesktopShowNotification.mockClear();
+
+    delete window.kanvibeDesktop;
 
     // Notification permission 리셋
     Object.defineProperty(global, "Notification", {
@@ -221,5 +225,37 @@ describe("useTaskNotification", () => {
 
     // Then
     expect(mockRequestPermission).toHaveBeenCalled();
+  });
+
+  it("should use Electron native notification bridge on desktop", async () => {
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      showNotification: mockDesktopShowNotification,
+    };
+
+    const { useTaskNotification } = await import("@/hooks/useTaskNotification");
+    const { result } = renderHook(() => useTaskNotification());
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await act(async () => {
+      await result.current.notifyTaskStatusChanged({
+        projectName: "kanvibe",
+        branchName: "feat/electron",
+        taskTitle: "네이티브 알림",
+        description: "OS 알림 테스트",
+        newStatus: "review",
+        taskId: "task-desktop",
+        locale: "ko",
+      });
+    });
+
+    expect(mockDesktopShowNotification).toHaveBeenCalledWith({
+      title: "kanvibe — feat/electron",
+      body: "네이티브 알림: review로 변경\nOS 알림 테스트",
+      taskId: "task-desktop",
+      locale: "ko",
+    });
+    expect(mockShowNotification).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useTaskNotification.ts
+++ b/src/hooks/useTaskNotification.ts
@@ -4,6 +4,8 @@ import { useEffect, useCallback, useRef } from "react";
 
 type NotificationLocale = "ko" | "en" | "zh";
 
+const NOTIFICATION_ICON_PATH = "/icons/icon-192x192.png";
+
 const NOTIFICATION_MESSAGES = {
   ko: {
     formatStatusChanged: (taskTitle: string, newStatus: string) => `${taskTitle}: ${newStatus}로 변경`,
@@ -49,12 +51,62 @@ export interface HookStatusTargetMissingNotification {
   locale: string;
 }
 
+interface BrowserNotificationData {
+  taskId?: string;
+  locale: string;
+}
+
+function isDesktopNotificationAvailable() {
+  return typeof window !== "undefined" && window.kanvibeDesktop?.isDesktop === true;
+}
+
+async function showNotificationViaDesktopBridge(title: string, body: string, data: BrowserNotificationData) {
+  if (!isDesktopNotificationAvailable()) {
+    return false;
+  }
+
+  await window.kanvibeDesktop?.showNotification({
+    title,
+    body,
+    taskId: data.taskId,
+    locale: data.locale,
+  });
+
+  return true;
+}
+
+async function showNotificationViaServiceWorker(title: string, body: string, data: BrowserNotificationData) {
+  if (!("serviceWorker" in navigator)) {
+    return false;
+  }
+
+  const registration = await navigator.serviceWorker.getRegistration();
+  if (!registration) {
+    return false;
+  }
+
+  await registration.showNotification(title, {
+    body,
+    icon: NOTIFICATION_ICON_PATH,
+    data,
+  });
+
+  return true;
+}
+
 /** hooks 경유 task 상태 변경 시 Browser Notification을 발송하는 훅 */
 export function useTaskNotification() {
   const isPermissionGranted = useRef(false);
 
   useEffect(() => {
-    if (typeof window === "undefined" || !("Notification" in window)) return;
+    if (typeof window === "undefined") return;
+
+    if (isDesktopNotificationAvailable()) {
+      isPermissionGranted.current = true;
+      return;
+    }
+
+    if (!("Notification" in window)) return;
 
     if (Notification.permission === "granted") {
       isPermissionGranted.current = true;
@@ -76,19 +128,16 @@ export function useTaskNotification() {
         bodyParts.push(payload.description);
       }
 
-      // Service Worker의 notificationclick 이벤트를 수신하려면
-      // ServiceWorkerRegistration.showNotification()을 사용해야 함
       try {
-        const registration = await navigator.serviceWorker.getRegistration();
-        if (registration) {
-          registration.showNotification(title, {
-            body: bodyParts.join("\n"),
-            icon: "/kanvibe-logo.svg",
-            data: {
-              taskId: payload.taskId,
-              locale: payload.locale,
-            },
-          });
+        const body = bodyParts.join("\n");
+        const data = {
+          taskId: payload.taskId,
+          locale: payload.locale,
+        };
+
+        const isDesktopNotificationShown = await showNotificationViaDesktopBridge(title, body, data);
+        if (!isDesktopNotificationShown) {
+          await showNotificationViaServiceWorker(title, body, data);
         }
       } catch (err) {
         console.error("[Notification] Failed to show notification:", err);
@@ -109,15 +158,14 @@ export function useTaskNotification() {
           : messages.taskNotFound;
 
       try {
-        const registration = await navigator.serviceWorker.getRegistration();
-        if (registration) {
-          registration.showNotification(title, {
-            body: `${messages.formatMissingStatus(payload.requestedStatus)}\n${reasonMessage}`,
-            icon: "/kanvibe-logo.svg",
-            data: {
-              locale: payload.locale,
-            },
-          });
+        const body = `${messages.formatMissingStatus(payload.requestedStatus)}\n${reasonMessage}`;
+        const data = {
+          locale: payload.locale,
+        };
+
+        const isDesktopNotificationShown = await showNotificationViaDesktopBridge(title, body, data);
+        if (!isDesktopNotificationShown) {
+          await showNotificationViaServiceWorker(title, body, data);
         }
       } catch (err) {
         console.error("[Notification] Failed to show missing target notification:", err);

--- a/src/types/kanvibeDesktop.d.ts
+++ b/src/types/kanvibeDesktop.d.ts
@@ -1,0 +1,15 @@
+interface KanvibeDesktopNotificationPayload {
+  title: string;
+  body: string;
+  taskId?: string;
+  locale: string;
+}
+
+interface KanvibeDesktopApi {
+  isDesktop: boolean;
+  showNotification: (payload: KanvibeDesktopNotificationPayload) => Promise<boolean>;
+}
+
+interface Window {
+  kanvibeDesktop?: KanvibeDesktopApi;
+}


### PR DESCRIPTION
## Summary
- route task notifications through the Electron main process so desktop builds show native OS notifications while keeping the latest multi-window behavior from `refactor/nextron`
- focus the KanVibe window and navigate to the related task when a desktop notification is clicked, with updated preload and notification hook coverage
- document the `--aiauthor` flag in both commit-skill copies and their PR guide so commit footers and PR bodies can include an AI author marker only when explicitly requested

## Verification
- `node --check electron/main.js`