### PR TITLE
Fix Electron hook notifications with task-based status updates

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -9,8 +9,8 @@ require("tsx/cjs");
 
 const DEFAULT_LOCALE = "ko";
 const RENDERER_DEV_URL = process.env.KANVIBE_RENDERER_URL || null;
-const HOOK_SERVER_HOST = process.env.KANVIBE_HOOK_HOST || "127.0.0.1";
-const HOOK_SERVER_PORT = Number.parseInt(process.env.PORT || "4885", 10);
+const HOOK_SERVER_HOST = "localhost";
+const HOOK_SERVER_PORT = 9736;
 
 const isHeadlessLinuxRuntime = !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
 

--- a/src/desktop/main/services/__tests__/hookService.test.ts
+++ b/src/desktop/main/services/__tests__/hookService.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
     findOneBy: vi.fn(),
   },
   taskRepo: {
+    findOne: vi.fn(),
     findOneBy: vi.fn(),
     save: vi.fn(),
     create: vi.fn(),
@@ -59,7 +60,7 @@ describe("hookService.updateHookTaskStatus", () => {
     vi.clearAllMocks();
   });
 
-  it("projectId로 작업 상태를 변경한다", async () => {
+  it("taskId로 작업 상태를 변경한다", async () => {
     const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
     const project = { id: "project-1", name: "kanvibe" };
     const task = {
@@ -68,27 +69,24 @@ describe("hookService.updateHookTaskStatus", () => {
       description: "debug electron hook",
       branchName: "fix-electron-notification",
       projectId: project.id,
+      project,
       status: TaskStatus.PROGRESS,
       sessionType: null,
       sessionName: null,
       worktreePath: null,
       sshHost: null,
     };
-
-    mocks.projectRepo.findOneBy.mockResolvedValue(project);
-    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.taskRepo.findOne.mockResolvedValue(task);
     mocks.taskRepo.save.mockImplementation(async (value) => value);
 
     const result = await updateHookTaskStatus({
-      branchName: task.branchName,
-      projectId: project.id,
+      taskId: task.id,
       status: TaskStatus.REVIEW,
     });
 
-    expect(mocks.projectRepo.findOneBy).toHaveBeenCalledWith({ id: project.id });
-    expect(mocks.taskRepo.findOneBy).toHaveBeenCalledWith({
-      branchName: task.branchName,
-      projectId: project.id,
+    expect(mocks.taskRepo.findOne).toHaveBeenCalledWith({
+      where: { id: task.id },
+      relations: ["project"],
     });
     expect(mocks.broadcastTaskStatusChanged).toHaveBeenCalledWith({
       projectName: project.name,
@@ -109,17 +107,16 @@ describe("hookService.updateHookTaskStatus", () => {
     });
   });
 
-  it("project 식별자가 없으면 400을 반환한다", async () => {
+  it("task 식별자가 없으면 400을 반환한다", async () => {
     const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
     const result = await updateHookTaskStatus({
-      branchName: "fix-electron-notification",
-      projectId: "",
+      taskId: "",
       status: TaskStatus.REVIEW,
     });
 
     expect(result).toEqual({
       success: false,
-      error: "branchName, projectId, status는 필수입니다.",
+      error: "taskId, status는 필수입니다.",
       status: 400,
     });
   });

--- a/src/desktop/main/services/__tests__/hookService.test.ts
+++ b/src/desktop/main/services/__tests__/hookService.test.ts
@@ -59,7 +59,7 @@ describe("hookService.updateHookTaskStatus", () => {
     vi.clearAllMocks();
   });
 
-  it("projectName으로 작업 상태를 변경한다", async () => {
+  it("projectId로 작업 상태를 변경한다", async () => {
     const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
     const project = { id: "project-1", name: "kanvibe" };
     const task = {
@@ -81,11 +81,11 @@ describe("hookService.updateHookTaskStatus", () => {
 
     const result = await updateHookTaskStatus({
       branchName: task.branchName,
-      projectName: project.name,
+      projectId: project.id,
       status: TaskStatus.REVIEW,
     });
 
-    expect(mocks.projectRepo.findOneBy).toHaveBeenCalledWith({ name: project.name });
+    expect(mocks.projectRepo.findOneBy).toHaveBeenCalledWith({ id: project.id });
     expect(mocks.taskRepo.findOneBy).toHaveBeenCalledWith({
       branchName: task.branchName,
       projectId: project.id,
@@ -109,49 +109,17 @@ describe("hookService.updateHookTaskStatus", () => {
     });
   });
 
-  it("기존 projectId 필드에 프로젝트명이 들어와도 조회를 이어간다", async () => {
-    const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
-    const project = { id: "project-1", name: "kanvibe" };
-    const task = {
-      id: "task-1",
-      title: "Fix notification",
-      description: null,
-      branchName: "fix-electron-notification",
-      projectId: project.id,
-      status: TaskStatus.PROGRESS,
-      sessionType: null,
-      sessionName: null,
-      worktreePath: null,
-      sshHost: null,
-    };
-
-    mocks.projectRepo.findOneBy.mockResolvedValueOnce(null).mockResolvedValueOnce(project);
-    mocks.taskRepo.findOneBy.mockResolvedValue(task);
-    mocks.taskRepo.save.mockImplementation(async (value) => value);
-
-    await updateHookTaskStatus({
-      branchName: task.branchName,
-      projectId: project.name,
-      status: TaskStatus.REVIEW,
-    });
-
-    expect(mocks.projectRepo.findOneBy).toHaveBeenNthCalledWith(1, { id: project.name });
-    expect(mocks.projectRepo.findOneBy).toHaveBeenNthCalledWith(2, { name: project.name });
-    expect(mocks.broadcastTaskStatusChanged).toHaveBeenCalledWith(
-      expect.objectContaining({ projectName: project.name })
-    );
-  });
-
   it("project 식별자가 없으면 400을 반환한다", async () => {
     const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
     const result = await updateHookTaskStatus({
       branchName: "fix-electron-notification",
+      projectId: "",
       status: TaskStatus.REVIEW,
     });
 
     expect(result).toEqual({
       success: false,
-      error: "branchName, projectName 또는 projectId, status는 필수입니다.",
+      error: "branchName, projectId, status는 필수입니다.",
       status: 400,
     });
   });

--- a/src/desktop/main/services/__tests__/hookService.test.ts
+++ b/src/desktop/main/services/__tests__/hookService.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const entityMocks = vi.hoisted(() => ({
+  TaskStatus: {
+    TODO: "todo",
+    PROGRESS: "progress",
+    PENDING: "pending",
+    REVIEW: "review",
+    DONE: "done",
+  },
+  SessionType: {
+    TMUX: "tmux",
+    ZELLIJ: "zellij",
+  },
+}));
+
+const mocks = vi.hoisted(() => ({
+  projectRepo: {
+    findOneBy: vi.fn(),
+  },
+  taskRepo: {
+    findOneBy: vi.fn(),
+    save: vi.fn(),
+    create: vi.fn(),
+  },
+  createWorktreeWithSession: vi.fn(),
+  broadcastBoardUpdate: vi.fn(),
+  broadcastHookStatusTargetMissing: vi.fn(),
+  broadcastTaskStatusChanged: vi.fn(),
+  cleanupTaskResources: vi.fn(),
+}));
+
+vi.mock("@/entities/KanbanTask", () => entityMocks);
+
+const { TaskStatus } = entityMocks;
+
+vi.mock("@/lib/database", () => ({
+  getProjectRepository: vi.fn(async () => mocks.projectRepo),
+  getTaskRepository: vi.fn(async () => mocks.taskRepo),
+}));
+
+vi.mock("@/lib/worktree", () => ({
+  createWorktreeWithSession: mocks.createWorktreeWithSession,
+}));
+
+vi.mock("@/lib/boardNotifier", () => ({
+  broadcastBoardUpdate: mocks.broadcastBoardUpdate,
+  broadcastHookStatusTargetMissing: mocks.broadcastHookStatusTargetMissing,
+  broadcastTaskStatusChanged: mocks.broadcastTaskStatusChanged,
+}));
+
+vi.mock("@/desktop/main/services/kanbanService", () => ({
+  cleanupTaskResources: mocks.cleanupTaskResources,
+}));
+
+describe("hookService.updateHookTaskStatus", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("projectName으로 작업 상태를 변경한다", async () => {
+    const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
+    const project = { id: "project-1", name: "kanvibe" };
+    const task = {
+      id: "task-1",
+      title: "Fix notification",
+      description: "debug electron hook",
+      branchName: "fix-electron-notification",
+      projectId: project.id,
+      status: TaskStatus.PROGRESS,
+      sessionType: null,
+      sessionName: null,
+      worktreePath: null,
+      sshHost: null,
+    };
+
+    mocks.projectRepo.findOneBy.mockResolvedValue(project);
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.taskRepo.save.mockImplementation(async (value) => value);
+
+    const result = await updateHookTaskStatus({
+      branchName: task.branchName,
+      projectName: project.name,
+      status: TaskStatus.REVIEW,
+    });
+
+    expect(mocks.projectRepo.findOneBy).toHaveBeenCalledWith({ name: project.name });
+    expect(mocks.taskRepo.findOneBy).toHaveBeenCalledWith({
+      branchName: task.branchName,
+      projectId: project.id,
+    });
+    expect(mocks.broadcastTaskStatusChanged).toHaveBeenCalledWith({
+      projectName: project.name,
+      branchName: task.branchName,
+      taskTitle: task.title,
+      description: task.description,
+      newStatus: TaskStatus.REVIEW,
+      taskId: task.id,
+    });
+    expect(result).toEqual({
+      success: true,
+      data: {
+        id: task.id,
+        status: TaskStatus.REVIEW,
+        branchName: task.branchName,
+        projectName: project.name,
+      },
+    });
+  });
+
+  it("기존 projectId 필드에 프로젝트명이 들어와도 조회를 이어간다", async () => {
+    const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
+    const project = { id: "project-1", name: "kanvibe" };
+    const task = {
+      id: "task-1",
+      title: "Fix notification",
+      description: null,
+      branchName: "fix-electron-notification",
+      projectId: project.id,
+      status: TaskStatus.PROGRESS,
+      sessionType: null,
+      sessionName: null,
+      worktreePath: null,
+      sshHost: null,
+    };
+
+    mocks.projectRepo.findOneBy.mockResolvedValueOnce(null).mockResolvedValueOnce(project);
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.taskRepo.save.mockImplementation(async (value) => value);
+
+    await updateHookTaskStatus({
+      branchName: task.branchName,
+      projectId: project.name,
+      status: TaskStatus.REVIEW,
+    });
+
+    expect(mocks.projectRepo.findOneBy).toHaveBeenNthCalledWith(1, { id: project.name });
+    expect(mocks.projectRepo.findOneBy).toHaveBeenNthCalledWith(2, { name: project.name });
+    expect(mocks.broadcastTaskStatusChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ projectName: project.name })
+    );
+  });
+
+  it("project 식별자가 없으면 400을 반환한다", async () => {
+    const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
+    const result = await updateHookTaskStatus({
+      branchName: "fix-electron-notification",
+      status: TaskStatus.REVIEW,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "branchName, projectName 또는 projectId, status는 필수입니다.",
+      status: 400,
+    });
+  });
+});

--- a/src/desktop/main/services/hookService.ts
+++ b/src/desktop/main/services/hookService.ts
@@ -24,26 +24,8 @@ export interface HookStartInput {
 
 export interface HookStatusInput {
   branchName: string;
-  projectId?: string;
-  projectName?: string;
+  projectId: string;
   status: string;
-}
-
-async function findProjectForHook(input: HookStatusInput) {
-  const projectRepo = await getProjectRepository();
-
-  if (input.projectName) {
-    return projectRepo.findOneBy({ name: input.projectName });
-  }
-
-  if (!input.projectId) {
-    return null;
-  }
-
-  return (
-    (await projectRepo.findOneBy({ id: input.projectId })) ??
-    projectRepo.findOneBy({ name: input.projectId })
-  );
 }
 
 export async function startHookTask(input: HookStartInput) {
@@ -102,12 +84,10 @@ export async function startHookTask(input: HookStartInput) {
 }
 
 export async function updateHookTaskStatus(input: HookStatusInput) {
-  const projectLookupValue = input.projectName || input.projectId;
-
-  if (!input.branchName || !projectLookupValue || !input.status) {
+  if (!input.branchName || !input.projectId || !input.status) {
     return {
       success: false,
-      error: "branchName, projectName 또는 projectId, status는 필수입니다.",
+      error: "branchName, projectId, status는 필수입니다.",
       status: 400,
     };
   }
@@ -121,11 +101,12 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
     };
   }
 
-  const project = await findProjectForHook(input);
+  const projectRepo = await getProjectRepository();
+  const project = await projectRepo.findOneBy({ id: input.projectId });
 
   if (!project) {
     broadcastHookStatusTargetMissing({
-      projectName: projectLookupValue,
+      projectName: input.projectId,
       branchName: input.branchName,
       requestedStatus: taskStatus,
       reason: "project-not-found",
@@ -133,7 +114,7 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
 
     return {
       success: false,
-      error: `프로젝트를 찾을 수 없습니다: ${projectLookupValue}`,
+      error: `프로젝트를 찾을 수 없습니다: ${input.projectId}`,
       status: 404,
     };
   }

--- a/src/desktop/main/services/hookService.ts
+++ b/src/desktop/main/services/hookService.ts
@@ -23,8 +23,7 @@ export interface HookStartInput {
 }
 
 export interface HookStatusInput {
-  branchName: string;
-  projectId: string;
+  taskId: string;
   status: string;
 }
 
@@ -84,10 +83,10 @@ export async function startHookTask(input: HookStartInput) {
 }
 
 export async function updateHookTaskStatus(input: HookStatusInput) {
-  if (!input.branchName || !input.projectId || !input.status) {
+  if (!input.taskId || !input.status) {
     return {
       success: false,
-      error: "branchName, projectId, status는 필수입니다.",
+      error: "taskId, status는 필수입니다.",
       status: 400,
     };
   }
@@ -101,44 +100,27 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
     };
   }
 
-  const projectRepo = await getProjectRepository();
-  const project = await projectRepo.findOneBy({ id: input.projectId });
-
-  if (!project) {
-    broadcastHookStatusTargetMissing({
-      projectName: input.projectId,
-      branchName: input.branchName,
-      requestedStatus: taskStatus,
-      reason: "project-not-found",
-    });
-
-    return {
-      success: false,
-      error: `프로젝트를 찾을 수 없습니다: ${input.projectId}`,
-      status: 404,
-    };
-  }
-
   const taskRepo = await getTaskRepository();
-  const task = await taskRepo.findOneBy({
-    branchName: input.branchName,
-    projectId: project.id,
+  const task = await taskRepo.findOne({
+    where: { id: input.taskId },
+    relations: ["project"],
   });
 
   if (!task) {
     broadcastHookStatusTargetMissing({
-      projectName: project.name,
-      branchName: input.branchName,
+      taskId: input.taskId,
       requestedStatus: taskStatus,
       reason: "task-not-found",
     });
 
     return {
       success: false,
-      error: `작업을 찾을 수 없습니다: ${project.name}/${input.branchName}`,
+      error: `작업을 찾을 수 없습니다: ${input.taskId}`,
       status: 404,
     };
   }
+
+  const projectName = task.project?.name || task.projectId || "Unknown project";
 
   if (taskStatus === TaskStatus.DONE) {
     await cleanupTaskResources(task);
@@ -153,8 +135,8 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
 
   broadcastBoardUpdate();
   broadcastTaskStatusChanged({
-    projectName: project.name,
-    branchName: input.branchName,
+    projectName,
+    branchName: task.branchName || "",
     taskTitle: saved.title,
     description: saved.description,
     newStatus: taskStatus,
@@ -166,8 +148,8 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
     data: {
       id: saved.id,
       status: saved.status,
-      branchName: input.branchName,
-      projectName: project.name,
+      branchName: saved.branchName,
+      projectName,
     },
   };
 }

--- a/src/desktop/main/services/hookService.ts
+++ b/src/desktop/main/services/hookService.ts
@@ -24,8 +24,26 @@ export interface HookStartInput {
 
 export interface HookStatusInput {
   branchName: string;
-  projectName: string;
+  projectId?: string;
+  projectName?: string;
   status: string;
+}
+
+async function findProjectForHook(input: HookStatusInput) {
+  const projectRepo = await getProjectRepository();
+
+  if (input.projectName) {
+    return projectRepo.findOneBy({ name: input.projectName });
+  }
+
+  if (!input.projectId) {
+    return null;
+  }
+
+  return (
+    (await projectRepo.findOneBy({ id: input.projectId })) ??
+    projectRepo.findOneBy({ name: input.projectId })
+  );
 }
 
 export async function startHookTask(input: HookStartInput) {
@@ -84,10 +102,12 @@ export async function startHookTask(input: HookStartInput) {
 }
 
 export async function updateHookTaskStatus(input: HookStatusInput) {
-  if (!input.branchName || !input.projectName || !input.status) {
+  const projectLookupValue = input.projectName || input.projectId;
+
+  if (!input.branchName || !projectLookupValue || !input.status) {
     return {
       success: false,
-      error: "branchName, projectName, status는 필수입니다.",
+      error: "branchName, projectName 또는 projectId, status는 필수입니다.",
       status: 400,
     };
   }
@@ -101,12 +121,11 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
     };
   }
 
-  const projectRepo = await getProjectRepository();
-  const project = await projectRepo.findOneBy({ name: input.projectName });
+  const project = await findProjectForHook(input);
 
   if (!project) {
     broadcastHookStatusTargetMissing({
-      projectName: input.projectName,
+      projectName: projectLookupValue,
       branchName: input.branchName,
       requestedStatus: taskStatus,
       reason: "project-not-found",
@@ -114,7 +133,7 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
 
     return {
       success: false,
-      error: `프로젝트를 찾을 수 없습니다: ${input.projectName}`,
+      error: `프로젝트를 찾을 수 없습니다: ${projectLookupValue}`,
       status: 404,
     };
   }
@@ -127,7 +146,7 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
 
   if (!task) {
     broadcastHookStatusTargetMissing({
-      projectName: input.projectName,
+      projectName: project.name,
       branchName: input.branchName,
       requestedStatus: taskStatus,
       reason: "task-not-found",
@@ -135,7 +154,7 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
 
     return {
       success: false,
-      error: `작업을 찾을 수 없습니다: ${input.projectName}/${input.branchName}`,
+      error: `작업을 찾을 수 없습니다: ${project.name}/${input.branchName}`,
       status: 404,
     };
   }
@@ -153,7 +172,7 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
 
   broadcastBoardUpdate();
   broadcastTaskStatusChanged({
-    projectName: input.projectName,
+    projectName: project.name,
     branchName: input.branchName,
     taskTitle: saved.title,
     description: saved.description,
@@ -167,7 +186,7 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
       id: saved.id,
       status: saved.status,
       branchName: input.branchName,
-      projectName: input.projectName,
+      projectName: project.name,
     },
   };
 }

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -151,10 +151,10 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
         if (!project.sshHost && session.worktreePath) {
           const kanvibeUrl = "http://localhost:9736";
           await Promise.allSettled([
-            setupClaudeHooks(session.worktreePath, project.name, kanvibeUrl),
-            setupGeminiHooks(session.worktreePath, project.name, kanvibeUrl),
-            setupCodexHooks(session.worktreePath, project.name, kanvibeUrl),
-            setupOpenCodeHooks(session.worktreePath, project.name, kanvibeUrl),
+            setupClaudeHooks(session.worktreePath, project.id, kanvibeUrl),
+            setupGeminiHooks(session.worktreePath, project.id, kanvibeUrl),
+            setupCodexHooks(session.worktreePath, project.id, kanvibeUrl),
+            setupOpenCodeHooks(session.worktreePath, project.id, kanvibeUrl),
           ]);
         }
       }
@@ -337,10 +337,10 @@ export async function branchFromTask(
     try {
       const kanvibeUrl = "http://localhost:9736";
       await Promise.allSettled([
-        setupClaudeHooks(session.worktreePath, project.name, kanvibeUrl),
-        setupGeminiHooks(session.worktreePath, project.name, kanvibeUrl),
-        setupCodexHooks(session.worktreePath, project.name, kanvibeUrl),
-        setupOpenCodeHooks(session.worktreePath, project.name, kanvibeUrl),
+        setupClaudeHooks(session.worktreePath, project.id, kanvibeUrl),
+        setupGeminiHooks(session.worktreePath, project.id, kanvibeUrl),
+        setupCodexHooks(session.worktreePath, project.id, kanvibeUrl),
+        setupOpenCodeHooks(session.worktreePath, project.id, kanvibeUrl),
       ]);
     } catch (error) {
       console.error("Hooks 설정 실패:", error);

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -149,7 +149,7 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
 
         /** 로컬 worktree에 모든 AI 에이전트 hooks를 자동 설정한다 */
         if (!project.sshHost && session.worktreePath) {
-          const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+          const kanvibeUrl = "http://localhost:9736";
           await Promise.allSettled([
             setupClaudeHooks(session.worktreePath, project.name, kanvibeUrl),
             setupGeminiHooks(session.worktreePath, project.name, kanvibeUrl),
@@ -335,7 +335,7 @@ export async function branchFromTask(
   /** 로컬 worktree에 모든 AI 에이전트 hooks를 자동 설정한다 */
   if (!project.sshHost && session.worktreePath) {
     try {
-      const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+      const kanvibeUrl = "http://localhost:9736";
       await Promise.allSettled([
         setupClaudeHooks(session.worktreePath, project.name, kanvibeUrl),
         setupGeminiHooks(session.worktreePath, project.name, kanvibeUrl),

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -128,6 +128,9 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
     status: TaskStatus.TODO,
   });
 
+  let hookTargetPath: string | null = null;
+  let shouldInstallHooks = false;
+
   if (input.branchName && input.sessionType && input.projectId) {
     try {
       const projectRepo = await getProjectRepository();
@@ -146,24 +149,14 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
         task.worktreePath = session.worktreePath;
         task.sessionName = session.sessionName;
         task.sshHost = project.sshHost;
-
-        /** 로컬 worktree에 모든 AI 에이전트 hooks를 자동 설정한다 */
-        if (!project.sshHost && session.worktreePath) {
-          const kanvibeUrl = "http://localhost:9736";
-          await Promise.allSettled([
-            setupClaudeHooks(session.worktreePath, project.id, kanvibeUrl),
-            setupGeminiHooks(session.worktreePath, project.id, kanvibeUrl),
-            setupCodexHooks(session.worktreePath, project.id, kanvibeUrl),
-            setupOpenCodeHooks(session.worktreePath, project.id, kanvibeUrl),
-          ]);
-        }
+        hookTargetPath = session.worktreePath;
+        shouldInstallHooks = !project.sshHost && Boolean(session.worktreePath);
       }
     } catch (error) {
       console.error("Worktree/세션 생성 실패:", error);
     }
   }
 
-  /** 해당 status 컬럼의 마지막 순서로 배치한다 */
   const maxResult = await repo
     .createQueryBuilder("t")
     .select("MAX(t.displayOrder)", "max")
@@ -172,6 +165,17 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
   task.displayOrder = (maxResult?.max ?? -1) + 1;
 
   const saved = await repo.save(task);
+
+  if (shouldInstallHooks && hookTargetPath) {
+    const kanvibeUrl = "http://localhost:9736";
+    await Promise.allSettled([
+      setupClaudeHooks(hookTargetPath, saved.id, kanvibeUrl),
+      setupGeminiHooks(hookTargetPath, saved.id, kanvibeUrl),
+      setupCodexHooks(hookTargetPath, saved.id, kanvibeUrl),
+      setupOpenCodeHooks(hookTargetPath, saved.id, kanvibeUrl),
+    ]);
+  }
+
   broadcastBoardUpdate();
   return serialize(saved);
 }
@@ -332,22 +336,22 @@ export async function branchFromTask(
   task.sshHost = project.sshHost;
   task.status = TaskStatus.PROGRESS;
 
-  /** 로컬 worktree에 모든 AI 에이전트 hooks를 자동 설정한다 */
+  const saved = await repo.save(task);
+
   if (!project.sshHost && session.worktreePath) {
     try {
       const kanvibeUrl = "http://localhost:9736";
       await Promise.allSettled([
-        setupClaudeHooks(session.worktreePath, project.id, kanvibeUrl),
-        setupGeminiHooks(session.worktreePath, project.id, kanvibeUrl),
-        setupCodexHooks(session.worktreePath, project.id, kanvibeUrl),
-        setupOpenCodeHooks(session.worktreePath, project.id, kanvibeUrl),
+        setupClaudeHooks(session.worktreePath, saved.id, kanvibeUrl),
+        setupGeminiHooks(session.worktreePath, saved.id, kanvibeUrl),
+        setupCodexHooks(session.worktreePath, saved.id, kanvibeUrl),
+        setupOpenCodeHooks(session.worktreePath, saved.id, kanvibeUrl),
       ]);
     } catch (error) {
       console.error("Hooks 설정 실패:", error);
     }
   }
 
-  const saved = await repo.save(task);
   broadcastBoardUpdate();
   return serialize(saved);
 }

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -224,10 +224,10 @@ export async function scanAndRegisterProjects(
       if (!sshHost) {
         try {
           const kanvibeUrl = "http://localhost:9736";
-          await setupClaudeHooks(repoPath, projectName, kanvibeUrl);
-          await setupGeminiHooks(repoPath, projectName, kanvibeUrl);
-          await setupCodexHooks(repoPath, projectName, kanvibeUrl);
-          await setupOpenCodeHooks(repoPath, projectName, kanvibeUrl);
+          await setupClaudeHooks(repoPath, project.id, kanvibeUrl);
+          await setupGeminiHooks(repoPath, project.id, kanvibeUrl);
+          await setupCodexHooks(repoPath, project.id, kanvibeUrl);
+          await setupOpenCodeHooks(repoPath, project.id, kanvibeUrl);
           result.hooksSetup.push(projectName);
         } catch (hookError) {
           result.errors.push(
@@ -393,7 +393,7 @@ export async function installProjectHooks(
 
   try {
     const kanvibeUrl = "http://localhost:9736";
-    await setupClaudeHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupClaudeHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -427,7 +427,7 @@ export async function installTaskHooks(
   try {
     const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupClaudeHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupClaudeHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -459,7 +459,7 @@ export async function installProjectGeminiHooks(
 
   try {
     const kanvibeUrl = "http://localhost:9736";
-    await setupGeminiHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupGeminiHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -493,7 +493,7 @@ export async function installTaskGeminiHooks(
   try {
     const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupGeminiHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupGeminiHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -523,7 +523,7 @@ export async function installProjectCodexHooks(
 
   try {
     const kanvibeUrl = "http://localhost:9736";
-    await setupCodexHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupCodexHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -555,7 +555,7 @@ export async function installTaskCodexHooks(
   try {
     const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupCodexHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupCodexHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -575,7 +575,7 @@ export async function installProjectOpenCodeHooks(
 
   try {
     const kanvibeUrl = "http://localhost:9736";
-    await setupOpenCodeHooks(project.repoPath, project.name, kanvibeUrl);
+    await setupOpenCodeHooks(project.repoPath, project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -599,7 +599,7 @@ export async function installTaskOpenCodeHooks(
   try {
     const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupOpenCodeHooks(targetPath, task.project.name, kanvibeUrl);
+    await setupOpenCodeHooks(targetPath, task.project.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -22,20 +22,17 @@ function serialize<T>(data: T): T {
 }
 
 /** 프로젝트의 메인 브랜치 태스크를 생성하고 tmux 세션을 자동 연결한다 */
-async function createDefaultBranchTask(project: Project): Promise<void> {
+async function createDefaultBranchTask(project: Project) {
   const taskRepo = await getTaskRepository();
 
-  /** 해당 프로젝트에 이미 기본 브랜치 태스크가 있으면 생성하지 않는다 */
   const existing = await taskRepo.findOneBy({ branchName: project.defaultBranch, projectId: project.id });
-  if (existing) return;
+  if (existing) return existing;
 
-  /** orphan 태스크(projectId 없음)가 있으면 현재 프로젝트에 연결한다 */
   const orphan = await taskRepo.findOneBy({ branchName: project.defaultBranch, projectId: IsNull() });
   if (orphan) {
     orphan.projectId = project.id;
     orphan.baseBranch = project.defaultBranch;
-    await taskRepo.save(orphan);
-    return;
+    return taskRepo.save(orphan);
   }
 
   const task = taskRepo.create({
@@ -63,7 +60,12 @@ async function createDefaultBranchTask(project: Project): Promise<void> {
     console.error("메인 브랜치 tmux 세션 생성 실패:", error);
   }
 
-  await taskRepo.save(task);
+  return taskRepo.save(task);
+}
+
+async function getProjectRootTask(projectId: string, defaultBranch: string) {
+  const taskRepo = await getTaskRepository();
+  return taskRepo.findOneBy({ projectId, branchName: defaultBranch });
 }
 
 /** 등록된 모든 프로젝트를 반환한다 */
@@ -120,7 +122,7 @@ export async function registerProject(
   });
 
   const saved = await repo.save(project);
-  await createDefaultBranchTask(saved);
+          const defaultTask = await createDefaultBranchTask(saved);
   broadcastBoardUpdate();
   return { success: true, project: serialize(saved) };
 }
@@ -213,21 +215,23 @@ export async function scanAndRegisterProjects(
       existingPaths.add(pathKey);
       result.registered.push(projectName);
 
+      let defaultTask = null;
+
       /** 기본 브랜치 태스크 생성 실패는 프로젝트 등록 결과에 영향을 주지 않는다 */
       try {
-        await createDefaultBranchTask(saved);
+        defaultTask = await createDefaultBranchTask(saved);
       } catch (taskError) {
         console.error(`${projectName} 기본 브랜치 태스크 생성 실패:`, taskError);
       }
 
       /** 로컬 repo에 Claude Code / Gemini CLI / Codex CLI hooks를 자동 설정한다 */
-      if (!sshHost) {
+      if (!sshHost && defaultTask) {
         try {
           const kanvibeUrl = "http://localhost:9736";
-          await setupClaudeHooks(repoPath, project.id, kanvibeUrl);
-          await setupGeminiHooks(repoPath, project.id, kanvibeUrl);
-          await setupCodexHooks(repoPath, project.id, kanvibeUrl);
-          await setupOpenCodeHooks(repoPath, project.id, kanvibeUrl);
+          await setupClaudeHooks(repoPath, defaultTask.id, kanvibeUrl);
+          await setupGeminiHooks(repoPath, defaultTask.id, kanvibeUrl);
+          await setupCodexHooks(repoPath, defaultTask.id, kanvibeUrl);
+          await setupOpenCodeHooks(repoPath, defaultTask.id, kanvibeUrl);
           result.hooksSetup.push(projectName);
         } catch (hookError) {
           result.errors.push(
@@ -391,9 +395,12 @@ export async function installProjectHooks(
   if (!project) return { success: false, error: "프로젝트를 찾을 수 없습니다." };
   if (project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
 
+  const task = await getProjectRootTask(project.id, project.defaultBranch);
+  if (!task) return { success: false, error: "기본 브랜치 태스크를 찾을 수 없습니다." };
+
   try {
     const kanvibeUrl = "http://localhost:9736";
-    await setupClaudeHooks(project.repoPath, project.id, kanvibeUrl);
+    await setupClaudeHooks(project.repoPath, task.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -427,7 +434,7 @@ export async function installTaskHooks(
   try {
     const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupClaudeHooks(targetPath, task.project.id, kanvibeUrl);
+    await setupClaudeHooks(targetPath, task.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -457,9 +464,12 @@ export async function installProjectGeminiHooks(
   if (!project) return { success: false, error: "프로젝트를 찾을 수 없습니다." };
   if (project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
 
+  const task = await getProjectRootTask(project.id, project.defaultBranch);
+  if (!task) return { success: false, error: "기본 브랜치 태스크를 찾을 수 없습니다." };
+
   try {
     const kanvibeUrl = "http://localhost:9736";
-    await setupGeminiHooks(project.repoPath, project.id, kanvibeUrl);
+    await setupGeminiHooks(project.repoPath, task.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -493,7 +503,7 @@ export async function installTaskGeminiHooks(
   try {
     const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupGeminiHooks(targetPath, task.project.id, kanvibeUrl);
+    await setupGeminiHooks(targetPath, task.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -521,9 +531,12 @@ export async function installProjectCodexHooks(
   if (!project) return { success: false, error: "프로젝트를 찾을 수 없습니다." };
   if (project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
 
+  const task = await getProjectRootTask(project.id, project.defaultBranch);
+  if (!task) return { success: false, error: "기본 브랜치 태스크를 찾을 수 없습니다." };
+
   try {
     const kanvibeUrl = "http://localhost:9736";
-    await setupCodexHooks(project.repoPath, project.id, kanvibeUrl);
+    await setupCodexHooks(project.repoPath, task.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -555,7 +568,7 @@ export async function installTaskCodexHooks(
   try {
     const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupCodexHooks(targetPath, task.project.id, kanvibeUrl);
+    await setupCodexHooks(targetPath, task.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -573,9 +586,12 @@ export async function installProjectOpenCodeHooks(
   const project = await projectRepo.findOneBy({ id: projectId });
   if (!project) return { success: false, error: "Project not found" };
 
+  const task = await getProjectRootTask(project.id, project.defaultBranch);
+  if (!task) return { success: false, error: "Default branch task not found" };
+
   try {
     const kanvibeUrl = "http://localhost:9736";
-    await setupOpenCodeHooks(project.repoPath, project.id, kanvibeUrl);
+    await setupOpenCodeHooks(project.repoPath, task.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {
@@ -599,7 +615,7 @@ export async function installTaskOpenCodeHooks(
   try {
     const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
-    await setupOpenCodeHooks(targetPath, task.project.id, kanvibeUrl);
+    await setupOpenCodeHooks(targetPath, task.id, kanvibeUrl);
     return { success: true };
   } catch (error) {
     return {

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -223,7 +223,7 @@ export async function scanAndRegisterProjects(
       /** 로컬 repo에 Claude Code / Gemini CLI / Codex CLI hooks를 자동 설정한다 */
       if (!sshHost) {
         try {
-          const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+          const kanvibeUrl = "http://localhost:9736";
           await setupClaudeHooks(repoPath, projectName, kanvibeUrl);
           await setupGeminiHooks(repoPath, projectName, kanvibeUrl);
           await setupCodexHooks(repoPath, projectName, kanvibeUrl);
@@ -392,7 +392,7 @@ export async function installProjectHooks(
   if (project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
 
   try {
-    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const kanvibeUrl = "http://localhost:9736";
     await setupClaudeHooks(project.repoPath, project.name, kanvibeUrl);
     return { success: true };
   } catch (error) {
@@ -425,7 +425,7 @@ export async function installTaskHooks(
   if (task.project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
 
   try {
-    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
     await setupClaudeHooks(targetPath, task.project.name, kanvibeUrl);
     return { success: true };
@@ -458,7 +458,7 @@ export async function installProjectGeminiHooks(
   if (project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
 
   try {
-    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const kanvibeUrl = "http://localhost:9736";
     await setupGeminiHooks(project.repoPath, project.name, kanvibeUrl);
     return { success: true };
   } catch (error) {
@@ -491,7 +491,7 @@ export async function installTaskGeminiHooks(
   if (task.project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
 
   try {
-    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
     await setupGeminiHooks(targetPath, task.project.name, kanvibeUrl);
     return { success: true };
@@ -522,7 +522,7 @@ export async function installProjectCodexHooks(
   if (project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
 
   try {
-    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const kanvibeUrl = "http://localhost:9736";
     await setupCodexHooks(project.repoPath, project.name, kanvibeUrl);
     return { success: true };
   } catch (error) {
@@ -553,7 +553,7 @@ export async function installTaskCodexHooks(
   if (task.project.sshHost) return { success: false, error: "SSH 원격 프로젝트는 지원하지 않습니다." };
 
   try {
-    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
     await setupCodexHooks(targetPath, task.project.name, kanvibeUrl);
     return { success: true };
@@ -574,7 +574,7 @@ export async function installProjectOpenCodeHooks(
   if (!project) return { success: false, error: "Project not found" };
 
   try {
-    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const kanvibeUrl = "http://localhost:9736";
     await setupOpenCodeHooks(project.repoPath, project.name, kanvibeUrl);
     return { success: true };
   } catch (error) {
@@ -597,7 +597,7 @@ export async function installTaskOpenCodeHooks(
   if (!task?.project) return { success: false, error: "Task or project not found" };
 
   try {
-    const kanvibeUrl = `http://localhost:${process.env.PORT || 4885}`;
+    const kanvibeUrl = "http://localhost:9736";
     const targetPath = task.worktreePath || task.project.repoPath;
     await setupOpenCodeHooks(targetPath, task.project.name, kanvibeUrl);
     return { success: true };

--- a/src/hooks/__tests__/useTaskNotification.test.ts
+++ b/src/hooks/__tests__/useTaskNotification.test.ts
@@ -153,7 +153,7 @@ describe("useTaskNotification", () => {
     expect(mockShowNotification).not.toHaveBeenCalled();
   });
 
-  it("should show missing target notification without taskId when hook target is missing", async () => {
+  it("should show missing target notification when hook target is missing", async () => {
     // Given
     const { useTaskNotification } = await import("@/hooks/useTaskNotification");
     const { result } = renderHook(() => useTaskNotification());
@@ -163,8 +163,7 @@ describe("useTaskNotification", () => {
     // When
     await act(async () => {
       await result.current.notifyHookStatusTargetMissing({
-        projectName: "case-study",
-        branchName: "feat/test",
+        taskId: "task-404",
         requestedStatus: "review",
         reason: "task-not-found",
         locale: "ko",
@@ -172,8 +171,8 @@ describe("useTaskNotification", () => {
     });
 
     // Then
-    expect(mockShowNotification).toHaveBeenCalledWith("case-study — feat/test", {
-      body: "review 상태로 변경하지 못했습니다.\n브랜치에 연결된 작업을 찾지 못했습니다.",
+    expect(mockShowNotification).toHaveBeenCalledWith("Hook target missing — task-404", {
+      body: "review 상태로 변경하지 못했습니다.\n연결된 작업을 찾지 못했습니다.",
       icon: "/icons/icon-192x192.png",
       data: { locale: "ko" },
     });
@@ -189,17 +188,16 @@ describe("useTaskNotification", () => {
     // When
     await act(async () => {
       await result.current.notifyHookStatusTargetMissing({
-        projectName: "case-study",
-        branchName: "feat/test",
+        taskId: "task-404",
         requestedStatus: "review",
-        reason: "project-not-found",
+        reason: "task-not-found",
         locale: "en",
       });
     });
 
     // Then
-    expect(mockShowNotification).toHaveBeenCalledWith("case-study — feat/test", {
-      body: "Failed to change status to review.\nProject was not found.",
+    expect(mockShowNotification).toHaveBeenCalledWith("Hook target missing — task-404", {
+      body: "Failed to change status to review.\nNo matching task was found.",
       icon: "/icons/icon-192x192.png",
       data: { locale: "en" },
     });

--- a/src/hooks/useTaskNotification.ts
+++ b/src/hooks/useTaskNotification.ts
@@ -10,20 +10,17 @@ const NOTIFICATION_MESSAGES = {
   ko: {
     formatStatusChanged: (taskTitle: string, newStatus: string) => `${taskTitle}: ${newStatus}로 변경`,
     formatMissingStatus: (requestedStatus: string) => `${requestedStatus} 상태로 변경하지 못했습니다.`,
-    projectNotFound: "프로젝트를 찾지 못했습니다.",
-    taskNotFound: "브랜치에 연결된 작업을 찾지 못했습니다.",
+    taskNotFound: "연결된 작업을 찾지 못했습니다.",
   },
   en: {
     formatStatusChanged: (taskTitle: string, newStatus: string) => `${taskTitle}: changed to ${newStatus}`,
     formatMissingStatus: (requestedStatus: string) => `Failed to change status to ${requestedStatus}.`,
-    projectNotFound: "Project was not found.",
-    taskNotFound: "No task linked to this branch was found.",
+    taskNotFound: "No matching task was found.",
   },
   zh: {
     formatStatusChanged: (taskTitle: string, newStatus: string) => `${taskTitle}: 已变更为${newStatus}`,
     formatMissingStatus: (requestedStatus: string) => `未能变更为 ${requestedStatus} 状态。`,
-    projectNotFound: "未找到项目。",
-    taskNotFound: "未找到与该分支关联的任务。",
+    taskNotFound: "未找到匹配的任务。",
   },
 } as const;
 
@@ -44,10 +41,9 @@ export interface TaskStatusNotification {
 }
 
 export interface HookStatusTargetMissingNotification {
-  projectName: string;
-  branchName: string;
+  taskId: string;
   requestedStatus: string;
-  reason: "project-not-found" | "task-not-found";
+  reason: "task-not-found";
   locale: string;
 }
 
@@ -169,11 +165,8 @@ export function useTaskNotification() {
       if (!isPermissionGranted.current) return;
 
       const messages = NOTIFICATION_MESSAGES[getNotificationLocale(payload.locale)];
-      const title = `${payload.projectName} — ${payload.branchName}`;
-      const reasonMessage =
-        payload.reason === "project-not-found"
-          ? messages.projectNotFound
-          : messages.taskNotFound;
+      const title = `Hook target missing — ${payload.taskId}`;
+      const reasonMessage = messages.taskNotFound;
 
       try {
         const body = `${messages.formatMissingStatus(payload.requestedStatus)}\n${reasonMessage}`;

--- a/src/lib/__tests__/boardNotifier.test.ts
+++ b/src/lib/__tests__/boardNotifier.test.ts
@@ -56,8 +56,7 @@ describe("boardNotifier", () => {
   it("should deliver hook-status-target-missing message with payload to subscribers", async () => {
     const { broadcastHookStatusTargetMissing, subscribeToBoardEvents } = await import("@/lib/boardNotifier");
     const payload = {
-      projectName: "case-study",
-      branchName: "feat/test",
+      taskId: "task-404",
       requestedStatus: "review",
       reason: "task-not-found" as const,
     };

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -21,7 +21,7 @@ describe("codexHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
 
       // Then
       const status = await getCodexHooksStatus(repoPath);
@@ -33,15 +33,15 @@ describe("codexHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
 
       // Then
       const status = await getCodexHooksStatus(repoPath);
       expect(status.hasConfigEntry).toBe(true);
 
       const hookContent = await readFile(join(repoPath, ".codex", "hooks", "kanvibe-notify-hook.sh"), "utf-8");
-      expect(hookContent).toContain("PROJECT_ID=\"project-1\"");
-      expect(hookContent).toContain("projectId");
+      expect(hookContent).toContain("TASK_ID=\"task-1\"");
+      expect(hookContent).toContain("taskId");
     });
 
     it("should mark as installed when both hook and config exist", async () => {
@@ -49,7 +49,7 @@ describe("codexHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
 
       // Then
       const status = await getCodexHooksStatus(repoPath);
@@ -59,10 +59,10 @@ describe("codexHooksSetup", () => {
     it("should not add duplicate notify entry", async () => {
       // Given
       const repoPath = tempDir;
-      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
 
       // When - setup again
-      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
 
       // Then - should still be installed
       const status = await getCodexHooksStatus(repoPath);
@@ -87,7 +87,7 @@ describe("codexHooksSetup", () => {
     it("should detect installed status correctly", async () => {
       // Given
       const repoPath = tempDir;
-      await setupCodexHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
 
       // When
       const status = await getCodexHooksStatus(repoPath);

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -40,8 +40,8 @@ describe("codexHooksSetup", () => {
       expect(status.hasConfigEntry).toBe(true);
 
       const hookContent = await readFile(join(repoPath, ".codex", "hooks", "kanvibe-notify-hook.sh"), "utf-8");
-      expect(hookContent).toContain("PROJECT_ID=\"project-1\"");
-      expect(hookContent).toContain("projectId");
+      expect(hookContent).toContain("PROJECT_NAME=\"project-1\"");
+      expect(hookContent).toContain("projectName");
     });
 
     it("should mark as installed when both hook and config exist", async () => {

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -40,8 +40,8 @@ describe("codexHooksSetup", () => {
       expect(status.hasConfigEntry).toBe(true);
 
       const hookContent = await readFile(join(repoPath, ".codex", "hooks", "kanvibe-notify-hook.sh"), "utf-8");
-      expect(hookContent).toContain("PROJECT_NAME=\"project-1\"");
-      expect(hookContent).toContain("projectName");
+      expect(hookContent).toContain("PROJECT_ID=\"project-1\"");
+      expect(hookContent).toContain("projectId");
     });
 
     it("should mark as installed when both hook and config exist", async () => {

--- a/src/lib/__tests__/geminiHooksSetup.test.ts
+++ b/src/lib/__tests__/geminiHooksSetup.test.ts
@@ -20,11 +20,11 @@ describe("geminiHooksSetup", () => {
     it("should create hook scripts and settings.json in .gemini directory", async () => {
       // Given
       const repoPath = tmpDir;
-      const projectName = "project-1";
+      const projectId = "project-1";
       const kanvibeUrl = "http://localhost:9736";
 
       // When
-      await setupGeminiHooks(repoPath, projectName, kanvibeUrl);
+      await setupGeminiHooks(repoPath, projectId, kanvibeUrl);
 
       // Then
       const promptScript = await readFile(
@@ -42,8 +42,8 @@ describe("geminiHooksSetup", () => {
       expect(promptScript).toContain("#!/bin/bash");
       expect(promptScript).toContain("BeforeAgent");
       expect(promptScript).toContain(kanvibeUrl);
-      expect(promptScript).toContain(projectName);
-      expect(promptScript).toContain("projectName");
+      expect(promptScript).toContain(projectId);
+      expect(promptScript).toContain("projectId");
       expect(promptScript).toContain("echo '{}'");
 
       expect(stopScript).toContain("#!/bin/bash");

--- a/src/lib/__tests__/geminiHooksSetup.test.ts
+++ b/src/lib/__tests__/geminiHooksSetup.test.ts
@@ -20,11 +20,11 @@ describe("geminiHooksSetup", () => {
     it("should create hook scripts and settings.json in .gemini directory", async () => {
       // Given
       const repoPath = tmpDir;
-      const projectId = "project-1";
-      const kanvibeUrl = "http://localhost:4885";
+      const projectName = "project-1";
+      const kanvibeUrl = "http://localhost:9736";
 
       // When
-      await setupGeminiHooks(repoPath, projectId, kanvibeUrl);
+      await setupGeminiHooks(repoPath, projectName, kanvibeUrl);
 
       // Then
       const promptScript = await readFile(
@@ -42,8 +42,8 @@ describe("geminiHooksSetup", () => {
       expect(promptScript).toContain("#!/bin/bash");
       expect(promptScript).toContain("BeforeAgent");
       expect(promptScript).toContain(kanvibeUrl);
-      expect(promptScript).toContain(projectId);
-      expect(promptScript).toContain("projectId");
+      expect(promptScript).toContain(projectName);
+      expect(promptScript).toContain("projectName");
       expect(promptScript).toContain("echo '{}'");
 
       expect(stopScript).toContain("#!/bin/bash");
@@ -88,7 +88,7 @@ describe("geminiHooksSetup", () => {
       );
 
       // When
-      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:9736");
 
       // Then
       const settings = JSON.parse(
@@ -107,10 +107,10 @@ describe("geminiHooksSetup", () => {
 
     it("should not duplicate hooks when called multiple times", async () => {
       // Given
-      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:9736");
 
       // When
-      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:9736");
 
       // Then
       const settings = JSON.parse(
@@ -128,7 +128,7 @@ describe("geminiHooksSetup", () => {
   describe("getGeminiHooksStatus", () => {
     it("should return installed: true after setupGeminiHooks", async () => {
       // Given
-      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:4885");
+      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:9736");
 
       // When
       const status = await getGeminiHooksStatus(tmpDir);

--- a/src/lib/__tests__/geminiHooksSetup.test.ts
+++ b/src/lib/__tests__/geminiHooksSetup.test.ts
@@ -20,11 +20,11 @@ describe("geminiHooksSetup", () => {
     it("should create hook scripts and settings.json in .gemini directory", async () => {
       // Given
       const repoPath = tmpDir;
-      const projectId = "project-1";
+      const taskId = "task-1";
       const kanvibeUrl = "http://localhost:9736";
 
       // When
-      await setupGeminiHooks(repoPath, projectId, kanvibeUrl);
+      await setupGeminiHooks(repoPath, taskId, kanvibeUrl);
 
       // Then
       const promptScript = await readFile(
@@ -42,8 +42,8 @@ describe("geminiHooksSetup", () => {
       expect(promptScript).toContain("#!/bin/bash");
       expect(promptScript).toContain("BeforeAgent");
       expect(promptScript).toContain(kanvibeUrl);
-      expect(promptScript).toContain(projectId);
-      expect(promptScript).toContain("projectId");
+      expect(promptScript).toContain(taskId);
+      expect(promptScript).toContain("taskId");
       expect(promptScript).toContain("echo '{}'");
 
       expect(stopScript).toContain("#!/bin/bash");
@@ -88,7 +88,7 @@ describe("geminiHooksSetup", () => {
       );
 
       // When
-      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:9736");
+      await setupGeminiHooks(tmpDir, "task-1", "http://localhost:9736");
 
       // Then
       const settings = JSON.parse(
@@ -107,10 +107,10 @@ describe("geminiHooksSetup", () => {
 
     it("should not duplicate hooks when called multiple times", async () => {
       // Given
-      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:9736");
+      await setupGeminiHooks(tmpDir, "task-1", "http://localhost:9736");
 
       // When
-      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:9736");
+      await setupGeminiHooks(tmpDir, "task-1", "http://localhost:9736");
 
       // Then
       const settings = JSON.parse(
@@ -128,7 +128,7 @@ describe("geminiHooksSetup", () => {
   describe("getGeminiHooksStatus", () => {
     it("should return installed: true after setupGeminiHooks", async () => {
       // Given
-      await setupGeminiHooks(tmpDir, "project-1", "http://localhost:9736");
+      await setupGeminiHooks(tmpDir, "task-1", "http://localhost:9736");
 
       // When
       const status = await getGeminiHooksStatus(tmpDir);

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -21,7 +21,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:3000");
 
       // Then
       const status = await getOpenCodeHooksStatus(repoPath);
@@ -33,7 +33,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -41,8 +41,8 @@ describe("openCodeHooksSetup", () => {
 
       expect(pluginContent).toContain("KanvibePlugin");
       expect(pluginContent).toContain("/api/hooks/status");
-      expect(pluginContent).toContain('const PROJECT_ID = "project-1";');
-      expect(pluginContent).toContain("projectId: PROJECT_ID");
+      expect(pluginContent).toContain('const TASK_ID = "task-1";');
+      expect(pluginContent).toContain("taskId: TASK_ID");
     });
 
     it("should generate plugin with all event handlers for status tracking", async () => {
@@ -50,7 +50,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -68,7 +68,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -86,7 +86,7 @@ describe("openCodeHooksSetup", () => {
       const repoPath = tempDir;
 
       // When
-      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:3000");
 
       // Then
       const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
@@ -111,10 +111,10 @@ describe("openCodeHooksSetup", () => {
     it("should not fail when called twice (overwrites existing plugin)", async () => {
       // Given
       const repoPath = tempDir;
-      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:3000");
 
       // When - setup again
-      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:3000");
 
       // Then - should still be installed correctly
       const status = await getOpenCodeHooksStatus(repoPath);
@@ -126,7 +126,7 @@ describe("openCodeHooksSetup", () => {
     it("should return installed: true after setup", async () => {
       // Given
       const repoPath = tempDir;
-      await setupOpenCodeHooks(repoPath, "project-1", "http://localhost:3000");
+      await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:3000");
 
       // When
       const status = await getOpenCodeHooksStatus(repoPath);

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -41,8 +41,8 @@ describe("openCodeHooksSetup", () => {
 
       expect(pluginContent).toContain("KanvibePlugin");
       expect(pluginContent).toContain("/api/hooks/status");
-      expect(pluginContent).toContain('const PROJECT_NAME = "project-1";');
-      expect(pluginContent).toContain("projectName: PROJECT_NAME");
+      expect(pluginContent).toContain('const PROJECT_ID = "project-1";');
+      expect(pluginContent).toContain("projectId: PROJECT_ID");
     });
 
     it("should generate plugin with all event handlers for status tracking", async () => {

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -41,8 +41,8 @@ describe("openCodeHooksSetup", () => {
 
       expect(pluginContent).toContain("KanvibePlugin");
       expect(pluginContent).toContain("/api/hooks/status");
-      expect(pluginContent).toContain('const PROJECT_ID = "project-1";');
-      expect(pluginContent).toContain("projectId: PROJECT_ID");
+      expect(pluginContent).toContain('const PROJECT_NAME = "project-1";');
+      expect(pluginContent).toContain("projectName: PROJECT_NAME");
     });
 
     it("should generate plugin with all event handlers for status tracking", async () => {

--- a/src/lib/boardNotifier.ts
+++ b/src/lib/boardNotifier.ts
@@ -14,10 +14,9 @@ export interface TaskStatusChangedPayload {
 }
 
 export interface HookStatusTargetMissingPayload {
-  projectName: string;
-  branchName: string;
+  taskId: string;
   requestedStatus: string;
-  reason: "project-not-found" | "task-not-found";
+  reason: "task-not-found";
 }
 
 export type BoardEventPayload =

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -3,23 +3,18 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, projectId: string): string {
+function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: UserPromptSubmit
-# 사용자가 prompt를 입력하면 현재 브랜치의 작업을 PROGRESS로 변경한다.
+# 사용자가 prompt를 입력하면 현재 task를 PROGRESS로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
-
-BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
-  exit 0
-fi
+TASK_ID="${taskId}"
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"progress\\"}" \\
+  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"progress\\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -27,23 +22,18 @@ exit 0
 }
 
 /** Stop hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, projectId: string): string {
+function generateStopHookScript(kanvibeUrl: string, taskId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: Stop
-# AI 응답이 완료되면 현재 브랜치의 작업을 REVIEW로 변경한다.
+# AI 응답이 완료되면 현재 task를 REVIEW로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
-
-BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
-  exit 0
-fi
+TASK_ID="${taskId}"
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -51,23 +41,18 @@ exit 0
 }
 
 /** PreToolUse(AskUserQuestion) hook bash 스크립트를 생성한다 */
-function generateQuestionHookScript(kanvibeUrl: string, projectId: string): string {
+function generateQuestionHookScript(kanvibeUrl: string, taskId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: PreToolUse (AskUserQuestion)
-# Claude가 사용자에게 질문할 때 현재 브랜치의 작업을 PENDING으로 변경한다.
+# Claude가 사용자에게 질문할 때 현재 task를 PENDING으로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
-
-BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
-  exit 0
-fi
+TASK_ID="${taskId}"
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"pending\\"}" \\
+  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"pending\\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -112,7 +97,7 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
  */
 export async function setupClaudeHooks(
   repoPath: string,
-  projectId: string,
+  taskId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const claudeDir = path.join(repoPath, ".claude");
@@ -125,9 +110,9 @@ export async function setupClaudeHooks(
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
   const questionScriptPath = path.join(hooksDir, "kanvibe-question-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectId), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectId), "utf-8");
-  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId), "utf-8");
+  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, taskId), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
   await chmod(questionScriptPath, 0o755);

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -3,14 +3,14 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, projectName: string): string {
+function generatePromptHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: UserPromptSubmit
 # 사용자가 prompt를 입력하면 현재 브랜치의 작업을 PROGRESS로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -19,7 +19,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"progress\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"progress\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -27,14 +27,14 @@ exit 0
 }
 
 /** Stop hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, projectName: string): string {
+function generateStopHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: Stop
 # AI 응답이 완료되면 현재 브랜치의 작업을 REVIEW로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -43,7 +43,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -51,14 +51,14 @@ exit 0
 }
 
 /** PreToolUse(AskUserQuestion) hook bash 스크립트를 생성한다 */
-function generateQuestionHookScript(kanvibeUrl: string, projectName: string): string {
+function generateQuestionHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: PreToolUse (AskUserQuestion)
 # Claude가 사용자에게 질문할 때 현재 브랜치의 작업을 PENDING으로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -67,7 +67,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"pending\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"pending\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -112,7 +112,7 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
  */
 export async function setupClaudeHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const claudeDir = path.join(repoPath, ".claude");
@@ -125,9 +125,9 @@ export async function setupClaudeHooks(
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
   const questionScriptPath = path.join(hooksDir, "kanvibe-question-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectName), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectName), "utf-8");
-  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, projectId), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
   await chmod(questionScriptPath, 0o755);

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -3,14 +3,14 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, projectId: string): string {
+function generatePromptHookScript(kanvibeUrl: string, projectName: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: UserPromptSubmit
 # 사용자가 prompt를 입력하면 현재 브랜치의 작업을 PROGRESS로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
+PROJECT_NAME="${projectName}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -19,7 +19,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"progress\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"progress\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -27,14 +27,14 @@ exit 0
 }
 
 /** Stop hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, projectId: string): string {
+function generateStopHookScript(kanvibeUrl: string, projectName: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: Stop
 # AI 응답이 완료되면 현재 브랜치의 작업을 REVIEW로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
+PROJECT_NAME="${projectName}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -43,7 +43,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -51,14 +51,14 @@ exit 0
 }
 
 /** PreToolUse(AskUserQuestion) hook bash 스크립트를 생성한다 */
-function generateQuestionHookScript(kanvibeUrl: string, projectId: string): string {
+function generateQuestionHookScript(kanvibeUrl: string, projectName: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: PreToolUse (AskUserQuestion)
 # Claude가 사용자에게 질문할 때 현재 브랜치의 작업을 PENDING으로 변경한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
+PROJECT_NAME="${projectName}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -67,7 +67,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"pending\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"pending\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -112,7 +112,7 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
  */
 export async function setupClaudeHooks(
   repoPath: string,
-  projectId: string,
+  projectName: string,
   kanvibeUrl: string
 ): Promise<void> {
   const claudeDir = path.join(repoPath, ".claude");
@@ -125,9 +125,9 @@ export async function setupClaudeHooks(
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
   const questionScriptPath = path.join(hooksDir, "kanvibe-question-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectId), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectId), "utf-8");
-  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, projectName), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
   await chmod(questionScriptPath, 0o755);

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -8,15 +8,15 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** notify hook bash 스크립트를 생성한다 (agent-turn-complete → REVIEW) */
-function generateNotifyHookScript(kanvibeUrl: string, projectId: string): string {
+function generateNotifyHookScript(kanvibeUrl: string, taskId: string): string {
   return `#!/bin/bash
 
 # KanVibe Codex CLI Hook: notify (agent-turn-complete)
-# Codex 응답이 완료되면 현재 브랜치의 작업을 REVIEW로 변경한다.
+# Codex 응답이 완료되면 현재 task를 REVIEW로 변경한다.
 # Codex notify 스크립트는 첫 번째 인자로 JSON payload를 받는다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
+TASK_ID="${taskId}"
 
 JSON_PAYLOAD="$1"
 
@@ -26,14 +26,9 @@ if [ "$EVENT_TYPE" != "agent-turn-complete" ]; then
   exit 0
 fi
 
-BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
-  exit 0
-fi
-
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -63,7 +58,7 @@ function hasKanvibeNotify(configContent: string): boolean {
  */
 export async function setupCodexHooks(
   repoPath: string,
-  projectId: string,
+  taskId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const codexDir = path.join(repoPath, ".codex");
@@ -73,7 +68,7 @@ export async function setupCodexHooks(
   await mkdir(hooksDir, { recursive: true });
 
   const notifyScriptPath = path.join(hooksDir, HOOK_SCRIPT_NAME);
-  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, taskId), "utf-8");
   await chmod(notifyScriptPath, 0o755);
 
   const configContent = await readConfigToml(configPath);
@@ -84,7 +79,6 @@ export async function setupCodexHooks(
     if (configContent.trim().length === 0) {
       await writeFile(configPath, notifyLine, "utf-8");
     } else {
-      /** 기존 notify 설정이 있으면 교체, 없으면 추가한다 */
       if (/^notify\s*=/m.test(configContent)) {
         const updated = configContent.replace(/^notify\s*=.*$/m, `notify = [".codex/hooks/${HOOK_SCRIPT_NAME}"]`);
         await writeFile(configPath, updated, "utf-8");

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -8,7 +8,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** notify hook bash 스크립트를 생성한다 (agent-turn-complete → REVIEW) */
-function generateNotifyHookScript(kanvibeUrl: string, projectId: string): string {
+function generateNotifyHookScript(kanvibeUrl: string, projectName: string): string {
   return `#!/bin/bash
 
 # KanVibe Codex CLI Hook: notify (agent-turn-complete)
@@ -16,7 +16,7 @@ function generateNotifyHookScript(kanvibeUrl: string, projectId: string): string
 # Codex notify 스크립트는 첫 번째 인자로 JSON payload를 받는다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
+PROJECT_NAME="${projectName}"
 
 JSON_PAYLOAD="$1"
 
@@ -33,7 +33,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -63,7 +63,7 @@ function hasKanvibeNotify(configContent: string): boolean {
  */
 export async function setupCodexHooks(
   repoPath: string,
-  projectId: string,
+  projectName: string,
   kanvibeUrl: string
 ): Promise<void> {
   const codexDir = path.join(repoPath, ".codex");
@@ -73,7 +73,7 @@ export async function setupCodexHooks(
   await mkdir(hooksDir, { recursive: true });
 
   const notifyScriptPath = path.join(hooksDir, HOOK_SCRIPT_NAME);
-  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, projectName), "utf-8");
   await chmod(notifyScriptPath, 0o755);
 
   const configContent = await readConfigToml(configPath);

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -8,7 +8,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** notify hook bash 스크립트를 생성한다 (agent-turn-complete → REVIEW) */
-function generateNotifyHookScript(kanvibeUrl: string, projectName: string): string {
+function generateNotifyHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Codex CLI Hook: notify (agent-turn-complete)
@@ -16,7 +16,7 @@ function generateNotifyHookScript(kanvibeUrl: string, projectName: string): stri
 # Codex notify 스크립트는 첫 번째 인자로 JSON payload를 받는다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 JSON_PAYLOAD="$1"
 
@@ -33,7 +33,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -63,7 +63,7 @@ function hasKanvibeNotify(configContent: string): boolean {
  */
 export async function setupCodexHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const codexDir = path.join(repoPath, ".codex");
@@ -73,7 +73,7 @@ export async function setupCodexHooks(
   await mkdir(hooksDir, { recursive: true });
 
   const notifyScriptPath = path.join(hooksDir, HOOK_SCRIPT_NAME);
-  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, projectId), "utf-8");
   await chmod(notifyScriptPath, 0o755);
 
   const configContent = await readConfigToml(configPath);

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -8,7 +8,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** BeforeAgent hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, projectName: string): string {
+function generatePromptHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: BeforeAgent
@@ -16,7 +16,7 @@ function generatePromptHookScript(kanvibeUrl: string, projectName: string): stri
 # Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -26,7 +26,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"progress\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"progress\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -35,7 +35,7 @@ exit 0
 }
 
 /** AfterAgent hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, projectName: string): string {
+function generateStopHookScript(kanvibeUrl: string, projectId: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: AfterAgent
@@ -43,7 +43,7 @@ function generateStopHookScript(kanvibeUrl: string, projectName: string): string
 # Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_NAME="${projectName}"
+PROJECT_ID="${projectId}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -53,7 +53,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -104,7 +104,7 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
  */
 export async function setupGeminiHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const geminiDir = path.join(repoPath, ".gemini");
@@ -116,8 +116,8 @@ export async function setupGeminiHooks(
   const promptScriptPath = path.join(hooksDir, "kanvibe-prompt-hook.sh");
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectName), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectId), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
 

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -8,7 +8,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** BeforeAgent hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, projectId: string): string {
+function generatePromptHookScript(kanvibeUrl: string, projectName: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: BeforeAgent
@@ -16,7 +16,7 @@ function generatePromptHookScript(kanvibeUrl: string, projectId: string): string
 # Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
+PROJECT_NAME="${projectName}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -26,7 +26,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"progress\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"progress\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -35,7 +35,7 @@ exit 0
 }
 
 /** AfterAgent hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, projectId: string): string {
+function generateStopHookScript(kanvibeUrl: string, projectName: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: AfterAgent
@@ -43,7 +43,7 @@ function generateStopHookScript(kanvibeUrl: string, projectId: string): string {
 # Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
+PROJECT_NAME="${projectName}"
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
@@ -53,7 +53,7 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectName\\": \\"\${PROJECT_NAME}\\", \\"status\\": \\"review\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -104,7 +104,7 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
  */
 export async function setupGeminiHooks(
   repoPath: string,
-  projectId: string,
+  projectName: string,
   kanvibeUrl: string
 ): Promise<void> {
   const geminiDir = path.join(repoPath, ".gemini");
@@ -116,8 +116,8 @@ export async function setupGeminiHooks(
   const promptScriptPath = path.join(hooksDir, "kanvibe-prompt-hook.sh");
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectId), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectName), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
 

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -8,25 +8,19 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** BeforeAgent hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, projectId: string): string {
+function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: BeforeAgent
-# 사용자가 prompt를 입력하면 현재 브랜치의 작업을 PROGRESS로 변경한다.
+# 사용자가 prompt를 입력하면 현재 task를 PROGRESS로 변경한다.
 # Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
-
-BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
-  echo '{}'
-  exit 0
-fi
+TASK_ID="${taskId}"
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"progress\\"}" \\
+  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"progress\\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -35,25 +29,19 @@ exit 0
 }
 
 /** AfterAgent hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, projectId: string): string {
+function generateStopHookScript(kanvibeUrl: string, taskId: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: AfterAgent
-# AI 응답이 완료되면 현재 브랜치의 작업을 REVIEW로 변경한다.
+# AI 응답이 완료되면 현재 task를 REVIEW로 변경한다.
 # Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
 
 KANVIBE_URL="${kanvibeUrl}"
-PROJECT_ID="${projectId}"
-
-BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
-  echo '{}'
-  exit 0
-fi
+TASK_ID="${taskId}"
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"branchName\\": \\"\${BRANCH_NAME}\\", \\"projectId\\": \\"\${PROJECT_ID}\\", \\"status\\": \\"review\\"}" \\
+  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -104,7 +92,7 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
  */
 export async function setupGeminiHooks(
   repoPath: string,
-  projectId: string,
+  taskId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const geminiDir = path.join(repoPath, ".gemini");
@@ -116,8 +104,8 @@ export async function setupGeminiHooks(
   const promptScriptPath = path.join(hooksDir, "kanvibe-prompt-hook.sh");
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, projectId), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
 
@@ -136,11 +124,9 @@ export async function setupGeminiHooks(
       matcher: "*",
       hooks: [
         {
-          name: "kanvibe-prompt",
           type: "command",
-          command: "$GEMINI_PROJECT_DIR/.gemini/hooks/kanvibe-prompt-hook.sh",
-          timeout: 5000,
-          description: "KanVibe: 작업 시작 시 status를 progress로 변경",
+          command: '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-prompt-hook.sh',
+          timeout: 10000,
         },
       ],
     });
@@ -154,11 +140,9 @@ export async function setupGeminiHooks(
       matcher: "*",
       hooks: [
         {
-          name: "kanvibe-stop",
           type: "command",
-          command: "$GEMINI_PROJECT_DIR/.gemini/hooks/kanvibe-stop-hook.sh",
-          timeout: 5000,
-          description: "KanVibe: 작업 완료 시 status를 review로 변경",
+          command: '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-stop-hook.sh',
+          timeout: 10000,
         },
       ],
     });

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -12,7 +12,7 @@ const PLUGIN_FILE_NAME = "kanvibe-plugin.ts";
 const PLUGIN_DIR_NAME = "plugins";
 
 /** OpenCode plugin TypeScript 파일 내용을 생성한다 */
-function generatePluginScript(kanvibeUrl: string, projectName: string): string {
+function generatePluginScript(kanvibeUrl: string, projectId: string): string {
   return `import type { Plugin } from "@opencode-ai/plugin";
 
 /**
@@ -22,7 +22,7 @@ function generatePluginScript(kanvibeUrl: string, projectName: string): string {
  */
 export const KanvibePlugin: Plugin = async ({ $, client }) => {
   const KANVIBE_URL = "${kanvibeUrl}";
-  const PROJECT_NAME = "${projectName}";
+  const PROJECT_ID = "${projectId}";
 
   async function getBranchName(): Promise<string | null> {
     try {
@@ -43,7 +43,7 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
       await fetch(\`\${KANVIBE_URL}/api/hooks/status\`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ branchName, projectName: PROJECT_NAME, status }),
+        body: JSON.stringify({ branchName, projectId: PROJECT_ID, status }),
       });
     } catch {
       /* 네트워크 에러 무시 */
@@ -159,7 +159,7 @@ function hasKanvibePlugin(pluginContent: string): boolean {
  */
 export async function setupOpenCodeHooks(
   repoPath: string,
-  projectName: string,
+  projectId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const openCodeDir = path.join(repoPath, ".opencode");
@@ -168,7 +168,7 @@ export async function setupOpenCodeHooks(
   await mkdir(pluginsDir, { recursive: true });
 
   const pluginPath = path.join(pluginsDir, PLUGIN_FILE_NAME);
-  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, projectName), "utf-8");
+  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, projectId), "utf-8");
 
   try {
     await addAiToolPatternsToGitExclude(repoPath);

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -12,7 +12,7 @@ const PLUGIN_FILE_NAME = "kanvibe-plugin.ts";
 const PLUGIN_DIR_NAME = "plugins";
 
 /** OpenCode plugin TypeScript 파일 내용을 생성한다 */
-function generatePluginScript(kanvibeUrl: string, projectId: string): string {
+function generatePluginScript(kanvibeUrl: string, taskId: string): string {
   return `import type { Plugin } from "@opencode-ai/plugin";
 
 /**
@@ -20,30 +20,16 @@ function generatePluginScript(kanvibeUrl: string, projectId: string): string {
  * message.updated(user) → progress, question.asked → pending,
  * question.replied → progress, session.idle → review, session.deleted → done 상태 변경
  */
-export const KanvibePlugin: Plugin = async ({ $, client }) => {
+export const KanvibePlugin: Plugin = async ({ client }) => {
   const KANVIBE_URL = "${kanvibeUrl}";
-  const PROJECT_ID = "${projectId}";
-
-  async function getBranchName(): Promise<string | null> {
-    try {
-      const result = await $\`git rev-parse --abbrev-ref HEAD\`.quiet();
-      const branch = result.text().trim();
-      if (!branch || branch === "HEAD") return null;
-      return branch;
-    } catch {
-      return null;
-    }
-  }
+  const TASK_ID = "${taskId}";
 
   async function updateStatus(status: string): Promise<void> {
-    const branchName = await getBranchName();
-    if (!branchName) return;
-
     try {
       await fetch(\`\${KANVIBE_URL}/api/hooks/status\`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ branchName, projectId: PROJECT_ID, status }),
+        body: JSON.stringify({ taskId: TASK_ID, status }),
       });
     } catch {
       /* 네트워크 에러 무시 */
@@ -159,7 +145,7 @@ function hasKanvibePlugin(pluginContent: string): boolean {
  */
 export async function setupOpenCodeHooks(
   repoPath: string,
-  projectId: string,
+  taskId: string,
   kanvibeUrl: string
 ): Promise<void> {
   const openCodeDir = path.join(repoPath, ".opencode");
@@ -168,7 +154,7 @@ export async function setupOpenCodeHooks(
   await mkdir(pluginsDir, { recursive: true });
 
   const pluginPath = path.join(pluginsDir, PLUGIN_FILE_NAME);
-  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, taskId), "utf-8");
 
   try {
     await addAiToolPatternsToGitExclude(repoPath);

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -12,7 +12,7 @@ const PLUGIN_FILE_NAME = "kanvibe-plugin.ts";
 const PLUGIN_DIR_NAME = "plugins";
 
 /** OpenCode plugin TypeScript 파일 내용을 생성한다 */
-function generatePluginScript(kanvibeUrl: string, projectId: string): string {
+function generatePluginScript(kanvibeUrl: string, projectName: string): string {
   return `import type { Plugin } from "@opencode-ai/plugin";
 
 /**
@@ -22,7 +22,7 @@ function generatePluginScript(kanvibeUrl: string, projectId: string): string {
  */
 export const KanvibePlugin: Plugin = async ({ $, client }) => {
   const KANVIBE_URL = "${kanvibeUrl}";
-  const PROJECT_ID = "${projectId}";
+  const PROJECT_NAME = "${projectName}";
 
   async function getBranchName(): Promise<string | null> {
     try {
@@ -43,7 +43,7 @@ export const KanvibePlugin: Plugin = async ({ $, client }) => {
       await fetch(\`\${KANVIBE_URL}/api/hooks/status\`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ branchName, projectId: PROJECT_ID, status }),
+        body: JSON.stringify({ branchName, projectName: PROJECT_NAME, status }),
       });
     } catch {
       /* 네트워크 에러 무시 */
@@ -159,7 +159,7 @@ function hasKanvibePlugin(pluginContent: string): boolean {
  */
 export async function setupOpenCodeHooks(
   repoPath: string,
-  projectId: string,
+  projectName: string,
   kanvibeUrl: string
 ): Promise<void> {
   const openCodeDir = path.join(repoPath, ".opencode");
@@ -168,7 +168,7 @@ export async function setupOpenCodeHooks(
   await mkdir(pluginsDir, { recursive: true });
 
   const pluginPath = path.join(pluginsDir, PLUGIN_FILE_NAME);
-  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, projectId), "utf-8");
+  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, projectName), "utf-8");
 
   try {
     await addAiToolPatternsToGitExclude(repoPath);


### PR DESCRIPTION
## Summary
- hardcode the Electron hook bridge to `http://localhost:9736` so locally installed AI CLIs can always reach the desktop app
- switch generated Claude, Gemini, Codex, and OpenCode hook payloads from branch and project lookups to direct `taskId` status updates
- update the desktop hook service, notifications, and regression tests to follow the task-based contract consistently

## Testing
- `NODE_PATH="/home/rookedsysc/Documents/kanvibe/kanvibe/node_modules" node "/home/rookedsysc/Documents/kanvibe/kanvibe/node_modules/vitest/vitest.mjs" run src/desktop/main/services/__tests__/hookService.test.ts src/lib/__tests__/boardNotifier.test.ts src/lib/__tests__/codexHooksSetup.test.ts src/lib/__tests__/geminiHooksSetup.test.ts src/lib/__tests__/openCodeHooksSetup.test.ts`

## Notes
- `src/hooks/__tests__/useTaskNotification.test.ts` was updated but not executed in this worktree because `@testing-library/react` is not installed here.