### PR TITLE
Desktop renderer migration with Electron runtime and merge conflict fixes

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -35,8 +35,9 @@ encoding: "utf-8"
 # whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
-# list of additional paths to ignore in all projects
-# same syntax as gitignore, so you can use * and **
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -44,7 +45,9 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
 # Below is the complete list of tools for convenience.
 # To make sure you have the latest list of tools, and to view their descriptions, 
 # execute `uv run scripts/print_tool_overview.py`.
@@ -85,7 +88,8 @@ read_only: false
 #  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
 excluded_tools: []
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
@@ -111,8 +115,10 @@ default_modes:
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
 
-# override of the corresponding setting in serena_config.yml, see the documentation there.
-# If null or missing, the value from the global config is used.
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
 symbol_info_budget:
 
 # The language backend to use for this project.
@@ -130,3 +136,17 @@ line_ending:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -7,16 +7,13 @@ directories:
   buildResources: resources
 
 files:
-  - boot.js
+  - build/renderer/**/*
   - electron/**/*
   - messages/**/*
-  - next.config.ts
   - package.json
   - public/**/*
-  - server.ts
   - tsconfig.json
   - src/**/*
-  - .next/**/*
 
 extraResources:
   - from: resources/database

--- a/electron/hookServer.js
+++ b/electron/hookServer.js
@@ -1,0 +1,64 @@
+const http = require("node:http");
+const path = require("node:path");
+
+function readJsonBody(request) {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+    request.on("error", reject);
+  });
+}
+
+function writeJson(response, statusCode, payload) {
+  response.writeHead(statusCode, { "Content-Type": "application/json" });
+  response.end(JSON.stringify(payload));
+}
+
+function createHookServer({ host, port }) {
+  const hookService = require(path.join(process.cwd(), "src", "desktop", "main", "services", "hookService.ts"));
+
+  const server = http.createServer(async (request, response) => {
+    if (request.method === "POST" && request.url === "/api/hooks/start") {
+      try {
+        const result = await hookService.startHookTask(await readJsonBody(request));
+        writeJson(response, result.status || 200, result);
+      } catch (error) {
+        writeJson(response, 500, { success: false, error: error instanceof Error ? error.message : "서버 오류" });
+      }
+      return;
+    }
+
+    if (request.method === "POST" && request.url === "/api/hooks/status") {
+      try {
+        const result = await hookService.updateHookTaskStatus(await readJsonBody(request));
+        writeJson(response, result.status || 200, result);
+      } catch (error) {
+        writeJson(response, 500, { success: false, error: error instanceof Error ? error.message : "서버 오류" });
+      }
+      return;
+    }
+
+    writeJson(response, 404, { success: false, error: "Not found" });
+  });
+
+  server.listen(port, host, () => {
+    console.log(`[kanvibe] Hook server listening on http://${host}:${port}`);
+  });
+
+  server.on("error", (error) => {
+    console.error("[kanvibe] Hook server failed:", error);
+  });
+
+  return server;
+}
+
+module.exports = { createHookServer };

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,10 +1,15 @@
+const fs = require("node:fs");
 const http = require("node:http");
 const path = require("node:path");
 const process = require("node:process");
-const { app, BrowserWindow, session } = require("electron");
+const { app, BrowserWindow, ipcMain, session } = require("electron");
 
