### PR TITLE
Fix board header overlap with mac window controls

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -200,6 +200,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const [isDoneAlertDismissed, setIsDoneAlertDismissed] = useState(doneAlertDismissed);
   const [pendingDoneResult, setPendingDoneResult] = useState<DropResult | null>(null);
   const [currentDefaultSessionType, setCurrentDefaultSessionType] = useState<SessionType>(defaultSessionType);
+  const [needsMacDesktopHeaderOffset, setNeedsMacDesktopHeaderOffset] = useState(false);
   const [, startDragPersistenceTransition] = useTransition();
 
   /** projectId → 표시할 프로젝트 이름 매핑. worktree 프로젝트는 메인 프로젝트 이름으로 resolve한다 */
@@ -339,6 +340,12 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
     setCurrentDefaultSessionType(defaultSessionType);
   }, [defaultSessionType]);
 
+  useEffect(() => {
+    const isDesktopApp = window.kanvibeDesktop?.isDesktop === true;
+    const isMacDesktop = navigator.userAgent.includes("Mac") || navigator.platform.toLowerCase().includes("mac");
+    setNeedsMacDesktopHeaderOffset(isDesktopApp && isMacDesktop);
+  }, []);
+
   const handleLoadMoreDone = useCallback(async () => {
     if (isLoadingMore) return;
     setIsLoadingMore(true);
@@ -460,7 +467,9 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
 
   return (
     <div className="min-h-screen">
-      <header className="flex items-center justify-between px-6 py-4 border-b border-border-default bg-bg-surface">
+      <header
+        className={`flex items-center justify-between px-6 pb-4 border-b border-border-default bg-bg-surface ${needsMacDesktopHeaderOffset ? "pt-10" : "pt-4"}`}
+      >
         <div className="flex items-center gap-2">
           <img src="/kanvibe-logo.svg" alt="KanVibe" className="h-6 w-6" />
           <h1 className="text-xl font-bold text-text-primary">{t("title")}</h1>

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -6,6 +6,13 @@ import { SessionType, TaskStatus } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import type { TasksByStatus } from "@/app/actions/kanban";
 
+function mockNavigatorPlatform(platform: string) {
+  Object.defineProperty(window.navigator, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
 }));
@@ -147,6 +154,8 @@ function createTasksWithTodo(): TasksByStatus {
 describe("Board defaultSessionType sync", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete window.kanvibeDesktop;
+    mockNavigatorPlatform("Linux x86_64");
   });
 
   it("defaultSessionType prop이 변경되면 내부 상태와 하위 컴포넌트가 동기화된다", async () => {
@@ -218,6 +227,29 @@ describe("Board defaultSessionType sync", () => {
 
     await waitFor(() => {
       expect(reorderTasks).toHaveBeenCalledWith(TaskStatus.TODO, ["task-1"]);
+    });
+  });
+
+  it("맥 데스크톱 앱에서는 헤더 상단에 추가 여백을 준다", async () => {
+    window.kanvibeDesktop = { isDesktop: true };
+    mockNavigatorPlatform("MacIntel");
+
+    const { container } = render(
+      <Board
+        initialTasks={createEmptyTasks()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("header")?.className).toContain("pt-10");
     });
   });
 });


### PR DESCRIPTION
## Summary
- add extra top padding to the board header only in the mac desktop app
- prevent the KanVibe logo and title from overlapping with the traffic light window controls
- add a board test that covers the mac desktop header offset