### PR TITLE
fix: use project ids for hook-driven status updates

### DIFF
--- a/src/app/actions/kanban.ts
+++ b/src/app/actions/kanban.ts
@@ -153,10 +153,10 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
         if (!project.sshHost && session.worktreePath) {
           const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
           await Promise.allSettled([
-            setupClaudeHooks(session.worktreePath, project.name, kanvibeUrl),
-            setupGeminiHooks(session.worktreePath, project.name, kanvibeUrl),
-            setupCodexHooks(session.worktreePath, project.name, kanvibeUrl),
-            setupOpenCodeHooks(session.worktreePath, project.name, kanvibeUrl),
+            setupClaudeHooks(session.worktreePath, project.id, kanvibeUrl),
+            setupGeminiHooks(session.worktreePath, project.id, kanvibeUrl),
+            setupCodexHooks(session.worktreePath, project.id, kanvibeUrl),
+            setupOpenCodeHooks(session.worktreePath, project.id, kanvibeUrl),
           ]);
         }
       }
@@ -343,10 +343,10 @@ export async function branchFromTask(
     try {
       const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
       await Promise.allSettled([
-        setupClaudeHooks(session.worktreePath, project.name, kanvibeUrl),
-        setupGeminiHooks(session.worktreePath, project.name, kanvibeUrl),
-        setupCodexHooks(session.worktreePath, project.name, kanvibeUrl),
-        setupOpenCodeHooks(session.worktreePath, project.name, kanvibeUrl),
+          setupClaudeHooks(session.worktreePath, project.id, kanvibeUrl),
+          setupGeminiHooks(session.worktreePath, project.id, kanvibeUrl),
+          setupCodexHooks(session.worktreePath, project.id, kanvibeUrl),
+          setupOpenCodeHooks(session.worktreePath, project.id, kanvibeUrl),
       ]);
     } catch (error) {
       console.error("Hooks 설정 실패:", error);

--- a/src/app/actions/project.ts
+++ b/src/app/actions/project.ts
@@ -221,10 +221,10 @@ export async function scanAndRegisterProjects(
       if (!sshHost) {
         try {
           const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
-          await setupClaudeHooks(repoPath, projectName, kanvibeUrl);
-          await setupGeminiHooks(repoPath, projectName, kanvibeUrl);
-          await setupCodexHooks(repoPath, projectName, kanvibeUrl);
-          await setupOpenCodeHooks(repoPath, projectName, kanvibeUrl);
+          await setupClaudeHooks(repoPath, saved.id, kanvibeUrl);
+          await setupGeminiHooks(repoPath, saved.id, kanvibeUrl);
+          await setupCodexHooks(repoPath, saved.id, kanvibeUrl);
+          await setupOpenCodeHooks(repoPath, saved.id, kanvibeUrl);
           result.hooksSetup.push(projectName);
         } catch (hookError) {
           result.errors.push(
@@ -390,7 +390,7 @@ export async function installProjectHooks(
 
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
-    await setupClaudeHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupClaudeHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -424,7 +424,7 @@ export async function installTaskHooks(
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupClaudeHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupClaudeHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -456,7 +456,7 @@ export async function installProjectGeminiHooks(
 
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
-    await setupGeminiHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupGeminiHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -490,7 +490,7 @@ export async function installTaskGeminiHooks(
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupGeminiHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupGeminiHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -520,7 +520,7 @@ export async function installProjectCodexHooks(
 
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
-    await setupCodexHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupCodexHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -552,7 +552,7 @@ export async function installTaskCodexHooks(
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupCodexHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupCodexHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -572,7 +572,7 @@ export async function installProjectOpenCodeHooks(
 
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
-    await setupOpenCodeHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupOpenCodeHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -596,7 +596,7 @@ export async function installTaskOpenCodeHooks(
   try {
     const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupOpenCodeHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupOpenCodeHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {

--- a/src/app/api/hooks/status/__tests__/route.test.ts
+++ b/src/app/api/hooks/status/__tests__/route.test.ts
@@ -45,7 +45,7 @@ describe("POST /api/hooks/status", () => {
       method: "POST",
       body: JSON.stringify({
         branchName: "feat/missing-project",
-        projectName: "case-study",
+        projectId: "project-1",
         status: "review",
       }),
     });
@@ -60,10 +60,10 @@ describe("POST /api/hooks/status", () => {
     expect(response.status).toBe(404);
     expect(body).toEqual({
       success: false,
-      error: "프로젝트를 찾을 수 없습니다: case-study",
+      error: "프로젝트를 찾을 수 없습니다: project-1",
     });
     expect(mockBroadcastHookStatusTargetMissing).toHaveBeenCalledWith({
-      projectName: "case-study",
+      projectName: "project-1",
       branchName: "feat/missing-project",
       requestedStatus: "review",
       reason: "project-not-found",
@@ -85,7 +85,7 @@ describe("POST /api/hooks/status", () => {
       method: "POST",
       body: JSON.stringify({
         branchName: "feat/missing-task",
-        projectName: "case-study",
+        projectId: "project-1",
         status: "review",
       }),
     });
@@ -111,5 +111,61 @@ describe("POST /api/hooks/status", () => {
     expect(mockTaskSave).not.toHaveBeenCalled();
     expect(mockBroadcastBoardUpdate).not.toHaveBeenCalled();
     expect(mockBroadcastTaskStatusChanged).not.toHaveBeenCalled();
+  });
+
+  it("should update task status by projectId and broadcast project name from database", async () => {
+    // Given
+    mockProjectFindOneBy.mockResolvedValue({
+      id: "project-1",
+      name: "case-study",
+    });
+    mockTaskFindOneBy.mockResolvedValue({
+      id: "task-1",
+      title: "feat/existing-task",
+      description: "desc",
+      status: "todo",
+      branchName: "feat/existing-task",
+      projectId: "project-1",
+    });
+    mockTaskSave.mockImplementation(async (task) => task);
+
+    const request = new Request("http://localhost:4885/api/hooks/status", {
+      method: "POST",
+      body: JSON.stringify({
+        branchName: "feat/existing-task",
+        projectId: "project-1",
+        status: "review",
+      }),
+    });
+
+    const { POST } = await import("@/app/api/hooks/status/route");
+
+    // When
+    const response = await POST(request as never);
+    const body = await response.json();
+
+    // Then
+    expect(response.status).toBe(200);
+    expect(mockTaskFindOneBy).toHaveBeenCalledWith({
+      branchName: "feat/existing-task",
+      projectId: "project-1",
+    });
+    expect(mockBroadcastTaskStatusChanged).toHaveBeenCalledWith({
+      projectName: "case-study",
+      branchName: "feat/existing-task",
+      taskTitle: "feat/existing-task",
+      description: "desc",
+      newStatus: "review",
+      taskId: "task-1",
+    });
+    expect(body).toEqual({
+      success: true,
+      data: {
+        id: "task-1",
+        status: "review",
+        branchName: "feat/existing-task",
+        projectId: "project-1",
+      },
+    });
   });
 });

--- a/src/app/api/hooks/status/route.ts
+++ b/src/app/api/hooks/status/route.ts
@@ -18,17 +18,17 @@ const STATUS_MAP: Record<string, TaskStatus> = {
 };
 
 /**
- * Hook API: branchName + projectName 기반 작업 상태 업데이트.
+ * Hook API: branchName + projectId 기반 작업 상태 업데이트.
  * Claude Code hooks에서 호출하여 현재 브랜치의 작업 상태를 자동 변경한다.
  */
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { branchName, projectName, status } = body;
+    const { branchName, projectId, status } = body;
 
-    if (!branchName || !projectName || !status) {
+    if (!branchName || !projectId || !status) {
       return NextResponse.json(
-        { success: false, error: "branchName, projectName, status는 필수입니다." },
+        { success: false, error: "branchName, projectId, status는 필수입니다." },
         { status: 400 }
       );
     }
@@ -42,18 +42,18 @@ export async function POST(request: NextRequest) {
     }
 
     const projectRepo = await getProjectRepository();
-    const project = await projectRepo.findOneBy({ name: projectName });
+    const project = await projectRepo.findOneBy({ id: projectId });
 
     if (!project) {
       broadcastHookStatusTargetMissing({
-        projectName,
+        projectName: projectId,
         branchName,
         requestedStatus: taskStatus,
         reason: "project-not-found",
       });
 
       return NextResponse.json(
-        { success: false, error: `프로젝트를 찾을 수 없습니다: ${projectName}` },
+        { success: false, error: `프로젝트를 찾을 수 없습니다: ${projectId}` },
         { status: 404 }
       );
     }
@@ -61,19 +61,19 @@ export async function POST(request: NextRequest) {
     const taskRepo = await getTaskRepository();
     const task = await taskRepo.findOneBy({
       branchName,
-      projectId: project.id,
+      projectId,
     });
 
     if (!task) {
       broadcastHookStatusTargetMissing({
-        projectName,
+        projectName: project.name,
         branchName,
         requestedStatus: taskStatus,
         reason: "task-not-found",
       });
 
       return NextResponse.json(
-        { success: false, error: `작업을 찾을 수 없습니다: ${projectName}/${branchName}` },
+        { success: false, error: `작업을 찾을 수 없습니다: ${project.name}/${branchName}` },
         { status: 404 }
       );
     }
@@ -91,7 +91,7 @@ export async function POST(request: NextRequest) {
     revalidatePath("/[locale]", "page");
     broadcastBoardUpdate();
     broadcastTaskStatusChanged({
-      projectName,
+      projectName: project.name,
       branchName,
       taskTitle: saved.title,
       description: saved.description,
@@ -101,7 +101,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      data: { id: saved.id, status: saved.status, branchName, projectName },
+      data: { id: saved.id, status: saved.status, branchName, projectId },
     });
   } catch (error) {
     console.error("Hook status 오류:", error);

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, rm } from "fs/promises";
+import { mkdtemp, readFile, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import { setupCodexHooks, getCodexHooksStatus } from "../codexHooksSetup";
@@ -21,7 +21,7 @@ describe("codexHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const status = await getCodexHooksStatus(repoPath);
@@ -33,11 +33,15 @@ describe("codexHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const status = await getCodexHooksStatus(repoPath);
       expect(status.hasConfigEntry).toBe(true);
+
+      const hookContent = await readFile(join(repoPath, ".codex", "hooks", "kanvibe-notify-hook.sh"), "utf-8");
+      expect(hookContent).toContain("PROJECT_ID=\"project-1\"");
+      expect(hookContent).toContain("projectId");
     });
 
     it("should mark as installed when both hook and config exist", async () => {
@@ -45,7 +49,7 @@ describe("codexHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const status = await getCodexHooksStatus(repoPath);
@@ -55,10 +59,10 @@ describe("codexHooksSetup", () => {
     it("should not add duplicate notify entry", async () => {
       // Given
       const repoPath = tempDir;
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // When - setup again
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then - should still be installed
       const status = await getCodexHooksStatus(repoPath);
@@ -83,7 +87,7 @@ describe("codexHooksSetup", () => {
     it("should detect installed status correctly", async () => {
       // Given
       const repoPath = tempDir;
-      await setupCodexHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
 
       // When
       const status = await getCodexHooksStatus(repoPath);

--- a/src/lib/__tests__/geminiHooksSetup.test.ts
+++ b/src/lib/__tests__/geminiHooksSetup.test.ts
@@ -20,11 +20,11 @@ describe("geminiHooksSetup", () => {
     it("should create hook scripts and settings.json in .gemini directory", async () => {
       // Given
       const repoPath = tmpDir;
-      const projectName = "test-project";
+      const projectId = "project-1";
       const kanvibeUrl = "http://localhost:4885";
 
       // When
-      await setupGeminiHooks(repoPath, projectName, kanvibeUrl);
+      await setupGeminiHooks(repoPath, projectId, kanvibeUrl);
 
       // Then
       const promptScript = await readFile(
@@ -42,7 +42,8 @@ describe("geminiHooksSetup", () => {
       expect(promptScript).toContain("#!/bin/bash");
       expect(promptScript).toContain("BeforeAgent");
       expect(promptScript).toContain(kanvibeUrl);
-      expect(promptScript).toContain(projectName);
+      expect(promptScript).toContain(projectId);
+      expect(promptScript).toContain("projectId");
       expect(promptScript).toContain("echo '{}'");
 
       expect(stopScript).toContain("#!/bin/bash");
@@ -87,7 +88,7 @@ describe("geminiHooksSetup", () => {
       );
 
       // When
-      await setupGeminiHooks(tmpDir, "test-project", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
 
       // Then
       const settings = JSON.parse(
@@ -106,10 +107,10 @@ describe("geminiHooksSetup", () => {
 
     it("should not duplicate hooks when called multiple times", async () => {
       // Given
-      await setupGeminiHooks(tmpDir, "test-project", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
 
       // When
-      await setupGeminiHooks(tmpDir, "test-project", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
 
       // Then
       const settings = JSON.parse(
@@ -127,7 +128,7 @@ describe("geminiHooksSetup", () => {
   describe("getGeminiHooksStatus", () => {
     it("should return installed: true after setupGeminiHooks", async () => {
       // Given
-      await setupGeminiHooks(tmpDir, "test-project", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
 
       // When
       const status = await getGeminiHooksStatus(tmpDir);

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -21,7 +21,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const status = await getOpenCodeHooksStatus(repoPath);
@@ -33,7 +33,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -41,6 +41,8 @@ describe("openCodeHooksSetup", () => {
 
       expect(pluginContent).toContain("KanvibePlugin");
       expect(pluginContent).toContain("/api/hooks/status");
+      expect(pluginContent).toContain('const PROJECT_ID = "project-1";');
+      expect(pluginContent).toContain("projectId: PROJECT_ID");
     });
 
     it("should generate plugin with all event handlers for status tracking", async () => {
@@ -48,7 +50,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -65,7 +67,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -82,7 +84,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -103,10 +105,10 @@ describe("openCodeHooksSetup", () => {
     it("should not fail when called twice (overwrites existing plugin)", async () => {
       // Given
       const repoPath = tempDir;
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // When - setup again
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // Then - should still be installed correctly
       const status = await getOpenCodeHooksStatus(repoPath);
@@ -118,7 +120,7 @@ describe("openCodeHooksSetup", () => {
     it("should return installed: true after setup", async () => {
       // Given
       const repoPath = tempDir;
-      await setupOpenCodeHooks(repoPath, "test-project", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
 
       // When
       const status = await getOpenCodeHooksStatus(repoPath);

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -3,14 +3,14 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, projectName: string): string {
+function generatePromptHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: UserPromptSubmit
 # 사용자가 prompt를 입력하면 현재 브랜치의 작업을 PROGRESS로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -19,7 +19,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"progress\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"progress\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -27,14 +27,14 @@ exit 0
 }
 
 /** Stop hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, projectName: string): string {
+function generateStopHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: Stop
 # AI 응답이 완료되면 현재 브랜치의 작업을 REVIEW로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -43,7 +43,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -51,14 +51,14 @@ exit 0
 }
 
 /** PreToolUse(AskUserQuestion) hook bash 스크립트를 생성한다 */
-function generateQuestionHookScript(kanvibeUrl: string, projectName: string): string {
+function generateQuestionHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: PreToolUse (AskUserQuestion)
 # Claude가 사용자에게 질문할 때 현재 브랜치의 작업을 PENDING으로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -67,7 +67,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"pending\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"pending\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -112,7 +112,7 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
  */
 export async function setupClaudeHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const claudeDir = path.join(repoPath, ".claude");
@@ -125,9 +125,9 @@ export async function setupClaudeHooks(
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
   const questionScriptPath = path.join(hooksDir, "kanvibe-question-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectName), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectName), "utf-8");
-  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, projectId), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
   await chmod(questionScriptPath, 0o755);

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -8,7 +8,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** notify hook bash 스크립트를 생성한다 (agent-turn-complete → REVIEW) */
-function generateNotifyHookScript(kanvibeUrl: string, projectName: string): string {
+function generateNotifyHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Codex CLI Hook: notify (agent-turn-complete)
@@ -16,7 +16,7 @@ function generateNotifyHookScript(kanvibeUrl: string, projectName: string): stri
 # Codex notify 스크립트는 첫 번째 인자로 JSON payload를 받는다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 JSON_PAYLOAD="$1"
 
@@ -33,7 +33,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -63,7 +63,7 @@ function hasKanvibeNotify(configContent: string): boolean {
  */
 export async function setupCodexHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const codexDir = path.join(repoPath, ".codex");
@@ -73,7 +73,7 @@ export async function setupCodexHooks(
   await mkdir(hooksDir, { recursive: true });
 
   const notifyScriptPath = path.join(hooksDir, HOOK_SCRIPT_NAME);
-  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, projectId), "utf-8");
   await chmod(notifyScriptPath, 0o755);
 
   const configContent = await readConfigToml(configPath);

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -8,7 +8,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** BeforeAgent hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, projectName: string): string {
+function generatePromptHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: BeforeAgent
@@ -16,7 +16,7 @@ function generatePromptHookScript(kanvibeUrl: string, projectName: string): stri
 # Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -26,7 +26,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"progress\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"progress\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -35,7 +35,7 @@ exit 0
 }
 
 /** AfterAgent hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, projectName: string): string {
+function generateStopHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: AfterAgent
@@ -43,7 +43,7 @@ function generateStopHookScript(kanvibeUrl: string, projectName: string): string
 # Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -53,7 +53,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -104,7 +104,7 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
  */
 export async function setupGeminiHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const geminiDir = path.join(repoPath, ".gemini");
@@ -116,8 +116,8 @@ export async function setupGeminiHooks(
   const promptScriptPath = path.join(hooksDir, "kanvibe-prompt-hook.sh");
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectName), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectId), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
 

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -11,7 +11,7 @@ const PLUGIN_FILE_NAME = "kanvibe-plugin.ts";
 const PLUGIN_DIR_NAME = "plugins";
 
 /** OpenCode plugin TypeScript 파일 내용을 생성한다 */
-function generatePluginScript(kanvibeUrl: string, projectName: string): string {
+function generatePluginScript(kanvibeUrl: string, projectId: string): string {
   return `import type { Plugin } from "@opencode-ai/plugin";
 
 /**
@@ -21,7 +21,7 @@ function generatePluginScript(kanvibeUrl: string, projectName: string): string {
  */
 export const KanvibePlugin: Plugin = async ({ $, client }) => {
   const KANVIBE_URL = "${kanvibeUrl}";
-  const PROJECT_NAME = "${projectName}";
+  const PROJECT_ID = "${projectId}";
 
   async function getBranchName(): Promise<string | null> {
     try {
@@ -42,7 +42,7 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
       await fetch(\`\${KANVIBE_URL}/api/hooks/status\`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ branchName, projectName: PROJECT_NAME, status }),
+        body: JSON.stringify({ branchName, projectId: PROJECT_ID, status }),
       });
     } catch {
       /* 네트워크 에러 무시 */
@@ -119,7 +119,7 @@ function hasKanvibePlugin(pluginContent: string): boolean {
  */
 export async function setupOpenCodeHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const openCodeDir = path.join(repoPath, ".opencode");
@@ -128,7 +128,7 @@ export async function setupOpenCodeHooks(
   await mkdir(pluginsDir, { recursive: true });
 
   const pluginPath = path.join(pluginsDir, PLUGIN_FILE_NAME);
-  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, projectId), "utf-8");
 
   try {
     await addAiToolPatternsToGitExclude(repoPath);


### PR DESCRIPTION
## Summary
- switch hook-driven task status updates from project name matching to project ID matching
- update generated Claude, Gemini, Codex, and OpenCode hook payloads to send `projectId`
- add tests that cover the new hook payload and database-backed project name notifications

## Testing
- pnpm check
- pnpm exec vitest run src/app/api/hooks/status/__tests__/route.test.ts src/lib/__tests__/codexHooksSetup.test.ts src/lib/__tests__/openCodeHooksSetup.test.ts src/lib/__tests__/geminiHooksSetup.test.ts