### PR TITLE
fix(opencode): filter subagent sessions from hook status updates

### DIFF
--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -58,6 +58,7 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toContain('"question.asked"');
       expect(pluginContent).toContain('"question.replied"');
       expect(pluginContent).toContain('"session.idle"');
+      expect(pluginContent).toContain('"session.deleted"');
     });
 
     it("should map event types to correct statuses", async () => {
@@ -75,6 +76,7 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toMatch(/question\.asked[\s\S]*?pending/);
       expect(pluginContent).toMatch(/question\.replied[\s\S]*?progress/);
       expect(pluginContent).toMatch(/session\.idle[\s\S]*?review/);
+      expect(pluginContent).toMatch(/session\.deleted[\s\S]*?done/);
     });
 
     it("should filter subagent sessions before updating statuses", async () => {
@@ -89,15 +91,19 @@ describe("openCodeHooksSetup", () => {
       const pluginContent = await readFile(pluginPath, "utf-8");
 
       expect(pluginContent).toContain("const sessionCache = new Map<string, boolean>()");
+      expect(pluginContent).toContain("function getSessionID(source: any): string | undefined");
+      expect(pluginContent).toContain("function getParentSessionID(source: any): string | null | undefined");
       expect(pluginContent).toContain("client.session.get");
       expect(pluginContent).toContain("sessionCache.has(sessionID)");
       expect(pluginContent).toContain("sessionCache.set(sessionID, isMain)");
       expect(pluginContent).toContain("result.data?.parentID");
       expect(pluginContent).toContain("properties?.info ?? (event as any).properties?.message");
-      expect(pluginContent).toMatch(/message\.updated[\s\S]*?isMainSession\(message\.sessionID\)/);
-      expect(pluginContent).toMatch(/question\.asked[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
-      expect(pluginContent).toMatch(/question\.replied[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
-      expect(pluginContent).toMatch(/session\.idle[\s\S]*?isMainSession\(event\.properties\.sessionID\)/);
+      expect(pluginContent).toContain("return sessionCache.get(sessionID) ?? false");
+      expect(pluginContent).toMatch(/message\.updated[\s\S]*?isMainSession\(message\)/);
+      expect(pluginContent).toMatch(/question\.asked[\s\S]*?isMainSession\(event\.properties\)/);
+      expect(pluginContent).toMatch(/question\.replied[\s\S]*?isMainSession\(event\.properties\)/);
+      expect(pluginContent).toMatch(/session\.idle[\s\S]*?isMainSession\(event\.properties\)/);
+      expect(pluginContent).toMatch(/session\.deleted[\s\S]*?isMainSession\(event\.properties\)/);
     });
 
     it("should not fail when called twice (overwrites existing plugin)", async () => {

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -4,7 +4,8 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 
 /**
  * OpenCode는 `.opencode/plugins/` 디렉토리에 TypeScript 플러그인을 배치하여 hooks를 등록한다.
- * message.updated(user) → progress, question.asked → pending, question.replied → progress, session.idle → review 상태를 전송한다.
+ * message.updated(user) → progress, question.asked → pending,
+ * question.replied → progress, session.idle → review, session.deleted → done 상태를 전송한다.
  */
 
 const PLUGIN_FILE_NAME = "kanvibe-plugin.ts";
@@ -17,7 +18,7 @@ function generatePluginScript(kanvibeUrl: string, projectName: string): string {
 /**
  * KanVibe OpenCode Plugin
  * message.updated(user) → progress, question.asked → pending,
- * question.replied → progress, session.idle → review 상태 변경
+ * question.replied → progress, session.idle → review, session.deleted → done 상태 변경
  */
 export const KanvibePlugin: Plugin = async ({ $, client }) => {
   const KANVIBE_URL = "${kanvibeUrl}";
@@ -51,8 +52,40 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
 
   const sessionCache = new Map<string, boolean>();
 
-  async function isMainSession(sessionID: string | undefined): Promise<boolean> {
+  function getSessionID(source: any): string | undefined {
+    return (
+      source?.sessionID ??
+      source?.sessionId ??
+      source?.id ??
+      source?.session?.id ??
+      source?.info?.sessionID ??
+      source?.info?.sessionId ??
+      source?.info?.id
+    );
+  }
+
+  function getParentSessionID(source: any): string | null | undefined {
+    return (
+      source?.parentID ??
+      source?.parentId ??
+      source?.session?.parentID ??
+      source?.session?.parentId ??
+      source?.info?.parentID ??
+      source?.info?.parentId
+    );
+  }
+
+  async function isMainSession(source: any): Promise<boolean> {
+    const sessionID = getSessionID(source);
     if (!sessionID) return false;
+
+    const parentSessionID = getParentSessionID(source);
+    if (parentSessionID !== undefined) {
+      const isMain = !parentSessionID;
+      sessionCache.set(sessionID, isMain);
+      return isMain;
+    }
+
     if (sessionCache.has(sessionID)) return sessionCache.get(sessionID)!;
 
     try {
@@ -67,7 +100,7 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
 
       return isMain;
     } catch {
-      return false;
+      return sessionCache.get(sessionID) ?? false;
     }
   }
 
@@ -77,30 +110,37 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
         const message =
           (event as any).properties?.info ?? (event as any).properties?.message;
 
-        if (message?.role === "user" && (await isMainSession(message.sessionID))) {
+        if (message?.role === "user" && (await isMainSession(message))) {
           await updateStatus("progress");
         }
       }
       if (event.type === "question.asked") {
-        if (!(await isMainSession(event.properties.sessionID))) {
+        if (!(await isMainSession(event.properties))) {
           return;
         }
 
         await updateStatus("pending");
       }
       if (event.type === "question.replied") {
-        if (!(await isMainSession(event.properties.sessionID))) {
+        if (!(await isMainSession(event.properties))) {
           return;
         }
 
         await updateStatus("progress");
       }
       if (event.type === "session.idle") {
-        if (!(await isMainSession(event.properties.sessionID))) {
+        if (!(await isMainSession(event.properties))) {
           return;
         }
 
         await updateStatus("review");
+      }
+      if (event.type === "session.deleted") {
+        if (!(await isMainSession(event.properties))) {
+          return;
+        }
+
+        await updateStatus("done");
       }
     },
   };


### PR DESCRIPTION
## Summary
- prevent subagent sessions from changing Kanvibe hook statuses
- resolve session and parent identifiers from the event payload before falling back to the OpenCode session API
- cover the updated session filtering and `session.deleted` handling in the generated plugin tests

## Changes
- update the generated OpenCode plugin to inspect multiple session id shapes and cache whether a session is a main session
- keep non-main sessions from sending hook updates and mark main sessions as `done` on `session.deleted`
- extend the plugin generation tests to verify the new event handling and session shape support