-const PORT = process.env.PORT || "4885";
-const DEFAULT_LOCALE = process.env.KANVIBE_LOCALE || "ko";
+require("tsx/cjs");
+
+const RENDERER_DEV_URL = process.env.KANVIBE_RENDERER_URL || null;
+const HOOK_SERVER_HOST = process.env.KANVIBE_HOOK_HOST || "127.0.0.1";
+const HOOK_SERVER_PORT = Number.parseInt(process.env.PORT || "4885", 10);
+
 const isHeadlessLinuxRuntime = !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
 
 if (process.platform === "linux") {
@@ -16,9 +21,30 @@ if (process.platform === "linux") {
 }
 
 let mainWindow = null;
-let serverBootstrapped = false;
+let hookServer = null;
 
-async function waitForServer(url, retries = 80) {
+function ensureRuntimeEnvironment() {
+  const appRoot = app.getAppPath();
+  process.chdir(appRoot);
+  process.env.KANVIBE_DESKTOP = "true";
+  process.env.KANVIBE_HOST = HOOK_SERVER_HOST;
+  process.env.PORT = String(HOOK_SERVER_PORT);
+  process.env.KANVIBE_APP_DATA_DIR = app.getPath("userData");
+  process.env.KANVIBE_SEED_DB_PATH = app.isPackaged
+    ? path.join(process.resourcesPath, "database", "app.seed.db")
+    : path.join(appRoot, "resources", "database", "app.seed.db");
+
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = app.isPackaged ? "production" : "development";
+  }
+}
+
+function getRendererEntryPath() {
+  const appRoot = app.getAppPath();
+  return path.join(appRoot, "build", "renderer", "index.html");
+}
+
+async function waitForUrl(url, retries = 80) {
   for (let attempt = 0; attempt < retries; attempt += 1) {
     const isReady = await new Promise((resolve) => {
       const request = http.get(url, (response) => {
@@ -40,38 +66,94 @@ async function waitForServer(url, retries = 80) {
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
 
-  throw new Error(`KanVibe server did not become ready on ${url}`);
+  throw new Error(`Renderer did not become ready on ${url}`);
 }
 
-function bootstrapInternalServer() {
-  if (serverBootstrapped) {
+function registerDesktopHandlers() {
+  const { desktopServices } = require(path.join(app.getAppPath(), "src", "desktop", "main", "serviceRegistry.ts"));
+  const {
+    openTerminal,
+    writeTerminal,
+    resizeTerminal,
+    focusTerminal,
+    closeTerminal,
+    closeWindowTerminals,
+  } = require(path.join(app.getAppPath(), "src", "desktop", "main", "terminalBridge.ts"));
+
+  ipcMain.handle("kanvibe:invoke", async (_event, namespace, method, args) => {
+    const service = desktopServices[namespace];
+    if (!service) {
+      throw new Error(`Unknown desktop service namespace: ${namespace}`);
+    }
+
+    const targetMethod = service[method];
+    if (typeof targetMethod !== "function") {
+      throw new Error(`Unknown desktop service method: ${namespace}.${method}`);
+    }
+
+    return targetMethod(...(Array.isArray(args) ? args : []));
+  });
+
+  ipcMain.handle("kanvibe:terminal-open", async (event, taskId, cols, rows) => {
+    return openTerminal(event.sender, taskId, cols, rows);
+  });
+
+  ipcMain.on("kanvibe:terminal-write", (event, taskId, data) => {
+    writeTerminal(event.sender.id, taskId, data);
+  });
+
+  ipcMain.on("kanvibe:terminal-resize", (event, taskId, cols, rows) => {
+    resizeTerminal(event.sender.id, taskId, cols, rows);
+  });
+
+  ipcMain.on("kanvibe:terminal-focus", (_event, taskId) => {
+    focusTerminal(taskId);
+  });
+
+  ipcMain.on("kanvibe:terminal-close", (event, taskId) => {
+    closeTerminal(event.sender.id, taskId);
+  });
+
+  app.on("web-contents-created", (_createdEvent, webContents) => {
+    webContents.once("destroyed", () => {
+      closeWindowTerminals(webContents.id);
+    });
+  });
+}
+
+function registerBoardEventForwarding() {
+  const { subscribeToBoardEvents } = require(path.join(app.getAppPath(), "src", "lib", "boardNotifier.ts"));
+
+  return subscribeToBoardEvents((payload) => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) {
+        window.webContents.send("kanvibe:board-event", payload);
+      }
+    }
+  });
+}
+
+function startHookServer() {
+  const { createHookServer } = require(path.join(app.getAppPath(), "electron", "hookServer.js"));
+  hookServer = createHookServer({ host: HOOK_SERVER_HOST, port: HOOK_SERVER_PORT });
+}
+
+async function loadRenderer(window) {
+  if (RENDERER_DEV_URL) {
+    await waitForUrl(RENDERER_DEV_URL);
+    await window.loadURL(RENDERER_DEV_URL);
     return;
   }
 
-  const appRoot = app.getAppPath();
-  process.chdir(appRoot);
-  process.env.PORT = PORT;
-  process.env.KANVIBE_DESKTOP = "true";
-  process.env.KANVIBE_HOST = "127.0.0.1";
-  process.env.KANVIBE_APP_DATA_DIR = app.getPath("userData");
-  process.env.KANVIBE_SEED_DB_PATH = app.isPackaged
-    ? path.join(process.resourcesPath, "database", "app.seed.db")
-    : path.join(appRoot, "resources", "database", "app.seed.db");
-
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = app.isPackaged ? "production" : "development";
+  const rendererEntryPath = getRendererEntryPath();
+  if (!fs.existsSync(rendererEntryPath)) {
+    throw new Error(`Renderer build not found: ${rendererEntryPath}`);
   }
 
-  require(path.join(appRoot, "boot.js"));
-  serverBootstrapped = true;
+  await window.loadFile(rendererEntryPath);
 }
 
 async function createMainWindow() {
-  bootstrapInternalServer();
-
-  const startUrl = `http://127.0.0.1:${PORT}/${DEFAULT_LOCALE}/login`;
-  await waitForServer(startUrl);
-
   mainWindow = new BrowserWindow({
     width: 1600,
     height: 1000,
@@ -86,7 +168,7 @@ async function createMainWindow() {
     },
   });
 
-  await mainWindow.loadURL(startUrl);
+  await loadRenderer(mainWindow);
 
   mainWindow.on("closed", () => {
     mainWindow = null;
@@ -94,9 +176,14 @@ async function createMainWindow() {
 }
 
 app.whenReady().then(async () => {
+  ensureRuntimeEnvironment();
   session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
     callback(permission === "notifications");
   });
+
+  registerDesktopHandlers();
+  const unsubscribeBoardEvents = registerBoardEventForwarding();
+  startHookServer();
 
   await createMainWindow();
 
@@ -104,6 +191,11 @@ app.whenReady().then(async () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       await createMainWindow();
     }
+  });
+
+  app.on("before-quit", () => {
+    unsubscribeBoardEvents();
+    hookServer?.close();
   });
 });
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,5 +1,44 @@
-const { contextBridge } = require("electron");
+const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("kanvibeDesktop", {
   isDesktop: true,
+  invoke(namespace, method, args) {
+    return ipcRenderer.invoke("kanvibe:invoke", namespace, method, args);
+  },
+  onBoardEvent(listener) {
+    const handler = (_event, payload) => listener(payload);
+    ipcRenderer.on("kanvibe:board-event", handler);
+    return () => {
+      ipcRenderer.removeListener("kanvibe:board-event", handler);
+    };
+  },
+  openTerminal(taskId, cols, rows) {
+    return ipcRenderer.invoke("kanvibe:terminal-open", taskId, cols, rows);
+  },
+  writeTerminal(taskId, data) {
+    ipcRenderer.send("kanvibe:terminal-write", taskId, data);
+  },
+  resizeTerminal(taskId, cols, rows) {
+    ipcRenderer.send("kanvibe:terminal-resize", taskId, cols, rows);
+  },
+  focusTerminal(taskId) {
+    ipcRenderer.send("kanvibe:terminal-focus", taskId);
+  },
+  closeTerminal(taskId) {
+    ipcRenderer.send("kanvibe:terminal-close", taskId);
+  },
+  onTerminalData(listener) {
+    const handler = (_event, payload) => listener(payload);
+    ipcRenderer.on("kanvibe:terminal-data", handler);
+    return () => {
+      ipcRenderer.removeListener("kanvibe:terminal-data", handler);
+    };
+  },
+  onTerminalClose(listener) {
+    const handler = (_event, payload) => listener(payload);
+    ipcRenderer.on("kanvibe:terminal-close", handler);
+    return () => {
+      ipcRenderer.removeListener("kanvibe:terminal-close", handler);
+    };
+  },
 });

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KanVibe</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/desktop/renderer/main.tsx"></script>
+  </body>
+  </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12403 @@
+{
+  "name": "kanvibe",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kanvibe",
+      "version": "0.1.0",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@hello-pangea/dnd": "^18.0.1",
+        "@monaco-editor/react": "^4.7.0",
+        "@radix-ui/react-switch": "^1.2.6",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-web-links": "^0.12.0",
+        "@xterm/xterm": "^6.0.0",
+        "better-sqlite3": "^12.6.2",
+        "next": "16.1.6",
+        "next-intl": "^4.8.2",
+        "node-pty": "^1.1.0",
+        "react": "19.2.3",
+        "react-colorful": "^5.6.1",
+        "react-dom": "19.2.3",
+        "react-router-dom": "^7.9.4",
+        "reflect-metadata": "^0.2.2",
+        "ssh2": "^1.17.0",
+        "tsx": "^4.21.0",
+        "typeorm": "^0.3.28",
+        "uuid": "^13.0.0",
+        "ws": "^8.19.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.58.2",
+        "@tailwindcss/postcss": "^4",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/better-sqlite3": "^7.6.13",
+        "@types/node": "^20",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "@types/ssh2": "^1.15.5",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.18.1",
+        "@vitejs/plugin-react": "^5.1.4",
+        "electron": "^37.2.6",
+        "electron-builder": "^26.0.12",
+        "eslint": "^9",
+        "eslint-config-next": "16.1.6",
+        "jsdom": "^28.1.0",
+        "tailwindcss": "^4",
+        "typescript": "5.9.3",
+        "vite": "^7.1.10",
+        "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": "24.x"
+      }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.27",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@develar/schema-utils": {
+      "version": "2.6.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.0",
+        "ajv-keywords": "^3.4.1"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/fuses": {
+      "version": "1.8.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "electron-fuses": "dist/bin.js"
+      }
+    },
+    "node_modules/@electron/fuses/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/get/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@electron/get/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@electron/get/node_modules/universalify": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@electron/notarize": {
+      "version": "2.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/osx-sign": {
+      "version": "1.3.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "compare-version": "^0.1.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.0.0",
+        "isbinaryfile": "^4.0.8",
+        "minimist": "^1.2.6",
+        "plist": "^3.0.5"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.js",
+        "electron-osx-sign": "bin/electron-osx-sign.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.1.1",
+        "detect-libc": "^2.0.1",
+        "got": "^11.7.0",
+        "graceful-fs": "^4.2.11",
+        "node-abi": "^4.2.0",
+        "node-api-version": "^0.2.1",
+        "node-gyp": "^11.2.0",
+        "ora": "^5.1.0",
+        "read-binary-file-arch": "^1.0.6",
+        "semver": "^7.3.5",
+        "tar": "^7.5.6",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/node-abi": {
+      "version": "4.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/universal": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^3.3.1",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.3.1",
+        "dir-compare": "^4.2.0",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.4"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/minimatch": {
+      "version": "9.0.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.2.2",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.0",
+        "@formatjs/intl-localematcher": "0.8.1",
+        "decimal.js": "^10.6.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.1",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.1",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.1.1",
+        "@formatjs/icu-skeleton-parser": "2.1.1",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.1.1",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "18.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "css-box-model": "^1.2.1",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.1.6",
+      "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "16.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.1.6",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sqltools/formatter": {
+      "version": "1.2.5",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/core": {
+      "version": "1.15.11",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.25"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.11",
+        "@swc/core-darwin-x64": "1.15.11",
+        "@swc/core-linux-arm-gnueabihf": "1.15.11",
+        "@swc/core-linux-arm64-gnu": "1.15.11",
+        "@swc/core-linux-arm64-musl": "1.15.11",
+        "@swc/core-linux-x64-gnu": "1.15.11",
+        "@swc/core-linux-x64-musl": "1.15.11",
+        "@swc/core-win32-arm64-msvc": "1.15.11",
+        "@swc/core-win32-ia32-msvc": "1.15.11",
+        "@swc/core-win32-x64-msvc": "1.15.11"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.11",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.11.tgz",
+      "integrity": "sha512-S52Gu1QtPSfBYDiejlcfp9GlN+NjTZBRRNsz8PNwBgSE626/FUf2PcllVUix7jqkoMC+t0rS8t+2/aSWlMuQtA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.11.tgz",
+      "integrity": "sha512-lXJs8oXo6Z4yCpimpQ8vPeCjkgoHu5NoMvmJZ8qxDyU99KVdg6KwU9H79vzrmB+HfH+dCZ7JGMqMF//f8Cfvdg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.11.tgz",
+      "integrity": "sha512-chRsz1K52/vj8Mfq/QOugVphlKPWlMh10V99qfH41hbGvwAU6xSPd681upO4bKiOr9+mRIZZW+EfJqY42ZzRyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.11.tgz",
+      "integrity": "sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.11.tgz",
+      "integrity": "sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.11.tgz",
+      "integrity": "sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.11.tgz",
+      "integrity": "sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.11.tgz",
+      "integrity": "sha512-6XnzORkZCQzvTQ6cPrU7iaT9+i145oLwnin8JrfsLG41wl26+5cNQ2XV3zcbrnFEV6esjOceom9YO1w9mGJByw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.11.tgz",
+      "integrity": "sha512-IQ2n6af7XKLL6P1gIeZACskSxK8jWtoKpJWLZmdXTDj1MGzktUy4i+FvpdtxFmJWNavRWH1VmTr6kAubRDHeKw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.25",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.1.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "enhanced-resolve": "^5.18.3",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.30.2",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.1.18",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.1.18",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.18",
+        "@tailwindcss/oxide-darwin-x64": "4.1.18",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.18",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
+      "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.1.18",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
+      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
+      "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
+      "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
+      "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
+      "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
+      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
+      "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
+      "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
+      "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
+      "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.1.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.1.18",
+        "@tailwindcss/oxide": "4.1.18",
+        "postcss": "^8.4.41",
+        "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.33",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/plist": {
+      "version": "3.0.5",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/verror": {
+      "version": "1.10.11",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.55.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.55.0",
+        "@typescript-eslint/type-utils": "8.55.0",
+        "@typescript-eslint/utils": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.55.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.55.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.55.0",
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.55.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.55.0",
+        "@typescript-eslint/types": "^8.55.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.55.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.55.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.55.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0",
+        "@typescript-eslint/utils": "8.55.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.55.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.55.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.55.0",
+        "@typescript-eslint/tsconfig-utils": "8.55.0",
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.55.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.55.0",
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.55.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.55.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
+    "node_modules/7zip-bin": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abbrev": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "4.2.0",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/app-builder-bin": {
+      "version": "5.0.0-alpha.12",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/app-builder-lib": {
+      "version": "26.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@develar/schema-utils": "~2.6.5",
+        "@electron/asar": "3.4.1",
+        "@electron/fuses": "^1.8.0",
+        "@electron/get": "^3.0.0",
+        "@electron/notarize": "2.5.0",
+        "@electron/osx-sign": "1.3.3",
+        "@electron/rebuild": "^4.0.3",
+        "@electron/universal": "2.0.3",
+        "@malept/flatpak-bundler": "^0.4.0",
+        "@types/fs-extra": "9.0.13",
+        "async-exit-hook": "^2.0.1",
+        "builder-util": "26.8.1",
+        "builder-util-runtime": "9.5.1",
+        "chromium-pickle-js": "^0.2.0",
+        "ci-info": "4.3.1",
+        "debug": "^4.3.4",
+        "dotenv": "^16.4.5",
+        "dotenv-expand": "^11.0.6",
+        "ejs": "^3.1.8",
+        "electron-publish": "26.8.1",
+        "fs-extra": "^10.1.0",
+        "hosted-git-info": "^4.1.0",
+        "isbinaryfile": "^5.0.0",
+        "jiti": "^2.4.2",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.3",
+        "lazy-val": "^1.0.5",
+        "minimatch": "^10.0.3",
+        "plist": "3.1.0",
+        "proper-lockfile": "^4.1.2",
+        "resedit": "^1.7.0",
+        "semver": "~7.7.3",
+        "tar": "^7.5.7",
+        "temp-file": "^3.4.0",
+        "tiny-async-pool": "1.3.0",
+        "which": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "dmg-builder": "26.8.1",
+        "electron-builder-squirrel-windows": "26.8.1"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/get": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/isbinaryfile": {
+      "version": "5.0.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/minimatch": {
+      "version": "10.2.4",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/universalify": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/app-root-path": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.6.2",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/builder-util": {
+      "version": "26.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.6",
+        "7zip-bin": "~5.2.0",
+        "app-builder-bin": "5.0.0-alpha.12",
+        "builder-util-runtime": "9.5.1",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "js-yaml": "^4.1.0",
+        "sanitize-filename": "^1.6.3",
+        "source-map-support": "^0.5.19",
+        "stat-mode": "^1.0.0",
+        "temp-file": "^3.4.0",
+        "tiny-async-pool": "1.3.0"
+      }
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "9.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "19.0.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^4.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^12.0.0",
+        "tar": "^7.4.3",
+        "unique-filename": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001770",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "license": "ISC"
+    },
+    "node_modules/chromium-pickle-js": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ci-info": {
+      "version": "4.3.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone-response/node_modules/mimic-response": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/compare-version": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.19",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "license": "MIT"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.1",
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/dir-compare": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.5",
+        "p-limit": "^3.1.0 "
+      }
+    },
+    "node_modules/dmg-builder": {
+      "version": "26.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
+        "fs-extra": "^10.1.0",
+        "iconv-lite": "^0.6.2",
+        "js-yaml": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "dmg-license": "^1.0.11"
+      }
+    },
+    "node_modules/dmg-license": {
+      "version": "1.0.11",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "@types/plist": "^3.0.1",
+        "@types/verror": "^1.10.3",
+        "ajv": "^6.10.0",
+        "crc": "^3.8.0",
+        "iconv-corefoundation": "^1.1.7",
+        "plist": "^3.0.4",
+        "smart-buffer": "^4.0.2",
+        "verror": "^1.10.0"
+      },
+      "bin": {
+        "dmg-license": "bin/dmg-license.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "license": "MIT"
+    },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron": {
+      "version": "37.10.3",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^22.7.7",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-builder": {
+      "version": "26.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
+        "builder-util-runtime": "9.5.1",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "dmg-builder": "26.8.1",
+        "fs-extra": "^10.1.0",
+        "lazy-val": "^1.0.5",
+        "simple-update-notifier": "2.0.0",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "electron-builder": "cli.js",
+        "install-app-deps": "install-app-deps.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "26.8.1",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
+        "electron-winstaller": "5.4.0"
+      }
+    },
+    "node_modules/electron-builder/node_modules/ci-info": {
+      "version": "4.4.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-publish": {
+      "version": "26.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.11",
+        "builder-util": "26.8.1",
+        "builder-util-runtime": "9.5.1",
+        "chalk": "^4.1.2",
+        "form-data": "^4.0.5",
+        "fs-extra": "^10.1.0",
+        "lazy-val": "^1.0.5",
+        "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.286",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/electron-winstaller": {
+      "version": "5.4.0",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.1",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "lodash": "^4.17.21",
+        "temp": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@electron/windows-sign": "^1.1.2"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/universalify": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "22.19.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.19.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.1",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.2",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "16.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "16.1.6",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^7.0.0",
+        "globals": "16.4.0",
+        "typescript-eslint": "^8.46.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/globals": {
+      "version": "16.4.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-corefoundation": {
+      "version": "1.1.7",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "node-addon-api": "^1.6.3"
+      },
+      "engines": {
+        "node": "^8.11.2 || >=10"
+      }
+    },
+    "node_modules/iconv-corefoundation/node_modules/node-addon-api": {
+      "version": "1.7.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/icu-minify": {
+      "version": "4.8.2",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.1.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.1.1",
+        "@formatjs/fast-memoize": "3.1.0",
+        "@formatjs/icu-messageformat-parser": "3.5.1",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "license": "MIT"
+    },
+    "node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.30.2",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.30.2",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-freebsd-x64": "1.30.2",
+        "lightningcss-linux-arm-gnueabihf": "1.30.2",
+        "lightningcss-linux-arm64-gnu": "1.30.2",
+        "lightningcss-linux-arm64-musl": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2",
+        "lightningcss-linux-x64-musl": "1.30.2",
+        "lightningcss-win32-arm64-msvc": "1.30.2",
+        "lightningcss-win32-x64-msvc": "1.30.2"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.30.2",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "license": "ISC"
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "14.0.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/agent": "^3.0.0",
+        "cacache": "^19.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^4.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1",
+        "ssri": "^12.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "license": "MIT"
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.25.0",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.1.6",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.1.6",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.1.6",
+        "@next/swc-darwin-x64": "16.1.6",
+        "@next/swc-linux-arm64-gnu": "16.1.6",
+        "@next/swc-linux-arm64-musl": "16.1.6",
+        "@next/swc-linux-x64-gnu": "16.1.6",
+        "@next/swc-linux-x64-musl": "16.1.6",
+        "@next/swc-win32-arm64-msvc": "16.1.6",
+        "@next/swc-win32-x64-msvc": "16.1.6",
+        "sharp": "^0.34.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "4.8.2",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "icu-minify": "^4.8.2",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.8.2",
+        "po-parser": "^2.1.1",
+        "use-intl": "^4.8.2"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl-swc-plugin-extractor": {
+      "version": "4.8.2",
+      "license": "MIT"
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.88.0",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "license": "MIT"
+    },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "11.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^14.0.3",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.4.3",
+        "tinyglobby": "^0.2.12",
+        "which": "^5.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "8.1.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pe-library": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/po-parser": {
+      "version": "2.1.1",
+      "license": "MIT"
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.14.0",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.0",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "license": "MIT"
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "license": "Apache-2.0"
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resedit": {
+      "version": "1.7.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "dev": true,
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/sql-highlight": {
+      "version": "6.1.0",
+      "funding": [
+        "https://github.com/scriptcoded/sql-highlight?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/scriptcoded"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
+    "node_modules/ssri": {
+      "version": "12.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stat-mode": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "license": "MIT"
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.18",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.11",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/temp-file": {
+      "version": "3.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "fs-extra": "^10.0.0"
+      }
+    },
+    "node_modules/tiny-async-pool": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.5.0"
+      }
+    },
+    "node_modules/tiny-async-pool/node_modules/semver": {
+      "version": "5.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "license": "Unlicense"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typeorm": {
+      "version": "0.3.28",
+      "license": "MIT",
+      "dependencies": {
+        "@sqltools/formatter": "^1.2.5",
+        "ansis": "^4.2.0",
+        "app-root-path": "^3.1.0",
+        "buffer": "^6.0.3",
+        "dayjs": "^1.11.19",
+        "debug": "^4.4.3",
+        "dedent": "^1.7.0",
+        "dotenv": "^16.6.1",
+        "glob": "^10.5.0",
+        "reflect-metadata": "^0.2.2",
+        "sha.js": "^2.4.12",
+        "sql-highlight": "^6.1.0",
+        "tslib": "^2.8.1",
+        "uuid": "^11.1.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "typeorm": "cli.js",
+        "typeorm-ts-node-commonjs": "cli-ts-node-commonjs.js",
+        "typeorm-ts-node-esm": "cli-ts-node-esm.js"
+      },
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/typeorm"
+      },
+      "peerDependencies": {
+        "@google-cloud/spanner": "^5.18.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@sap/hana-client": "^2.14.22",
+        "better-sqlite3": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
+        "ioredis": "^5.0.4",
+        "mongodb": "^5.8.0 || ^6.0.0",
+        "mssql": "^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0",
+        "mysql2": "^2.2.5 || ^3.0.1",
+        "oracledb": "^6.3.0",
+        "pg": "^8.5.1",
+        "pg-native": "^3.0.0",
+        "pg-query-stream": "^4.0.0",
+        "redis": "^3.1.1 || ^4.0.0 || ^5.0.14",
+        "sql.js": "^1.4.0",
+        "sqlite3": "^5.0.3",
+        "ts-node": "^10.7.0",
+        "typeorm-aurora-data-api-driver": "^2.0.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@google-cloud/spanner": {
+          "optional": true
+        },
+        "@sap/hana-client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "mssql": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "oracledb": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-native": {
+          "optional": true
+        },
+        "pg-query-stream": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        },
+        "typeorm-aurora-data-api-driver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typeorm/node_modules/buffer": {
+      "version": "6.0.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/typeorm/node_modules/uuid": {
+      "version": "11.1.0",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.55.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.55.0",
+        "@typescript-eslint/parser": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0",
+        "@typescript-eslint/utils": "8.55.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unique-filename": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.8.2",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.8.2",
+        "intl-messageformat": "^11.1.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which/node_modules/isexe": {
+      "version": "3.1.5",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   },
   "main": "electron/main.js",
   "scripts": {
-    "predev": "node scripts/ensure-native-runtime.cjs",
+    "predev": "node scripts/ensure-native-runtime.cjs --electron",
     "predb:prepare": "node scripts/ensure-native-runtime.cjs",
-    "prestart": "node scripts/ensure-native-runtime.cjs",
+    "predesktop:dev": "node scripts/ensure-native-runtime.cjs --electron",
+    "prestart": "node scripts/ensure-native-runtime.cjs --electron",
     "dev": "node scripts/run-desktop-dev.cjs",
     "build": "vite build",
     "start": "node scripts/run-desktop-start.cjs",
@@ -24,7 +25,7 @@
     "test:e2e:login": "bash -lc 'for port in 4884 4885; do fuser -k \"$port\"/tcp 2>/dev/null || true; done; rm -f .next/dev/lock; playwright test tests/e2e/login.spec.js'",
     "test": "vitest run",
     "test:watch": "vitest",
-    "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null || true"
+    "postinstall": "node scripts/postinstall.cjs"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "predev": "node scripts/ensure-native-runtime.cjs",
     "predb:prepare": "node scripts/ensure-native-runtime.cjs",
     "prestart": "node scripts/ensure-native-runtime.cjs",
-    "dev": "node boot.js",
-    "build": "next build",
-    "start": "node boot.js",
+    "dev": "node scripts/run-desktop-dev.cjs",
+    "build": "vite build",
+    "start": "node scripts/run-desktop-start.cjs",
     "desktop:dev": "node scripts/run-desktop-dev.cjs",
     "db:prepare": "tsx scripts/build-seed-db.ts",
     "dist": "pnpm db:prepare && pnpm build && electron-builder --mac dmg zip",
@@ -55,6 +55,7 @@
     "react": "19.2.3",
     "react-colorful": "^5.6.1",
     "react-dom": "19.2.3",
+    "react-router-dom": "^7.9.4",
     "reflect-metadata": "^0.2.2",
     "ssh2": "^1.17.0",
     "tsx": "^4.21.0",
@@ -82,6 +83,7 @@
     "jsdom": "^28.1.0",
     "tailwindcss": "^4",
     "typescript": "5.9.3",
+    "vite": "^7.1.10",
     "vitest": "^4.0.18"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      react-router-dom:
+        specifier: ^7.9.4
+        version: 7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -123,6 +126,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vite:
+        specifier: ^7.1.10
+        version: 7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@20.19.33)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.2)(tsx@4.21.0)
@@ -2054,6 +2060,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -3597,6 +3607,23 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.14.0:
+    resolution: {integrity: sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.14.0:
+    resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
@@ -3737,6 +3764,9 @@ packages:
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6225,6 +6255,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   core-util-is@1.0.2:
     optional: true
 
@@ -8032,6 +8064,20 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-router-dom@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-router: 7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+
+  react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.3
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.3(react@19.2.3)
+
   react@19.2.3: {}
 
   read-binary-file-arch@1.0.6:
@@ -8206,6 +8252,8 @@ snapshots:
     dependencies:
       type-fest: 0.13.1
     optional: true
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/scripts/ensure-native-runtime.cjs
+++ b/scripts/ensure-native-runtime.cjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const { execFileSync } = require("node:child_process");
+const path = require("node:path");
 
 const REQUIRED_NODE_MAJOR = 24;
 const isRunningInsideElectron = Boolean(process.versions.electron);
@@ -39,7 +40,7 @@ function loadBetterSqlite3() {
   return require("better-sqlite3");
 }
 
-function verifyBetterSqlite3Binding() {
+function verifyNodeBetterSqlite3Binding() {
   const BetterSqlite3 = loadBetterSqlite3();
   const database = new BetterSqlite3(":memory:");
 
@@ -49,6 +50,22 @@ function verifyBetterSqlite3Binding() {
   } finally {
     database.close();
   }
+}
+
+function verifyElectronBetterSqlite3Binding() {
+  execFileSync("pnpm", ["exec", "electron", path.join(__dirname, "verify-electron-better-sqlite3.cjs")], {
+    stdio: "inherit",
+    env: process.env,
+  });
+}
+
+function verifyBetterSqlite3Binding() {
+  if (isElectronTarget && !isRunningInsideElectron) {
+    verifyElectronBetterSqlite3Binding();
+    return;
+  }
+
+  verifyNodeBetterSqlite3Binding();
 }
 
 function rebuildNativeDependency() {
@@ -62,8 +79,8 @@ function rebuildNativeDependency() {
       throw new Error("better-sqlite3 ABI mismatch in packaged Electron runtime");
     }
 
-    console.warn("[kanvibe] Detected Electron native ABI mismatch. Rebuilding app dependencies for Electron...");
-    execFileSync("pnpm", ["exec", "electron-builder", "install-app-deps"], {
+    console.warn("[kanvibe] Detected Electron native ABI mismatch. Rebuilding better-sqlite3 for Electron from source...");
+    execFileSync("pnpm", ["exec", "electron-rebuild", "-f", "--build-from-source", "-w", "better-sqlite3"], {
       stdio: "inherit",
       env,
     });
@@ -87,7 +104,7 @@ function printRebuildFailureGuidance(error) {
       return;
     }
 
-    console.error("[kanvibe] Try running `pnpm exec electron-builder install-app-deps` and launch the desktop app again.");
+    console.error("[kanvibe] Try running `pnpm exec electron-rebuild -f --build-from-source -w better-sqlite3` and launch the desktop app again.");
     return;
   }
 

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+const { chmodSync, existsSync } = require("node:fs");
+const { execFileSync } = require("node:child_process");
+const path = require("node:path");
+
+const REQUIRED_NODE_MAJOR = 24;
+
+function getNodeMajor() {
+  return Number.parseInt(process.versions.node.split(".")[0] || "0", 10);
+}
+
+function chmodNodePtySpawnHelper() {
+  const helperPath = path.join(
+    process.cwd(),
+    "node_modules",
+    "node-pty",
+    "prebuilds",
+    "darwin-arm64",
+    "spawn-helper",
+  );
+
+  if (!existsSync(helperPath)) {
+    return;
+  }
+
+  try {
+    chmodSync(helperPath, 0o755);
+  } catch {
+    // 권한 보정 실패는 개발 환경에 따라 발생할 수 있어 설치를 막지 않는다.
+  }
+}
+
+function hasElectronBuilderInstalled() {
+  try {
+    require.resolve("electron-builder");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function rebuildElectronNativeDependencies() {
+  console.warn("[kanvibe] Postinstall: rebuilding native dependencies for the Electron runtime...");
+  execFileSync("pnpm", ["exec", "electron-rebuild", "-f", "--build-from-source", "-w", "better-sqlite3"], {
+    stdio: "inherit",
+    env: process.env,
+  });
+}
+
+function main() {
+  chmodNodePtySpawnHelper();
+
+  if (getNodeMajor() !== REQUIRED_NODE_MAJOR) {
+    console.warn(
+      `[kanvibe] Postinstall: skipping Electron native rebuild because Node ${process.versions.node} is active. Use Node ${REQUIRED_NODE_MAJOR}.x and run \`pnpm exec electron-rebuild -f --build-from-source -w better-sqlite3\` if needed.`,
+    );
+    return;
+  }
+
+  if (!hasElectronBuilderInstalled()) {
+    return;
+  }
+
+  try {
+    rebuildElectronNativeDependencies();
+  } catch (error) {
+    console.warn("[kanvibe] Postinstall: Electron native rebuild failed.");
+    console.warn(String(error?.message || error));
+  }
+}
+
+main();

--- a/scripts/run-desktop-dev.cjs
+++ b/scripts/run-desktop-dev.cjs
@@ -33,7 +33,7 @@ function ensureSupportedNodeVersion() {
 
 function installElectronNativeDependencies() {
   console.warn("[kanvibe] Rebuilding native dependencies for the Electron runtime...");
-  execFileSync("pnpm", ["exec", "electron-builder", "install-app-deps"], {
+  execFileSync("pnpm", ["exec", "electron-rebuild", "-f", "--build-from-source", "-w", "better-sqlite3"], {
     stdio: "inherit",
     env: process.env,
   });

--- a/scripts/run-desktop-dev.cjs
+++ b/scripts/run-desktop-dev.cjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
-const { execFileSync } = require("node:child_process");
+const { execFileSync, spawn } = require("node:child_process");
+const http = require("node:http");
 
 const REQUIRED_NODE_MAJOR = 24;
+const DEV_SERVER_URL = "http://127.0.0.1:5173";
 
 function getNodeMajor() {
   return Number.parseInt(process.versions.node.split(".")[0] || "0", 10);
@@ -25,7 +27,7 @@ function ensureSupportedNodeVersion() {
   console.error(
     `[kanvibe] Unsupported Node.js runtime ${process.versions.node}. KanVibe desktop dev requires Node ${REQUIRED_NODE_MAJOR}.x.`,
   );
-  console.error(`[kanvibe] Run \`nvm use ${REQUIRED_NODE_MAJOR}\` and then retry \`pnpm desktop:dev\`.`);
+  console.error(`[kanvibe] Run \`nvm use ${REQUIRED_NODE_MAJOR}\` and then retry \`pnpm dev\`.`);
   process.exit(1);
 }
 
@@ -45,14 +47,60 @@ function installProjectDependencies() {
   });
 }
 
-function launchElectron() {
-  execFileSync("pnpm", ["exec", "electron", "."], {
+function waitForUrl(url, retries = 80) {
+  return new Promise((resolve, reject) => {
+    let attempt = 0;
+
+    const tryRequest = () => {
+      const request = http.get(url, (response) => {
+        response.resume();
+        if (response.statusCode && response.statusCode < 500) {
+          resolve();
+          return;
+        }
+
+        retry();
+      });
+
+      request.on("error", retry);
+      request.setTimeout(1000, () => {
+        request.destroy();
+        retry();
+      });
+    };
+
+    const retry = () => {
+      attempt += 1;
+      if (attempt >= retries) {
+        reject(new Error(`Dev server did not become ready on ${url}`));
+        return;
+      }
+
+      setTimeout(tryRequest, 500);
+    };
+
+    tryRequest();
+  });
+}
+
+function spawnViteServer() {
+  return spawn("pnpm", ["exec", "vite", "--host", "127.0.0.1", "--port", "5173"], {
     stdio: "inherit",
     env: process.env,
   });
 }
 
-function main() {
+function spawnElectron() {
+  return spawn("pnpm", ["exec", "electron", "."], {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      KANVIBE_RENDERER_URL: DEV_SERVER_URL,
+    },
+  });
+}
+
+async function main() {
   ensureSupportedNodeVersion();
 
   if (!hasBetterSqlite3Installed()) {
@@ -60,7 +108,33 @@ function main() {
   }
 
   installElectronNativeDependencies();
-  launchElectron();
+
+  const viteProcess = spawnViteServer();
+
+  const stopChildren = () => {
+    if (!viteProcess.killed) {
+      viteProcess.kill("SIGTERM");
+    }
+  };
+
+  process.on("SIGINT", stopChildren);
+  process.on("SIGTERM", stopChildren);
+
+  try {
+    await waitForUrl(DEV_SERVER_URL);
+  } catch (error) {
+    stopChildren();
+    throw error;
+  }
+
+  const electronProcess = spawnElectron();
+  electronProcess.on("exit", (code) => {
+    stopChildren();
+    process.exit(code ?? 0);
+  });
 }
 
-main();
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/run-desktop-start.cjs
+++ b/scripts/run-desktop-start.cjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+const { execFileSync, spawn } = require("node:child_process");
+const { existsSync } = require("node:fs");
+const path = require("node:path");
+
+const REQUIRED_NODE_MAJOR = 24;
+const RENDERER_ENTRY_PATH = path.join(process.cwd(), "build", "renderer", "index.html");
+
+function getNodeMajor() {
+  return Number.parseInt(process.versions.node.split(".")[0] || "0", 10);
+}
+
+function hasBetterSqlite3Installed() {
+  try {
+    require.resolve("better-sqlite3");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureSupportedNodeVersion() {
+  if (getNodeMajor() === REQUIRED_NODE_MAJOR) {
+    return;
+  }
+
+  console.error(
+    `[kanvibe] Unsupported Node.js runtime ${process.versions.node}. KanVibe desktop start requires Node ${REQUIRED_NODE_MAJOR}.x.`,
+  );
+  console.error(`[kanvibe] Run \`nvm use ${REQUIRED_NODE_MAJOR}\` and then retry \`pnpm start\`.`);
+  process.exit(1);
+}
+
+function installElectronNativeDependencies() {
+  console.warn("[kanvibe] Rebuilding native dependencies for the Electron runtime...");
+  execFileSync("pnpm", ["exec", "electron-builder", "install-app-deps"], {
+    stdio: "inherit",
+    env: process.env,
+  });
+}
+
+function installProjectDependencies() {
+  console.warn("[kanvibe] Installing project dependencies because better-sqlite3 is missing...");
+  execFileSync("pnpm", ["install"], {
+    stdio: "inherit",
+    env: process.env,
+  });
+}
+
+function ensureRendererBuild() {
+  if (existsSync(RENDERER_ENTRY_PATH)) {
+    return;
+  }
+
+  console.warn("[kanvibe] Renderer build not found. Running `pnpm build` first...");
+  execFileSync("pnpm", ["build"], {
+    stdio: "inherit",
+    env: process.env,
+  });
+}
+
+function main() {
+  ensureSupportedNodeVersion();
+
+  if (!hasBetterSqlite3Installed()) {
+    installProjectDependencies();
+  }
+
+  installElectronNativeDependencies();
+  ensureRendererBuild();
+
+  const child = spawn("pnpm", ["exec", "electron", "."], {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  child.on("exit", (code) => {
+    process.exit(code ?? 0);
+  });
+}
+
+main();

--- a/scripts/run-desktop-start.cjs
+++ b/scripts/run-desktop-start.cjs
@@ -34,7 +34,7 @@ function ensureSupportedNodeVersion() {
 
 function installElectronNativeDependencies() {
   console.warn("[kanvibe] Rebuilding native dependencies for the Electron runtime...");
-  execFileSync("pnpm", ["exec", "electron-builder", "install-app-deps"], {
+  execFileSync("pnpm", ["exec", "electron-rebuild", "-f", "--build-from-source", "-w", "better-sqlite3"], {
     stdio: "inherit",
     env: process.env,
   });

--- a/scripts/verify-electron-better-sqlite3.cjs
+++ b/scripts/verify-electron-better-sqlite3.cjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const BetterSqlite3 = require("better-sqlite3");
+
+const database = new BetterSqlite3(":memory:");
+
+try {
+  database.pragma("journal_mode = WAL");
+  database.prepare("SELECT 1").get();
+} finally {
+  database.close();
+}
+
+process.exit(0);

--- a/src/app/actions/kanban.ts
+++ b/src/app/actions/kanban.ts
@@ -153,10 +153,10 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
         if (!project.sshHost && session.worktreePath) {
           const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
           await Promise.allSettled([
-            setupClaudeHooks(session.worktreePath, project.name, kanvibeUrl),
-            setupGeminiHooks(session.worktreePath, project.name, kanvibeUrl),
-            setupCodexHooks(session.worktreePath, project.name, kanvibeUrl),
-            setupOpenCodeHooks(session.worktreePath, project.name, kanvibeUrl),
+            setupClaudeHooks(session.worktreePath, project.id, kanvibeUrl),
+            setupGeminiHooks(session.worktreePath, project.id, kanvibeUrl),
+            setupCodexHooks(session.worktreePath, project.id, kanvibeUrl),
+            setupOpenCodeHooks(session.worktreePath, project.id, kanvibeUrl),
           ]);
         }
       }
@@ -343,10 +343,10 @@ export async function branchFromTask(
     try {
       const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
       await Promise.allSettled([
-        setupClaudeHooks(session.worktreePath, project.name, kanvibeUrl),
-        setupGeminiHooks(session.worktreePath, project.name, kanvibeUrl),
-        setupCodexHooks(session.worktreePath, project.name, kanvibeUrl),
-        setupOpenCodeHooks(session.worktreePath, project.name, kanvibeUrl),
+          setupClaudeHooks(session.worktreePath, project.id, kanvibeUrl),
+          setupGeminiHooks(session.worktreePath, project.id, kanvibeUrl),
+          setupCodexHooks(session.worktreePath, project.id, kanvibeUrl),
+          setupOpenCodeHooks(session.worktreePath, project.id, kanvibeUrl),
       ]);
     } catch (error) {
       console.error("Hooks 설정 실패:", error);

--- a/src/app/actions/project.ts
+++ b/src/app/actions/project.ts
@@ -221,10 +221,10 @@ export async function scanAndRegisterProjects(
       if (!sshHost) {
         try {
           const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
-          await setupClaudeHooks(repoPath, projectName, kanvibeUrl);
-          await setupGeminiHooks(repoPath, projectName, kanvibeUrl);
-          await setupCodexHooks(repoPath, projectName, kanvibeUrl);
-          await setupOpenCodeHooks(repoPath, projectName, kanvibeUrl);
+          await setupClaudeHooks(repoPath, saved.id, kanvibeUrl);
+          await setupGeminiHooks(repoPath, saved.id, kanvibeUrl);
+          await setupCodexHooks(repoPath, saved.id, kanvibeUrl);
+          await setupOpenCodeHooks(repoPath, saved.id, kanvibeUrl);
           result.hooksSetup.push(projectName);
         } catch (hookError) {
           result.errors.push(
@@ -390,7 +390,7 @@ export async function installProjectHooks(
 
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
-    await setupClaudeHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupClaudeHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -424,7 +424,7 @@ export async function installTaskHooks(
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupClaudeHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupClaudeHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -456,7 +456,7 @@ export async function installProjectGeminiHooks(
 
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
-    await setupGeminiHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupGeminiHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -490,7 +490,7 @@ export async function installTaskGeminiHooks(
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupGeminiHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupGeminiHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -520,7 +520,7 @@ export async function installProjectCodexHooks(
 
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
-    await setupCodexHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupCodexHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -552,7 +552,7 @@ export async function installTaskCodexHooks(
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupCodexHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupCodexHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -572,7 +572,7 @@ export async function installProjectOpenCodeHooks(
 
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
-    await setupOpenCodeHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupOpenCodeHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -596,7 +596,7 @@ export async function installTaskOpenCodeHooks(
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupOpenCodeHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupOpenCodeHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {

--- a/src/app/api/hooks/status/__tests__/route.test.ts
+++ b/src/app/api/hooks/status/__tests__/route.test.ts
@@ -45,7 +45,7 @@ describe("POST /api/hooks/status", () => {
       method: "POST",
       body: JSON.stringify({
         branchName: "feat/missing-project",
-        projectName: "case-study",
+        projectId: "project-1",
         status: "review",
       }),
     });
@@ -60,10 +60,10 @@ describe("POST /api/hooks/status", () => {
     expect(response.status).toBe(404);
     expect(body).toEqual({
       success: false,
-      error: "프로젝트를 찾을 수 없습니다: case-study",
+      error: "프로젝트를 찾을 수 없습니다: project-1",
     });
     expect(mockBroadcastHookStatusTargetMissing).toHaveBeenCalledWith({
-      projectName: "case-study",
+      projectName: "project-1",
       branchName: "feat/missing-project",
       requestedStatus: "review",
       reason: "project-not-found",
@@ -85,7 +85,7 @@ describe("POST /api/hooks/status", () => {
       method: "POST",
       body: JSON.stringify({
         branchName: "feat/missing-task",
-        projectName: "case-study",
+        projectId: "project-1",
         status: "review",
       }),
     });
@@ -111,5 +111,61 @@ describe("POST /api/hooks/status", () => {
     expect(mockTaskSave).not.toHaveBeenCalled();
     expect(mockBroadcastBoardUpdate).not.toHaveBeenCalled();
     expect(mockBroadcastTaskStatusChanged).not.toHaveBeenCalled();
+  });
+
+  it("should update task status by projectId and broadcast project name from database", async () => {
+    // Given
+    mockProjectFindOneBy.mockResolvedValue({
+      id: "project-1",
+      name: "case-study",
+    });
+    mockTaskFindOneBy.mockResolvedValue({
+      id: "task-1",
+      title: "feat/existing-task",
+      description: "desc",
+      status: "todo",
+      branchName: "feat/existing-task",
+      projectId: "project-1",
+    });
+    mockTaskSave.mockImplementation(async (task) => task);
+
+    const request = new Request("http://localhost:4885/api/hooks/status", {
+      method: "POST",
+      body: JSON.stringify({
+        branchName: "feat/existing-task",
+        projectId: "project-1",
+        status: "review",
+      }),
+    });
+
+    const { POST } = await import("@/app/api/hooks/status/route");
+
+    // When
+    const response = await POST(request as never);
+    const body = await response.json();
+
+    // Then
+    expect(response.status).toBe(200);
+    expect(mockTaskFindOneBy).toHaveBeenCalledWith({
+      branchName: "feat/existing-task",
+      projectId: "project-1",
+    });
+    expect(mockBroadcastTaskStatusChanged).toHaveBeenCalledWith({
+      projectName: "case-study",
+      branchName: "feat/existing-task",
+      taskTitle: "feat/existing-task",
+      description: "desc",
+      newStatus: "review",
+      taskId: "task-1",
+    });
+    expect(body).toEqual({
+      success: true,
+      data: {
+        id: "task-1",
+        status: "review",
+        branchName: "feat/existing-task",
+        projectId: "project-1",
+      },
+    });
   });
 });

--- a/src/app/api/hooks/status/route.ts
+++ b/src/app/api/hooks/status/route.ts
@@ -18,17 +18,17 @@ const STATUS_MAP: Record<string, TaskStatus> = {
 };
 
 /**
- * Hook API: branchName + projectName 기반 작업 상태 업데이트.
+ * Hook API: branchName + projectId 기반 작업 상태 업데이트.
  * Claude Code hooks에서 호출하여 현재 브랜치의 작업 상태를 자동 변경한다.
  */
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { branchName, projectName, status } = body;
+    const { branchName, projectId, status } = body;
 
-    if (!branchName || !projectName || !status) {
+    if (!branchName || !projectId || !status) {
       return NextResponse.json(
-        { success: false, error: "branchName, projectName, status는 필수입니다." },
+        { success: false, error: "branchName, projectId, status는 필수입니다." },
         { status: 400 }
       );
     }
@@ -42,18 +42,18 @@ export async function POST(request: NextRequest) {
     }
 
     const projectRepo = await getProjectRepository();
-    const project = await projectRepo.findOneBy({ name: projectName });
+    const project = await projectRepo.findOneBy({ id: projectId });
 
     if (!project) {
       broadcastHookStatusTargetMissing({
-        projectName,
+        projectName: projectId,
         branchName,
         requestedStatus: taskStatus,
         reason: "project-not-found",
       });
 
       return NextResponse.json(
-        { success: false, error: `프로젝트를 찾을 수 없습니다: ${projectName}` },
+        { success: false, error: `프로젝트를 찾을 수 없습니다: ${projectId}` },
         { status: 404 }
       );
     }
@@ -61,19 +61,19 @@ export async function POST(request: NextRequest) {
     const taskRepo = await getTaskRepository();
     const task = await taskRepo.findOneBy({
       branchName,
-      projectId: project.id,
+      projectId,
     });
 
     if (!task) {
       broadcastHookStatusTargetMissing({
-        projectName,
+        projectName: project.name,
         branchName,
         requestedStatus: taskStatus,
         reason: "task-not-found",
       });
 
       return NextResponse.json(
-        { success: false, error: `작업을 찾을 수 없습니다: ${projectName}/${branchName}` },
+        { success: false, error: `작업을 찾을 수 없습니다: ${project.name}/${branchName}` },
         { status: 404 }
       );
     }
@@ -91,7 +91,7 @@ export async function POST(request: NextRequest) {
     revalidatePath("/[locale]", "page");
     broadcastBoardUpdate();
     broadcastTaskStatusChanged({
-      projectName,
+      projectName: project.name,
       branchName,
       taskTitle: saved.title,
       description: saved.description,
@@ -101,7 +101,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      data: { id: saved.id, status: saved.status, branchName, projectName },
+      data: { id: saved.id, status: saved.status, branchName, projectId },
     });
   } catch (error) {
     console.error("Hook status 오류:", error);

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -200,6 +200,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const [isDoneAlertDismissed, setIsDoneAlertDismissed] = useState(doneAlertDismissed);
   const [pendingDoneResult, setPendingDoneResult] = useState<DropResult | null>(null);
   const [currentDefaultSessionType, setCurrentDefaultSessionType] = useState<SessionType>(defaultSessionType);
+  const [needsMacDesktopHeaderOffset, setNeedsMacDesktopHeaderOffset] = useState(false);
   const [, startDragPersistenceTransition] = useTransition();
 
   /** projectId → 표시할 프로젝트 이름 매핑. worktree 프로젝트는 메인 프로젝트 이름으로 resolve한다 */
@@ -339,6 +340,12 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
     setCurrentDefaultSessionType(defaultSessionType);
   }, [defaultSessionType]);
 
+  useEffect(() => {
+    const isDesktopApp = window.kanvibeDesktop?.isDesktop === true;
+    const isMacDesktop = navigator.userAgent.includes("Mac") || navigator.platform.toLowerCase().includes("mac");
+    setNeedsMacDesktopHeaderOffset(isDesktopApp && isMacDesktop);
+  }, []);
+
   const handleLoadMoreDone = useCallback(async () => {
     if (isLoadingMore) return;
     setIsLoadingMore(true);
@@ -460,7 +467,9 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
 
   return (
     <div className="min-h-screen">
-      <header className="flex items-center justify-between px-6 py-4 border-b border-border-default bg-bg-surface">
+      <header
+        className={`flex items-center justify-between px-6 pb-4 border-b border-border-default bg-bg-surface ${needsMacDesktopHeaderOffset ? "pt-10" : "pt-4"}`}
+      >
         <div className="flex items-center gap-2">
           <img src="/kanvibe-logo.svg" alt="KanVibe" className="h-6 w-6" />
           <h1 className="text-xl font-bold text-text-primary">{t("title")}</h1>

--- a/src/components/FolderSearchInput.tsx
+++ b/src/components/FolderSearchInput.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { fuzzyMatch, type FuzzyMatch } from "@/utils/fuzzySearch";
 import HighlightedText from "@/components/HighlightedText";
+import { listSubdirectories } from "@/app/actions/project";
 
 interface FolderSearchInputProps {
   onSelect: (path: string) => void;
@@ -37,14 +38,11 @@ export default function FolderSearchInput({
   const parentPath = lastSlash > 0 ? inputValue.substring(0, lastSlash) : "~";
   const searchTerm = lastSlash >= 0 ? inputValue.substring(lastSlash + 1) : "";
 
-  /** 지정 경로의 하위 디렉토리를 API에서 가져온다 */
+  /** 지정 경로의 하위 디렉토리를 런타임에서 가져온다 */
   const fetchDirectories = useCallback(async (dirPath: string) => {
     setIsLoading(true);
     try {
-      const params = new URLSearchParams({ path: dirPath });
-      if (sshHost) params.set("sshHost", sshHost);
-      const res = await fetch(`/api/directories?${params}`);
-      const result: string[] = await res.json();
+      const result = await listSubdirectories(dirPath, sshHost);
       setDirectories(result);
     } catch {
       setDirectories([]);

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -6,6 +6,13 @@ import { SessionType, TaskStatus } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import type { TasksByStatus } from "@/app/actions/kanban";
 
+function mockNavigatorPlatform(platform: string) {
+  Object.defineProperty(window.navigator, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
 }));
@@ -147,6 +154,8 @@ function createTasksWithTodo(): TasksByStatus {
 describe("Board defaultSessionType sync", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete window.kanvibeDesktop;
+    mockNavigatorPlatform("Linux x86_64");
   });
 
   it("defaultSessionType prop이 변경되면 내부 상태와 하위 컴포넌트가 동기화된다", async () => {
@@ -218,6 +227,29 @@ describe("Board defaultSessionType sync", () => {
 
     await waitFor(() => {
       expect(reorderTasks).toHaveBeenCalledWith(TaskStatus.TODO, ["task-1"]);
+    });
+  });
+
+  it("맥 데스크톱 앱에서는 헤더 상단에 추가 여백을 준다", async () => {
+    window.kanvibeDesktop = { isDesktop: true };
+    mockNavigatorPlatform("MacIntel");
+
+    const { container } = render(
+      <Board
+        initialTasks={createEmptyTasks()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("header")?.className).toContain("pt-10");
     });
   });
 });

--- a/src/desktop/main/serviceRegistry.ts
+++ b/src/desktop/main/serviceRegistry.ts
@@ -1,0 +1,19 @@
+import * as appSettings from "@/desktop/main/services/appSettingsService";
+import * as auth from "@/desktop/main/services/authService";
+import * as diff from "@/desktop/main/services/diffService";
+import * as hooks from "@/desktop/main/services/hookService";
+import * as kanban from "@/desktop/main/services/kanbanService";
+import * as paneLayout from "@/desktop/main/services/paneLayoutService";
+import * as project from "@/desktop/main/services/projectService";
+
+export const desktopServices = {
+  appSettings,
+  auth,
+  diff,
+  hooks,
+  kanban,
+  paneLayout,
+  project,
+} as const;
+
+export type DesktopServiceNamespace = keyof typeof desktopServices;

--- a/src/desktop/main/services/appSettingsService.ts
+++ b/src/desktop/main/services/appSettingsService.ts
@@ -1,0 +1,120 @@
+import { getAppSettingsRepository } from "@/lib/database";
+import { SessionType } from "@/entities/KanbanTask";
+
+const SIDEBAR_COLLAPSED_KEY = "sidebar_default_collapsed";
+const SIDEBAR_HINT_DISMISSED_KEY = "sidebar_hint_dismissed";
+const NOTIFICATION_ENABLED_KEY = "notification_enabled";
+const NOTIFICATION_STATUSES_KEY = "notification_statuses";
+
+/** 기본 알림 대상 상태 (사용자가 직접 설정하는 todo/done은 제외) */
+const DEFAULT_NOTIFICATION_STATUSES = ["progress", "pending", "review"];
+
+/**
+ * 키로 앱 설정값을 조회한다.
+ * @param key 설정 키
+ * @returns 설정값 문자열, 없으면 null
+ */
+export async function getAppSetting(key: string): Promise<string | null> {
+  const repo = await getAppSettingsRepository();
+  const setting = await repo.findOne({ where: { key } });
+  return setting?.value ?? null;
+}
+
+/**
+ * 앱 설정값을 저장한다. 기존 키가 있으면 업데이트, 없으면 생성한다.
+ * @param key 설정 키
+ * @param value 설정값
+ */
+export async function setAppSetting(key: string, value: string): Promise<void> {
+  const repo = await getAppSettingsRepository();
+  const existing = await repo.findOne({ where: { key } });
+
+  if (existing) {
+    existing.value = value;
+    await repo.save(existing);
+  } else {
+    const setting = repo.create({ key, value });
+    await repo.save(setting);
+  }
+}
+
+/** 사이드바 기본 접힘 상태를 조회한다 */
+export async function getSidebarDefaultCollapsed(): Promise<boolean> {
+  const value = await getAppSetting(SIDEBAR_COLLAPSED_KEY);
+  return value === "true";
+}
+
+/** 사이드바 기본 접힘 상태를 저장한다 */
+export async function setSidebarDefaultCollapsed(collapsed: boolean): Promise<void> {
+  await setAppSetting(SIDEBAR_COLLAPSED_KEY, String(collapsed));
+}
+
+/** 사이드바 힌트 숨김 여부를 조회한다 */
+export async function getSidebarHintDismissed(): Promise<boolean> {
+  const value = await getAppSetting(SIDEBAR_HINT_DISMISSED_KEY);
+  return value === "true";
+}
+
+/** 사이드바 힌트를 다시 보지 않기로 설정한다 */
+export async function dismissSidebarHint(): Promise<void> {
+  await setAppSetting(SIDEBAR_HINT_DISMISSED_KEY, "true");
+}
+
+const DONE_ALERT_DISMISSED_KEY = "done_alert_dismissed";
+
+/** Done 이동 경고 다시 묻지 않기 여부를 조회한다 */
+export async function getDoneAlertDismissed(): Promise<boolean> {
+  const value = await getAppSetting(DONE_ALERT_DISMISSED_KEY);
+  return value === "true";
+}
+
+/** Done 이동 경고를 다시 묻지 않기로 설정한다 */
+export async function dismissDoneAlert(): Promise<void> {
+  await setAppSetting(DONE_ALERT_DISMISSED_KEY, "true");
+}
+
+/** 알림 설정을 조회한다. 키가 없으면 기본값(전체 활성화)을 반환한다 */
+export async function getNotificationSettings(): Promise<{
+  isEnabled: boolean;
+  enabledStatuses: string[];
+}> {
+  const [enabledValue, statusesValue] = await Promise.all([
+    getAppSetting(NOTIFICATION_ENABLED_KEY),
+    getAppSetting(NOTIFICATION_STATUSES_KEY),
+  ]);
+
+  const isEnabled = enabledValue !== "false";
+  let enabledStatuses = DEFAULT_NOTIFICATION_STATUSES;
+  if (statusesValue) {
+    try {
+      enabledStatuses = JSON.parse(statusesValue);
+    } catch {
+      /* 파싱 실패 시 기본값 사용 */
+    }
+  }
+
+  return { isEnabled, enabledStatuses };
+}
+
+/** 알림 전역 활성화 상태를 저장한다 */
+export async function setNotificationEnabled(enabled: boolean): Promise<void> {
+  await setAppSetting(NOTIFICATION_ENABLED_KEY, String(enabled));
+}
+
+/** 알림 수신 대상 상태 목록을 저장한다 */
+export async function setNotificationStatuses(statuses: string[]): Promise<void> {
+  await setAppSetting(NOTIFICATION_STATUSES_KEY, JSON.stringify(statuses));
+}
+
+const DEFAULT_SESSION_TYPE_KEY = "default_session_type";
+
+/** 기본 세션 타입을 조회한다. 미설정 시 "tmux"를 반환한다 */
+export async function getDefaultSessionType(): Promise<SessionType> {
+  const value = await getAppSetting(DEFAULT_SESSION_TYPE_KEY);
+  return value === SessionType.ZELLIJ ? SessionType.ZELLIJ : SessionType.TMUX;
+}
+
+/** 기본 세션 타입을 저장한다 */
+export async function setDefaultSessionType(sessionType: SessionType): Promise<void> {
+  await setAppSetting(DEFAULT_SESSION_TYPE_KEY, sessionType);
+}

--- a/src/desktop/main/services/authService.ts
+++ b/src/desktop/main/services/authService.ts
@@ -1,0 +1,34 @@
+import { clearDesktopSession, createDesktopSession, hasDesktopSession } from "@/desktop/main/sessionStore";
+
+function getConfiguredUsername(): string {
+  return process.env.KANVIBE_USER || "admin";
+}
+
+function getConfiguredPassword(): string {
+  return process.env.KANVIBE_PASSWORD || "changeme";
+}
+
+export function validateCredentials(username: string, password: string): boolean {
+  return username === getConfiguredUsername() && password === getConfiguredPassword();
+}
+
+export async function login(username: string, password: string): Promise<{ success: boolean; error?: string }> {
+  if (!username || !password) {
+    return { success: false, error: "아이디와 비밀번호를 입력해주세요." };
+  }
+
+  if (!validateCredentials(username, password)) {
+    return { success: false, error: "아이디 또는 비밀번호가 올바르지 않습니다." };
+  }
+
+  createDesktopSession();
+  return { success: true };
+}
+
+export async function logout(): Promise<void> {
+  clearDesktopSession();
+}
+
+export async function getSessionState(): Promise<{ isAuthenticated: boolean }> {
+  return { isAuthenticated: hasDesktopSession() };
+}

--- a/src/desktop/main/services/diffService.ts
+++ b/src/desktop/main/services/diffService.ts
@@ -1,0 +1,243 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+import path from "path";
+import { readFile, writeFile } from "fs/promises";
+import { getTaskRepository } from "@/lib/database";
+
+const execAsync = promisify(exec);
+
+export interface DiffFile {
+  path: string;
+  status: "added" | "modified" | "deleted" | "renamed";
+  additions: number;
+  deletions: number;
+}
+
+/** git status 문자를 사람이 읽기 쉬운 상태 문자열로 변환한다 */
+function parseGitStatus(statusLetter: string): DiffFile["status"] {
+  switch (statusLetter) {
+    case "A":
+      return "added";
+    case "D":
+      return "deleted";
+    case "M":
+      return "modified";
+    default:
+      if (statusLetter.startsWith("R")) return "renamed";
+      return "modified";
+  }
+}
+
+/**
+ * 파일 경로가 worktree 디렉토리 내부에 있는지 검증한다.
+ * 경로 탐색 공격(path traversal)을 방지하기 위해 ".." 포함 여부와
+ * resolve된 절대 경로가 worktreePath로 시작하는지 확인한다.
+ */
+function validateFilePath(worktreePath: string, filePath: string): string {
+  if (filePath.includes("..")) {
+    throw new Error("잘못된 파일 경로: 상위 디렉토리 참조가 포함되어 있습니다");
+  }
+
+  const resolvedPath = path.resolve(worktreePath, filePath);
+
+  if (!resolvedPath.startsWith(worktreePath)) {
+    throw new Error("잘못된 파일 경로: worktree 외부 접근이 감지되었습니다");
+  }
+
+  return resolvedPath;
+}
+
+/** 태스크 ID로 worktree 관련 정보(worktreePath, branchName, baseBranch)를 조회한다 */
+async function getTaskWorktreeInfo(taskId: string) {
+  const repo = await getTaskRepository();
+  const task = await repo.findOne({ where: { id: taskId } });
+
+  if (!task) {
+    throw new Error("태스크를 찾을 수 없습니다");
+  }
+
+  if (!task.worktreePath) {
+    throw new Error("worktree 경로가 설정되지 않은 태스크입니다");
+  }
+
+  if (!task.branchName) {
+    throw new Error("브랜치가 설정되지 않은 태스크입니다");
+  }
+
+  return {
+    worktreePath: task.worktreePath,
+    branchName: task.branchName,
+    baseBranch: task.baseBranch ?? "main",
+  };
+}
+
+/** git status의 porcelain 포맷 문자를 DiffFile 상태로 변환한다 */
+function parseWorkingTreeStatus(
+  xy: string
+): DiffFile["status"] | null {
+  const index = xy[0];
+  const worktree = xy[1];
+
+  if (xy === "??") return "added";
+  if (index === "A" || worktree === "A") return "added";
+  if (index === "D" || worktree === "D") return "deleted";
+  if (index === "M" || worktree === "M") return "modified";
+  if (index === "R" || worktree === "R") return "renamed";
+  return null;
+}
+
+/**
+ * baseBranch와 현재 브랜치 사이에서 변경된 파일 목록을 조회한다.
+ * 커밋된 브랜치 차이뿐 아니라 working directory의
+ * untracked/unstaged/staged 파일도 포함한다.
+ */
+export async function getGitDiffFiles(
+  taskId: string
+): Promise<DiffFile[]> {
+  try {
+    const { worktreePath, branchName, baseBranch } =
+      await getTaskWorktreeInfo(taskId);
+
+    /**
+     * 커밋된 브랜치 diff(name-status, numstat)와
+     * working directory 상태(git status)를 동시에 조회한다.
+     * git diff는 브랜치가 존재하지 않으면 실패할 수 있으므로 개별 에러를 허용한다.
+     */
+    const emptyResult = { stdout: "" };
+    const [nameStatusResult, numstatResult, workingTreeResult] =
+      await Promise.all([
+        execAsync(`git diff ${baseBranch}...${branchName} --name-status`, {
+          cwd: worktreePath,
+        }).catch(() => emptyResult),
+        execAsync(`git diff ${baseBranch}...${branchName} --numstat`, {
+          cwd: worktreePath,
+        }).catch(() => emptyResult),
+        execAsync("git status --porcelain --untracked-files=all", {
+          cwd: worktreePath,
+        }),
+      ]);
+
+    /** numstat 결과를 파일 경로 기준으로 맵핑한다 */
+    const statsByPath = new Map<
+      string,
+      { additions: number; deletions: number }
+    >();
+    if (numstatResult.stdout.trim()) {
+      for (const line of numstatResult.stdout.trim().split("\n")) {
+        const [added, deleted, ...pathParts] = line.split("\t");
+        const filePath = pathParts.join("\t");
+        statsByPath.set(filePath, {
+          additions: added === "-" ? 0 : parseInt(added, 10),
+          deletions: deleted === "-" ? 0 : parseInt(deleted, 10),
+        });
+      }
+    }
+
+    /** 커밋된 브랜치 diff에서 파일 목록을 구성한다 */
+    const fileMap = new Map<string, DiffFile>();
+
+    if (nameStatusResult.stdout.trim()) {
+      for (const line of nameStatusResult.stdout.trim().split("\n")) {
+        const parts = line.split("\t");
+        const statusLetter = parts[0];
+        /** rename의 경우 "R100\told\tnew" 형태이므로 마지막 경로를 사용한다 */
+        const filePath = parts.length >= 3 ? parts[2] : parts[1];
+        const stats = statsByPath.get(filePath) ?? {
+          additions: 0,
+          deletions: 0,
+        };
+        fileMap.set(filePath, {
+          path: filePath,
+          status: parseGitStatus(statusLetter),
+          additions: stats.additions,
+          deletions: stats.deletions,
+        });
+      }
+    }
+
+    /** working directory의 변경/untracked 파일을 추가한다 (커밋된 diff에 없는 파일만) */
+    const workingTreeLines = workingTreeResult.stdout.replace(/\n$/, "");
+    if (workingTreeLines) {
+      for (const line of workingTreeLines.split("\n")) {
+        const xy = line.substring(0, 2);
+        const filePath = line.substring(3);
+        if (fileMap.has(filePath)) continue;
+
+        const status = parseWorkingTreeStatus(xy);
+        if (!status) continue;
+
+        fileMap.set(filePath, {
+          path: filePath,
+          status,
+          additions: 0,
+          deletions: 0,
+        });
+      }
+    }
+
+    return Array.from(fileMap.values());
+  } catch (error) {
+    console.error("git diff 파일 목록 조회 실패:", error);
+    return [];
+  }
+}
+
+/** baseBranch 기준의 원본 파일 내용을 조회한다. 파일이 존재하지 않으면 빈 문자열을 반환한다 */
+export async function getOriginalFileContent(
+  taskId: string,
+  filePath: string
+): Promise<string> {
+  try {
+    const { worktreePath, baseBranch } =
+      await getTaskWorktreeInfo(taskId);
+
+    validateFilePath(worktreePath, filePath);
+
+    const { stdout } = await execAsync(
+      `git show ${baseBranch}:${filePath}`,
+      { cwd: worktreePath }
+    );
+
+    return stdout;
+  } catch (error) {
+    /** 파일이 baseBranch에 존재하지 않는 경우(신규 파일) 빈 문자열을 반환한다 */
+    return "";
+  }
+}
+
+/** worktree에서 현재 파일 내용을 읽어 반환한다 */
+export async function getFileContent(
+  taskId: string,
+  filePath: string
+): Promise<string> {
+  try {
+    const { worktreePath } = await getTaskWorktreeInfo(taskId);
+    const resolvedPath = validateFilePath(worktreePath, filePath);
+
+    const content = await readFile(resolvedPath, "utf-8");
+    return content;
+  } catch (error) {
+    console.error("파일 내용 읽기 실패:", error);
+    return "";
+  }
+}
+
+/** worktree 내 파일에 내용을 저장한다 */
+export async function saveFileContent(
+  taskId: string,
+  filePath: string,
+  content: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const { worktreePath } = await getTaskWorktreeInfo(taskId);
+    const resolvedPath = validateFilePath(worktreePath, filePath);
+
+    await writeFile(resolvedPath, content, "utf-8");
+    return { success: true };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "파일 저장 중 알 수 없는 오류가 발생했습니다";
+    console.error("파일 저장 실패:", error);
+    return { success: false, error: message };
+  }
+}

--- a/src/desktop/main/services/hookService.ts
+++ b/src/desktop/main/services/hookService.ts
@@ -1,0 +1,173 @@
+import { TaskStatus, SessionType } from "@/entities/KanbanTask";
+import { getProjectRepository, getTaskRepository } from "@/lib/database";
+import { createWorktreeWithSession } from "@/lib/worktree";
+import { broadcastBoardUpdate, broadcastHookStatusTargetMissing, broadcastTaskStatusChanged } from "@/lib/boardNotifier";
+import { cleanupTaskResources } from "@/desktop/main/services/kanbanService";
+
+const STATUS_MAP: Record<string, TaskStatus> = {
+  todo: TaskStatus.TODO,
+  progress: TaskStatus.PROGRESS,
+  pending: TaskStatus.PENDING,
+  review: TaskStatus.REVIEW,
+  done: TaskStatus.DONE,
+};
+
+export interface HookStartInput {
+  title: string;
+  branchName?: string;
+  agentType?: string;
+  sessionType?: SessionType;
+  sshHost?: string;
+  projectId?: string;
+  baseBranch?: string;
+}
+
+export interface HookStatusInput {
+  branchName: string;
+  projectName: string;
+  status: string;
+}
+
+export async function startHookTask(input: HookStartInput) {
+  if (!input.title) {
+    return { success: false, error: "title은 필수입니다.", status: 400 };
+  }
+
+  const repo = await getTaskRepository();
+  const task = repo.create({
+    title: input.title,
+    branchName: input.branchName || null,
+    agentType: input.agentType || null,
+    sessionType: input.sessionType || null,
+    sshHost: input.sshHost || null,
+    projectId: input.projectId || null,
+    baseBranch: input.baseBranch || null,
+    status: TaskStatus.PROGRESS,
+  });
+
+  if (input.branchName && input.sessionType && input.projectId) {
+    try {
+      const projectRepo = await getProjectRepository();
+      const project = await projectRepo.findOneBy({ id: input.projectId });
+
+      if (project) {
+        const baseBranch = input.baseBranch || project.defaultBranch;
+        const session = await createWorktreeWithSession(
+          project.repoPath,
+          input.branchName,
+          baseBranch,
+          input.sessionType,
+          project.sshHost,
+          input.projectId,
+        );
+        task.baseBranch = baseBranch;
+        task.worktreePath = session.worktreePath;
+        task.sessionName = session.sessionName;
+        task.sshHost = project.sshHost;
+      }
+    } catch (error) {
+      console.error("Hook worktree/세션 생성 실패:", error);
+    }
+  }
+
+  const saved = await repo.save(task);
+  broadcastBoardUpdate();
+
+  return {
+    success: true,
+    data: {
+      id: saved.id,
+      status: saved.status,
+      sessionName: saved.sessionName,
+    },
+  };
+}
+
+export async function updateHookTaskStatus(input: HookStatusInput) {
+  if (!input.branchName || !input.projectName || !input.status) {
+    return {
+      success: false,
+      error: "branchName, projectName, status는 필수입니다.",
+      status: 400,
+    };
+  }
+
+  const taskStatus = STATUS_MAP[input.status.toLowerCase()];
+  if (!taskStatus) {
+    return {
+      success: false,
+      error: `유효하지 않은 상태입니다: ${input.status}`,
+      status: 400,
+    };
+  }
+
+  const projectRepo = await getProjectRepository();
+  const project = await projectRepo.findOneBy({ name: input.projectName });
+
+  if (!project) {
+    broadcastHookStatusTargetMissing({
+      projectName: input.projectName,
+      branchName: input.branchName,
+      requestedStatus: taskStatus,
+      reason: "project-not-found",
+    });
+
+    return {
+      success: false,
+      error: `프로젝트를 찾을 수 없습니다: ${input.projectName}`,
+      status: 404,
+    };
+  }
+
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOneBy({
+    branchName: input.branchName,
+    projectId: project.id,
+  });
+
+  if (!task) {
+    broadcastHookStatusTargetMissing({
+      projectName: input.projectName,
+      branchName: input.branchName,
+      requestedStatus: taskStatus,
+      reason: "task-not-found",
+    });
+
+    return {
+      success: false,
+      error: `작업을 찾을 수 없습니다: ${input.projectName}/${input.branchName}`,
+      status: 404,
+    };
+  }
+
+  if (taskStatus === TaskStatus.DONE) {
+    await cleanupTaskResources(task);
+    task.sessionType = null;
+    task.sessionName = null;
+    task.worktreePath = null;
+    task.sshHost = null;
+  }
+
+  task.status = taskStatus;
+  const saved = await taskRepo.save(task);
+
+  broadcastBoardUpdate();
+  broadcastTaskStatusChanged({
+    projectName: input.projectName,
+    branchName: input.branchName,
+    taskTitle: saved.title,
+    description: saved.description,
+    newStatus: taskStatus,
+    taskId: saved.id,
+  });
+
+  return {
+    success: true,
+    data: {
+      id: saved.id,
+      status: saved.status,
+      branchName: input.branchName,
+      projectName: input.projectName,
+    },
+  };
+}

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -1,0 +1,479 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+import { Not, Like } from "typeorm";
+import { getTaskRepository } from "@/lib/database";
+import { KanbanTask, TaskStatus, SessionType } from "@/entities/KanbanTask";
+import { TaskPriority } from "@/entities/TaskPriority";
+import { createWorktreeWithSession, removeWorktreeAndBranch, createSessionWithoutWorktree, removeSessionOnly } from "@/lib/worktree";
+import { getProjectRepository } from "@/lib/database";
+import { setupClaudeHooks } from "@/lib/claudeHooksSetup";
+import { setupGeminiHooks } from "@/lib/geminiHooksSetup";
+import { setupCodexHooks } from "@/lib/codexHooksSetup";
+import { setupOpenCodeHooks } from "@/lib/openCodeHooksSetup";
+import { broadcastBoardUpdate } from "@/lib/boardNotifier";
+
+const execAsync = promisify(exec);
+
+export type TasksByStatus = Record<TaskStatus, KanbanTask[]>;
+
+export interface TasksByStatusWithMeta {
+  tasks: TasksByStatus;
+  doneTotal: number;
+  doneLimit: number;
+}
+
+export interface LoadMoreDoneResponse {
+  tasks: KanbanTask[];
+  doneTotal: number;
+}
+
+const DONE_PAGE_SIZE = 20;
+
+/** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
+function serialize<T>(data: T): T {
+  return JSON.parse(JSON.stringify(data));
+}
+
+/** 모든 작업을 상태별로 그룹핑하여 반환한다. Done 컬럼은 첫 페이지만 로드한다 */
+export async function getTasksByStatus(): Promise<TasksByStatusWithMeta> {
+  const repo = await getTaskRepository();
+
+  const nonDoneTasks = await repo.find({
+    where: { status: Not(TaskStatus.DONE) },
+    order: { displayOrder: "ASC", createdAt: "ASC" },
+  });
+
+  const [doneTasks, doneTotal] = await repo.findAndCount({
+    where: { status: TaskStatus.DONE },
+    order: { displayOrder: "ASC", createdAt: "ASC" },
+    take: DONE_PAGE_SIZE,
+  });
+
+  const grouped: TasksByStatus = {
+    [TaskStatus.TODO]: [],
+    [TaskStatus.PROGRESS]: [],
+    [TaskStatus.PENDING]: [],
+    [TaskStatus.REVIEW]: [],
+    [TaskStatus.DONE]: doneTasks,
+  };
+
+  for (const task of nonDoneTasks) {
+    grouped[task.status].push(task);
+  }
+
+  return serialize({ tasks: grouped, doneTotal, doneLimit: DONE_PAGE_SIZE });
+}
+
+/** Done 태스크를 추가 로드한다 */
+export async function getMoreDoneTasks(
+  offset: number,
+  limit: number = DONE_PAGE_SIZE
+): Promise<LoadMoreDoneResponse> {
+  const repo = await getTaskRepository();
+
+  const [tasks, doneTotal] = await repo.findAndCount({
+    where: { status: TaskStatus.DONE },
+    order: { displayOrder: "ASC", createdAt: "ASC" },
+    skip: offset,
+    take: limit,
+  });
+
+  return serialize({ tasks, doneTotal });
+}
+
+/** 단일 작업을 ID로 조회한다 */
+export async function getTaskById(taskId: string): Promise<KanbanTask | null> {
+  const repo = await getTaskRepository();
+  const task = await repo.findOne({ where: { id: taskId }, relations: ["project"] });
+  return task ? serialize(task) : null;
+}
+
+/** 같은 프로젝트 내에서 branchName이 일치하는 태스크 ID를 조회 */
+export async function getTaskIdByProjectAndBranch(
+  projectId: string,
+  branchName: string,
+): Promise<string | null> {
+  const repo = await getTaskRepository();
+  const task = await repo.findOne({
+    where: { projectId, branchName },
+    select: ["id"],
+  });
+  return task?.id ?? null;
+}
+
+export interface CreateTaskInput {
+  title: string;
+  description?: string;
+  branchName?: string;
+  baseBranch?: string;
+  sessionType?: SessionType;
+  sshHost?: string;
+  projectId?: string;
+  priority?: TaskPriority;
+}
+
+/** 새 작업을 생성한다. branchName + projectId가 있으면 worktree와 세션도 함께 생성한다 */
+export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
+  const repo = await getTaskRepository();
+
+  const task = repo.create({
+    title: input.title || input.branchName || "Untitled",
+    description: input.description || null,
+    branchName: input.branchName || null,
+    baseBranch: input.baseBranch || null,
+    sessionType: input.sessionType || null,
+    sshHost: input.sshHost || null,
+    projectId: input.projectId || null,
+    priority: input.priority || null,
+    status: TaskStatus.TODO,
+  });
+
+  if (input.branchName && input.sessionType && input.projectId) {
+    try {
+      const projectRepo = await getProjectRepository();
+      const project = await projectRepo.findOneBy({ id: input.projectId });
+
+      if (project) {
+        const baseBranch = input.baseBranch || project.defaultBranch;
+        const session = await createWorktreeWithSession(
+          project.repoPath,
+          input.branchName,
+          baseBranch,
+          input.sessionType,
+          project.sshHost,
+          input.projectId
+        );
+        task.worktreePath = session.worktreePath;
+        task.sessionName = session.sessionName;
+        task.sshHost = project.sshHost;
+
+        /** 로컬 worktree에 모든 AI 에이전트 hooks를 자동 설정한다 */
+        if (!project.sshHost && session.worktreePath) {
+          const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+          await Promise.allSettled([
+            setupClaudeHooks(session.worktreePath, project.name, kanvibeUrl),
+            setupGeminiHooks(session.worktreePath, project.name, kanvibeUrl),
+            setupCodexHooks(session.worktreePath, project.name, kanvibeUrl),
+            setupOpenCodeHooks(session.worktreePath, project.name, kanvibeUrl),
+          ]);
+        }
+      }
+    } catch (error) {
+      console.error("Worktree/세션 생성 실패:", error);
+    }
+  }
+
+  /** 해당 status 컬럼의 마지막 순서로 배치한다 */
+  const maxResult = await repo
+    .createQueryBuilder("t")
+    .select("MAX(t.displayOrder)", "max")
+    .where("t.status = :status", { status: task.status })
+    .getRawOne();
+  task.displayOrder = (maxResult?.max ?? -1) + 1;
+
+  const saved = await repo.save(task);
+  broadcastBoardUpdate();
+  return serialize(saved);
+}
+
+/** 작업의 상태를 변경한다 */
+export async function updateTaskStatus(
+  taskId: string,
+  newStatus: TaskStatus
+): Promise<KanbanTask | null> {
+  const repo = await getTaskRepository();
+  const task = await repo.findOneBy({ id: taskId });
+  if (!task) return null;
+
+  if (newStatus === TaskStatus.DONE) {
+    await cleanupTaskResources(task);
+    task.sessionType = null;
+    task.sessionName = null;
+    task.worktreePath = null;
+    task.sshHost = null;
+  }
+
+  task.status = newStatus;
+  const saved = await repo.save(task);
+  broadcastBoardUpdate();
+  return serialize(saved);
+}
+
+/** 작업의 정보를 부분 업데이트한다 */
+export async function updateTask(
+  taskId: string,
+  updates: Partial<Pick<KanbanTask, "title" | "description" | "priority">>
+): Promise<KanbanTask | null> {
+  const repo = await getTaskRepository();
+  const task = await repo.findOneBy({ id: taskId });
+  if (!task) return null;
+
+  if (updates.title !== undefined) task.title = updates.title;
+  if (updates.description !== undefined) task.description = updates.description;
+  if (updates.priority !== undefined) task.priority = updates.priority;
+
+  const saved = await repo.save(task);
+  return serialize(saved);
+}
+
+/** 프로젝트의 color(hex)를 변경하고, 같은 repo의 worktree 프로젝트에도 동일하게 반영한다 */
+export async function updateProjectColor(
+  projectId: string,
+  color: string
+): Promise<void> {
+  const repo = await getProjectRepository();
+  const project = await repo.findOneBy({ id: projectId });
+  if (!project) return;
+
+  project.color = color;
+  await repo.save(project);
+
+  // worktree 프로젝트들의 color도 함께 업데이트한다
+  const mainRepoPath = project.repoPath.includes("__worktrees")
+    ? project.repoPath.split("__worktrees")[0]
+    : project.repoPath;
+
+  const relatedProjects = await repo.find({
+    where: { repoPath: Like(`${mainRepoPath}%`) },
+  });
+
+  for (const related of relatedProjects) {
+    if (related.id === projectId) continue;
+    related.color = color;
+    await repo.save(related);
+  }
+
+}
+
+/** 작업에 연결된 worktree, 세션, 브랜치를 정리한다. task 레코드는 삭제하지 않는다 */
+export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
+  let project = null;
+  if (task.projectId) {
+    const projectRepo = await getProjectRepository();
+    project = await projectRepo.findOneBy({ id: task.projectId });
+  }
+
+  const isProjectRoot = project && task.worktreePath === project.repoPath;
+
+  /** 브랜치별 독립 세션 정리 */
+  if (task.sessionType && task.sessionName) {
+    try {
+      await removeSessionOnly(
+        task.sessionType,
+        task.sessionName,
+        task.sshHost
+      );
+    } catch (error) {
+      console.error("세션 정리 실패:", error);
+    }
+  }
+
+  /** worktree + 브랜치 정리 (프로젝트 루트 브랜치 제외) */
+  if (task.branchName && !isProjectRoot) {
+    try {
+      await removeWorktreeAndBranch(
+        project?.repoPath || process.cwd(),
+        task.branchName,
+        task.sshHost
+      );
+    } catch (error) {
+      console.error("worktree/브랜치 정리 실패:", error);
+    }
+  }
+}
+
+/** 작업을 삭제한다. worktree와 세션이 있으면 함께 정리한다 */
+export async function deleteTask(taskId: string): Promise<boolean> {
+  const repo = await getTaskRepository();
+  const task = await repo.findOneBy({ id: taskId });
+  if (!task) return false;
+
+  await cleanupTaskResources(task);
+
+  await repo.remove(task);
+  broadcastBoardUpdate();
+  return true;
+}
+
+/**
+ * 기존 작업에서 브랜치를 분기한다.
+ * worktree + 세션을 생성하고 상태를 progress로 변경한다.
+ */
+export async function branchFromTask(
+  taskId: string,
+  projectId: string,
+  baseBranch: string,
+  branchName: string,
+  sessionType: SessionType
+): Promise<KanbanTask | null> {
+  const repo = await getTaskRepository();
+  const task = await repo.findOneBy({ id: taskId });
+  if (!task) return null;
+
+  const projectRepo = await getProjectRepository();
+  const project = await projectRepo.findOneBy({ id: projectId });
+  if (!project) return null;
+
+  const session = await createWorktreeWithSession(
+    project.repoPath,
+    branchName,
+    baseBranch,
+    sessionType,
+    project.sshHost,
+    projectId
+  );
+
+  task.projectId = projectId;
+  task.branchName = branchName;
+  task.baseBranch = baseBranch;
+  task.sessionType = sessionType;
+  task.sessionName = session.sessionName;
+  task.worktreePath = session.worktreePath;
+  task.sshHost = project.sshHost;
+  task.status = TaskStatus.PROGRESS;
+
+  /** 로컬 worktree에 모든 AI 에이전트 hooks를 자동 설정한다 */
+  if (!project.sshHost && session.worktreePath) {
+    try {
+      const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+      await Promise.allSettled([
+        setupClaudeHooks(session.worktreePath, project.name, kanvibeUrl),
+        setupGeminiHooks(session.worktreePath, project.name, kanvibeUrl),
+        setupCodexHooks(session.worktreePath, project.name, kanvibeUrl),
+        setupOpenCodeHooks(session.worktreePath, project.name, kanvibeUrl),
+      ]);
+    } catch (error) {
+      console.error("Hooks 설정 실패:", error);
+    }
+  }
+
+  const saved = await repo.save(task);
+  broadcastBoardUpdate();
+  return serialize(saved);
+}
+
+/**
+ * 세션이 없는 태스크에 터미널 세션을 연결한다.
+ * worktree를 생성하지 않고 기존 디렉토리(프로젝트 루트 또는 worktree 경로)에 window/tab을 생성한다.
+ */
+export async function connectTerminalSession(
+  taskId: string,
+  sessionType: SessionType
+): Promise<KanbanTask | null> {
+  const repo = await getTaskRepository();
+  const task = await repo.findOneBy({ id: taskId });
+  if (!task || !task.projectId) return null;
+
+  const branchForSession = task.branchName || task.baseBranch;
+  if (!branchForSession) return null;
+
+  const projectRepo = await getProjectRepository();
+  const project = await projectRepo.findOneBy({ id: task.projectId });
+  if (!project) return null;
+
+  const workingDir = task.worktreePath || project.repoPath;
+
+  try {
+    const session = await createSessionWithoutWorktree(
+      project.repoPath,
+      branchForSession,
+      sessionType,
+      project.sshHost,
+      workingDir,
+    );
+
+    task.sessionType = sessionType;
+    task.sessionName = session.sessionName;
+    task.worktreePath = workingDir;
+    task.sshHost = project.sshHost;
+    task.status = TaskStatus.PROGRESS;
+
+    const saved = await repo.save(task);
+    broadcastBoardUpdate();
+    return serialize(saved);
+  } catch (error) {
+    console.error("터미널 세션 생성 실패:", error);
+    return null;
+  }
+}
+
+/** 컬럼 내 작업 순서를 변경한다 */
+export async function reorderTasks(
+  status: TaskStatus,
+  orderedIds: string[]
+): Promise<void> {
+  const repo = await getTaskRepository();
+
+  const updates = orderedIds.map((id, index) =>
+    repo.update(id, { displayOrder: index })
+  );
+
+  await Promise.all(updates);
+}
+
+/** 드래그로 태스크를 다른 컬럼으로 이동할 때 사용한다. revalidation 없이 DB만 갱신한다 */
+export async function moveTaskToColumn(
+  taskId: string,
+  newStatus: TaskStatus,
+  destOrderedIds: string[]
+): Promise<void> {
+  const repo = await getTaskRepository();
+
+  if (newStatus === TaskStatus.DONE) {
+    const task = await repo.findOneBy({ id: taskId });
+    if (task) {
+      await cleanupTaskResources(task);
+      await repo.update(taskId, {
+        status: newStatus,
+        sessionType: null,
+        sessionName: null,
+        worktreePath: null,
+        sshHost: null,
+      });
+    }
+  } else {
+    await repo.update(taskId, { status: newStatus });
+  }
+
+  const reorderUpdates = destOrderedIds.map((id, index) =>
+    repo.update(id, { displayOrder: index })
+  );
+
+  await Promise.all(reorderUpdates);
+}
+
+/**
+ * 작업의 브랜치에 연결된 PR URL을 조회하여 DB에 저장한다.
+ * `gh pr list` CLI를 사용하며, PR이 없으면 null을 유지한다.
+ */
+export async function fetchAndSavePrUrl(taskId: string): Promise<string | null> {
+  const repo = await getTaskRepository();
+  const task = await repo.findOneBy({ id: taskId });
+  if (!task?.branchName) return null;
+
+  let repoPath: string | null = null;
+  if (task.projectId) {
+    const projectRepo = await getProjectRepository();
+    const project = await projectRepo.findOneBy({ id: task.projectId });
+    if (project) repoPath = project.repoPath;
+  }
+
+  try {
+    const cwd = repoPath ?? process.cwd();
+    const { stdout } = await execAsync(
+      `gh pr list --head "${task.branchName}" --json url -q ".[0].url"`,
+      { cwd }
+    );
+    const prUrl = stdout.trim();
+
+    if (prUrl) {
+      task.prUrl = prUrl;
+      await repo.save(task);
+      return prUrl;
+    }
+  } catch (error) {
+    console.error("PR URL 조회 실패:", error);
+  }
+
+  return null;
+}

--- a/src/desktop/main/services/paneLayoutService.ts
+++ b/src/desktop/main/services/paneLayoutService.ts
@@ -1,0 +1,80 @@
+import { getPaneLayoutConfigRepository } from "@/lib/database";
+import { PaneLayoutConfig, PaneLayoutType, type PaneCommand } from "@/entities/PaneLayoutConfig";
+
+/** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
+function serialize<T>(data: T): T {
+  return JSON.parse(JSON.stringify(data));
+}
+
+/** 글로벌 기본 pane 레이아웃 조회 */
+export async function getGlobalPaneLayout(): Promise<PaneLayoutConfig | null> {
+  const repo = await getPaneLayoutConfigRepository();
+  const config = await repo.findOne({ where: { isGlobal: true } });
+  return config ? serialize(config) : null;
+}
+
+/** 프로젝트별 pane 레이아웃 조회 (프로젝트 설정만, fallback 없음) */
+export async function getProjectPaneLayout(projectId: string): Promise<PaneLayoutConfig | null> {
+  const repo = await getPaneLayoutConfigRepository();
+  const config = await repo.findOne({ where: { projectId } });
+  return config ? serialize(config) : null;
+}
+
+/** 프로젝트에 적용될 실제 pane 레이아웃 조회 (프로젝트 → 글로벌 fallback) */
+export async function getEffectivePaneLayout(projectId?: string): Promise<PaneLayoutConfig | null> {
+  if (projectId) {
+    const projectConfig = await getProjectPaneLayout(projectId);
+    if (projectConfig) return projectConfig;
+  }
+  return getGlobalPaneLayout();
+}
+
+/** 모든 pane 레이아웃 설정 조회 (글로벌 + 프로젝트별) */
+export async function getAllPaneLayouts(): Promise<PaneLayoutConfig[]> {
+  const repo = await getPaneLayoutConfigRepository();
+  const configs = await repo.find({ order: { isGlobal: "DESC", createdAt: "ASC" } });
+  return serialize(configs);
+}
+
+export interface SavePaneLayoutInput {
+  layoutType: PaneLayoutType;
+  panes: PaneCommand[];
+  projectId?: string | null;
+  isGlobal?: boolean;
+}
+
+/** pane 레이아웃 저장 (upsert 패턴: 기존 설정이 있으면 업데이트, 없으면 생성) */
+export async function savePaneLayout(input: SavePaneLayoutInput): Promise<PaneLayoutConfig> {
+  const repo = await getPaneLayoutConfigRepository();
+
+  let existing: PaneLayoutConfig | null = null;
+  if (input.isGlobal) {
+    existing = await repo.findOne({ where: { isGlobal: true } });
+  } else if (input.projectId) {
+    existing = await repo.findOne({ where: { projectId: input.projectId } });
+  }
+
+  if (existing) {
+    existing.layoutType = input.layoutType;
+    existing.panes = input.panes;
+    const saved = await repo.save(existing);
+    return serialize(saved);
+  }
+
+  const config = repo.create({
+    layoutType: input.layoutType,
+    panes: input.panes,
+    projectId: input.projectId || null,
+    isGlobal: input.isGlobal ?? false,
+  });
+
+  const saved = await repo.save(config);
+  return serialize(saved);
+}
+
+/** pane 레이아웃 삭제 */
+export async function deletePaneLayout(id: string): Promise<boolean> {
+  const repo = await getPaneLayoutConfigRepository();
+  const result = await repo.delete(id);
+  return (result.affected ?? 0) > 0;
+}

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -1,0 +1,704 @@
+import { getProjectRepository, getTaskRepository } from "@/lib/database";
+import { Project } from "@/entities/Project";
+import { validateGitRepo, getDefaultBranch, listBranches, scanGitRepos, listWorktrees, execGit } from "@/lib/gitOperations";
+import { TaskStatus, SessionType } from "@/entities/KanbanTask";
+import { IsNull } from "typeorm";
+import { isSessionAlive, formatSessionName, createSessionWithoutWorktree } from "@/lib/worktree";
+import { setupClaudeHooks, getClaudeHooksStatus, type ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
+import { setupGeminiHooks, getGeminiHooksStatus, type GeminiHooksStatus } from "@/lib/geminiHooksSetup";
+import { setupCodexHooks, getCodexHooksStatus, type CodexHooksStatus } from "@/lib/codexHooksSetup";
+import { setupOpenCodeHooks, getOpenCodeHooksStatus, type OpenCodeHooksStatus } from "@/lib/openCodeHooksSetup";
+import { aggregateAiSessions, getAiSessionDetail } from "@/lib/aiSessions/aggregateAiSessions";
+import type { AggregatedAiSessionDetail, AggregatedAiSessionsResult, AiMessageRole, AiSessionProvider } from "@/lib/aiSessions/types";
+import { homedir } from "os";
+import path from "path";
+import { computeProjectColor } from "@/lib/projectColor";
+import { broadcastBoardUpdate } from "@/lib/boardNotifier";
+import { getAvailableHosts as readAvailableHosts } from "@/lib/sshConfig";
+
+/** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
+function serialize<T>(data: T): T {
+  return JSON.parse(JSON.stringify(data));
+}
+
+/** 프로젝트의 메인 브랜치 태스크를 생성하고 tmux 세션을 자동 연결한다 */
+async function createDefaultBranchTask(project: Project): Promise<void> {
+  const taskRepo = await getTaskRepository();
+
+  /** 해당 프로젝트에 이미 기본 브랜치 태스크가 있으면 생성하지 않는다 */
+  const existing = await taskRepo.findOneBy({ branchName: project.defaultBranch, projectId: project.id });
+  if (existing) return;
+
+  /** orphan 태스크(projectId 없음)가 있으면 현재 프로젝트에 연결한다 */
+  const orphan = await taskRepo.findOneBy({ branchName: project.defaultBranch, projectId: IsNull() });
+  if (orphan) {
+    orphan.projectId = project.id;
+    orphan.baseBranch = project.defaultBranch;
+    await taskRepo.save(orphan);
+    return;
+  }
+
+  const task = taskRepo.create({
+    title: project.defaultBranch,
+    branchName: project.defaultBranch,
+    status: TaskStatus.TODO,
+    projectId: project.id,
+    baseBranch: project.defaultBranch,
+  });
+
+  try {
+    const session = await createSessionWithoutWorktree(
+      project.repoPath,
+      project.defaultBranch,
+      SessionType.TMUX,
+      project.sshHost,
+      project.repoPath,
+    );
+    task.sessionType = SessionType.TMUX;
+    task.sessionName = session.sessionName;
+    task.worktreePath = project.repoPath;
+    task.sshHost = project.sshHost;
+    task.status = TaskStatus.PROGRESS;
+  } catch (error) {
+    console.error("메인 브랜치 tmux 세션 생성 실패:", error);
+  }
+
+  await taskRepo.save(task);
+}
+
+/** 등록된 모든 프로젝트를 반환한다 */
+export async function getAllProjects(): Promise<Project[]> {
+  const repo = await getProjectRepository();
+  const projects = await repo.find({ order: { createdAt: "ASC" } });
+  return serialize(projects);
+}
+
+export async function getAvailableHosts(): Promise<string[]> {
+  return readAvailableHosts();
+}
+
+/** 단일 프로젝트를 ID로 조회한다 */
+export async function getProjectById(projectId: string): Promise<Project | null> {
+  const repo = await getProjectRepository();
+  const project = await repo.findOneBy({ id: projectId });
+  return project ? serialize(project) : null;
+}
+
+/**
+ * 새 프로젝트를 등록한다.
+ * git 저장소 유효성을 검증하고 기본 브랜치를 자동 감지한다.
+ */
+export async function registerProject(
+  name: string,
+  repoPath: string,
+  sshHost?: string
+): Promise<{ success: boolean; error?: string; project?: Project }> {
+  if (!name || !repoPath) {
+    return { success: false, error: "이름과 경로는 필수입니다." };
+  }
+
+  const isValid = await validateGitRepo(repoPath, sshHost || null);
+  if (!isValid) {
+    return { success: false, error: "유효한 git 저장소가 아닙니다." };
+  }
+
+  const repo = await getProjectRepository();
+
+  const existing = await repo.findOneBy({ name });
+  if (existing) {
+    return { success: false, error: "이미 같은 이름의 프로젝트가 있습니다." };
+  }
+
+  const defaultBranch = await getDefaultBranch(repoPath, sshHost || null);
+
+  const project = repo.create({
+    name,
+    repoPath,
+    defaultBranch,
+    sshHost: sshHost || null,
+    color: computeProjectColor(name),
+  });
+
+  const saved = await repo.save(project);
+  await createDefaultBranchTask(saved);
+  broadcastBoardUpdate();
+  return { success: true, project: serialize(saved) };
+}
+
+/** 프로젝트를 삭제한다. 연결된 작업의 projectId는 FK cascade로 null이 된다 */
+export async function deleteProject(projectId: string): Promise<boolean> {
+  const repo = await getProjectRepository();
+  const project = await repo.findOneBy({ id: projectId });
+  if (!project) return false;
+
+  await repo.remove(project);
+  broadcastBoardUpdate();
+  return true;
+}
+
+export interface ScanResult {
+  registered: string[];
+  skipped: string[];
+  errors: string[];
+  worktreeTasks: string[];
+  hooksSetup: string[];
+}
+
+/**
+ * 지정 디렉토리 하위의 git 저장소를 스캔하여 미등록 프로젝트를 일괄 등록한다.
+ * 이미 동일 경로로 등록된 프로젝트는 건너뛰고, 이름 중복 시 상위 디렉토리를 포함하여 구분한다.
+ */
+export async function scanAndRegisterProjects(
+  rootPath: string,
+  sshHost?: string
+): Promise<ScanResult> {
+  const result: ScanResult = { registered: [], skipped: [], errors: [], worktreeTasks: [], hooksSetup: [] };
+
+  const repoPaths = await scanGitRepos(rootPath, sshHost || null);
+  if (repoPaths.length === 0) {
+    return result;
+  }
+
+  const repo = await getProjectRepository();
+  const existing = await repo.find();
+  const existingPaths = new Set(
+    existing.map((p) => `${p.sshHost || ""}:${p.repoPath}`)
+  );
+  const existingNames = new Set(existing.map((p) => p.name));
+
+  /** 폴더명 기반 프로젝트 이름을 생성한다. 중복 시 상위 디렉토리를 포함한다 */
+  function resolveProjectName(repoPath: string): string {
+    const baseName = path.basename(repoPath);
+    if (!existingNames.has(baseName)) {
+      existingNames.add(baseName);
+      return baseName;
+    }
+
+    const parentName = path.basename(path.dirname(repoPath));
+    const combinedName = `${parentName}/${baseName}`;
+    if (!existingNames.has(combinedName)) {
+      existingNames.add(combinedName);
+      return combinedName;
+    }
+
+    let counter = 2;
+    while (existingNames.has(`${baseName}-${counter}`)) {
+      counter++;
+    }
+    const numberedName = `${baseName}-${counter}`;
+    existingNames.add(numberedName);
+    return numberedName;
+  }
+
+  for (const repoPath of repoPaths) {
+    const pathKey = `${sshHost || ""}:${repoPath}`;
+    if (existingPaths.has(pathKey)) {
+      result.skipped.push(repoPath);
+      continue;
+    }
+
+    try {
+      const defaultBranch = await getDefaultBranch(repoPath, sshHost || null);
+      const projectName = resolveProjectName(repoPath);
+
+      const project = repo.create({
+        name: projectName,
+        repoPath,
+        defaultBranch,
+        sshHost: sshHost || null,
+        color: computeProjectColor(projectName),
+      });
+
+      const saved = await repo.save(project);
+      existingPaths.add(pathKey);
+      result.registered.push(projectName);
+
+      /** 기본 브랜치 태스크 생성 실패는 프로젝트 등록 결과에 영향을 주지 않는다 */
+      try {
+        await createDefaultBranchTask(saved);
+      } catch (taskError) {
+        console.error(`${projectName} 기본 브랜치 태스크 생성 실패:`, taskError);
+      }
+
+      /** 로컬 repo에 Claude Code / Gemini CLI / Codex CLI hooks를 자동 설정한다 */
+      if (!sshHost) {
+        try {
+          const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+          await setupClaudeHooks(repoPath, projectName, kanvibeUrl);
+          await setupGeminiHooks(repoPath, projectName, kanvibeUrl);
+          await setupCodexHooks(repoPath, projectName, kanvibeUrl);
+          await setupOpenCodeHooks(repoPath, projectName, kanvibeUrl);
+          result.hooksSetup.push(projectName);
+        } catch (hookError) {
+          result.errors.push(
+            `${projectName} hooks 설정 실패: ${hookError instanceof Error ? hookError.message : "알 수 없는 오류"}`
+          );
+        }
+      }
+    } catch (error) {
+      result.errors.push(
+        `${repoPath}: ${error instanceof Error ? error.message : "등록 실패"}`
+      );
+    }
+  }
+
+  /** 등록된 모든 프로젝트의 worktree를 스캔하여 미등록 브랜치를 TODO task로 생성한다 */
+  const allProjects = await repo.find();
+  const taskRepo = await getTaskRepository();
+
+  for (const project of allProjects) {
+    try {
+      const worktrees = await listWorktrees(project.repoPath, project.sshHost);
+
+      for (const wt of worktrees) {
+        if (wt.isBare || !wt.branch) continue;
+
+        /** 메인 작업 디렉토리(프로젝트 루트)는 기본 브랜치 태스크와 중복되므로 건너뛴다 */
+        if (wt.path === project.repoPath) continue;
+
+        /** 해당 프로젝트에 이미 동일 브랜치 태스크가 있으면 건너뛴다 */
+        const existingTask = await taskRepo.findOneBy({ branchName: wt.branch, projectId: project.id });
+        if (existingTask) continue;
+
+        /** orphan 태스크(projectId 없음)가 있으면 현재 프로젝트에 연결한다 */
+        const orphanTask = await taskRepo.findOneBy({ branchName: wt.branch, projectId: IsNull() });
+        if (orphanTask) {
+          orphanTask.projectId = project.id;
+          orphanTask.worktreePath = wt.path;
+          orphanTask.baseBranch = orphanTask.baseBranch || project.defaultBranch;
+          await taskRepo.save(orphanTask);
+          result.worktreeTasks.push(wt.branch);
+          continue;
+        }
+
+        /** 브랜치명 기반 독립 세션이 존재하면 연결 정보를 설정한다 */
+        const sessionName = formatSessionName(path.basename(project.repoPath), wt.branch);
+        const hasSession = await isSessionAlive(
+          SessionType.TMUX,
+          sessionName,
+          project.sshHost
+        );
+
+        const task = taskRepo.create({
+          title: wt.branch,
+          branchName: wt.branch,
+          worktreePath: wt.path,
+          projectId: project.id,
+          baseBranch: project.defaultBranch,
+          status: hasSession ? TaskStatus.PROGRESS : TaskStatus.TODO,
+          ...(hasSession && {
+            sessionType: SessionType.TMUX,
+            sessionName,
+            sshHost: project.sshHost,
+          }),
+        });
+        await taskRepo.save(task);
+        result.worktreeTasks.push(wt.branch);
+      }
+    } catch (error) {
+      result.errors.push(
+        `${project.name} worktree 스캔 실패: ${error instanceof Error ? error.message : "알 수 없는 오류"}`
+      );
+    }
+
+    /** 메인 브랜치 태스크에 활성 tmux 세션이 있으면 자동 연결한다 */
+    try {
+      const mainBranchTask = await taskRepo.findOneBy({
+        projectId: project.id,
+        baseBranch: project.defaultBranch,
+        branchName: project.defaultBranch,
+      });
+
+      if (mainBranchTask && !mainBranchTask.sessionType) {
+        const sessionName = formatSessionName(path.basename(project.repoPath), project.defaultBranch);
+        const hasSession = await isSessionAlive(
+          SessionType.TMUX,
+          sessionName,
+          project.sshHost,
+        );
+
+        if (hasSession) {
+          mainBranchTask.sessionType = SessionType.TMUX;
+          mainBranchTask.sessionName = sessionName;
+          mainBranchTask.worktreePath = project.repoPath;
+          mainBranchTask.sshHost = project.sshHost;
+          mainBranchTask.status = TaskStatus.PROGRESS;
+          await taskRepo.save(mainBranchTask);
+        }
+      }
+    } catch (error) {
+      console.error(`${project.name} 메인 브랜치 세션 감지 실패:`, error);
+    }
+  }
+
+  broadcastBoardUpdate();
+  return result;
+}
+
+/** 지정 디렉토리의 직속 하위 디렉토리 이름 목록을 반환한다 (fzf drill-down 탐색용) */
+export async function listSubdirectories(
+  parentPath: string,
+  sshHost?: string
+): Promise<string[]> {
+  const resolvedPath = parentPath.startsWith("~")
+    ? parentPath.replace(/^~/, homedir())
+    : parentPath;
+
+  try {
+    const output = await execGit(
+      `find "${resolvedPath}" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort`,
+      sshHost || null
+    );
+
+    if (!output) return [];
+
+    return output
+      .split("\n")
+      .filter(Boolean)
+      .map((dir) => path.basename(dir))
+      .filter((name) => !name.startsWith("."));
+  } catch {
+    return [];
+  }
+}
+
+/** 프로젝트의 브랜치 목록을 반환한다 */
+export async function getProjectBranches(projectId: string): Promise<string[]> {
+  const repo = await getProjectRepository();
+  const project = await repo.findOneBy({ id: projectId });
+  if (!project) return [];
+
+  return listBranches(project.repoPath, project.sshHost);
+}
+
+/** 프로젝트의 Claude Code hooks 설치 상태를 조회한다 */
+export async function getProjectHooksStatus(
+  projectId: string
+): Promise<ClaudeHooksStatus | null> {
+  const repo = await getProjectRepository();
+  const project = await repo.findOneBy({ id: projectId });
+  if (!project || project.sshHost) return null;
+
+  return getClaudeHooksStatus(project.repoPath);
+}
+
+/** 프로젝트에 Claude Code hooks를 설치한다 */
+export async function installProjectHooks(
+  projectId: string
+): Promise<{ success: boolean; error?: string }> {
+  const repo = await getProjectRepository();
+  const project = await repo.findOneBy({ id: projectId });
+  if (!project) return { success: false, error: "프로젝트를 찾을 수 없습니다." };
+  if (project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
+
+  try {
+    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    await setupClaudeHooks(project.repoPath, project.name, kanvibeUrl);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "hooks 설정 실패",
+    };
+  }
+}
+
+/** 태스크의 worktree 또는 프로젝트 경로에서 Claude Code hooks 상태를 조회한다 */
+export async function getTaskHooksStatus(
+  taskId: string
+): Promise<ClaudeHooksStatus | null> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOne({ where: { id: taskId }, relations: ["project"] });
+  if (!task?.project || task.project.sshHost) return null;
+
+  const targetPath = task.worktreePath || task.project.repoPath;
+  return getClaudeHooksStatus(targetPath);
+}
+
+/** 태스크의 worktree 또는 프로젝트 경로에 Claude Code hooks를 설치한다 */
+export async function installTaskHooks(
+  taskId: string
+): Promise<{ success: boolean; error?: string }> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOne({ where: { id: taskId }, relations: ["project"] });
+  if (!task?.project) return { success: false, error: "프로젝트를 찾을 수 없습니다." };
+  if (task.project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
+
+  try {
+    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const targetPath = task.worktreePath || task.project.repoPath;
+    await setupClaudeHooks(targetPath, task.project.name, kanvibeUrl);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "hooks 설정 실패",
+    };
+  }
+}
+
+/** 프로젝트의 Gemini CLI hooks 설치 상태를 조회한다 */
+export async function getProjectGeminiHooksStatus(
+  projectId: string
+): Promise<GeminiHooksStatus | null> {
+  const repo = await getProjectRepository();
+  const project = await repo.findOneBy({ id: projectId });
+  if (!project || project.sshHost) return null;
+
+  return getGeminiHooksStatus(project.repoPath);
+}
+
+/** 프로젝트에 Gemini CLI hooks를 설치한다 */
+export async function installProjectGeminiHooks(
+  projectId: string
+): Promise<{ success: boolean; error?: string }> {
+  const repo = await getProjectRepository();
+  const project = await repo.findOneBy({ id: projectId });
+  if (!project) return { success: false, error: "프로젝트를 찾을 수 없습니다." };
+  if (project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
+
+  try {
+    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    await setupGeminiHooks(project.repoPath, project.name, kanvibeUrl);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "hooks 설정 실패",
+    };
+  }
+}
+
+/** 태스크의 worktree 또는 프로젝트 경로에서 Gemini CLI hooks 상태를 조회한다 */
+export async function getTaskGeminiHooksStatus(
+  taskId: string
+): Promise<GeminiHooksStatus | null> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOne({ where: { id: taskId }, relations: ["project"] });
+  if (!task?.project || task.project.sshHost) return null;
+
+  const targetPath = task.worktreePath || task.project.repoPath;
+  return getGeminiHooksStatus(targetPath);
+}
+
+/** 태스크의 worktree 또는 프로젝트 경로에 Gemini CLI hooks를 설치한다 */
+export async function installTaskGeminiHooks(
+  taskId: string
+): Promise<{ success: boolean; error?: string }> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOne({ where: { id: taskId }, relations: ["project"] });
+  if (!task?.project) return { success: false, error: "프로젝트를 찾을 수 없습니다." };
+  if (task.project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
+
+  try {
+    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const targetPath = task.worktreePath || task.project.repoPath;
+    await setupGeminiHooks(targetPath, task.project.name, kanvibeUrl);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "hooks 설정 실패",
+    };
+  }
+}
+
+export async function getProjectCodexHooksStatus(
+  projectId: string
+): Promise<CodexHooksStatus | null> {
+  const repo = await getProjectRepository();
+  const project = await repo.findOneBy({ id: projectId });
+  if (!project || project.sshHost) return null;
+
+  return getCodexHooksStatus(project.repoPath);
+}
+
+export async function installProjectCodexHooks(
+  projectId: string
+): Promise<{ success: boolean; error?: string }> {
+  const repo = await getProjectRepository();
+  const project = await repo.findOneBy({ id: projectId });
+  if (!project) return { success: false, error: "프로젝트를 찾을 수 없습니다." };
+  if (project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
+
+  try {
+    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    await setupCodexHooks(project.repoPath, project.name, kanvibeUrl);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "hooks 설정 실패",
+    };
+  }
+}
+
+export async function getTaskCodexHooksStatus(
+  taskId: string
+): Promise<CodexHooksStatus | null> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOne({ where: { id: taskId }, relations: ["project"] });
+  if (!task?.project || task.project.sshHost) return null;
+
+  const targetPath = task.worktreePath || task.project.repoPath;
+  return getCodexHooksStatus(targetPath);
+}
+
+export async function installTaskCodexHooks(
+  taskId: string
+): Promise<{ success: boolean; error?: string }> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOne({ where: { id: taskId }, relations: ["project"] });
+  if (!task?.project) return { success: false, error: "프로젝트를 찾을 수 없습니다." };
+  if (task.project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
+
+  try {
+    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const targetPath = task.worktreePath || task.project.repoPath;
+    await setupCodexHooks(targetPath, task.project.name, kanvibeUrl);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "hooks 설정 실패",
+    };
+  }
+}
+
+/** 프로젝트 repo에 OpenCode hooks를 설치한다 */
+export async function installProjectOpenCodeHooks(
+  projectId: string
+): Promise<{ success: boolean; error?: string }> {
+  const projectRepo = await getProjectRepository();
+  const project = await projectRepo.findOneBy({ id: projectId });
+  if (!project) return { success: false, error: "Project not found" };
+
+  try {
+    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    await setupOpenCodeHooks(project.repoPath, project.name, kanvibeUrl);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
+/** 태스크의 worktree 또는 프로젝트 경로에 OpenCode hooks를 설치한다 */
+export async function installTaskOpenCodeHooks(
+  taskId: string
+): Promise<{ success: boolean; error?: string }> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOne({
+    where: { id: taskId },
+    relations: ["project"],
+  });
+  if (!task?.project) return { success: false, error: "Task or project not found" };
+
+  try {
+    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const targetPath = task.worktreePath || task.project.repoPath;
+    await setupOpenCodeHooks(targetPath, task.project.name, kanvibeUrl);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
+/** 태스크의 OpenCode hooks 설치 상태를 조회한다 */
+export async function getTaskOpenCodeHooksStatus(
+  taskId: string
+): Promise<OpenCodeHooksStatus | null> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOne({
+    where: { id: taskId },
+    relations: ["project"],
+  });
+  if (!task?.project) return null;
+
+  const targetPath = task.worktreePath || task.project.repoPath;
+  return getOpenCodeHooksStatus(targetPath);
+}
+
+/** 태스크와 연결된 로컬 AI 세션들을 집계한다 */
+export async function getTaskAiSessions(
+  taskId: string,
+  includeRepoSessions = false,
+  query?: string
+): Promise<AggregatedAiSessionsResult> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOne({
+    where: { id: taskId },
+    relations: ["project"],
+  });
+
+  if (!task?.project) {
+    return {
+      isRemote: false,
+      targetPath: null,
+      repoPath: null,
+      sessions: [],
+      sources: [],
+    };
+  }
+
+  const targetPath = task.worktreePath || task.project.repoPath;
+  if (task.project.sshHost) {
+    return {
+      isRemote: true,
+      targetPath,
+      repoPath: task.project.repoPath,
+      sessions: [],
+      sources: [],
+    };
+  }
+
+  return aggregateAiSessions({
+    worktreePath: targetPath,
+    repoPath: task.project.repoPath,
+    includeRepoSessions,
+    query,
+  });
+}
+
+export async function getTaskAiSessionDetail(
+  taskId: string,
+  provider: AiSessionProvider,
+  sessionId: string,
+  sourceRef?: string | null,
+  cursor?: string | null,
+  limit = 20,
+  includeRepoSessions = false,
+  query?: string,
+  roles?: AiMessageRole[]
+): Promise<AggregatedAiSessionDetail | null> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOne({
+    where: { id: taskId },
+    relations: ["project"],
+  });
+
+  if (!task?.project || task.project.sshHost) {
+    return null;
+  }
+
+  const targetPath = task.worktreePath || task.project.repoPath;
+  return getAiSessionDetail(
+    {
+      worktreePath: targetPath,
+      repoPath: task.project.repoPath,
+      includeRepoSessions,
+      query,
+      roles,
+    },
+    provider,
+    sessionId,
+    sourceRef,
+    cursor,
+    limit
+  );
+}

--- a/src/desktop/main/sessionStore.ts
+++ b/src/desktop/main/sessionStore.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { ensureKanvibeDataDirectory } from "@/lib/databasePaths";
+
+const SESSION_FILE_NAME = "desktop-session.json";
+
+function getSessionFilePath(): string {
+  return path.join(ensureKanvibeDataDirectory(), SESSION_FILE_NAME);
+}
+
+export function createDesktopSession(): string {
+  const token = randomUUID();
+  fs.writeFileSync(getSessionFilePath(), `${JSON.stringify({ token, createdAt: Date.now() })}\n`, {
+    mode: 0o600,
+  });
+  return token;
+}
+
+export function clearDesktopSession(): void {
+  const sessionFilePath = getSessionFilePath();
+  if (fs.existsSync(sessionFilePath)) {
+    fs.unlinkSync(sessionFilePath);
+  }
+}
+
+export function hasDesktopSession(): boolean {
+  const sessionFilePath = getSessionFilePath();
+  if (!fs.existsSync(sessionFilePath)) {
+    return false;
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(sessionFilePath, "utf8"));
+    return typeof parsed?.token === "string" && parsed.token.length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/desktop/main/terminalBridge.ts
+++ b/src/desktop/main/terminalBridge.ts
@@ -1,0 +1,161 @@
+import { EventEmitter } from "node:events";
+import type { WebContents } from "electron";
+import { getTaskRepository } from "@/lib/database";
+import { SessionType } from "@/entities/KanbanTask";
+import { attachLocalSession, attachRemoteSession, focusSession } from "@/lib/terminal";
+import { parseSSHConfig } from "@/lib/sshConfig";
+
+const OPEN = 1;
+const CLOSED = 3;
+
+class ElectronTerminalClient extends EventEmitter {
+  readonly OPEN = OPEN;
+  readyState = OPEN;
+
+  constructor(
+    private readonly webContents: WebContents,
+    private readonly taskId: string,
+  ) {
+    super();
+  }
+
+  send(data: string | Buffer) {
+    if (this.readyState !== OPEN || this.webContents.isDestroyed()) {
+      return;
+    }
+
+    this.webContents.send("kanvibe:terminal-data", {
+      taskId: this.taskId,
+      data: typeof data === "string" ? data : data.toString(),
+    });
+  }
+
+  close(_code?: number, reason?: string) {
+    if (this.readyState !== OPEN) {
+      return;
+    }
+
+    this.readyState = CLOSED;
+    this.emit("close");
+
+    if (!this.webContents.isDestroyed()) {
+      this.webContents.send("kanvibe:terminal-close", {
+        taskId: this.taskId,
+        reason: reason ?? null,
+      });
+    }
+  }
+
+  emitMessage(message: string) {
+    if (this.readyState !== OPEN) {
+      return;
+    }
+
+    this.emit("message", Buffer.from(message));
+  }
+}
+
+const terminalClients = new Map<string, ElectronTerminalClient>();
+
+function buildClientKey(webContentsId: number, taskId: string): string {
+  return `${webContentsId}:${taskId}`;
+}
+
+function getClient(webContentsId: number, taskId: string): ElectronTerminalClient | null {
+  return terminalClients.get(buildClientKey(webContentsId, taskId)) ?? null;
+}
+
+export async function openTerminal(
+  webContents: WebContents,
+  taskId: string,
+  cols: number,
+  rows: number,
+) {
+  const existingClient = getClient(webContents.id, taskId);
+  if (existingClient) {
+    existingClient.emitMessage(`\x01${JSON.stringify({ type: "resize", cols, rows })}`);
+    return { ok: true };
+  }
+
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOneBy({ id: taskId });
+
+  if (!task || !task.sessionType || !task.sessionName) {
+    return { ok: false, error: "작업에 연결된 세션이 없습니다." };
+  }
+
+  const client = new ElectronTerminalClient(webContents, taskId);
+  terminalClients.set(buildClientKey(webContents.id, taskId), client);
+
+  const finalizeClient = () => {
+    terminalClients.delete(buildClientKey(webContents.id, taskId));
+  };
+
+  client.once("close", finalizeClient);
+
+  try {
+    if (task.sshHost) {
+      const sshHosts = await parseSSHConfig();
+      const sshConfig = sshHosts.find((host) => host.host === task.sshHost);
+
+      if (!sshConfig) {
+        client.close(1008, `SSH 호스트를 찾을 수 없습니다: ${task.sshHost}`);
+        return { ok: false, error: `SSH 호스트를 찾을 수 없습니다: ${task.sshHost}` };
+      }
+
+      await attachRemoteSession(
+        taskId,
+        task.sshHost,
+        task.sessionType as SessionType,
+        task.sessionName,
+        client as never,
+        sshConfig,
+        cols,
+        rows,
+      );
+    } else {
+      await attachLocalSession(
+        taskId,
+        task.sessionType as SessionType,
+        task.sessionName,
+        client as never,
+        task.worktreePath,
+        cols,
+        rows,
+      );
+    }
+
+    return { ok: true };
+  } catch (error) {
+    finalizeClient();
+    client.close(1011, "터미널 연결 실패");
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "터미널 연결 실패",
+    };
+  }
+}
+
+export function writeTerminal(webContentsId: number, taskId: string, data: string) {
+  getClient(webContentsId, taskId)?.emitMessage(data);
+}
+
+export function resizeTerminal(webContentsId: number, taskId: string, cols: number, rows: number) {
+  getClient(webContentsId, taskId)?.emitMessage(`\x01${JSON.stringify({ type: "resize", cols, rows })}`);
+}
+
+export function focusTerminal(taskId: string) {
+  focusSession(taskId);
+}
+
+export function closeTerminal(webContentsId: number, taskId: string) {
+  getClient(webContentsId, taskId)?.close();
+}
+
+export function closeWindowTerminals(webContentsId: number) {
+  for (const [key, client] of terminalClients.entries()) {
+    if (key.startsWith(`${webContentsId}:`)) {
+      client.close();
+    }
+  }
+}

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { IntlProvider } from "next-intl";
+import { HashRouter, Navigate, Outlet, Route, Routes, useParams } from "react-router-dom";
+import LoginForm from "@/components/LoginForm";
+import NotificationListener from "@/desktop/renderer/components/NotificationListener";
+import { getSessionState } from "@/desktop/renderer/actions/auth";
+import { DEFAULT_LOCALE, getSafeLocale, isSupportedLocale, messagesByLocale } from "@/desktop/renderer/utils/locales";
+import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
+import BoardRoute from "@/desktop/renderer/routes/BoardRoute";
+import DiffRoute from "@/desktop/renderer/routes/DiffRoute";
+import PaneLayoutRoute from "@/desktop/renderer/routes/PaneLayoutRoute";
+import TaskDetailRoute from "@/desktop/renderer/routes/TaskDetailRoute";
+
+interface SessionState {
+  isAuthenticated: boolean;
+}
+
+function LocaleShell({ sessionLoading }: { sessionLoading: boolean }) {
+  const { locale } = useParams();
+  const safeLocale = getSafeLocale(locale);
+  const messages = useMemo(() => messagesByLocale[safeLocale], [safeLocale]);
+
+  if (locale && !isSupportedLocale(locale)) {
+    return <Navigate to={`/${DEFAULT_LOCALE}`} replace />;
+  }
+
+  return (
+    <IntlProvider locale={safeLocale} messages={messages}>
+      {!sessionLoading && <NotificationListener />}
+      <Outlet />
+    </IntlProvider>
+  );
+}
+
+function ProtectedRoute({ isAuthenticated, children }: { isAuthenticated: boolean; children: ReactNode }) {
+  const { locale } = useParams();
+  const safeLocale = getSafeLocale(locale);
+
+  if (!isAuthenticated) {
+    return <Navigate to={`/${safeLocale}/login`} replace />;
+  }
+
+  return <>{children}</>;
+}
+
+function AnonymousRoute({ isAuthenticated, children }: { isAuthenticated: boolean; children: ReactNode }) {
+  const { locale } = useParams();
+  const safeLocale = getSafeLocale(locale);
+
+  if (isAuthenticated) {
+    return <Navigate to={`/${safeLocale}`} replace />;
+  }
+
+  return <>{children}</>;
+}
+
+export default function App() {
+  const [sessionState, setSessionState] = useState<SessionState | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const reloadSession = () => {
+      getSessionState().then((nextState) => {
+        if (!cancelled) {
+          setSessionState(nextState);
+        }
+      });
+    };
+
+    reloadSession();
+
+    const handleSessionChanged = () => reloadSession();
+    window.addEventListener("kanvibe:session-changed", handleSessionChanged);
+
+    const unsubscribeBoardEvents = window.kanvibeDesktop.onBoardEvent((event) => {
+      if (event.type === "board-updated") {
+        triggerDesktopRefresh();
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener("kanvibe:session-changed", handleSessionChanged);
+      unsubscribeBoardEvents();
+    };
+  }, []);
+
+  const isAuthenticated = sessionState?.isAuthenticated ?? false;
+  const sessionLoading = sessionState === null;
+
+  return (
+    <HashRouter>
+      <Routes>
+        <Route path="/" element={<Navigate to={`/${DEFAULT_LOCALE}${isAuthenticated ? "" : "/login"}`} replace />} />
+        <Route path="/:locale" element={<LocaleShell sessionLoading={sessionLoading} />}>
+          <Route index element={sessionLoading ? <div className="min-h-screen flex items-center justify-center bg-bg-page text-text-muted">Loading...</div> : <ProtectedRoute isAuthenticated={isAuthenticated}><BoardRoute /></ProtectedRoute>} />
+          <Route path="login" element={sessionLoading ? <div className="min-h-screen flex items-center justify-center bg-bg-page text-text-muted">Loading...</div> : <AnonymousRoute isAuthenticated={isAuthenticated}><LoginForm /></AnonymousRoute>} />
+          <Route path="pane-layout" element={<ProtectedRoute isAuthenticated={isAuthenticated}><PaneLayoutRoute /></ProtectedRoute>} />
+          <Route path="task/:id" element={<ProtectedRoute isAuthenticated={isAuthenticated}><TaskDetailRoute /></ProtectedRoute>} />
+          <Route path="task/:id/diff" element={<ProtectedRoute isAuthenticated={isAuthenticated}><DiffRoute /></ProtectedRoute>} />
+        </Route>
+      </Routes>
+    </HashRouter>
+  );
+}

--- a/src/desktop/renderer/actions/appSettings.ts
+++ b/src/desktop/renderer/actions/appSettings.ts
@@ -1,0 +1,61 @@
+import type { SessionType } from "@/entities/KanbanTask";
+import { invokeDesktop } from "@/desktop/renderer/ipc";
+import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
+
+async function invokeAndRefresh<T>(method: string, ...args: unknown[]): Promise<T> {
+  const result = await invokeDesktop<T>("appSettings", method, ...args);
+  triggerDesktopRefresh();
+  return result;
+}
+
+export function getAppSetting(key: string): Promise<string | null> {
+  return invokeDesktop("appSettings", "getAppSetting", key);
+}
+
+export function setAppSetting(key: string, value: string): Promise<void> {
+  return invokeAndRefresh("setAppSetting", key, value);
+}
+
+export function getSidebarDefaultCollapsed(): Promise<boolean> {
+  return invokeDesktop("appSettings", "getSidebarDefaultCollapsed");
+}
+
+export function setSidebarDefaultCollapsed(collapsed: boolean): Promise<void> {
+  return invokeAndRefresh("setSidebarDefaultCollapsed", collapsed);
+}
+
+export function getSidebarHintDismissed(): Promise<boolean> {
+  return invokeDesktop("appSettings", "getSidebarHintDismissed");
+}
+
+export function dismissSidebarHint(): Promise<void> {
+  return invokeAndRefresh("dismissSidebarHint");
+}
+
+export function getDoneAlertDismissed(): Promise<boolean> {
+  return invokeDesktop("appSettings", "getDoneAlertDismissed");
+}
+
+export function dismissDoneAlert(): Promise<void> {
+  return invokeAndRefresh("dismissDoneAlert");
+}
+
+export function getNotificationSettings(): Promise<{ isEnabled: boolean; enabledStatuses: string[] }> {
+  return invokeDesktop("appSettings", "getNotificationSettings");
+}
+
+export function setNotificationEnabled(enabled: boolean): Promise<void> {
+  return invokeAndRefresh("setNotificationEnabled", enabled);
+}
+
+export function setNotificationStatuses(statuses: string[]): Promise<void> {
+  return invokeAndRefresh("setNotificationStatuses", statuses);
+}
+
+export function getDefaultSessionType(): Promise<SessionType> {
+  return invokeDesktop("appSettings", "getDefaultSessionType");
+}
+
+export function setDefaultSessionType(sessionType: SessionType): Promise<void> {
+  return invokeAndRefresh("setDefaultSessionType", sessionType);
+}

--- a/src/desktop/renderer/actions/auth.ts
+++ b/src/desktop/renderer/actions/auth.ts
@@ -1,0 +1,36 @@
+import { invokeDesktop } from "@/desktop/renderer/ipc";
+import { getSafeLocale } from "@/desktop/renderer/utils/locales";
+
+function getCurrentLocale(): string {
+  const path = window.location.hash.replace(/^#/, "") || "/ko/login";
+  return getSafeLocale(path.split("/").filter(Boolean)[0]);
+}
+
+function navigateTo(href: string) {
+  window.location.hash = `#${href}`;
+}
+
+export async function loginAction(formData: FormData): Promise<{ error: string } | void> {
+  const username = String(formData.get("username") || "");
+  const password = String(formData.get("password") || "");
+  const result = await invokeDesktop<{ success: boolean; error?: string }>("auth", "login", username, password);
+
+  if (!result.success) {
+    return { error: result.error || "로그인에 실패했습니다." };
+  }
+
+  const locale = getCurrentLocale();
+  window.dispatchEvent(new Event("kanvibe:session-changed"));
+  navigateTo(`/${locale}`);
+}
+
+export async function logoutAction(): Promise<void> {
+  await invokeDesktop<void>("auth", "logout");
+  const locale = getCurrentLocale();
+  window.dispatchEvent(new Event("kanvibe:session-changed"));
+  navigateTo(`/${locale}/login`);
+}
+
+export async function getSessionState(): Promise<{ isAuthenticated: boolean }> {
+  return invokeDesktop("auth", "getSessionState");
+}

--- a/src/desktop/renderer/actions/diff.ts
+++ b/src/desktop/renderer/actions/diff.ts
@@ -1,0 +1,20 @@
+import { invokeDesktop } from "@/desktop/renderer/ipc";
+import type { DiffFile } from "@/desktop/main/services/diffService";
+
+export type { DiffFile };
+
+export function getGitDiffFiles(taskId: string): Promise<DiffFile[]> {
+  return invokeDesktop("diff", "getGitDiffFiles", taskId);
+}
+
+export function getOriginalFileContent(taskId: string, filePath: string): Promise<string> {
+  return invokeDesktop("diff", "getOriginalFileContent", taskId, filePath);
+}
+
+export function getFileContent(taskId: string, filePath: string): Promise<string> {
+  return invokeDesktop("diff", "getFileContent", taskId, filePath);
+}
+
+export function saveFileContent(taskId: string, filePath: string, content: string): Promise<{ success: boolean; error?: string }> {
+  return invokeDesktop("diff", "saveFileContent", taskId, filePath, content);
+}

--- a/src/desktop/renderer/actions/kanban.ts
+++ b/src/desktop/renderer/actions/kanban.ts
@@ -1,0 +1,75 @@
+import type { KanbanTask, TaskStatus } from "@/entities/KanbanTask";
+import type { SessionType } from "@/entities/KanbanTask";
+import type { LoadMoreDoneResponse, TasksByStatus, TasksByStatusWithMeta, CreateTaskInput } from "@/desktop/main/services/kanbanService";
+import { invokeDesktop } from "@/desktop/renderer/ipc";
+
+export type { TasksByStatus, TasksByStatusWithMeta, LoadMoreDoneResponse, CreateTaskInput };
+
+export function getTasksByStatus(): Promise<TasksByStatusWithMeta> {
+  return invokeDesktop("kanban", "getTasksByStatus");
+}
+
+export function getMoreDoneTasks(offset: number, limit?: number): Promise<LoadMoreDoneResponse> {
+  return invokeDesktop("kanban", "getMoreDoneTasks", offset, limit);
+}
+
+export function getTaskById(taskId: string): Promise<KanbanTask | null> {
+  return invokeDesktop("kanban", "getTaskById", taskId);
+}
+
+export function getTaskIdByProjectAndBranch(projectId: string, branchName: string): Promise<string | null> {
+  return invokeDesktop("kanban", "getTaskIdByProjectAndBranch", projectId, branchName);
+}
+
+export function createTask(input: CreateTaskInput): Promise<KanbanTask> {
+  return invokeDesktop("kanban", "createTask", input);
+}
+
+export function updateTaskStatus(taskId: string, newStatus: TaskStatus): Promise<KanbanTask | null> {
+  return invokeDesktop("kanban", "updateTaskStatus", taskId, newStatus);
+}
+
+export function updateTask(
+  taskId: string,
+  updates: Partial<Pick<KanbanTask, "title" | "description" | "priority">>,
+): Promise<KanbanTask | null> {
+  return invokeDesktop("kanban", "updateTask", taskId, updates);
+}
+
+export function updateProjectColor(projectId: string, color: string): Promise<void> {
+  return invokeDesktop("kanban", "updateProjectColor", projectId, color);
+}
+
+export function cleanupTaskResources(task: KanbanTask): Promise<void> {
+  return invokeDesktop("kanban", "cleanupTaskResources", task);
+}
+
+export function deleteTask(taskId: string): Promise<boolean> {
+  return invokeDesktop("kanban", "deleteTask", taskId);
+}
+
+export function branchFromTask(
+  taskId: string,
+  projectId: string,
+  baseBranch: string,
+  branchName: string,
+  sessionType: SessionType,
+): Promise<KanbanTask | null> {
+  return invokeDesktop("kanban", "branchFromTask", taskId, projectId, baseBranch, branchName, sessionType);
+}
+
+export function connectTerminalSession(taskId: string, sessionType: SessionType): Promise<KanbanTask | null> {
+  return invokeDesktop("kanban", "connectTerminalSession", taskId, sessionType);
+}
+
+export function reorderTasks(status: TaskStatus, orderedIds: string[]): Promise<void> {
+  return invokeDesktop("kanban", "reorderTasks", status, orderedIds);
+}
+
+export function moveTaskToColumn(taskId: string, newStatus: TaskStatus, destOrderedIds: string[]): Promise<void> {
+  return invokeDesktop("kanban", "moveTaskToColumn", taskId, newStatus, destOrderedIds);
+}
+
+export function fetchAndSavePrUrl(taskId: string): Promise<string | null> {
+  return invokeDesktop("kanban", "fetchAndSavePrUrl", taskId);
+}

--- a/src/desktop/renderer/actions/paneLayout.ts
+++ b/src/desktop/renderer/actions/paneLayout.ts
@@ -1,0 +1,40 @@
+import { invokeDesktop } from "@/desktop/renderer/ipc";
+import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
+import type { PaneLayoutConfig, PaneLayoutType, PaneCommand } from "@/entities/PaneLayoutConfig";
+
+export interface SavePaneLayoutInput {
+  layoutType: PaneLayoutType;
+  panes: PaneCommand[];
+  projectId?: string | null;
+  isGlobal?: boolean;
+}
+
+async function invokeAndRefresh<T>(method: string, ...args: unknown[]): Promise<T> {
+  const result = await invokeDesktop<T>("paneLayout", method, ...args);
+  triggerDesktopRefresh();
+  return result;
+}
+
+export function getGlobalPaneLayout(): Promise<PaneLayoutConfig | null> {
+  return invokeDesktop("paneLayout", "getGlobalPaneLayout");
+}
+
+export function getProjectPaneLayout(projectId: string): Promise<PaneLayoutConfig | null> {
+  return invokeDesktop("paneLayout", "getProjectPaneLayout", projectId);
+}
+
+export function getEffectivePaneLayout(projectId?: string): Promise<PaneLayoutConfig | null> {
+  return invokeDesktop("paneLayout", "getEffectivePaneLayout", projectId);
+}
+
+export function getAllPaneLayouts(): Promise<PaneLayoutConfig[]> {
+  return invokeDesktop("paneLayout", "getAllPaneLayouts");
+}
+
+export function savePaneLayout(input: SavePaneLayoutInput): Promise<PaneLayoutConfig> {
+  return invokeAndRefresh("savePaneLayout", input);
+}
+
+export function deletePaneLayout(id: string): Promise<boolean> {
+  return invokeAndRefresh("deletePaneLayout", id);
+}

--- a/src/desktop/renderer/actions/project.ts
+++ b/src/desktop/renderer/actions/project.ts
@@ -1,0 +1,146 @@
+import { invokeDesktop } from "@/desktop/renderer/ipc";
+import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
+import type { Project } from "@/entities/Project";
+import type {
+  AggregatedAiSessionDetail,
+  AggregatedAiSessionsResult,
+  AiMessageRole,
+  AiSessionProvider,
+} from "@/lib/aiSessions/types";
+import type {
+  ClaudeHooksStatus,
+} from "@/lib/claudeHooksSetup";
+import type { GeminiHooksStatus } from "@/lib/geminiHooksSetup";
+import type { CodexHooksStatus } from "@/lib/codexHooksSetup";
+import type { OpenCodeHooksStatus } from "@/lib/openCodeHooksSetup";
+import type { ScanResult } from "@/desktop/main/services/projectService";
+
+async function invokeAndRefresh<T>(method: string, ...args: unknown[]): Promise<T> {
+  const result = await invokeDesktop<T>("project", method, ...args);
+  triggerDesktopRefresh();
+  return result;
+}
+
+export type { ScanResult };
+
+export function getAllProjects(): Promise<Project[]> {
+  return invokeDesktop("project", "getAllProjects");
+}
+
+export function getAvailableHosts(): Promise<string[]> {
+  return invokeDesktop("project", "getAvailableHosts");
+}
+
+export function getProjectById(projectId: string): Promise<Project | null> {
+  return invokeDesktop("project", "getProjectById", projectId);
+}
+
+export function registerProject(name: string, repoPath: string, sshHost?: string) {
+  return invokeAndRefresh<{ success: boolean; error?: string; project?: Project }>("registerProject", name, repoPath, sshHost);
+}
+
+export function deleteProject(projectId: string): Promise<boolean> {
+  return invokeAndRefresh("deleteProject", projectId);
+}
+
+export function scanAndRegisterProjects(rootPath: string, sshHost?: string): Promise<ScanResult> {
+  return invokeAndRefresh("scanAndRegisterProjects", rootPath, sshHost);
+}
+
+export function listSubdirectories(parentPath: string, sshHost?: string): Promise<string[]> {
+  return invokeDesktop("project", "listSubdirectories", parentPath, sshHost);
+}
+
+export function getProjectBranches(projectId: string): Promise<string[]> {
+  return invokeDesktop("project", "getProjectBranches", projectId);
+}
+
+export function getProjectHooksStatus(projectId: string): Promise<ClaudeHooksStatus | null> {
+  return invokeDesktop("project", "getProjectHooksStatus", projectId);
+}
+
+export function installProjectHooks(projectId: string): Promise<{ success: boolean; error?: string }> {
+  return invokeAndRefresh("installProjectHooks", projectId);
+}
+
+export function getTaskHooksStatus(taskId: string): Promise<ClaudeHooksStatus | null> {
+  return invokeDesktop("project", "getTaskHooksStatus", taskId);
+}
+
+export function installTaskHooks(taskId: string): Promise<{ success: boolean; error?: string }> {
+  return invokeAndRefresh("installTaskHooks", taskId);
+}
+
+export function getProjectGeminiHooksStatus(projectId: string): Promise<GeminiHooksStatus | null> {
+  return invokeDesktop("project", "getProjectGeminiHooksStatus", projectId);
+}
+
+export function installProjectGeminiHooks(projectId: string): Promise<{ success: boolean; error?: string }> {
+  return invokeAndRefresh("installProjectGeminiHooks", projectId);
+}
+
+export function getTaskGeminiHooksStatus(taskId: string): Promise<GeminiHooksStatus | null> {
+  return invokeDesktop("project", "getTaskGeminiHooksStatus", taskId);
+}
+
+export function installTaskGeminiHooks(taskId: string): Promise<{ success: boolean; error?: string }> {
+  return invokeAndRefresh("installTaskGeminiHooks", taskId);
+}
+
+export function getProjectCodexHooksStatus(projectId: string): Promise<CodexHooksStatus | null> {
+  return invokeDesktop("project", "getProjectCodexHooksStatus", projectId);
+}
+
+export function installProjectCodexHooks(projectId: string): Promise<{ success: boolean; error?: string }> {
+  return invokeAndRefresh("installProjectCodexHooks", projectId);
+}
+
+export function getTaskCodexHooksStatus(taskId: string): Promise<CodexHooksStatus | null> {
+  return invokeDesktop("project", "getTaskCodexHooksStatus", taskId);
+}
+
+export function installTaskCodexHooks(taskId: string): Promise<{ success: boolean; error?: string }> {
+  return invokeAndRefresh("installTaskCodexHooks", taskId);
+}
+
+export function installProjectOpenCodeHooks(projectId: string): Promise<{ success: boolean; error?: string }> {
+  return invokeAndRefresh("installProjectOpenCodeHooks", projectId);
+}
+
+export function installTaskOpenCodeHooks(taskId: string): Promise<{ success: boolean; error?: string }> {
+  return invokeAndRefresh("installTaskOpenCodeHooks", taskId);
+}
+
+export function getTaskOpenCodeHooksStatus(taskId: string): Promise<OpenCodeHooksStatus | null> {
+  return invokeDesktop("project", "getTaskOpenCodeHooksStatus", taskId);
+}
+
+export function getTaskAiSessions(taskId: string, includeRepoSessions = false, query?: string): Promise<AggregatedAiSessionsResult> {
+  return invokeDesktop("project", "getTaskAiSessions", taskId, includeRepoSessions, query);
+}
+
+export function getTaskAiSessionDetail(
+  taskId: string,
+  provider: AiSessionProvider,
+  sessionId: string,
+  sourceRef?: string | null,
+  cursor?: string | null,
+  limit = 20,
+  includeRepoSessions = false,
+  query?: string,
+  roles?: AiMessageRole[],
+): Promise<AggregatedAiSessionDetail | null> {
+  return invokeDesktop(
+    "project",
+    "getTaskAiSessionDetail",
+    taskId,
+    provider,
+    sessionId,
+    sourceRef,
+    cursor,
+    limit,
+    includeRepoSessions,
+    query,
+    roles,
+  );
+}

--- a/src/desktop/renderer/components/DiffPageClient.tsx
+++ b/src/desktop/renderer/components/DiffPageClient.tsx
@@ -1,0 +1,262 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import type { DiffFile } from "@/desktop/renderer/actions/diff";
+import { getFileContent, getOriginalFileContent, saveFileContent } from "@/desktop/renderer/actions/diff";
+import DiffFileEditor from "@/components/DiffFileEditor";
+import DiffFileTree from "@/components/DiffFileTree";
+import DiffMonacoViewer from "@/components/DiffMonacoViewer";
+
+type ViewMode = "diff" | "edit";
+
+interface DiffPageClientProps {
+  taskId: string;
+  files: DiffFile[];
+}
+
+interface FileContentState {
+  original: string;
+  modified: string;
+  loading: boolean;
+}
+
+function ChangeStatDots({ additions, deletions }: { additions: number; deletions: number }) {
+  const total = additions + deletions;
+  if (total === 0) {
+    return null;
+  }
+
+  const addDots = Math.round((additions / total) * 5);
+  const deleteDots = 5 - addDots;
+
+  return (
+    <span className="flex gap-0.5 ml-1">
+      {Array.from({ length: addDots }, (_, index) => (
+        <span key={`a${index}`} className="w-2 h-2 rounded-sm bg-green-500" />
+      ))}
+      {Array.from({ length: deleteDots }, (_, index) => (
+        <span key={`d${index}`} className="w-2 h-2 rounded-sm bg-red-500" />
+      ))}
+    </span>
+  );
+}
+
+const MIN_SIDEBAR_WIDTH = 180;
+const MAX_SIDEBAR_WIDTH = 500;
+const DEFAULT_SIDEBAR_WIDTH = 288;
+
+export default function DiffPageClient({ taskId, files }: DiffPageClientProps) {
+  const t = useTranslations("diffView");
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>("diff");
+  const [viewedFiles, setViewedFiles] = useState<Set<string>>(new Set());
+  const [fileContent, setFileContent] = useState<FileContentState>({ original: "", modified: "", loading: false });
+  const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
+  const isResizing = useRef(false);
+
+  const totalStats = useMemo(
+    () =>
+      files.reduce(
+        (accumulator, file) => ({
+          additions: accumulator.additions + file.additions,
+          deletions: accumulator.deletions + file.deletions,
+        }),
+        { additions: 0, deletions: 0 },
+      ),
+    [files],
+  );
+
+  const effectiveSelectedFile = selectedFile ?? files[0]?.path ?? null;
+
+  const handleSelectFile = useCallback(
+    async (filePath: string) => {
+      setSelectedFile(filePath);
+      setViewMode("diff");
+      setFileContent({ original: "", modified: "", loading: true });
+
+      const [original, modified] = await Promise.all([
+        getOriginalFileContent(taskId, filePath),
+        getFileContent(taskId, filePath),
+      ]);
+
+      setFileContent({ original, modified, loading: false });
+    },
+    [taskId],
+  );
+
+  useEffect(() => {
+    if (!effectiveSelectedFile) {
+      setFileContent({ original: "", modified: "", loading: false });
+      return;
+    }
+
+    setFileContent({ original: "", modified: "", loading: true });
+
+    Promise.all([
+      getOriginalFileContent(taskId, effectiveSelectedFile),
+      getFileContent(taskId, effectiveSelectedFile),
+    ]).then(([original, modified]) => {
+      setFileContent({ original, modified, loading: false });
+    });
+  }, [effectiveSelectedFile, taskId]);
+
+  const handleSave = useCallback(
+    async (content: string) => {
+      if (!selectedFile) {
+        return;
+      }
+
+      const result = await saveFileContent(taskId, selectedFile, content);
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+
+      setFileContent((previous) => ({ ...previous, modified: content }));
+    },
+    [selectedFile, taskId],
+  );
+
+  const toggleViewed = useCallback((filePath: string) => {
+    setViewedFiles((previous) => {
+      const next = new Set(previous);
+      if (next.has(filePath)) {
+        next.delete(filePath);
+      } else {
+        next.add(filePath);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleResizeStart = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      isResizing.current = true;
+      const startX = event.clientX;
+      const startWidth = sidebarWidth;
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        if (!isResizing.current) {
+          return;
+        }
+        const nextWidth = startWidth + (moveEvent.clientX - startX);
+        setSidebarWidth(Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, nextWidth)));
+      };
+
+      const handleMouseUp = () => {
+        isResizing.current = false;
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [sidebarWidth],
+  );
+
+  const selectedFileData = files.find((file) => file.path === effectiveSelectedFile);
+  const isDeletedFile = selectedFileData?.status === "deleted";
+
+  return (
+    <div className="flex flex-1 min-h-0 gap-0">
+      <aside className="shrink-0 bg-bg-surface border-r border-border-default flex flex-col" style={{ width: `${sidebarWidth}px` }}>
+        <div className="px-3 py-2.5 border-b border-border-default flex items-center justify-between">
+          <div>
+            <h3 className="text-xs font-semibold text-text-primary">{t("changedFiles")}</h3>
+            <div className="flex items-center gap-2 mt-0.5">
+              <span className="text-[10px] text-text-muted">{t("fileCount", { count: files.length })}</span>
+              {(totalStats.additions > 0 || totalStats.deletions > 0) && (
+                <span className="text-[10px]">
+                  <span className="text-green-600 font-medium">+{totalStats.additions}</span>{" "}
+                  <span className="text-red-500 font-medium">-{totalStats.deletions}</span>
+                </span>
+              )}
+            </div>
+          </div>
+          {files.length > 0 && <span className="text-[10px] text-text-muted whitespace-nowrap">{viewedFiles.size} / {files.length}</span>}
+        </div>
+        <div className="flex-1 overflow-y-auto p-1.5">
+          {files.length === 0 ? (
+            <p className="text-xs text-text-muted px-2 py-4 text-center">{t("noChanges")}</p>
+          ) : (
+            <DiffFileTree files={files} selectedFile={selectedFile} onSelectFile={handleSelectFile} viewedFiles={viewedFiles} />
+          )}
+        </div>
+      </aside>
+
+      <div onMouseDown={handleResizeStart} className="w-1 shrink-0 cursor-col-resize bg-transparent hover:bg-brand-primary/30 active:bg-brand-primary/50 transition-colors" />
+
+      <main className="flex-1 flex flex-col min-h-0 min-w-0">
+          {effectiveSelectedFile && selectedFileData ? (
+          <>
+            <div className="flex items-center gap-3 px-4 py-2 bg-bg-surface border-b border-border-default shrink-0">
+              <div className="flex bg-bg-page rounded-md border border-border-default p-0.5">
+                <button onClick={() => setViewMode("diff")} className={`px-2.5 py-1 text-xs rounded transition-colors ${viewMode === "diff" ? "bg-bg-surface text-text-primary font-medium shadow-xs" : "text-text-muted hover:text-text-secondary"}`}>
+                  {t("diffMode")}
+                </button>
+                {!isDeletedFile && (
+                  <button onClick={() => setViewMode("edit")} className={`px-2.5 py-1 text-xs rounded transition-colors ${viewMode === "edit" ? "bg-bg-surface text-text-primary font-medium shadow-xs" : "text-text-muted hover:text-text-secondary"}`}>
+                    {t("editMode")}
+                  </button>
+                )}
+              </div>
+
+              <span className="text-xs font-mono text-text-secondary truncate flex-1">{effectiveSelectedFile}</span>
+
+              <span className="flex items-center gap-1.5 shrink-0 text-xs font-mono">
+                <span className="text-green-600 font-semibold">+{selectedFileData.additions}</span>
+                <span className="text-red-500 font-semibold">-{selectedFileData.deletions}</span>
+                <ChangeStatDots additions={selectedFileData.additions} deletions={selectedFileData.deletions} />
+              </span>
+
+              <label className="flex items-center gap-1.5 shrink-0 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={viewedFiles.has(effectiveSelectedFile)}
+                  onChange={() => toggleViewed(effectiveSelectedFile)}
+                  className="w-3.5 h-3.5 rounded border-border-default text-brand-primary focus:ring-brand-primary cursor-pointer accent-[var(--color-brand-primary)]"
+                />
+                <span className="text-xs text-text-muted">{viewedFiles.has(effectiveSelectedFile) ? t("viewed") : t("markViewed")}</span>
+              </label>
+            </div>
+
+            <div className="flex-1 min-h-0">
+              {fileContent.loading ? (
+                <div className="flex-1 flex items-center justify-center h-full bg-bg-page">
+                  <div className="text-text-muted text-sm">Loading...</div>
+                </div>
+              ) : viewMode === "diff" ? (
+                <DiffMonacoViewer originalContent={fileContent.original} modifiedContent={fileContent.modified} filePath={effectiveSelectedFile} />
+              ) : (
+                <DiffFileEditor
+                  content={fileContent.modified}
+                  filePath={effectiveSelectedFile}
+                  onSave={handleSave}
+                  labels={{
+                    save: t("save"),
+                    saving: t("saving"),
+                    saved: t("saved"),
+                    saveError: t("saveError"),
+                  }}
+                />
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="flex-1 flex flex-col items-center justify-center bg-bg-page gap-3">
+            <svg width="48" height="48" viewBox="0 0 48 48" fill="none" className="text-text-muted opacity-30">
+              <path d="M12 8h16l8 8v24a4 4 0 01-4 4H12a4 4 0 01-4-4V12a4 4 0 014-4z" stroke="currentColor" strokeWidth="2" fill="none" />
+              <path d="M28 8v8h8" stroke="currentColor" strokeWidth="2" fill="none" />
+              <path d="M16 24h16M16 30h12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+            <p className="text-text-muted text-sm">{files.length > 0 ? t("changedFiles") : t("noChanges")}</p>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/desktop/renderer/components/NotificationListener.tsx
+++ b/src/desktop/renderer/components/NotificationListener.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { useLocale } from "next-intl";
+import { useTaskNotification } from "@/hooks/useTaskNotification";
+import { getNotificationSettings } from "@/desktop/renderer/actions/appSettings";
+import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
+
+export default function NotificationListener() {
+  const { notifyTaskStatusChanged, notifyHookStatusTargetMissing } = useTaskNotification();
+  const locale = useLocale();
+  const refreshSignal = useRefreshSignal();
+  const [settings, setSettings] = useState({
+    isEnabled: true,
+    enabledStatuses: ["progress", "pending", "review"],
+  });
+
+  useEffect(() => {
+    getNotificationSettings()
+      .then((nextSettings) => setSettings(nextSettings))
+      .catch(() => {
+        /* 설정 로드 실패 시 기본값 유지 */
+      });
+  }, [refreshSignal]);
+
+  useEffect(() => {
+    return window.kanvibeDesktop.onBoardEvent((event) => {
+      if (!settings.isEnabled) {
+        return;
+      }
+
+      if (event.type === "task-status-changed") {
+        if (!settings.enabledStatuses.includes(event.newStatus)) {
+          return;
+        }
+
+        notifyTaskStatusChanged({ ...event, locale });
+      }
+
+      if (event.type === "hook-status-target-missing") {
+        if (!settings.enabledStatuses.includes(event.requestedStatus)) {
+          return;
+        }
+
+        notifyHookStatusTargetMissing({ ...event, locale });
+      }
+    });
+  }, [locale, notifyHookStatusTargetMissing, notifyTaskStatusChanged, settings]);
+
+  return null;
+}

--- a/src/desktop/renderer/components/Terminal.tsx
+++ b/src/desktop/renderer/components/Terminal.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useRef } from "react";
+import "@xterm/xterm/css/xterm.css";
+
+interface TerminalProps {
+  taskId: string;
+}
+
+export default function Terminal({ taskId }: TerminalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const connect = useCallback(async () => {
+    if (!containerRef.current) {
+      return undefined;
+    }
+
+    const nerdFontFamily = "JetBrainsMono Nerd Font Mono";
+    const fontFamily = `'${nerdFontFamily}', monospace`;
+    const cdnBase = "https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/fonts";
+    const regular = new FontFace(nerdFontFamily, `url(${cdnBase}/JetBrainsMonoNerdFontMono-Regular.woff2)`, { weight: "400" });
+    const bold = new FontFace(nerdFontFamily, `url(${cdnBase}/JetBrainsMonoNerdFontMono-Bold.woff2)`, { weight: "700" });
+    document.fonts.add(regular);
+    document.fonts.add(bold);
+    await document.fonts.ready;
+    await Promise.all([regular.load(), bold.load()]);
+
+    const [{ Terminal: XTerm }, { FitAddon }, { WebLinksAddon }] = await Promise.all([
+      import("@xterm/xterm"),
+      import("@xterm/addon-fit"),
+      import("@xterm/addon-web-links"),
+    ]);
+
+    const terminal = new XTerm({
+      allowProposedApi: true,
+      cursorBlink: true,
+      fontSize: 14,
+      fontFamily,
+      rescaleOverlappingGlyphs: true,
+      theme: {
+        background: "#0a0a0a",
+        foreground: "#e4e4e7",
+        cursor: "#e4e4e7",
+        selectionBackground: "#3b82f680",
+      },
+    });
+
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+    terminal.loadAddon(new WebLinksAddon());
+    terminal.open(containerRef.current);
+    terminal.options.fontFamily = "monospace";
+    terminal.options.fontFamily = fontFamily;
+
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        fitAddon.fit();
+        resolve();
+      });
+    });
+
+    const terminalReady = await window.kanvibeDesktop.openTerminal(taskId, terminal.cols, terminal.rows);
+    if (!terminalReady.ok) {
+      terminal.writeln(`\r\n\x1b[31m${terminalReady.error || "터미널 연결 실패"}\x1b[0m`);
+    }
+
+    const unsubscribeData = window.kanvibeDesktop.onTerminalData((event) => {
+      if (event.taskId === taskId) {
+        terminal.write(event.data);
+      }
+    });
+
+    const unsubscribeClose = window.kanvibeDesktop.onTerminalClose((event) => {
+      if (event.taskId === taskId) {
+        terminal.writeln(`\r\n\x1b[31m${event.reason || "연결이 종료되었습니다."}\x1b[0m`);
+      }
+    });
+
+    terminal.onData((data) => {
+      window.kanvibeDesktop.writeTerminal(taskId, data);
+    });
+
+    terminal.onResize(({ cols, rows }) => {
+      window.kanvibeDesktop.resizeTerminal(taskId, cols, rows);
+    });
+
+    const resizeObserver = new ResizeObserver(() => {
+      fitAddon.fit();
+      window.kanvibeDesktop.resizeTerminal(taskId, terminal.cols, terminal.rows);
+    });
+    resizeObserver.observe(containerRef.current);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        window.kanvibeDesktop.focusTerminal(taskId);
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      resizeObserver.disconnect();
+      unsubscribeData();
+      unsubscribeClose();
+      window.kanvibeDesktop.closeTerminal(taskId);
+      terminal.dispose();
+    };
+  }, [taskId]);
+
+  useEffect(() => {
+    let cleanup: (() => void) | undefined;
+    connect().then((dispose) => {
+      cleanup = dispose;
+    });
+    return () => cleanup?.();
+  }, [connect]);
+
+  return <div ref={containerRef} className="w-full h-full overflow-hidden bg-terminal-bg" />;
+}

--- a/src/desktop/renderer/components/TerminalLoader.tsx
+++ b/src/desktop/renderer/components/TerminalLoader.tsx
@@ -1,0 +1,13 @@
+import Terminal from "@/desktop/renderer/components/Terminal";
+
+interface TerminalLoaderProps {
+  taskId: string;
+}
+
+export default function TerminalLoader({ taskId }: TerminalLoaderProps) {
+  return (
+    <div className="h-full">
+      <Terminal taskId={taskId} />
+    </div>
+  );
+}

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -1,0 +1,21 @@
+import type { DesktopServiceNamespace } from "@/desktop/main/serviceRegistry";
+import type { BoardEventPayload } from "@/lib/boardNotifier";
+
+declare global {
+  interface Window {
+    kanvibeDesktop: {
+      isDesktop: boolean;
+      invoke: (namespace: DesktopServiceNamespace, method: string, args: unknown[]) => Promise<unknown>;
+      onBoardEvent: (listener: (event: BoardEventPayload) => void) => () => void;
+      openTerminal: (taskId: string, cols: number, rows: number) => Promise<{ ok: boolean; error?: string }>;
+      writeTerminal: (taskId: string, data: string) => void;
+      resizeTerminal: (taskId: string, cols: number, rows: number) => void;
+      focusTerminal: (taskId: string) => void;
+      closeTerminal: (taskId: string) => void;
+      onTerminalData: (listener: (event: { taskId: string; data: string }) => void) => () => void;
+      onTerminalClose: (listener: (event: { taskId: string; reason: string | null }) => void) => () => void;
+    };
+  }
+}
+
+export {};

--- a/src/desktop/renderer/hooks/useAutoRefresh.ts
+++ b/src/desktop/renderer/hooks/useAutoRefresh.ts
@@ -11,5 +11,5 @@ export function useAutoRefresh() {
       router.refresh();
     }
     boardHasMountedBefore = true;
-  }, [router]);
+  }, [router.refresh]);
 }

--- a/src/desktop/renderer/hooks/useAutoRefresh.ts
+++ b/src/desktop/renderer/hooks/useAutoRefresh.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useRouter } from "@/desktop/renderer/navigation";
+
+let boardHasMountedBefore = false;
+
+export function useAutoRefresh() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (boardHasMountedBefore) {
+      router.refresh();
+    }
+    boardHasMountedBefore = true;
+  }, [router]);
+}

--- a/src/desktop/renderer/hooks/useProjectFilterParams.ts
+++ b/src/desktop/renderer/hooks/useProjectFilterParams.ts
@@ -1,0 +1,72 @@
+import { useEffect, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+const QUERY_PARAM_KEY = "projects";
+const SESSION_STORAGE_KEY = "kanvibe_project_filter";
+
+export function useProjectFilterParams(validProjectIds: string[]) {
+  const validIdSet = useMemo(() => new Set(validProjectIds), [validProjectIds]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedProjectIds = useMemo(() => {
+    const param = searchParams.get(QUERY_PARAM_KEY);
+    if (!param) {
+      return [];
+    }
+
+    return param.split(",").filter((id) => validIdSet.has(id));
+  }, [searchParams, validIdSet]);
+
+  useEffect(() => {
+    const param = searchParams.get(QUERY_PARAM_KEY);
+    if (param) {
+      syncToSessionStorage(param.split(",").filter((id) => validIdSet.has(id)));
+      return;
+    }
+
+    const restored = restoreFromSessionStorage(validIdSet);
+    if (restored.length > 0) {
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.set(QUERY_PARAM_KEY, restored.join(","));
+      setSearchParams(nextParams, { replace: true });
+    }
+  }, [searchParams, setSearchParams, validIdSet]);
+
+  const setSelectedProjectIds = (idsOrUpdater: string[] | ((prev: string[]) => string[])) => {
+    const nextIds = typeof idsOrUpdater === "function" ? idsOrUpdater(selectedProjectIds) : idsOrUpdater;
+    syncToSessionStorage(nextIds);
+
+    const nextParams = new URLSearchParams(searchParams);
+    if (nextIds.length > 0) {
+      nextParams.set(QUERY_PARAM_KEY, nextIds.join(","));
+    } else {
+      nextParams.delete(QUERY_PARAM_KEY);
+    }
+    setSearchParams(nextParams, { replace: true });
+  };
+
+  return [selectedProjectIds, setSelectedProjectIds] as const;
+}
+
+function syncToSessionStorage(ids: string[]) {
+  try {
+    if (ids.length > 0) {
+      sessionStorage.setItem(SESSION_STORAGE_KEY, ids.join(","));
+    } else {
+      sessionStorage.removeItem(SESSION_STORAGE_KEY);
+    }
+  } catch {
+    /* sessionStorage 접근 불가 시 무시 */
+  }
+}
+
+function restoreFromSessionStorage(validIdSet: Set<string>): string[] {
+  try {
+    const stored = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+    return stored.split(",").filter((id) => validIdSet.has(id));
+  } catch {
+    return [];
+  }
+}

--- a/src/desktop/renderer/ipc.ts
+++ b/src/desktop/renderer/ipc.ts
@@ -1,0 +1,9 @@
+import type { DesktopServiceNamespace } from "@/desktop/main/serviceRegistry";
+
+export function invokeDesktop<T>(
+  namespace: DesktopServiceNamespace,
+  method: string,
+  ...args: unknown[]
+): Promise<T> {
+  return window.kanvibeDesktop.invoke(namespace, method, args) as Promise<T>;
+}

--- a/src/desktop/renderer/main.tsx
+++ b/src/desktop/renderer/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "@/desktop/renderer/App";
+import "@/app/globals.css";
+
+const container = document.getElementById("root");
+
+if (!container) {
+  throw new Error("Renderer root container not found.");
+}
+
+createRoot(container).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/src/desktop/renderer/navigation.tsx
+++ b/src/desktop/renderer/navigation.tsx
@@ -1,0 +1,64 @@
+import type { AnchorHTMLAttributes, PropsWithChildren } from "react";
+import { Link as RouterLink, useLocation, useNavigate } from "react-router-dom";
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES, getSafeLocale, type SupportedLocale } from "@/desktop/renderer/utils/locales";
+import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
+
+function getLocaleFromPathname(pathname: string): SupportedLocale {
+  const firstSegment = pathname.split("/").filter(Boolean)[0];
+  return getSafeLocale(firstSegment);
+}
+
+export function localizeHref(href: string, currentLocale?: string): string {
+  if (!href.startsWith("/")) {
+    return href;
+  }
+
+  const locale = getSafeLocale(currentLocale);
+  const firstSegment = href.split("/").filter(Boolean)[0];
+  if (SUPPORTED_LOCALES.includes(firstSegment as SupportedLocale)) {
+    return href;
+  }
+
+  if (href === "/") {
+    return `/${locale}`;
+  }
+
+  return `/${locale}${href}`;
+}
+
+interface LinkProps extends PropsWithChildren<Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href">> {
+  href: string;
+  prefetch?: boolean;
+}
+
+export function Link({ href, children, prefetch: _prefetch, ...props }: LinkProps) {
+  const location = useLocation();
+  const localizedHref = localizeHref(href, getLocaleFromPathname(location.pathname));
+  return (
+    <RouterLink to={localizedHref} {...props}>
+      {children}
+    </RouterLink>
+  );
+}
+
+export function usePathname() {
+  return useLocation().pathname;
+}
+
+export function useRouter() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const currentLocale = getLocaleFromPathname(location.pathname);
+
+  return {
+    push: (href: string) => navigate(localizeHref(href, currentLocale)),
+    replace: (href: string) => navigate(localizeHref(href, currentLocale), { replace: true }),
+    refresh: () => triggerDesktopRefresh(),
+  };
+}
+
+export function redirect(input: { href: string; locale?: string } | string) {
+  const href = typeof input === "string" ? input : input.href;
+  const locale = typeof input === "string" ? DEFAULT_LOCALE : input.locale;
+  window.location.hash = `#${localizeHref(href, locale)}`;
+}

--- a/src/desktop/renderer/navigation.tsx
+++ b/src/desktop/renderer/navigation.tsx
@@ -1,4 +1,4 @@
-import type { AnchorHTMLAttributes, PropsWithChildren } from "react";
+import { useMemo, type AnchorHTMLAttributes, type PropsWithChildren } from "react";
 import { Link as RouterLink, useLocation, useNavigate } from "react-router-dom";
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES, getSafeLocale, type SupportedLocale } from "@/desktop/renderer/utils/locales";
 import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
@@ -50,11 +50,14 @@ export function useRouter() {
   const location = useLocation();
   const currentLocale = getLocaleFromPathname(location.pathname);
 
-  return {
-    push: (href: string) => navigate(localizeHref(href, currentLocale)),
-    replace: (href: string) => navigate(localizeHref(href, currentLocale), { replace: true }),
-    refresh: () => triggerDesktopRefresh(),
-  };
+  return useMemo(
+    () => ({
+      push: (href: string) => navigate(localizeHref(href, currentLocale)),
+      replace: (href: string) => navigate(localizeHref(href, currentLocale), { replace: true }),
+      refresh: () => triggerDesktopRefresh(),
+    }),
+    [currentLocale, navigate],
+  );
 }
 
 export function redirect(input: { href: string; locale?: string } | string) {

--- a/src/desktop/renderer/routes/BoardRoute.tsx
+++ b/src/desktop/renderer/routes/BoardRoute.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import Board from "@/components/Board";
+import { getDoneAlertDismissed, getDefaultSessionType, getNotificationSettings, getSidebarDefaultCollapsed } from "@/desktop/renderer/actions/appSettings";
+import { getTasksByStatus } from "@/desktop/renderer/actions/kanban";
+import { getAllProjects, getAvailableHosts } from "@/desktop/renderer/actions/project";
+import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
+
+interface BoardData {
+  tasks: Awaited<ReturnType<typeof getTasksByStatus>>;
+  sshHosts: string[];
+  projects: Awaited<ReturnType<typeof getAllProjects>>;
+  sidebarDefaultCollapsed: boolean;
+  doneAlertDismissed: boolean;
+  notificationSettings: Awaited<ReturnType<typeof getNotificationSettings>>;
+  defaultSessionType: Awaited<ReturnType<typeof getDefaultSessionType>>;
+}
+
+export default function BoardRoute() {
+  const refreshSignal = useRefreshSignal();
+  const [data, setData] = useState<BoardData | null>(null);
+
+  useEffect(() => {
+    document.title = "KanVibe";
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all([
+      getTasksByStatus(),
+      getAvailableHosts(),
+      getAllProjects(),
+      getSidebarDefaultCollapsed(),
+      getDoneAlertDismissed(),
+      getNotificationSettings(),
+      getDefaultSessionType(),
+    ]).then(([tasks, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings, defaultSessionType]) => {
+      if (!cancelled) {
+        setData({
+          tasks,
+          sshHosts,
+          projects,
+          sidebarDefaultCollapsed,
+          doneAlertDismissed,
+          notificationSettings,
+          defaultSessionType,
+        });
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshSignal]);
+
+  if (!data) {
+    return <div className="min-h-screen flex items-center justify-center bg-bg-page text-text-muted">Loading...</div>;
+  }
+
+  return (
+    <Board
+      initialTasks={data.tasks.tasks}
+      initialDoneTotal={data.tasks.doneTotal}
+      initialDoneLimit={data.tasks.doneLimit}
+      sshHosts={data.sshHosts}
+      projects={data.projects}
+      sidebarDefaultCollapsed={data.sidebarDefaultCollapsed}
+      doneAlertDismissed={data.doneAlertDismissed}
+      notificationSettings={data.notificationSettings}
+      defaultSessionType={data.defaultSessionType}
+    />
+  );
+}

--- a/src/desktop/renderer/routes/DiffRoute.tsx
+++ b/src/desktop/renderer/routes/DiffRoute.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { useParams } from "react-router-dom";
+import { Link } from "@/desktop/renderer/navigation";
+import { getGitDiffFiles } from "@/desktop/renderer/actions/diff";
+import { getTaskById } from "@/desktop/renderer/actions/kanban";
+import DiffPageClient from "@/desktop/renderer/components/DiffPageClient";
+import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
+
+export default function DiffRoute() {
+  const { id = "" } = useParams();
+  const t = useTranslations("diffView");
+  const refreshSignal = useRefreshSignal();
+  const [state, setState] = useState<{ task: Awaited<ReturnType<typeof getTaskById>>; files: Awaited<ReturnType<typeof getGitDiffFiles>> } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all([getTaskById(id), getGitDiffFiles(id)]).then(([task, files]) => {
+      if (!cancelled) {
+        setState({ task, files });
+        document.title = task?.branchName ? `Diff - ${task.branchName}` : "KanVibe";
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id, refreshSignal]);
+
+  if (!state) {
+    return <div className="min-h-screen flex items-center justify-center bg-bg-page text-text-muted">Loading...</div>;
+  }
+
+  if (!state.task) {
+    return <div className="min-h-screen flex items-center justify-center bg-bg-page text-text-muted">Task not found.</div>;
+  }
+
+  if (!state.task.branchName) {
+    return (
+      <div className="h-screen flex flex-col items-center justify-center bg-bg-page gap-4">
+        <p className="text-text-muted text-sm">{t("noBranch")}</p>
+        <Link href={`/task/${id}`} className="text-sm text-text-brand hover:underline">{t("backToTask")}</Link>
+      </div>
+    );
+  }
+
+  if (!state.task.worktreePath) {
+    return (
+      <div className="h-screen flex flex-col items-center justify-center bg-bg-page gap-4">
+        <p className="text-text-muted text-sm">{t("noWorktree")}</p>
+        <Link href={`/task/${id}`} className="text-sm text-text-brand hover:underline">{t("backToTask")}</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen flex flex-col bg-bg-page">
+      <header className="shrink-0 flex items-center gap-3 px-4 py-2.5 bg-bg-surface border-b border-border-default">
+        <Link href={`/task/${id}`} className="flex items-center gap-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="shrink-0">
+            <path d="M10 12L6 8L10 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          {t("backToTask")}
+        </Link>
+
+        <div className="h-4 w-px bg-border-default" />
+        <h1 className="text-sm font-semibold text-text-primary">{t("title")}</h1>
+
+        <div className="h-4 w-px bg-border-default" />
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs font-mono text-text-muted bg-tag-base-bg text-tag-base-text px-2 py-0.5 rounded-md">{state.task.baseBranch ?? "main"}</span>
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="text-text-muted">
+            <path d="M5 3l4 4-4 4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          <span className="text-xs font-mono bg-tag-branch-bg text-tag-branch-text px-2 py-0.5 rounded-md">{state.task.branchName}</span>
+        </div>
+
+        <div className="ml-auto flex items-center gap-2 text-xs text-text-muted">
+          <span>{state.files.length} files</span>
+        </div>
+      </header>
+
+      <DiffPageClient taskId={id} files={state.files} />
+    </div>
+  );
+}

--- a/src/desktop/renderer/routes/PaneLayoutRoute.tsx
+++ b/src/desktop/renderer/routes/PaneLayoutRoute.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import PaneLayoutEditor from "@/components/PaneLayoutEditor";
+import { Link } from "@/desktop/renderer/navigation";
+import { getAllProjects } from "@/desktop/renderer/actions/project";
+import { getGlobalPaneLayout, getProjectPaneLayout } from "@/desktop/renderer/actions/paneLayout";
+import type { PaneLayoutConfig } from "@/entities/PaneLayoutConfig";
+import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
+
+interface PaneLayoutState {
+  globalConfig: PaneLayoutConfig | null;
+  projects: Awaited<ReturnType<typeof getAllProjects>>;
+  projectConfigs: Map<string, PaneLayoutConfig | null>;
+}
+
+export default function PaneLayoutRoute() {
+  const t = useTranslations("paneLayout");
+  const refreshSignal = useRefreshSignal();
+  const [state, setState] = useState<PaneLayoutState | null>(null);
+
+  useEffect(() => {
+    document.title = "KanVibe - Pane Layout";
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const [globalConfig, projects] = await Promise.all([getGlobalPaneLayout(), getAllProjects()]);
+      const projectConfigs = new Map<string, PaneLayoutConfig | null>();
+
+      await Promise.all(projects.map(async (project) => {
+        try {
+          projectConfigs.set(project.id, await getProjectPaneLayout(project.id));
+        } catch {
+          projectConfigs.set(project.id, null);
+        }
+      }));
+
+      if (!cancelled) {
+        setState({ globalConfig, projects, projectConfigs });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshSignal]);
+
+  if (!state) {
+    return <div className="min-h-screen flex items-center justify-center bg-bg-page text-text-muted">Loading...</div>;
+  }
+
+  return (
+    <div className="min-h-screen bg-bg-page p-6">
+      <div className="max-w-2xl mx-auto space-y-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold text-text-primary">{t("title")}</h1>
+            <p className="text-sm text-text-secondary mt-1">{t("description")}</p>
+          </div>
+          <Link href="/" className="text-sm text-brand-primary hover:underline">{t("backToBoard")}</Link>
+        </div>
+
+        <section className="bg-bg-surface rounded-xl border border-border-default p-5">
+          <h2 className="text-sm font-semibold text-text-primary mb-1">{t("globalDefault")}</h2>
+          <p className="text-xs text-text-muted mb-4">{t("globalDescription")}</p>
+          <PaneLayoutEditor initialConfig={state.globalConfig} isGlobal />
+        </section>
+
+        <section>
+          <h2 className="text-sm font-semibold text-text-primary mb-1">{t("projectOverride")}</h2>
+          <p className="text-xs text-text-muted mb-4">{t("projectOverrideDescription")}</p>
+
+          {state.projects.length === 0 ? (
+            <p className="text-sm text-text-muted">{t("noProjects")}</p>
+          ) : (
+            <div className="space-y-4">
+              {state.projects.map((project) => {
+                const config = state.projectConfigs.get(project.id) ?? null;
+                return (
+                  <details key={project.id} className="bg-bg-surface rounded-xl border border-border-default">
+                    <summary className="flex items-center justify-between p-4 cursor-pointer select-none">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-text-primary">{project.name}</span>
+                        <span className={`text-xs px-2 py-0.5 rounded-full ${config ? "bg-brand-primary/10 text-brand-primary" : "bg-bg-page text-text-muted"}`}>
+                          {config ? t("hasOverride") : t("usingGlobal")}
+                        </span>
+                      </div>
+                      <span className="text-xs text-text-muted">{t("configure")}</span>
+                    </summary>
+                    <div className="p-4 pt-0 border-t border-border-default">
+                      <PaneLayoutEditor projectId={project.id} initialConfig={config} />
+                    </div>
+                  </details>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { useParams } from "react-router-dom";
+import AiSessionsCard from "@/components/AiSessionsCard";
+import CollapsibleSidebar from "@/components/CollapsibleSidebar";
+import ConnectTerminalForm from "@/components/ConnectTerminalForm";
+import DeleteTaskButton from "@/components/DeleteTaskButton";
+import DoneStatusButton from "@/components/DoneStatusButton";
+import HooksStatusCard from "@/components/HooksStatusCard";
+import TaskDetailInfoCard from "@/components/TaskDetailInfoCard";
+import TaskDetailTitleCard from "@/components/TaskDetailTitleCard";
+import { Link, useRouter } from "@/desktop/renderer/navigation";
+import { getDoneAlertDismissed, getSidebarDefaultCollapsed, getSidebarHintDismissed } from "@/desktop/renderer/actions/appSettings";
+import { getGitDiffFiles } from "@/desktop/renderer/actions/diff";
+import { deleteTask, fetchAndSavePrUrl, getTaskById, getTaskIdByProjectAndBranch, updateTaskStatus } from "@/desktop/renderer/actions/kanban";
+import {
+  getTaskAiSessions,
+  getTaskCodexHooksStatus,
+  getTaskGeminiHooksStatus,
+  getTaskHooksStatus,
+  getTaskOpenCodeHooksStatus,
+} from "@/desktop/renderer/actions/project";
+import TerminalLoader from "@/desktop/renderer/components/TerminalLoader";
+import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
+import { TaskStatus } from "@/entities/KanbanTask";
+
+const STATUS_TRANSITIONS = [
+  { status: TaskStatus.TODO, labelKey: "moveToTodo" },
+  { status: TaskStatus.PROGRESS, labelKey: "moveToProgress" },
+  { status: TaskStatus.REVIEW, labelKey: "moveToReview" },
+  { status: TaskStatus.DONE, labelKey: "moveToDone" },
+] as const;
+
+const AGENT_TAG_STYLES: Record<string, string> = {
+  claude: "bg-tag-claude-bg text-tag-claude-text",
+  gemini: "bg-tag-gemini-bg text-tag-gemini-text",
+  codex: "bg-tag-codex-bg text-tag-codex-text",
+};
+
+interface TaskDetailState {
+  task: NonNullable<Awaited<ReturnType<typeof getTaskById>>>;
+  baseBranchTaskId: string | null;
+  diffFiles: Awaited<ReturnType<typeof getGitDiffFiles>>;
+  claudeHooksStatus: Awaited<ReturnType<typeof getTaskHooksStatus>>;
+  geminiHooksStatus: Awaited<ReturnType<typeof getTaskGeminiHooksStatus>>;
+  codexHooksStatus: Awaited<ReturnType<typeof getTaskCodexHooksStatus>>;
+  openCodeHooksStatus: Awaited<ReturnType<typeof getTaskOpenCodeHooksStatus>>;
+  aiSessions: Awaited<ReturnType<typeof getTaskAiSessions>>;
+  sidebarDefaultCollapsed: boolean;
+  sidebarHintDismissed: boolean;
+  doneAlertDismissed: boolean;
+}
+
+export default function TaskDetailRoute() {
+  const { id = "" } = useParams();
+  const router = useRouter();
+  const t = useTranslations("taskDetail");
+  const refreshSignal = useRefreshSignal();
+  const [state, setState] = useState<TaskDetailState | null | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const task = await getTaskById(id);
+      if (!task) {
+        if (!cancelled) {
+          setState(null);
+        }
+        return;
+      }
+
+      if (task.branchName && !task.prUrl) {
+        const prUrl = await fetchAndSavePrUrl(task.id);
+        if (prUrl) {
+          task.prUrl = prUrl;
+        }
+      }
+
+      const baseBranchName = task.baseBranch ?? "main";
+      const foundTaskId = task.projectId ? await getTaskIdByProjectAndBranch(task.projectId, baseBranchName) : null;
+      const baseBranchTaskId = foundTaskId !== task.id ? foundTaskId : null;
+      const diffFiles = task.branchName ? await getGitDiffFiles(id) : [];
+      const [claudeHooksStatus, geminiHooksStatus, codexHooksStatus, openCodeHooksStatus, aiSessions, sidebarDefaultCollapsed, sidebarHintDismissed, doneAlertDismissed] = await Promise.all([
+        task.projectId ? getTaskHooksStatus(id) : Promise.resolve(null),
+        task.projectId ? getTaskGeminiHooksStatus(id) : Promise.resolve(null),
+        task.projectId ? getTaskCodexHooksStatus(id) : Promise.resolve(null),
+        task.projectId ? getTaskOpenCodeHooksStatus(id) : Promise.resolve(null),
+        task.projectId ? getTaskAiSessions(id) : Promise.resolve({ isRemote: false, targetPath: null, repoPath: null, sessions: [], sources: [] }),
+        getSidebarDefaultCollapsed(),
+        getSidebarHintDismissed(),
+        getDoneAlertDismissed(),
+      ]);
+
+      if (!cancelled) {
+        document.title = [task.branchName, task.project?.name].filter(Boolean).join(" - ") || "KanVibe";
+        setState({
+          task,
+          baseBranchTaskId,
+          diffFiles,
+          claudeHooksStatus,
+          geminiHooksStatus,
+          codexHooksStatus,
+          openCodeHooksStatus,
+          aiSessions,
+          sidebarDefaultCollapsed,
+          sidebarHintDismissed,
+          doneAlertDismissed,
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id, refreshSignal]);
+
+  const agentTagStyle = useMemo(
+    () => (state?.task.agentType ? AGENT_TAG_STYLES[state.task.agentType] ?? "bg-tag-neutral-bg text-tag-neutral-text" : null),
+    [state?.task.agentType],
+  );
+
+  if (state === undefined) {
+    return <div className="min-h-screen flex items-center justify-center bg-bg-page text-text-muted">Loading...</div>;
+  }
+
+  if (state === null) {
+    return <div className="min-h-screen flex items-center justify-center bg-bg-page text-text-muted">Task not found.</div>;
+  }
+
+  const hasTerminal = !!(state.task.sessionType && state.task.sessionName);
+
+  async function handleStatusChange(formData: FormData) {
+    const newStatus = formData.get("status") as TaskStatus;
+    await updateTaskStatus(id, newStatus);
+    if (newStatus === TaskStatus.DONE) {
+      router.push("/");
+      return;
+    }
+    router.refresh();
+  }
+
+  async function handleDelete() {
+    await deleteTask(id);
+    router.push("/");
+  }
+
+  return (
+    <div className="h-screen flex flex-col lg:flex-row bg-bg-page p-4 gap-4">
+      <CollapsibleSidebar defaultCollapsed={state.sidebarDefaultCollapsed} showHint={!state.sidebarHintDismissed}>
+        <Link href="/" className="flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary transition-colors">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="shrink-0">
+            <path d="M10 12L6 8L10 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          {t("backToBoard")}
+        </Link>
+
+        <TaskDetailTitleCard task={state.task} taskId={state.task.id} />
+
+        <TaskDetailInfoCard
+          task={state.task}
+          agentTagStyle={agentTagStyle}
+          baseBranchTaskId={state.baseBranchTaskId}
+          diffFileCount={state.diffFiles.length}
+        />
+
+        <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
+          <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">{t("actions")}</h3>
+          <div className="flex flex-wrap gap-2">
+            {STATUS_TRANSITIONS.filter((transition) => transition.status !== state.task.status).map((transition) => (
+              transition.status === TaskStatus.DONE ? (
+                <DoneStatusButton
+                  key={transition.status}
+                  statusChangeAction={handleStatusChange}
+                  label={t(transition.labelKey)}
+                  hasCleanableResources={!!(state.task.branchName || state.task.sessionType)}
+                  doneAlertDismissed={state.doneAlertDismissed}
+                />
+              ) : (
+                <form key={transition.status} action={handleStatusChange}>
+                  <input type="hidden" name="status" value={transition.status} />
+                  <button type="submit" className="px-3 py-1.5 text-xs bg-bg-page border border-border-default hover:border-brand-primary hover:text-text-brand text-text-secondary rounded-md transition-colors">
+                    {t(transition.labelKey)}
+                  </button>
+                </form>
+              )
+            ))}
+          </div>
+          <div className="mt-3 pt-3 border-t border-border-subtle">
+            <DeleteTaskButton deleteAction={handleDelete} />
+          </div>
+        </div>
+
+        <HooksStatusCard
+          taskId={state.task.id}
+          initialClaudeStatus={state.claudeHooksStatus}
+          initialGeminiStatus={state.geminiHooksStatus}
+          initialCodexStatus={state.codexHooksStatus}
+          initialOpenCodeStatus={state.openCodeHooksStatus}
+          isRemote={!!state.task.sshHost}
+        />
+
+        <AiSessionsCard taskId={state.task.id} data={state.aiSessions} />
+      </CollapsibleSidebar>
+
+      <main className="flex-1 flex flex-col min-h-0 min-w-0">
+        {hasTerminal ? (
+          <div className="flex-1 flex flex-col min-h-0 rounded-lg overflow-hidden shadow-md">
+            <div className="bg-terminal-chrome flex items-center gap-2 px-4 py-2.5 shrink-0">
+              <span className="w-3 h-3 rounded-full bg-traffic-close" />
+              <span className="w-3 h-3 rounded-full bg-traffic-minimize" />
+              <span className="w-3 h-3 rounded-full bg-traffic-maximize" />
+              <span className="ml-3 text-xs text-terminal-text font-mono truncate">{state.task.sessionName ?? t("terminal")}</span>
+            </div>
+            <div className="flex-1 min-h-0 bg-terminal-bg">
+              <TerminalLoader taskId={state.task.id} />
+            </div>
+          </div>
+        ) : (
+          <div className="flex-1 flex items-center justify-center border border-dashed border-border-default rounded-lg bg-bg-surface">
+            {state.task.projectId ? <ConnectTerminalForm taskId={state.task.id} /> : <p className="text-text-muted text-sm">{t("noTerminal")}</p>}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/desktop/renderer/utils/locales.ts
+++ b/src/desktop/renderer/utils/locales.ts
@@ -1,0 +1,22 @@
+import enMessages from "../../../../messages/en.json";
+import koMessages from "../../../../messages/ko.json";
+import zhMessages from "../../../../messages/zh.json";
+
+export const DEFAULT_LOCALE = "ko";
+export const SUPPORTED_LOCALES = ["ko", "en", "zh"] as const;
+
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+export const messagesByLocale: Record<SupportedLocale, Record<string, unknown>> = {
+  en: enMessages,
+  ko: koMessages,
+  zh: zhMessages,
+};
+
+export function isSupportedLocale(locale: string | undefined): locale is SupportedLocale {
+  return !!locale && SUPPORTED_LOCALES.includes(locale as SupportedLocale);
+}
+
+export function getSafeLocale(locale: string | undefined): SupportedLocale {
+  return isSupportedLocale(locale) ? locale : DEFAULT_LOCALE;
+}

--- a/src/desktop/renderer/utils/refresh.ts
+++ b/src/desktop/renderer/utils/refresh.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+const REFRESH_EVENT_NAME = "kanvibe:navigation-refresh";
+
+export function triggerDesktopRefresh() {
+  window.dispatchEvent(new Event(REFRESH_EVENT_NAME));
+}
+
+export function subscribeToDesktopRefresh(listener: () => void): () => void {
+  window.addEventListener(REFRESH_EVENT_NAME, listener);
+  return () => {
+    window.removeEventListener(REFRESH_EVENT_NAME, listener);
+  };
+}
+
+export function useRefreshSignal() {
+  const [signal, setSignal] = useState(0);
+
+  useEffect(() => subscribeToDesktopRefresh(() => setSignal((value) => value + 1)), []);
+
+  return signal;
+}

--- a/src/hooks/useTaskNotification.ts
+++ b/src/hooks/useTaskNotification.ts
@@ -49,6 +49,21 @@ export interface HookStatusTargetMissingNotification {
   locale: string;
 }
 
+function showDesktopNotification(title: string, options: NotificationOptions) {
+  if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+    return navigator.serviceWorker.getRegistration().then((registration) => {
+      if (registration) {
+        return registration.showNotification(title, options);
+      }
+
+      new Notification(title, options);
+    });
+  }
+
+  new Notification(title, options);
+  return Promise.resolve();
+}
+
 /** hooks 경유 task 상태 변경 시 Browser Notification을 발송하는 훅 */
 export function useTaskNotification() {
   const isPermissionGranted = useRef(false);
@@ -76,20 +91,15 @@ export function useTaskNotification() {
         bodyParts.push(payload.description);
       }
 
-      // Service Worker의 notificationclick 이벤트를 수신하려면
-      // ServiceWorkerRegistration.showNotification()을 사용해야 함
       try {
-        const registration = await navigator.serviceWorker.getRegistration();
-        if (registration) {
-          registration.showNotification(title, {
-            body: bodyParts.join("\n"),
-            icon: "/kanvibe-logo.svg",
-            data: {
-              taskId: payload.taskId,
-              locale: payload.locale,
-            },
-          });
-        }
+        await showDesktopNotification(title, {
+          body: bodyParts.join("\n"),
+          icon: "/kanvibe-logo.svg",
+          data: {
+            taskId: payload.taskId,
+            locale: payload.locale,
+          },
+        });
       } catch (err) {
         console.error("[Notification] Failed to show notification:", err);
       }
@@ -109,16 +119,13 @@ export function useTaskNotification() {
           : messages.taskNotFound;
 
       try {
-        const registration = await navigator.serviceWorker.getRegistration();
-        if (registration) {
-          registration.showNotification(title, {
-            body: `${messages.formatMissingStatus(payload.requestedStatus)}\n${reasonMessage}`,
-            icon: "/kanvibe-logo.svg",
-            data: {
-              locale: payload.locale,
-            },
-          });
-        }
+        await showDesktopNotification(title, {
+          body: `${messages.formatMissingStatus(payload.requestedStatus)}\n${reasonMessage}`,
+          icon: "/kanvibe-logo.svg",
+          data: {
+            locale: payload.locale,
+          },
+        });
       } catch (err) {
         console.error("[Notification] Failed to show missing target notification:", err);
       }

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, rm } from "fs/promises";
+import { mkdtemp, readFile, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import { setupCodexHooks, getCodexHooksStatus } from "../codexHooksSetup";
@@ -21,7 +21,7 @@ describe("codexHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const status = await getCodexHooksStatus(repoPath);
@@ -33,11 +33,15 @@ describe("codexHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const status = await getCodexHooksStatus(repoPath);
       expect(status.hasConfigEntry).toBe(true);
+
+      const hookContent = await readFile(join(repoPath, ".codex", "hooks", "kanvibe-notify-hook.sh"), "utf-8");
+      expect(hookContent).toContain("PROJECT_ID=\"project-1\"");
+      expect(hookContent).toContain("projectId");
     });
 
     it("should mark as installed when both hook and config exist", async () => {
@@ -45,7 +49,7 @@ describe("codexHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const status = await getCodexHooksStatus(repoPath);
@@ -55,10 +59,10 @@ describe("codexHooksSetup", () => {
     it("should not add duplicate notify entry", async () => {
       // Given
       const repoPath = tempDir;
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // When - setup again
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then - should still be installed
       const status = await getCodexHooksStatus(repoPath);
@@ -83,7 +87,7 @@ describe("codexHooksSetup", () => {
     it("should detect installed status correctly", async () => {
       // Given
       const repoPath = tempDir;
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // When
       const status = await getCodexHooksStatus(repoPath);

--- a/src/lib/__tests__/geminiHooksSetup.test.ts
+++ b/src/lib/__tests__/geminiHooksSetup.test.ts
@@ -20,11 +20,11 @@ describe("geminiHooksSetup", () => {
     it("should create hook scripts and settings.json in .gemini directory", async () => {
       // Given
       const repoPath = tmpDir;
-      const projectName = "test-project";
+      const projectId = "project-1";
       const kanvibeUrl = "http://localhost:4885";
 
       // When
-      await setupGeminiHooks(repoPath, projectName, kanvibeUrl);
+      await setupGeminiHooks(repoPath, projectId, kanvibeUrl);
 
       // Then
       const promptScript = await readFile(
@@ -42,7 +42,8 @@ describe("geminiHooksSetup", () => {
       expect(promptScript).toContain("#!/bin/bash");
       expect(promptScript).toContain("BeforeAgent");
       expect(promptScript).toContain(kanvibeUrl);
-      expect(promptScript).toContain(projectName);
+      expect(promptScript).toContain(projectId);
+      expect(promptScript).toContain("projectId");
       expect(promptScript).toContain("echo '{}'");
 
       expect(stopScript).toContain("#!/bin/bash");
@@ -87,7 +88,7 @@ describe("geminiHooksSetup", () => {
       );
 
       // When
-      await setupGeminiHooks(tmpDir, "test-project", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
 
       // Then
       const settings = JSON.parse(
@@ -106,10 +107,10 @@ describe("geminiHooksSetup", () => {
 
     it("should not duplicate hooks when called multiple times", async () => {
       // Given
-      await setupGeminiHooks(tmpDir, "test-project", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
 
       // When
-      await setupGeminiHooks(tmpDir, "test-project", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
 
       // Then
       const settings = JSON.parse(
@@ -127,7 +128,7 @@ describe("geminiHooksSetup", () => {
   describe("getGeminiHooksStatus", () => {
     it("should return installed: true after setupGeminiHooks", async () => {
       // Given
-      await setupGeminiHooks(tmpDir, "test-project", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
 
       // When
       const status = await getGeminiHooksStatus(tmpDir);

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -58,6 +58,7 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toContain('"question.asked"');
       expect(pluginContent).toContain('"question.replied"');
       expect(pluginContent).toContain('"session.idle"');
+      expect(pluginContent).toContain('"session.deleted"');
     });
 
     it("should map event types to correct statuses", async () => {
@@ -75,6 +76,7 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toMatch(/question\.asked[\s\S]*?pending/);
       expect(pluginContent).toMatch(/question\.replied[\s\S]*?progress/);
       expect(pluginContent).toMatch(/session\.idle[\s\S]*?review/);
+      expect(pluginContent).toMatch(/session\.deleted[\s\S]*?done/);
     });
 
     it("should filter subagent sessions before updating statuses", async () => {
@@ -89,15 +91,19 @@ describe("openCodeHooksSetup", () => {
       const pluginContent = await readFile(pluginPath, "utf-8");
 
       expect(pluginContent).toContain("const sessionCache = new Map<string, boolean>()");
+      expect(pluginContent).toContain("function getSessionID(source: any): string | undefined");
+      expect(pluginContent).toContain("function getParentSessionID(source: any): string | null | undefined");
       expect(pluginContent).toContain("client.session.get");
       expect(pluginContent).toContain("sessionCache.has(sessionID)");
       expect(pluginContent).toContain("sessionCache.set(sessionID, isMain)");
       expect(pluginContent).toContain("result.data?.parentID");
       expect(pluginContent).toContain("properties?.info ?? (event as any).properties?.message");
-      expect(pluginContent).toMatch(/message\.updated[\s\S]*?isMainSession\(message\.sessionID\)/);
-      expect(pluginContent).toMatch(/question\.asked[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
-      expect(pluginContent).toMatch(/question\.replied[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
-      expect(pluginContent).toMatch(/session\.idle[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
+      expect(pluginContent).toContain("return sessionCache.get(sessionID) ?? false");
+      expect(pluginContent).toMatch(/message\.updated[\s\S]*?isMainSession\(message\)/);
+      expect(pluginContent).toMatch(/question\.asked[\s\S]*?isMainSession\(event\.properties\)/);
+      expect(pluginContent).toMatch(/question\.replied[\s\S]*?isMainSession\(event\.properties\)/);
+      expect(pluginContent).toMatch(/session\.idle[\s\S]*?isMainSession\(event\.properties\)/);
+      expect(pluginContent).toMatch(/session\.deleted[\s\S]*?isMainSession\(event\.properties\)/);
     });
 
     it("should not fail when called twice (overwrites existing plugin)", async () => {

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -21,7 +21,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const status = await getOpenCodeHooksStatus(repoPath);
@@ -33,7 +33,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -41,6 +41,8 @@ describe("openCodeHooksSetup", () => {
 
       expect(pluginContent).toContain("KanvibePlugin");
       expect(pluginContent).toContain("/api/hooks/status");
+      expect(pluginContent).toContain('const PROJECT_ID = "project-1";');
+      expect(pluginContent).toContain("projectId: PROJECT_ID");
     });
 
     it("should generate plugin with all event handlers for status tracking", async () => {
@@ -48,7 +50,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -65,7 +67,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -82,7 +84,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -103,10 +105,10 @@ describe("openCodeHooksSetup", () => {
     it("should not fail when called twice (overwrites existing plugin)", async () => {
       // Given
       const repoPath = tempDir;
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // When - setup again
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then - should still be installed correctly
       const status = await getOpenCodeHooksStatus(repoPath);
@@ -118,7 +120,7 @@ describe("openCodeHooksSetup", () => {
     it("should return installed: true after setup", async () => {
       // Given
       const repoPath = tempDir;
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // When
       const status = await getOpenCodeHooksStatus(repoPath);

--- a/src/lib/boardNotifier.ts
+++ b/src/lib/boardNotifier.ts
@@ -1,40 +1,7 @@
-import type { WebSocket } from "ws";
+import { EventEmitter } from "node:events";
 
-/** 보드 업데이트 알림을 수신할 WebSocket 클라이언트 목록 */
-const boardClients = new Set<WebSocket>();
-
-export function addBoardClient(ws: WebSocket) {
-  boardClients.add(ws);
-}
-
-export function removeBoardClient(ws: WebSocket) {
-  boardClients.delete(ws);
-}
-
-/** server.ts에서 직접 WS 클라이언트에 접근할 때 사용한다 */
-export function getBoardClients(): Set<WebSocket> {
-  return boardClients;
-}
-
-const BROADCAST_URL = `http://localhost:${process.env.PORT || 4885}/_internal/broadcast`;
-
-/**
- * 내부 HTTP 요청으로 custom server에 broadcast를 위임한다.
- * Turbopack이 API route를 별도 워커에서 실행하므로 in-memory Set이 공유되지 않는다.
- */
-function sendBroadcast(message: string) {
-  fetch(BROADCAST_URL, {
-    method: "POST",
-    body: message,
-    headers: { "Content-Type": "application/json" },
-  }).catch(() => {
-    /* 연결 실패 무시 (서버 시작 전 등) */
-  });
-}
-
-/** 연결된 모든 보드 클라이언트에 업데이트 알림을 전송한다 */
-export function broadcastBoardUpdate() {
-  sendBroadcast(JSON.stringify({ type: "board-updated" }));
+export interface BoardUpdatedPayload {
+  type: "board-updated";
 }
 
 export interface TaskStatusChangedPayload {
@@ -53,12 +20,56 @@ export interface HookStatusTargetMissingPayload {
   reason: "project-not-found" | "task-not-found";
 }
 
+export type BoardEventPayload =
+  | BoardUpdatedPayload
+  | ({ type: "task-status-changed" } & TaskStatusChangedPayload)
+  | ({ type: "hook-status-target-missing" } & HookStatusTargetMissingPayload);
+
+const boardEventEmitter = new EventEmitter();
+interface LegacyBoardClient {
+  readyState: number;
+  OPEN: number;
+  send: (message: string) => void;
+}
+
+const legacyBoardClients = new Set<LegacyBoardClient>();
+
+export function addBoardClient(client: LegacyBoardClient) {
+  legacyBoardClients.add(client);
+}
+
+export function removeBoardClient(client: LegacyBoardClient) {
+  legacyBoardClients.delete(client);
+}
+
+export function getBoardClients(): Set<LegacyBoardClient> {
+  return legacyBoardClients;
+}
+
+export function subscribeToBoardEvents(
+  listener: (payload: BoardEventPayload) => void,
+): () => void {
+  boardEventEmitter.on("event", listener);
+  return () => {
+    boardEventEmitter.off("event", listener);
+  };
+}
+
+function emitBoardEvent(payload: BoardEventPayload) {
+  boardEventEmitter.emit("event", payload);
+}
+
+/** 연결된 모든 데스크톱 렌더러에 업데이트 알림을 전송한다 */
+export function broadcastBoardUpdate() {
+  emitBoardEvent({ type: "board-updated" });
+}
+
 /** hooks 경유 상태 변경 시 task 상세 정보를 포함하여 브로드캐스트한다 */
 export function broadcastTaskStatusChanged(payload: TaskStatusChangedPayload) {
-  sendBroadcast(JSON.stringify({ type: "task-status-changed", ...payload }));
+  emitBoardEvent({ type: "task-status-changed", ...payload });
 }
 
 /** hooks 대상 조회 실패 시 미매칭 상황을 브로드캐스트한다 */
 export function broadcastHookStatusTargetMissing(payload: HookStatusTargetMissingPayload) {
-  sendBroadcast(JSON.stringify({ type: "hook-status-target-missing", ...payload }));
+  emitBoardEvent({ type: "hook-status-target-missing", ...payload });
 }

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -3,14 +3,14 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, projectName: string): string {
+function generatePromptHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: UserPromptSubmit
 # 사용자가 prompt를 입력하면 현재 브랜치의 작업을 PROGRESS로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -19,7 +19,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"progress\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"progress\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -27,14 +27,14 @@ exit 0
 }
 
 /** Stop hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, projectName: string): string {
+function generateStopHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: Stop
 # AI 응답이 완료되면 현재 브랜치의 작업을 REVIEW로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -43,7 +43,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -51,14 +51,14 @@ exit 0
 }
 
 /** PreToolUse(AskUserQuestion) hook bash 스크립트를 생성한다 */
-function generateQuestionHookScript(kanvibeUrl: string, projectName: string): string {
+function generateQuestionHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: PreToolUse (AskUserQuestion)
 # Claude가 사용자에게 질문할 때 현재 브랜치의 작업을 PENDING으로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -67,7 +67,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"pending\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"pending\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -112,7 +112,7 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
  */
 export async function setupClaudeHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const claudeDir = path.join(repoPath, ".claude");
@@ -125,9 +125,9 @@ export async function setupClaudeHooks(
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
   const questionScriptPath = path.join(hooksDir, "kanvibe-question-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectName), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectName), "utf-8");
-  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, projectId), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
   await chmod(questionScriptPath, 0o755);

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -8,7 +8,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** notify hook bash 스크립트를 생성한다 (agent-turn-complete → REVIEW) */
-function generateNotifyHookScript(kanvibeUrl: string, projectName: string): string {
+function generateNotifyHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Codex CLI Hook: notify (agent-turn-complete)
@@ -16,7 +16,7 @@ function generateNotifyHookScript(kanvibeUrl: string, projectName: string): stri
 # Codex notify 스크립트는 첫 번째 인자로 JSON payload를 받는다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 JSON_PAYLOAD="$1"
 
@@ -33,7 +33,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -63,7 +63,7 @@ function hasKanvibeNotify(configContent: string): boolean {
  */
 export async function setupCodexHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const codexDir = path.join(repoPath, ".codex");
@@ -73,7 +73,7 @@ export async function setupCodexHooks(
   await mkdir(hooksDir, { recursive: true });
 
   const notifyScriptPath = path.join(hooksDir, HOOK_SCRIPT_NAME);
-  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, projectId), "utf-8");
   await chmod(notifyScriptPath, 0o755);
 
   const configContent = await readConfigToml(configPath);

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -8,7 +8,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** BeforeAgent hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, projectName: string): string {
+function generatePromptHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: BeforeAgent
@@ -16,7 +16,7 @@ function generatePromptHookScript(kanvibeUrl: string, projectName: string): stri
 # Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -26,7 +26,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"progress\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"progress\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -35,7 +35,7 @@ exit 0
 }
 
 /** AfterAgent hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, projectName: string): string {
+function generateStopHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: AfterAgent
@@ -43,7 +43,7 @@ function generateStopHookScript(kanvibeUrl: string, projectName: string): string
 # Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -53,7 +53,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -104,7 +104,7 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
  */
 export async function setupGeminiHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const geminiDir = path.join(repoPath, ".gemini");
@@ -116,8 +116,8 @@ export async function setupGeminiHooks(
   const promptScriptPath = path.join(hooksDir, "kanvibe-prompt-hook.sh");
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectName), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectId), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
 

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -4,7 +4,8 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 
 /**
  * OpenCode는 `.opencode/plugins/` 디렉토리에 TypeScript 플러그인을 배치하여 hooks를 등록한다.
- * message.updated(user) → progress, question.asked → pending, question.replied → progress, session.idle → review 상태를 전송한다.
+ * message.updated(user) → progress, question.asked → pending,
+ * question.replied → progress, session.idle → review, session.deleted → done 상태를 전송한다.
  */
 
 const PLUGIN_FILE_NAME = "kanvibe-plugin.ts";
@@ -17,7 +18,7 @@ function generatePluginScript(kanvibeUrl: string, projectName: string): string {
 /**
  * KanVibe OpenCode Plugin
  * message.updated(user) → progress, question.asked → pending,
- * question.replied → progress, session.idle → review 상태 변경
+ * question.replied → progress, session.idle → review, session.deleted → done 상태 변경
  */
 export const KanvibePlugin: Plugin = async ({ $, client }) => {
   const KANVIBE_URL = "${kanvibeUrl}";
@@ -51,8 +52,40 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
 
   const sessionCache = new Map<string, boolean>();
 
-  async function isMainSession(sessionID: string | undefined): Promise<boolean> {
+  function getSessionID(source: any): string | undefined {
+    return (
+      source?.sessionID ??
+      source?.sessionId ??
+      source?.id ??
+      source?.session?.id ??
+      source?.info?.sessionID ??
+      source?.info?.sessionId ??
+      source?.info?.id
+    );
+  }
+
+  function getParentSessionID(source: any): string | null | undefined {
+    return (
+      source?.parentID ??
+      source?.parentId ??
+      source?.session?.parentID ??
+      source?.session?.parentId ??
+      source?.info?.parentID ??
+      source?.info?.parentId
+    );
+  }
+
+  async function isMainSession(source: any): Promise<boolean> {
+    const sessionID = getSessionID(source);
     if (!sessionID) return false;
+
+    const parentSessionID = getParentSessionID(source);
+    if (parentSessionID !== undefined) {
+      const isMain = !parentSessionID;
+      sessionCache.set(sessionID, isMain);
+      return isMain;
+    }
+
     if (sessionCache.has(sessionID)) return sessionCache.get(sessionID)!;
 
     try {
@@ -67,7 +100,7 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
 
       return isMain;
     } catch {
-      return false;
+      return sessionCache.get(sessionID) ?? false;
     }
   }
 
@@ -77,30 +110,37 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
         const message =
           (event as any).properties?.info ?? (event as any).properties?.message;
 
-        if (message?.role === "user" && (await isMainSession(message.sessionID))) {
+        if (message?.role === "user" && (await isMainSession(message))) {
           await updateStatus("progress");
         }
       }
       if (event.type === "question.asked") {
-        if (!(await isMainSession(event.properties.sessionID))) {
+        if (!(await isMainSession(event.properties))) {
           return;
         }
 
         await updateStatus("pending");
       }
       if (event.type === "question.replied") {
-        if (!(await isMainSession(event.properties.sessionID))) {
+        if (!(await isMainSession(event.properties))) {
           return;
         }
 
         await updateStatus("progress");
       }
       if (event.type === "session.idle") {
-        if (!(await isMainSession(event.properties.sessionID))) {
+        if (!(await isMainSession(event.properties))) {
           return;
         }
 
         await updateStatus("review");
+      }
+      if (event.type === "session.deleted") {
+        if (!(await isMainSession(event.properties))) {
+          return;
+        }
+
+        await updateStatus("done");
       }
     },
   };

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -11,7 +11,7 @@ const PLUGIN_FILE_NAME = "kanvibe-plugin.ts";
 const PLUGIN_DIR_NAME = "plugins";
 
 /** OpenCode plugin TypeScript 파일 내용을 생성한다 */
-function generatePluginScript(kanvibeUrl: string, projectName: string): string {
+function generatePluginScript(kanvibeUrl: string, projectId: string): string {
   return `import type { Plugin } from "@opencode-ai/plugin";
 
 /**
@@ -21,7 +21,7 @@ function generatePluginScript(kanvibeUrl: string, projectName: string): string {
  */
 export const KanvibePlugin: Plugin = async ({ $, client }) => {
   const KANVIBE_URL = "${kanvibeUrl}";
-  const PROJECT_NAME = "${projectName}";
+  const PROJECT_ID = "${projectId}";
 
   async function getBranchName(): Promise<string | null> {
     try {
@@ -42,7 +42,7 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
       await fetch(\`\${KANVIBE_URL}/api/hooks/status\`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ branchName, projectName: PROJECT_NAME, status }),
+        body: JSON.stringify({ branchName, projectId: PROJECT_ID, status }),
       });
     } catch {
       /* 네트워크 에러 무시 */
@@ -119,7 +119,7 @@ function hasKanvibePlugin(pluginContent: string): boolean {
  */
 export async function setupOpenCodeHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const openCodeDir = path.join(repoPath, ".opencode");
@@ -128,7 +128,7 @@ export async function setupOpenCodeHooks(
   await mkdir(pluginsDir, { recursive: true });
 
   const pluginPath = path.join(pluginsDir, PLUGIN_FILE_NAME);
-  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, projectId), "utf-8");
 
   try {
     await addAiToolPatternsToGitExclude(repoPath);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+const resolvePath = (relativePath: string) => path.resolve(__dirname, relativePath);
+
+export default defineConfig({
+  base: "./",
+  plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+    port: 5173,
+  },
+  build: {
+    outDir: "build/renderer",
+    emptyOutDir: true,
+  },
+  resolve: {
+    alias: [
+      { find: "@/app/actions/auth", replacement: resolvePath("./src/desktop/renderer/actions/auth.ts") },
+      { find: "@/app/actions/kanban", replacement: resolvePath("./src/desktop/renderer/actions/kanban.ts") },
+      { find: "@/app/actions/project", replacement: resolvePath("./src/desktop/renderer/actions/project.ts") },
+      { find: "@/app/actions/appSettings", replacement: resolvePath("./src/desktop/renderer/actions/appSettings.ts") },
+      { find: "@/app/actions/diff", replacement: resolvePath("./src/desktop/renderer/actions/diff.ts") },
+      { find: "@/app/actions/paneLayout", replacement: resolvePath("./src/desktop/renderer/actions/paneLayout.ts") },
+      { find: "@/i18n/navigation", replacement: resolvePath("./src/desktop/renderer/navigation.tsx") },
+      { find: "@/hooks/useAutoRefresh", replacement: resolvePath("./src/desktop/renderer/hooks/useAutoRefresh.ts") },
+      { find: "@/hooks/useProjectFilterParams", replacement: resolvePath("./src/desktop/renderer/hooks/useProjectFilterParams.ts") },
+      { find: "@", replacement: resolvePath("./src") },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- migrate the desktop app flow to an Electron-first renderer with dedicated main and renderer bridges
- add native runtime, SQLite, auth, hook, diff, pane layout, and terminal support for the desktop build
- resolve the latest desktop notification and bridge merge conflicts, then align the related tests and typings

## Testing
- pnpm exec tsc --noEmit