### PR TITLE
Improve remote SSH discovery and execution reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Review code changes directly in the browser with a GitHub-style diff viewer. Cli
 | Database | SQLite + TypeORM + better-sqlite3 |
 | Styling | Tailwind CSS v4 |
 | Terminal | xterm.js + WebSocket + node-pty |
-| SSH | ssh2 (Node.js) |
+| SSH | system ssh binary |
 | Drag & Drop | @hello-pangea/dnd |
 | i18n | next-intl |
 | Desktop Packaging | Electron + Electron Builder |

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -269,7 +269,7 @@ AI 에이전트 Hooks를 통한 태스크 상태 변경이 **브라우저 알림
 | Database | SQLite + TypeORM + better-sqlite3 |
 | Styling | Tailwind CSS v4 |
 | Terminal | xterm.js + WebSocket + node-pty |
-| SSH | ssh2 (Node.js) |
+| SSH | system ssh binary |
 | Drag & Drop | @hello-pangea/dnd |
 | i18n | next-intl |
 | Desktop Packaging | Electron + Electron Builder |

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -269,7 +269,7 @@ AI 代理 Hooks 触发的任务状态变更会发送**浏览器通知**，显示
 | 数据库 | SQLite + TypeORM + better-sqlite3 |
 | 样式 | Tailwind CSS v4 |
 | 终端 | xterm.js + WebSocket + node-pty |
-| SSH | ssh2 (Node.js) |
+| SSH | system ssh binary |
 | 拖放 | @hello-pangea/dnd |
 | 国际化 | next-intl |
 | 桌面打包 | Electron + Electron Builder |

--- a/electron/hookServer.js
+++ b/electron/hookServer.js
@@ -31,10 +31,24 @@ function writeJson(response, statusCode, payload) {
   response.end(JSON.stringify(payload));
 }
 
+function isAuthorized(request) {
+  const expectedToken = process.env.KANVIBE_HOOK_TOKEN;
+  if (!expectedToken) {
+    return true;
+  }
+
+  return request.headers["x-kanvibe-token"] === expectedToken;
+}
+
 function createHookServer({ host, port }) {
   const hookService = require(getHookServiceModulePath());
 
   const server = http.createServer(async (request, response) => {
+    if ((request.url === "/api/hooks/start" || request.url === "/api/hooks/status") && !isAuthorized(request)) {
+      writeJson(response, 401, { success: false, error: "Unauthorized" });
+      return;
+    }
+
     if (request.method === "POST" && request.url === "/api/hooks/start") {
       try {
         const result = await hookService.startHookTask(await readJsonBody(request));

--- a/electron/main.js
+++ b/electron/main.js
@@ -3,12 +3,13 @@ const http = require("node:http");
 const Module = require("node:module");
 const path = require("node:path");
 const process = require("node:process");
+const crypto = require("node:crypto");
 const { pathToFileURL } = require("node:url");
 const { app, BrowserWindow, ipcMain, Notification, session, shell } = require("electron");
 
 const DEFAULT_LOCALE = "ko";
 const RENDERER_DEV_URL = process.env.KANVIBE_RENDERER_URL || null;
-const HOOK_SERVER_HOST = "localhost";
+const HOOK_SERVER_HOST = "0.0.0.0";
 const HOOK_SERVER_PORT = 9736;
 const SHOULD_USE_SOURCE_MODULES = Boolean(RENDERER_DEV_URL);
 const originalResolveFilename = Module._resolveFilename;
@@ -70,6 +71,7 @@ function ensureRuntimeEnvironment() {
   process.chdir(appRoot);
   process.env.KANVIBE_DESKTOP = "true";
   process.env.KANVIBE_HOST = HOOK_SERVER_HOST;
+  process.env.KANVIBE_HOOK_TOKEN = process.env.KANVIBE_HOOK_TOKEN || crypto.randomUUID();
   process.env.PORT = String(HOOK_SERVER_PORT);
   process.env.KANVIBE_APP_DATA_DIR = app.getPath("userData");
   process.env.KANVIBE_SEED_DB_PATH = app.isPackaged

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "react-dom": "19.2.3",
         "react-router-dom": "^7.9.4",
         "reflect-metadata": "^0.2.2",
-        "ssh2": "^1.17.0",
         "tsx": "^4.21.0",
         "typeorm": "^0.3.28",
         "uuid": "^13.0.0",
@@ -39,7 +38,6 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "@types/ssh2": "^1.15.5",
         "@types/uuid": "^10.0.0",
         "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^5.1.4",
@@ -3679,6 +3677,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -3959,27 +4017,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/ssh2": {
-      "version": "1.15.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^18.11.18"
-      }
-    },
-    "node_modules/@types/ssh2/node_modules/@types/node": {
-      "version": "18.19.130",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/ssh2/node_modules/undici-types": {
-      "version": "5.26.5",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -5058,13 +5095,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "dev": true,
@@ -5186,13 +5216,6 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/better-sqlite3": {
@@ -5321,13 +5344,6 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/buildcheck": {
-      "version": "0.0.7",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/builder-util": {
       "version": "26.8.1",
@@ -5687,18 +5703,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/cpu-features": {
-      "version": "0.0.10",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "buildcheck": "~0.0.6",
-        "nan": "^2.19.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/crc": {
       "version": "3.8.0",
@@ -9071,11 +9075,6 @@
       "version": "2.1.3",
       "license": "MIT"
     },
-    "node_modules/nan": {
-      "version": "2.25.0",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "funding": [
@@ -10416,6 +10415,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
@@ -10825,21 +10825,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/ssh2": {
-      "version": "1.17.0",
-      "hasInstallScript": true,
-      "dependencies": {
-        "asn1": "^0.2.6",
-        "bcrypt-pbkdf": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      },
-      "optionalDependencies": {
-        "cpu-features": "~0.0.10",
-        "nan": "^2.23.0"
       }
     },
     "node_modules/ssri": {
@@ -11426,10 +11411,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
       "esbuild",
       "node-pty",
       "sharp",
-      "ssh2",
       "unrs-resolver",
       "better-sqlite3"
     ]
@@ -60,7 +59,6 @@
     "react-dom": "19.2.3",
     "react-router-dom": "^7.9.4",
     "reflect-metadata": "^0.2.2",
-    "ssh2": "^1.17.0",
     "tsx": "^4.21.0",
     "typeorm": "^0.3.28",
     "uuid": "^13.0.0",
@@ -75,7 +73,6 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@types/ssh2": "^1.15.5",
     "@types/uuid": "^10.0.0",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
-      ssh2:
-        specifier: ^1.17.0
-        version: 1.17.0
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -93,9 +90,6 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
-      '@types/ssh2':
-        specifier: ^1.15.5
-        version: 1.15.5
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
@@ -1464,9 +1458,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
   '@types/node@20.19.33':
     resolution: {integrity: sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==}
 
@@ -1486,9 +1477,6 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
-
-  '@types/ssh2@1.15.5':
-    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1824,9 +1812,6 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
-  asn1@0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
@@ -1886,9 +1871,6 @@ packages:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
 
-  bcrypt-pbkdf@1.0.2:
-    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
-
   better-sqlite3@12.6.2:
     resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
@@ -1936,10 +1918,6 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-
-  buildcheck@0.0.7:
-    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
-    engines: {node: '>=10.0.0'}
 
   builder-util-runtime@9.5.1:
     resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
@@ -2066,10 +2044,6 @@ packages:
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
-
-  cpu-features@0.0.10:
-    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
-    engines: {node: '>=10.0.0'}
 
   crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
@@ -3223,9 +3197,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nan@2.25.0:
-    resolution: {integrity: sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==}
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3871,10 +3842,6 @@ packages:
     resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
     engines: {node: '>=14'}
 
-  ssh2@1.17.0:
-    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
-    engines: {node: '>=10.16.0'}
-
   ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -4080,9 +4047,6 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  tweetnacl@0.14.5:
-    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
-
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -4177,9 +4141,6 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
-
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -5588,10 +5549,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@20.19.33':
     dependencies:
       undici-types: 6.21.0
@@ -5617,10 +5574,6 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 20.19.33
-
-  '@types/ssh2@1.15.5':
-    dependencies:
-      '@types/node': 18.19.130
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -6007,10 +5960,6 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
-  asn1@0.2.6:
-    dependencies:
-      safer-buffer: 2.1.2
-
   assert-plus@1.0.0:
     optional: true
 
@@ -6046,10 +5995,6 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.19: {}
-
-  bcrypt-pbkdf@1.0.2:
-    dependencies:
-      tweetnacl: 0.14.5
 
   better-sqlite3@12.6.2:
     dependencies:
@@ -6111,9 +6056,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-
-  buildcheck@0.0.7:
-    optional: true
 
   builder-util-runtime@9.5.1:
     dependencies:
@@ -6258,12 +6200,6 @@ snapshots:
   cookie@1.1.1: {}
 
   core-util-is@1.0.2:
-    optional: true
-
-  cpu-features@0.0.10:
-    dependencies:
-      buildcheck: 0.0.7
-      nan: 2.25.0
     optional: true
 
   crc@3.8.0:
@@ -7657,9 +7593,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nan@2.25.0:
-    optional: true
-
   nanoid@3.3.11: {}
 
   napi-build-utils@2.0.0: {}
@@ -8406,14 +8339,6 @@ snapshots:
 
   sql-highlight@6.1.0: {}
 
-  ssh2@1.17.0:
-    dependencies:
-      asn1: 0.2.6
-      bcrypt-pbkdf: 1.0.2
-    optionalDependencies:
-      cpu-features: 0.0.10
-      nan: 2.25.0
-
   ssri@12.0.0:
     dependencies:
       minipass: 7.1.2
@@ -8646,8 +8571,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  tweetnacl@0.14.5: {}
-
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -8731,8 +8654,6 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
-
-  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 

--- a/src/components/FolderSearchInput.tsx
+++ b/src/components/FolderSearchInput.tsx
@@ -161,7 +161,7 @@ export default function FolderSearchInput({
         autoComplete="off"
       />
       {/* form 전송을 위한 hidden input */}
-      <input type="hidden" name={name} value={selectedPath} />
+      <input type="hidden" name={name} value={selectedPath || inputValue} />
 
       {isOpen && (
         <div className="absolute z-50 left-0 right-0 mt-1 bg-bg-surface border border-border-default rounded-md shadow-lg max-h-60 overflow-y-auto">

--- a/src/components/__tests__/FolderSearchInput.test.tsx
+++ b/src/components/__tests__/FolderSearchInput.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import FolderSearchInput from "../FolderSearchInput";
+
+const mockListSubdirectories = vi.fn();
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    if (key === "folderCount") {
+      return `count:${values?.count}`;
+    }
+
+    return key;
+  },
+}));
+
+vi.mock("@/desktop/renderer/actions/project", () => ({
+  listSubdirectories: (...args: unknown[]) => mockListSubdirectories(...args),
+}));
+
+vi.mock("@/components/HighlightedText", () => ({
+  default: ({ text }: { text: string }) => <span>{text}</span>,
+}));
+
+describe("FolderSearchInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListSubdirectories.mockResolvedValue(["api", "web"]);
+  });
+
+  it("직접 입력한 원격 경로를 hidden input으로 제출한다", async () => {
+    // Given
+    render(<FolderSearchInput name="scanPath" sshHost="remote-host" onSelect={vi.fn()} />);
+
+    // When
+    const textbox = screen.getByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "~/workspace" } });
+
+    // Then
+    await waitFor(() => {
+      expect(mockListSubdirectories).toHaveBeenCalledWith("~", "remote-host");
+    });
+
+    const hiddenInput = document.querySelector('input[type="hidden"][name="scanPath"]') as HTMLInputElement;
+    expect(hiddenInput.value).toBe("~/workspace");
+  });
+
+  it("목록에서 선택한 경로가 있으면 선택 경로를 우선 제출한다", async () => {
+    // Given
+    const onSelect = vi.fn();
+    render(<FolderSearchInput name="scanPath" sshHost="remote-host" onSelect={onSelect} />);
+
+    // When
+    const textbox = screen.getByRole("textbox");
+    fireEvent.focus(textbox);
+
+    const option = await screen.findByRole("button", { name: "api" });
+    fireEvent.click(option);
+
+    // Then
+    const hiddenInput = document.querySelector('input[type="hidden"][name="scanPath"]') as HTMLInputElement;
+    expect(hiddenInput.value).toBe("~/api");
+    expect(onSelect).toHaveBeenCalledWith("~/api");
+  });
+});

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -140,4 +140,20 @@ describe("projectService.listSubdirectories", () => {
     );
     expect(result).toEqual(["projects"]);
   });
+
+  it("원격 틸드 경로는 원격 HOME 기준으로 스캔한다", async () => {
+    // Given
+    mocks.execGit.mockResolvedValue("/home/remote/projects\n");
+    const { listSubdirectories } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const result = await listSubdirectories("~/projects", "remote-host");
+
+    // Then
+    expect(mocks.execGit).toHaveBeenCalledWith(
+      'find "$HOME/projects" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort',
+      "remote-host",
+    );
+    expect(result).toEqual(["projects"]);
+  });
 });

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -3,11 +3,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   execGit: vi.fn(),
   homedir: vi.fn(() => "/home/tester"),
+  validateGitRepo: vi.fn(),
+  getDefaultBranch: vi.fn(),
+  scanGitRepos: vi.fn(),
+  getProjectRepository: vi.fn(),
+  getTaskRepository: vi.fn(),
+  createSessionWithoutWorktree: vi.fn(),
+  computeProjectColor: vi.fn(() => "blue"),
+  getDefaultSessionType: vi.fn(),
 }));
 
 vi.mock("@/lib/database", () => ({
-  getProjectRepository: vi.fn(),
-  getTaskRepository: vi.fn(),
+  getProjectRepository: mocks.getProjectRepository,
+  getTaskRepository: mocks.getTaskRepository,
 }));
 
 vi.mock("@/entities/Project", () => ({
@@ -33,10 +41,10 @@ vi.mock("typeorm", () => ({
 }));
 
 vi.mock("@/lib/gitOperations", () => ({
-  validateGitRepo: vi.fn(),
-  getDefaultBranch: vi.fn(),
+  validateGitRepo: mocks.validateGitRepo,
+  getDefaultBranch: mocks.getDefaultBranch,
   listBranches: vi.fn(),
-  scanGitRepos: vi.fn(),
+  scanGitRepos: mocks.scanGitRepos,
   listWorktrees: vi.fn(),
   execGit: mocks.execGit,
 }));
@@ -44,7 +52,7 @@ vi.mock("@/lib/gitOperations", () => ({
 vi.mock("@/lib/worktree", () => ({
   isSessionAlive: vi.fn(),
   formatSessionName: vi.fn(),
-  createSessionWithoutWorktree: vi.fn(),
+  createSessionWithoutWorktree: mocks.createSessionWithoutWorktree,
 }));
 
 vi.mock("@/lib/claudeHooksSetup", () => ({
@@ -80,7 +88,7 @@ vi.mock("os", () => ({
 }));
 
 vi.mock("@/lib/projectColor", () => ({
-  computeProjectColor: vi.fn(),
+  computeProjectColor: mocks.computeProjectColor,
 }));
 
 vi.mock("@/lib/boardNotifier", () => ({
@@ -92,7 +100,7 @@ vi.mock("@/lib/sshConfig", () => ({
 }));
 
 vi.mock("@/desktop/main/services/appSettingsService", () => ({
-  getDefaultSessionType: vi.fn(),
+  getDefaultSessionType: mocks.getDefaultSessionType,
 }));
 
 vi.mock("@/lib/remoteSessionDependency", () => ({
@@ -107,6 +115,7 @@ describe("projectService.listSubdirectories", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    mocks.getDefaultSessionType.mockResolvedValue("tmux");
   });
 
   it("원격 호스트에서도 세션 도구 검증 없이 디렉토리를 스캔한다", async () => {
@@ -155,5 +164,64 @@ describe("projectService.listSubdirectories", () => {
       "remote-host",
     );
     expect(result).toEqual(["projects"]);
+  });
+});
+
+describe("projectService remote registration flow", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.getDefaultSessionType.mockResolvedValue("tmux");
+  });
+
+  it("원격 스캔은 세션 의존성 검증 없이 git 저장소 검색을 진행한다", async () => {
+    mocks.scanGitRepos.mockResolvedValue(["/workspace/api"]);
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([]),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => ({ id: "project-1", ...value })),
+    });
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn().mockResolvedValue(null),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => value),
+    });
+    mocks.getDefaultBranch.mockResolvedValue("main");
+    mocks.createSessionWithoutWorktree.mockResolvedValue({ sessionName: "api-main" });
+
+    const { scanAndRegisterProjects } = await import("@/desktop/main/services/projectService");
+    const { ensureRemoteSessionDependency } = await import("@/lib/remoteSessionDependency");
+
+    const result = await scanAndRegisterProjects("~/workspace", "remote-host");
+
+    expect(mocks.scanGitRepos).toHaveBeenCalledWith("~/workspace", "remote-host");
+    expect(ensureRemoteSessionDependency).not.toHaveBeenCalled();
+    expect(result.registered).toEqual(["api"]);
+  });
+
+  it("원격 세션 생성이 실패해도 프로젝트 등록은 유지한다", async () => {
+    mocks.validateGitRepo.mockResolvedValue(true);
+    mocks.getDefaultBranch.mockResolvedValue("main");
+    mocks.createSessionWithoutWorktree.mockRejectedValue(new Error("tmux missing"));
+
+    const remove = vi.fn();
+    mocks.getProjectRepository.mockResolvedValue({
+      findOneBy: vi.fn().mockResolvedValue(null),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => ({ id: "project-1", ...value })),
+      remove,
+    });
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn().mockResolvedValue(null),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => ({ id: "task-1", ...value })),
+    });
+
+    const { registerProject } = await import("@/desktop/main/services/projectService");
+    const result = await registerProject("api", "/workspace/api", "remote-host");
+
+    expect(result.success).toBe(true);
+    expect(remove).not.toHaveBeenCalled();
+    expect(result.project).toMatchObject({ name: "api", sshHost: "remote-host" });
   });
 });

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execGit: vi.fn(),
+  homedir: vi.fn(() => "/home/tester"),
+}));
+
+vi.mock("@/lib/database", () => ({
+  getProjectRepository: vi.fn(),
+  getTaskRepository: vi.fn(),
+}));
+
+vi.mock("@/entities/Project", () => ({
+  Project: class Project {},
+}));
+
+vi.mock("@/entities/KanbanTask", () => ({
+  TaskStatus: {
+    TODO: "todo",
+    PROGRESS: "progress",
+    PENDING: "pending",
+    REVIEW: "review",
+    DONE: "done",
+  },
+  SessionType: {
+    TMUX: "tmux",
+    ZELLIJ: "zellij",
+  },
+}));
+
+vi.mock("typeorm", () => ({
+  IsNull: vi.fn(),
+}));
+
+vi.mock("@/lib/gitOperations", () => ({
+  validateGitRepo: vi.fn(),
+  getDefaultBranch: vi.fn(),
+  listBranches: vi.fn(),
+  scanGitRepos: vi.fn(),
+  listWorktrees: vi.fn(),
+  execGit: mocks.execGit,
+}));
+
+vi.mock("@/lib/worktree", () => ({
+  isSessionAlive: vi.fn(),
+  formatSessionName: vi.fn(),
+  createSessionWithoutWorktree: vi.fn(),
+}));
+
+vi.mock("@/lib/claudeHooksSetup", () => ({
+  setupClaudeHooks: vi.fn(),
+  getClaudeHooksStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/geminiHooksSetup", () => ({
+  setupGeminiHooks: vi.fn(),
+  getGeminiHooksStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/codexHooksSetup", () => ({
+  setupCodexHooks: vi.fn(),
+  getCodexHooksStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/openCodeHooksSetup", () => ({
+  setupOpenCodeHooks: vi.fn(),
+  getOpenCodeHooksStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/aiSessions/aggregateAiSessions", () => ({
+  aggregateAiSessions: vi.fn(),
+  getAiSessionDetail: vi.fn(),
+}));
+
+vi.mock("os", () => ({
+  default: {
+    homedir: mocks.homedir,
+  },
+  homedir: mocks.homedir,
+}));
+
+vi.mock("@/lib/projectColor", () => ({
+  computeProjectColor: vi.fn(),
+}));
+
+vi.mock("@/lib/boardNotifier", () => ({
+  broadcastBoardUpdate: vi.fn(),
+}));
+
+vi.mock("@/lib/sshConfig", () => ({
+  getAvailableHosts: vi.fn(),
+}));
+
+vi.mock("@/desktop/main/services/appSettingsService", () => ({
+  getDefaultSessionType: vi.fn(),
+}));
+
+vi.mock("@/lib/remoteSessionDependency", () => ({
+  ensureRemoteSessionDependency: vi.fn(),
+}));
+
+vi.mock("@/lib/kanvibeHooksInstaller", () => ({
+  installKanvibeHooks: vi.fn(),
+}));
+
+describe("projectService.listSubdirectories", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("원격 호스트에서도 세션 도구 검증 없이 디렉토리를 스캔한다", async () => {
+    // Given
+    mocks.execGit.mockResolvedValue("/workspace/api\n/workspace/web\n/workspace/.hidden\n");
+    const { listSubdirectories } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const result = await listSubdirectories("/workspace", "remote-host");
+
+    // Then
+    expect(mocks.execGit).toHaveBeenCalledWith(
+      'find "/workspace" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort',
+      "remote-host",
+    );
+    expect(result).toEqual(["api", "web"]);
+  });
+
+  it("틸드 경로는 홈 디렉토리로 치환해서 스캔한다", async () => {
+    // Given
+    mocks.execGit.mockResolvedValue("/home/tester/projects\n");
+    const { listSubdirectories } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const result = await listSubdirectories("~/", undefined);
+
+    // Then
+    expect(mocks.execGit).toHaveBeenCalledWith(
+      'find "/home/tester/" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort',
+      null,
+    );
+    expect(result).toEqual(["projects"]);
+  });
+});

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -6,11 +6,8 @@ import { KanbanTask, TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
 import { createWorktreeWithSession, removeWorktreeAndBranch, createSessionWithoutWorktree, removeSessionOnly } from "@/lib/worktree";
 import { getProjectRepository } from "@/lib/database";
-import { setupClaudeHooks } from "@/lib/claudeHooksSetup";
-import { setupGeminiHooks } from "@/lib/geminiHooksSetup";
-import { setupCodexHooks } from "@/lib/codexHooksSetup";
-import { setupOpenCodeHooks } from "@/lib/openCodeHooksSetup";
 import { broadcastBoardUpdate } from "@/lib/boardNotifier";
+import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
 
 const execAsync = promisify(exec);
 
@@ -150,10 +147,13 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
         task.sessionName = session.sessionName;
         task.sshHost = project.sshHost;
         hookTargetPath = session.worktreePath;
-        shouldInstallHooks = !project.sshHost && Boolean(session.worktreePath);
+        shouldInstallHooks = Boolean(session.worktreePath);
       }
     } catch (error) {
       console.error("Worktree/세션 생성 실패:", error);
+      if (input.sshHost || input.projectId) {
+        throw error;
+      }
     }
   }
 
@@ -167,13 +167,7 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
   const saved = await repo.save(task);
 
   if (shouldInstallHooks && hookTargetPath) {
-    const kanvibeUrl = "http://localhost:9736";
-    await Promise.allSettled([
-      setupClaudeHooks(hookTargetPath, saved.id, kanvibeUrl),
-      setupGeminiHooks(hookTargetPath, saved.id, kanvibeUrl),
-      setupCodexHooks(hookTargetPath, saved.id, kanvibeUrl),
-      setupOpenCodeHooks(hookTargetPath, saved.id, kanvibeUrl),
-    ]);
+    await installKanvibeHooks(hookTargetPath, saved.id, task.sshHost);
   }
 
   broadcastBoardUpdate();
@@ -194,7 +188,6 @@ export async function updateTaskStatus(
     task.sessionType = null;
     task.sessionName = null;
     task.worktreePath = null;
-    task.sshHost = null;
   }
 
   task.status = newStatus;
@@ -258,6 +251,7 @@ export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
   }
 
   const isProjectRoot = project && task.worktreePath === project.repoPath;
+  const sshHost = task.sshHost || project?.sshHost || null;
 
   /** 브랜치별 독립 세션 정리 */
   if (task.sessionType && task.sessionName) {
@@ -265,7 +259,7 @@ export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
       await removeSessionOnly(
         task.sessionType,
         task.sessionName,
-        task.sshHost
+        sshHost
       );
     } catch (error) {
       console.error("세션 정리 실패:", error);
@@ -278,7 +272,7 @@ export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
       await removeWorktreeAndBranch(
         project?.repoPath || process.cwd(),
         task.branchName,
-        task.sshHost
+        sshHost
       );
     } catch (error) {
       console.error("worktree/브랜치 정리 실패:", error);
@@ -338,15 +332,9 @@ export async function branchFromTask(
 
   const saved = await repo.save(task);
 
-  if (!project.sshHost && session.worktreePath) {
+  if (session.worktreePath) {
     try {
-      const kanvibeUrl = "http://localhost:9736";
-      await Promise.allSettled([
-        setupClaudeHooks(session.worktreePath, saved.id, kanvibeUrl),
-        setupGeminiHooks(session.worktreePath, saved.id, kanvibeUrl),
-        setupCodexHooks(session.worktreePath, saved.id, kanvibeUrl),
-        setupOpenCodeHooks(session.worktreePath, saved.id, kanvibeUrl),
-      ]);
+      await installKanvibeHooks(session.worktreePath, saved.id, project.sshHost);
     } catch (error) {
       console.error("Hooks 설정 실패:", error);
     }
@@ -426,14 +414,13 @@ export async function moveTaskToColumn(
   if (newStatus === TaskStatus.DONE) {
     const task = await repo.findOneBy({ id: taskId });
     if (task) {
-      await cleanupTaskResources(task);
-      await repo.update(taskId, {
-        status: newStatus,
-        sessionType: null,
-        sessionName: null,
-        worktreePath: null,
-        sshHost: null,
-      });
+        await cleanupTaskResources(task);
+        await repo.update(taskId, {
+          status: newStatus,
+          sessionType: null,
+          sessionName: null,
+          worktreePath: null,
+        });
     }
   } else {
     await repo.update(taskId, { status: newStatus });

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -16,7 +16,6 @@ import { computeProjectColor } from "@/lib/projectColor";
 import { broadcastBoardUpdate } from "@/lib/boardNotifier";
 import { getAvailableHosts as readAvailableHosts } from "@/lib/sshConfig";
 import { getDefaultSessionType } from "@/desktop/main/services/appSettingsService";
-import { ensureRemoteSessionDependency } from "@/lib/remoteSessionDependency";
 import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
 
 function resolveDirectorySearchPath(targetPath: string, sshHost?: string): string {
@@ -60,8 +59,6 @@ async function createDefaultBranchTask(project: Project) {
     baseBranch: project.defaultBranch,
   });
 
-  let installError: Error | null = null;
-
   try {
     const session = await createSessionWithoutWorktree(
       project.repoPath,
@@ -72,12 +69,11 @@ async function createDefaultBranchTask(project: Project) {
     );
     task.sessionType = defaultSessionType;
     task.sessionName = session.sessionName;
-    task.worktreePath = project.repoPath;
-    task.sshHost = project.sshHost;
-    task.status = TaskStatus.PROGRESS;
+     task.worktreePath = project.repoPath;
+     task.sshHost = project.sshHost;
+     task.status = TaskStatus.PROGRESS;
   } catch (error) {
     console.error("메인 브랜치 tmux 세션 생성 실패:", error);
-    installError = error instanceof Error ? error : new Error("기본 세션 생성 실패");
   }
 
   const savedTask = await taskRepo.save(task);
@@ -87,14 +83,7 @@ async function createDefaultBranchTask(project: Project) {
       await installKanvibeHooks(task.worktreePath, savedTask.id, project.sshHost);
     } catch (error) {
       console.error("기본 브랜치 hooks 설정 실패:", error);
-      if (!installError && error instanceof Error) {
-        installError = error;
-      }
     }
-  }
-
-  if (installError) {
-    throw installError;
   }
 
   return savedTask;
@@ -134,17 +123,6 @@ export async function registerProject(
 ): Promise<{ success: boolean; error?: string; project?: Project }> {
   if (!name || !repoPath) {
     return { success: false, error: "이름과 경로는 필수입니다." };
-  }
-
-  if (sshHost) {
-    try {
-      await ensureDefaultRemoteSessionDependency(sshHost);
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : "원격 호스트 검증 실패",
-      };
-    }
   }
 
   const isValid = await validateGitRepo(repoPath, sshHost || null);
@@ -212,15 +190,6 @@ export async function scanAndRegisterProjects(
   sshHost?: string
 ): Promise<ScanResult> {
   const result: ScanResult = { registered: [], skipped: [], errors: [], worktreeTasks: [], hooksSetup: [] };
-
-  if (sshHost) {
-    try {
-      await ensureDefaultRemoteSessionDependency(sshHost);
-    } catch (error) {
-      result.errors.push(error instanceof Error ? error.message : "원격 호스트 검증 실패");
-      return result;
-    }
-  }
 
   const repoPaths = await scanGitRepos(rootPath, sshHost || null);
   if (repoPaths.length === 0) {
@@ -436,11 +405,6 @@ export async function listSubdirectories(
     });
     return [];
   }
-}
-
-async function ensureDefaultRemoteSessionDependency(sshHost: string): Promise<void> {
-  const defaultSessionType = await getDefaultSessionType();
-  await ensureRemoteSessionDependency(defaultSessionType, sshHost);
 }
 
 /** 프로젝트의 브랜치 목록을 반환한다 */

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -19,6 +19,19 @@ import { getDefaultSessionType } from "@/desktop/main/services/appSettingsServic
 import { ensureRemoteSessionDependency } from "@/lib/remoteSessionDependency";
 import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
 
+function resolveDirectorySearchPath(targetPath: string, sshHost?: string): string {
+  if (!targetPath.startsWith("~")) {
+    return `"${targetPath}"`;
+  }
+
+  if (sshHost) {
+    const suffix = targetPath.slice(1);
+    return `"$HOME${suffix}"`;
+  }
+
+  return `"${targetPath.replace(/^~/, homedir())}"`;
+}
+
 /** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
 function serialize<T>(data: T): T {
   return JSON.parse(JSON.stringify(data));
@@ -400,13 +413,11 @@ export async function listSubdirectories(
   parentPath: string,
   sshHost?: string
 ): Promise<string[]> {
-  const resolvedPath = parentPath.startsWith("~")
-    ? parentPath.replace(/^~/, homedir())
-    : parentPath;
+  const resolvedPath = resolveDirectorySearchPath(parentPath, sshHost);
 
   try {
     const output = await execGit(
-      `find "${resolvedPath}" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort`,
+      `find ${resolvedPath} -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort`,
       sshHost || null
     );
 

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -414,12 +414,10 @@ export async function listSubdirectories(
   sshHost?: string
 ): Promise<string[]> {
   const resolvedPath = resolveDirectorySearchPath(parentPath, sshHost);
+  const command = `find ${resolvedPath} -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort`;
 
   try {
-    const output = await execGit(
-      `find ${resolvedPath} -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort`,
-      sshHost || null
-    );
+    const output = await execGit(command, sshHost || null);
 
     if (!output) return [];
 
@@ -428,7 +426,14 @@ export async function listSubdirectories(
       .filter(Boolean)
       .map((dir) => path.basename(dir))
       .filter((name) => !name.startsWith("."));
-  } catch {
+  } catch (error) {
+    console.error("[remote-scan] subdirectory scan failed", {
+      sshHost: sshHost || null,
+      parentPath,
+      resolvedPath,
+      command,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return [];
   }
 }

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -405,10 +405,6 @@ export async function listSubdirectories(
     : parentPath;
 
   try {
-    if (sshHost) {
-      await ensureDefaultRemoteSessionDependency(sshHost);
-    }
-
     const output = await execGit(
       `find "${resolvedPath}" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort`,
       sshHost || null

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -15,6 +15,9 @@ import path from "path";
 import { computeProjectColor } from "@/lib/projectColor";
 import { broadcastBoardUpdate } from "@/lib/boardNotifier";
 import { getAvailableHosts as readAvailableHosts } from "@/lib/sshConfig";
+import { getDefaultSessionType } from "@/desktop/main/services/appSettingsService";
+import { ensureRemoteSessionDependency } from "@/lib/remoteSessionDependency";
+import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
 
 /** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
 function serialize<T>(data: T): T {
@@ -24,6 +27,7 @@ function serialize<T>(data: T): T {
 /** 프로젝트의 메인 브랜치 태스크를 생성하고 tmux 세션을 자동 연결한다 */
 async function createDefaultBranchTask(project: Project) {
   const taskRepo = await getTaskRepository();
+  const defaultSessionType = await getDefaultSessionType();
 
   const existing = await taskRepo.findOneBy({ branchName: project.defaultBranch, projectId: project.id });
   if (existing) return existing;
@@ -43,24 +47,44 @@ async function createDefaultBranchTask(project: Project) {
     baseBranch: project.defaultBranch,
   });
 
+  let installError: Error | null = null;
+
   try {
     const session = await createSessionWithoutWorktree(
       project.repoPath,
       project.defaultBranch,
-      SessionType.TMUX,
+      defaultSessionType,
       project.sshHost,
       project.repoPath,
     );
-    task.sessionType = SessionType.TMUX;
+    task.sessionType = defaultSessionType;
     task.sessionName = session.sessionName;
     task.worktreePath = project.repoPath;
     task.sshHost = project.sshHost;
     task.status = TaskStatus.PROGRESS;
   } catch (error) {
     console.error("메인 브랜치 tmux 세션 생성 실패:", error);
+    installError = error instanceof Error ? error : new Error("기본 세션 생성 실패");
   }
 
-  return taskRepo.save(task);
+  const savedTask = await taskRepo.save(task);
+
+  if (task.worktreePath) {
+    try {
+      await installKanvibeHooks(task.worktreePath, savedTask.id, project.sshHost);
+    } catch (error) {
+      console.error("기본 브랜치 hooks 설정 실패:", error);
+      if (!installError && error instanceof Error) {
+        installError = error;
+      }
+    }
+  }
+
+  if (installError) {
+    throw installError;
+  }
+
+  return savedTask;
 }
 
 async function getProjectRootTask(projectId: string, defaultBranch: string) {
@@ -99,6 +123,17 @@ export async function registerProject(
     return { success: false, error: "이름과 경로는 필수입니다." };
   }
 
+  if (sshHost) {
+    try {
+      await ensureDefaultRemoteSessionDependency(sshHost);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "원격 호스트 검증 실패",
+      };
+    }
+  }
+
   const isValid = await validateGitRepo(repoPath, sshHost || null);
   if (!isValid) {
     return { success: false, error: "유효한 git 저장소가 아닙니다." };
@@ -122,7 +157,16 @@ export async function registerProject(
   });
 
   const saved = await repo.save(project);
-          const defaultTask = await createDefaultBranchTask(saved);
+  try {
+    await createDefaultBranchTask(saved);
+  } catch (error) {
+    await repo.remove(saved);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "기본 태스크 생성 실패",
+    };
+  }
+
   broadcastBoardUpdate();
   return { success: true, project: serialize(saved) };
 }
@@ -155,6 +199,15 @@ export async function scanAndRegisterProjects(
   sshHost?: string
 ): Promise<ScanResult> {
   const result: ScanResult = { registered: [], skipped: [], errors: [], worktreeTasks: [], hooksSetup: [] };
+
+  if (sshHost) {
+    try {
+      await ensureDefaultRemoteSessionDependency(sshHost);
+    } catch (error) {
+      result.errors.push(error instanceof Error ? error.message : "원격 호스트 검증 실패");
+      return result;
+    }
+  }
 
   const repoPaths = await scanGitRepos(rootPath, sshHost || null);
   if (repoPaths.length === 0) {
@@ -221,17 +274,20 @@ export async function scanAndRegisterProjects(
       try {
         defaultTask = await createDefaultBranchTask(saved);
       } catch (taskError) {
+        await repo.remove(saved);
+        existingPaths.delete(pathKey);
+        result.registered = result.registered.filter((name) => name !== projectName);
         console.error(`${projectName} 기본 브랜치 태스크 생성 실패:`, taskError);
+        result.errors.push(
+          `${projectName} 기본 브랜치 태스크 생성 실패: ${taskError instanceof Error ? taskError.message : "알 수 없는 오류"}`,
+        );
+        continue;
       }
 
-      /** 로컬 repo에 Claude Code / Gemini CLI / Codex CLI hooks를 자동 설정한다 */
-      if (!sshHost && defaultTask) {
+      /** 기본 브랜치 작업이 준비되면 hooks를 자동 설정한다 */
+      if (defaultTask) {
         try {
-          const kanvibeUrl = "http://localhost:9736";
-          await setupClaudeHooks(repoPath, defaultTask.id, kanvibeUrl);
-          await setupGeminiHooks(repoPath, defaultTask.id, kanvibeUrl);
-          await setupCodexHooks(repoPath, defaultTask.id, kanvibeUrl);
-          await setupOpenCodeHooks(repoPath, defaultTask.id, kanvibeUrl);
+          await installKanvibeHooks(repoPath, defaultTask.id, sshHost || null);
           result.hooksSetup.push(projectName);
         } catch (hookError) {
           result.errors.push(
@@ -349,6 +405,10 @@ export async function listSubdirectories(
     : parentPath;
 
   try {
+    if (sshHost) {
+      await ensureDefaultRemoteSessionDependency(sshHost);
+    }
+
     const output = await execGit(
       `find "${resolvedPath}" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort`,
       sshHost || null
@@ -364,6 +424,11 @@ export async function listSubdirectories(
   } catch {
     return [];
   }
+}
+
+async function ensureDefaultRemoteSessionDependency(sshHost: string): Promise<void> {
+  const defaultSessionType = await getDefaultSessionType();
+  await ensureRemoteSessionDependency(defaultSessionType, sshHost);
 }
 
 /** 프로젝트의 브랜치 목록을 반환한다 */

--- a/src/desktop/main/terminalBridge.ts
+++ b/src/desktop/main/terminalBridge.ts
@@ -4,6 +4,7 @@ import { getTaskRepository } from "@/lib/database";
 import { SessionType } from "@/entities/KanbanTask";
 import { attachLocalSession, attachRemoteSession, focusSession } from "@/lib/terminal";
 import { parseSSHConfig } from "@/lib/sshConfig";
+import { ensureRemoteSessionDependency } from "@/lib/remoteSessionDependency";
 
 const OPEN = 1;
 const CLOSED = 3;
@@ -95,6 +96,8 @@ export async function openTerminal(
 
   try {
     if (task.sshHost) {
+      await ensureRemoteSessionDependency(task.sessionType as SessionType, task.sshHost);
+
       const sshHosts = await parseSSHConfig();
       const sshConfig = sshHosts.find((host) => host.host === task.sshHost);
 

--- a/src/lib/__tests__/claudeHooksSetup.test.ts
+++ b/src/lib/__tests__/claudeHooksSetup.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { setupClaudeHooks, getClaudeHooksStatus } from "../claudeHooksSetup";
+
+describe("claudeHooksSetup", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "claude-hook-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("토큰이 있으면 모든 hook 스크립트에 인증 헤더를 포함한다", async () => {
+    // Given
+    const repoPath = tempDir;
+
+    // When
+    await setupClaudeHooks(repoPath, "task-1", "http://192.168.0.10:9736", "auth-token");
+
+    // Then
+    const promptScript = await readFile(join(repoPath, ".claude", "hooks", "kanvibe-prompt-hook.sh"), "utf-8");
+    const stopScript = await readFile(join(repoPath, ".claude", "hooks", "kanvibe-stop-hook.sh"), "utf-8");
+    const questionScript = await readFile(join(repoPath, ".claude", "hooks", "kanvibe-question-hook.sh"), "utf-8");
+
+    expect(promptScript).toContain('X-Kanvibe-Token: auth-token');
+    expect(stopScript).toContain('X-Kanvibe-Token: auth-token');
+    expect(questionScript).toContain('X-Kanvibe-Token: auth-token');
+
+    const status = await getClaudeHooksStatus(repoPath);
+    expect(status.installed).toBe(true);
+  });
+});

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -89,7 +89,7 @@ describe("gitOperations.resolvePathForShell", () => {
         "-o",
         "IdentitiesOnly=yes",
         "-T",
-        "tester@example.com",
+        "remote-host",
         "sh -lc 'pwd'",
       ],
       expect.objectContaining({ maxBuffer: 10 * 1024 * 1024 }),

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -2,6 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   homedir: vi.fn(() => "/home/local-user"),
+  exec: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({
+  default: {
+    exec: mocks.exec,
+    execFile: mocks.execFile,
+  },
+  exec: mocks.exec,
+  execFile: mocks.execFile,
 }));
 
 vi.mock("os", () => ({
@@ -37,5 +48,52 @@ describe("gitOperations.resolvePathForShell", () => {
 
     // Then
     expect(result).toBe('"$HOME/work"');
+  });
+
+  it("원격 명령 실행은 ssh 바이너리와 옵션을 사용한다", async () => {
+    // Given
+    mocks.execFile.mockImplementation((_file: string, _args: string[], _options: unknown, callback: (error: null, result: { stdout: string }) => void) => {
+      callback(null, { stdout: "ok\n" });
+    });
+
+    vi.doMock("@/lib/sshConfig", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/sshConfig")>();
+      return {
+        ...actual,
+        parseSSHConfig: vi.fn(async () => [{
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        }]),
+      };
+    });
+
+    const { execGit } = await import("@/lib/gitOperations");
+
+    // When
+    const result = await execGit("pwd", "remote-host");
+
+    // Then
+    expect(result).toBe("ok");
+    expect(mocks.execFile).toHaveBeenCalledWith(
+      "ssh",
+      [
+        "-i",
+        "/tmp/test-key",
+        "-p",
+        "2202",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "IdentitiesOnly=yes",
+        "-T",
+        "tester@example.com",
+        "sh -lc 'pwd'",
+      ],
+      expect.objectContaining({ maxBuffer: 10 * 1024 * 1024 }),
+      expect.any(Function),
+    );
   });
 });

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  homedir: vi.fn(() => "/home/local-user"),
+}));
+
+vi.mock("os", () => ({
+  default: {
+    homedir: mocks.homedir,
+  },
+  homedir: mocks.homedir,
+}));
+
+describe("gitOperations.resolvePathForShell", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("로컬 틸드 경로는 로컬 홈 디렉토리로 확장한다", async () => {
+    // Given
+    const { resolvePathForShell } = await import("@/lib/gitOperations");
+
+    // When
+    const result = resolvePathForShell("~/work");
+
+    // Then
+    expect(result).toBe('"/home/local-user/work"');
+  });
+
+  it("원격 틸드 경로는 원격 HOME 기준으로 검색한다", async () => {
+    // Given
+    const { resolvePathForShell } = await import("@/lib/gitOperations");
+
+    // When
+    const result = resolvePathForShell("~/work", "remote-host");
+
+    // Then
+    expect(result).toBe('"$HOME/work"');
+  });
+});

--- a/src/lib/__tests__/hookEndpoint.test.ts
+++ b/src/lib/__tests__/hookEndpoint.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockNetworkInterfaces = vi.fn();
+
+vi.mock("node:os", () => ({
+  default: {
+    networkInterfaces: mockNetworkInterfaces,
+  },
+  networkInterfaces: mockNetworkInterfaces,
+}));
+
+describe("hookEndpoint", () => {
+  const originalExternalHost = process.env.KANVIBE_EXTERNAL_HOST;
+  const originalHookToken = process.env.KANVIBE_HOOK_TOKEN;
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.KANVIBE_EXTERNAL_HOST;
+    delete process.env.KANVIBE_HOOK_TOKEN;
+    mockNetworkInterfaces.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalExternalHost === undefined) {
+      delete process.env.KANVIBE_EXTERNAL_HOST;
+    } else {
+      process.env.KANVIBE_EXTERNAL_HOST = originalExternalHost;
+    }
+
+    if (originalHookToken === undefined) {
+      delete process.env.KANVIBE_HOOK_TOKEN;
+    } else {
+      process.env.KANVIBE_HOOK_TOKEN = originalHookToken;
+    }
+  });
+
+  it("원격 호스트가 있으면 명시된 외부 주소를 hook 서버 경로로 사용한다", async () => {
+    // Given
+    process.env.KANVIBE_EXTERNAL_HOST = "192.168.0.5";
+    const { getHookServerUrl } = await import("@/lib/hookEndpoint");
+
+    // When
+    const result = getHookServerUrl("remote-devbox");
+
+    // Then
+    expect(result).toBe("http://192.168.0.5:9736");
+  });
+
+  it("원격 호스트가 없으면 내부망 IPv4 주소를 우선 선택한다", async () => {
+    // Given
+    mockNetworkInterfaces.mockReturnValue({
+      lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+      wlan0: [{ address: "192.168.1.20", family: "IPv4", internal: false }],
+      eth0: [{ address: "8.8.8.8", family: "IPv4", internal: false }],
+    });
+    const { getHookServerUrl } = await import("@/lib/hookEndpoint");
+
+    // When
+    const result = getHookServerUrl("remote-devbox");
+
+    // Then
+    expect(result).toBe("http://192.168.1.20:9736");
+  });
+
+  it("원격 호스트가 없으면 localhost 경로를 사용한다", async () => {
+    // Given
+    const { getHookServerUrl } = await import("@/lib/hookEndpoint");
+
+    // When
+    const result = getHookServerUrl(null);
+
+    // Then
+    expect(result).toBe("http://localhost:9736");
+  });
+
+  it("hook 토큰은 환경변수 값을 그대로 반환한다", async () => {
+    // Given
+    process.env.KANVIBE_HOOK_TOKEN = "secret-token";
+    const { getHookServerToken } = await import("@/lib/hookEndpoint");
+
+    // When
+    const result = getHookServerToken();
+
+    // Then
+    expect(result).toBe("secret-token");
+  });
+});

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSetupClaudeHooks = vi.fn();
+const mockSetupGeminiHooks = vi.fn();
+const mockSetupCodexHooks = vi.fn();
+const mockSetupOpenCodeHooks = vi.fn();
+const mockExecGit = vi.fn();
+const mockGetHookServerUrl = vi.fn();
+const mockGetHookServerToken = vi.fn();
+
+vi.mock("@/lib/claudeHooksSetup", () => ({
+  setupClaudeHooks: (...args: unknown[]) => mockSetupClaudeHooks(...args),
+  generatePromptHookScript: vi.fn(() => "claude prompt"),
+  generateStopHookScript: vi.fn(() => "claude stop"),
+  generateQuestionHookScript: vi.fn(() => "claude question"),
+}));
+
+vi.mock("@/lib/geminiHooksSetup", () => ({
+  setupGeminiHooks: (...args: unknown[]) => mockSetupGeminiHooks(...args),
+  generatePromptHookScript: vi.fn(() => "gemini prompt"),
+  generateStopHookScript: vi.fn(() => "gemini stop"),
+}));
+
+vi.mock("@/lib/codexHooksSetup", () => ({
+  setupCodexHooks: (...args: unknown[]) => mockSetupCodexHooks(...args),
+  generateNotifyHookScript: vi.fn(() => "codex notify"),
+  HOOK_SCRIPT_NAME: "kanvibe-notify-hook.sh",
+  CONFIG_FILE_NAME: "config.toml",
+}));
+
+vi.mock("@/lib/openCodeHooksSetup", () => ({
+  setupOpenCodeHooks: (...args: unknown[]) => mockSetupOpenCodeHooks(...args),
+  generatePluginScript: vi.fn(() => "open code plugin"),
+  PLUGIN_DIR_NAME: "plugins",
+  PLUGIN_FILE_NAME: "kanvibe-plugin.ts",
+}));
+
+vi.mock("@/lib/gitOperations", () => ({
+  execGit: (...args: unknown[]) => mockExecGit(...args),
+}));
+
+vi.mock("@/lib/hookEndpoint", () => ({
+  getHookServerUrl: (...args: unknown[]) => mockGetHookServerUrl(...args),
+  getHookServerToken: (...args: unknown[]) => mockGetHookServerToken(...args),
+}));
+
+describe("kanvibeHooksInstaller", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockGetHookServerUrl.mockReturnValue("http://192.168.0.8:9736");
+    mockGetHookServerToken.mockReturnValue("token-123");
+    mockExecGit.mockResolvedValue("");
+  });
+
+  it("로컬 프로젝트면 기존 hook setup 함수들에 서버 URL과 토큰을 전달한다", async () => {
+    // Given
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    await installKanvibeHooks("/repo", "task-1", null);
+
+    // Then
+    expect(mockSetupClaudeHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736", "token-123");
+    expect(mockSetupGeminiHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736", "token-123");
+    expect(mockSetupCodexHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736", "token-123");
+    expect(mockSetupOpenCodeHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736", "token-123");
+    expect(mockExecGit).not.toHaveBeenCalled();
+  });
+
+  it("원격 프로젝트면 SSH 명령으로 hook 파일을 설치한다", async () => {
+    // Given
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
+
+    // Then
+    expect(mockSetupClaudeHooks).not.toHaveBeenCalled();
+    expect(mockExecGit).toHaveBeenCalled();
+    expect(mockGetHookServerUrl).toHaveBeenCalledWith("remote-host");
+  });
+
+  it("로컬 hook 설치 중 하나라도 실패하면 예외를 전파한다", async () => {
+    // Given
+    mockSetupOpenCodeHooks.mockRejectedValueOnce(new Error("open code failed"));
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    const result = installKanvibeHooks("/repo", "task-3", null);
+
+    // Then
+    await expect(result).rejects.toThrow("open code failed");
+  });
+});

--- a/src/lib/__tests__/remoteSessionDependency.test.ts
+++ b/src/lib/__tests__/remoteSessionDependency.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionType } from "@/entities/KanbanTask";
+
+const mockExecGit = vi.fn();
+
+vi.mock("@/lib/gitOperations", () => ({
+  execGit: (...args: unknown[]) => mockExecGit(...args),
+}));
+
+describe("remoteSessionDependency", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("로컬 세션이면 원격 설치 검증을 건너뛴다", async () => {
+    // Given
+    const { ensureRemoteSessionDependency } = await import("@/lib/remoteSessionDependency");
+
+    // When
+    await ensureRemoteSessionDependency(SessionType.TMUX, null);
+
+    // Then
+    expect(mockExecGit).not.toHaveBeenCalled();
+  });
+
+  it("원격에 도구가 이미 있으면 설치를 시도하지 않는다", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("");
+    const { ensureRemoteSessionDependency } = await import("@/lib/remoteSessionDependency");
+
+    // When
+    await ensureRemoteSessionDependency(SessionType.TMUX, "remote-a");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledTimes(1);
+    expect(mockExecGit).toHaveBeenCalledWith("command -v tmux >/dev/null 2>&1", "remote-a");
+  });
+
+  it("원격에 도구가 없으면 자동 설치 후 다시 검증한다", async () => {
+    // Given
+    mockExecGit
+      .mockRejectedValueOnce(new Error("missing"))
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("");
+    const { ensureRemoteSessionDependency } = await import("@/lib/remoteSessionDependency");
+
+    // When
+    await ensureRemoteSessionDependency(SessionType.ZELLIJ, "remote-b");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledTimes(3);
+    expect(mockExecGit.mock.calls[1]?.[0]).toContain("cargo install --locked zellij");
+    expect(mockExecGit.mock.calls[2]).toEqual(["command -v zellij >/dev/null 2>&1", "remote-b"]);
+  });
+
+  it("자동 설치에 실패하면 호스트를 차단하고 다음 요청도 즉시 실패시킨다", async () => {
+    // Given
+    mockExecGit
+      .mockRejectedValueOnce(new Error("missing"))
+      .mockRejectedValueOnce(new Error("sudo unavailable"));
+    const { ensureRemoteSessionDependency } = await import("@/lib/remoteSessionDependency");
+
+    // When
+    const firstAttempt = ensureRemoteSessionDependency(SessionType.TMUX, "remote-c");
+
+    // Then
+    await expect(firstAttempt).rejects.toThrow(/remote-c 호스트.*tmux 설치/);
+
+    mockExecGit.mockClear();
+    await expect(ensureRemoteSessionDependency(SessionType.TMUX, "remote-c")).rejects.toThrow(/원격 접근을 차단/);
+    expect(mockExecGit).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/remoteSessionDependency.test.ts
+++ b/src/lib/__tests__/remoteSessionDependency.test.ts
@@ -51,6 +51,8 @@ describe("remoteSessionDependency", () => {
     // Then
     expect(mockExecGit).toHaveBeenCalledTimes(3);
     expect(mockExecGit.mock.calls[1]?.[0]).toContain("cargo install --locked zellij");
+    expect(mockExecGit.mock.calls[1]?.[0]).toContain("run_install() {");
+    expect(mockExecGit.mock.calls[1]?.[0]).not.toContain("run_install() {;");
     expect(mockExecGit.mock.calls[2]).toEqual(["command -v zellij >/dev/null 2>&1", "remote-b"]);
   });
 

--- a/src/lib/__tests__/sshConfig.test.ts
+++ b/src/lib/__tests__/sshConfig.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  homedir: vi.fn(() => "/home/local-user"),
+}));
+
+vi.mock("fs/promises", () => ({
+  default: {
+    readFile: mocks.readFile,
+  },
+  readFile: mocks.readFile,
+}));
+
+vi.mock("os", () => ({
+  default: {
+    homedir: mocks.homedir,
+  },
+  homedir: mocks.homedir,
+}));
+
+describe("sshConfig.parseSSHConfig", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("expands concrete host aliases and skips wildcard aliases", async () => {
+    mocks.readFile.mockResolvedValue(`Host app-prod app-bastion *.internal\n  HostName example.com\n  User tester\n  Port 2202\n  IdentityFile ~/.ssh/custom_key\n`);
+
+    const { parseSSHConfig } = await import("@/lib/sshConfig");
+
+    await expect(parseSSHConfig()).resolves.toEqual([
+      {
+        host: "app-prod",
+        hostname: "example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/home/local-user/.ssh/custom_key",
+      },
+      {
+        host: "app-bastion",
+        hostname: "example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/home/local-user/.ssh/custom_key",
+      },
+    ]);
+  });
+});

--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -293,3 +293,50 @@ describe("attachLocalSession — zellij 세션 생성 및 레이아웃 적용", 
     );
   });
 });
+
+describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("should spawn ssh with tty options for remote tmux attach", async () => {
+    // Given
+    const { attachRemoteSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
+
+    // When
+    await attachRemoteSession(
+      "task-r1",
+      "remote-host",
+      SessionType.TMUX,
+      "remote-session",
+      createMockWs(),
+      {
+        hostname: "example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/tmp/test-key",
+      },
+    );
+
+    // Then
+    expect(nodePty.spawn).toHaveBeenCalledWith(
+      "ssh",
+      [
+        "-i",
+        "/tmp/test-key",
+        "-p",
+        "2202",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "IdentitiesOnly=yes",
+        "-tt",
+        "tester@example.com",
+        expect.stringContaining('tmux has-session -t "remote-session"'),
+      ],
+      expect.objectContaining({ cwd: expect.any(String) }),
+    );
+  });
+});

--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -306,18 +306,19 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     const nodePty = await import("node-pty");
 
     // When
-    await attachRemoteSession(
-      "task-r1",
-      "remote-host",
-      SessionType.TMUX,
-      "remote-session",
-      createMockWs(),
-      {
-        hostname: "example.com",
-        port: 2202,
-        username: "tester",
-        privateKeyPath: "/tmp/test-key",
-      },
+      await attachRemoteSession(
+        "task-r1",
+        "remote-host",
+        SessionType.TMUX,
+        "remote-session",
+        createMockWs(),
+        {
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        },
     );
 
     // Then
@@ -333,7 +334,7 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
         "-o",
         "IdentitiesOnly=yes",
         "-tt",
-        "tester@example.com",
+        "remote-host",
         expect.stringContaining('tmux has-session -t "remote-session"'),
       ],
       expect.objectContaining({ cwd: expect.any(String) }),

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -1,9 +1,10 @@
 import { readFile, writeFile, mkdir, chmod, access } from "fs/promises";
 import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import { buildCurlAuthHeader } from "@/lib/hookAuth";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
+export function generatePromptHookScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: UserPromptSubmit
@@ -14,7 +15,7 @@ TASK_ID="${taskId}"
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"progress\\\"}" \\
+${buildCurlAuthHeader(authToken)}  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"progress\\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -22,7 +23,7 @@ exit 0
 }
 
 /** Stop hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, taskId: string): string {
+export function generateStopHookScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: Stop
@@ -33,7 +34,7 @@ TASK_ID="${taskId}"
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
+${buildCurlAuthHeader(authToken)}  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -41,7 +42,7 @@ exit 0
 }
 
 /** PreToolUse(AskUserQuestion) hook bash 스크립트를 생성한다 */
-function generateQuestionHookScript(kanvibeUrl: string, taskId: string): string {
+export function generateQuestionHookScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
   return `#!/bin/bash
 
 # KanVibe Claude Code Hook: PreToolUse (AskUserQuestion)
@@ -52,7 +53,7 @@ TASK_ID="${taskId}"
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"pending\\\"}" \\
+${buildCurlAuthHeader(authToken)}  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"pending\\\"}" \\
   > /dev/null 2>&1
 
 exit 0
@@ -98,7 +99,8 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
 export async function setupClaudeHooks(
   repoPath: string,
   taskId: string,
-  kanvibeUrl: string
+  kanvibeUrl: string,
+  authToken?: string,
 ): Promise<void> {
   const claudeDir = path.join(repoPath, ".claude");
   const hooksDir = path.join(claudeDir, "hooks");
@@ -110,9 +112,9 @@ export async function setupClaudeHooks(
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
   const questionScriptPath = path.join(hooksDir, "kanvibe-question-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId), "utf-8");
-  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, taskId), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId, authToken), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId, authToken), "utf-8");
+  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, taskId, authToken), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
   await chmod(questionScriptPath, 0o755);

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile, mkdir, chmod, access } from "fs/promises";
 import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import { buildCurlAuthHeader } from "@/lib/hookAuth";
 
 /**
  * Codex CLI는 현재 notify 설정의 agent-turn-complete 이벤트만 지원한다.
@@ -8,7 +9,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** notify hook bash 스크립트를 생성한다 (agent-turn-complete → REVIEW) */
-function generateNotifyHookScript(kanvibeUrl: string, taskId: string): string {
+export function generateNotifyHookScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
   return `#!/bin/bash
 
 # KanVibe Codex CLI Hook: notify (agent-turn-complete)
@@ -28,15 +29,15 @@ fi
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
+${buildCurlAuthHeader(authToken)}  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
   > /dev/null 2>&1
 
 exit 0
 `;
 }
 
-const HOOK_SCRIPT_NAME = "kanvibe-notify-hook.sh";
-const CONFIG_FILE_NAME = "config.toml";
+export const HOOK_SCRIPT_NAME = "kanvibe-notify-hook.sh";
+export const CONFIG_FILE_NAME = "config.toml";
 
 /** 기존 config.toml 내용을 읽거나 빈 문자열을 반환한다 */
 async function readConfigToml(configPath: string): Promise<string> {
@@ -59,7 +60,8 @@ function hasKanvibeNotify(configContent: string): boolean {
 export async function setupCodexHooks(
   repoPath: string,
   taskId: string,
-  kanvibeUrl: string
+  kanvibeUrl: string,
+  authToken?: string,
 ): Promise<void> {
   const codexDir = path.join(repoPath, ".codex");
   const hooksDir = path.join(codexDir, "hooks");
@@ -68,7 +70,7 @@ export async function setupCodexHooks(
   await mkdir(hooksDir, { recursive: true });
 
   const notifyScriptPath = path.join(hooksDir, HOOK_SCRIPT_NAME);
-  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, taskId), "utf-8");
+  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, taskId, authToken), "utf-8");
   await chmod(notifyScriptPath, 0o755);
 
   const configContent = await readConfigToml(configPath);

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -17,13 +17,14 @@ const globalForDb = globalThis as unknown as {
 
 function createDataSource(): DataSource {
   const databasePath = getRuntimeDatabasePath();
+  const shouldLogSql = process.env.TYPEORM_LOGGING === "true";
 
   return new DataSource({
     type: "better-sqlite3",
     database: databasePath,
     entities: [KanbanTask, Project, PaneLayoutConfig, AppSettings],
     synchronize: false,
-    logging: process.env.NODE_ENV !== "production",
+    logging: shouldLogSql,
     prepareDatabase: (database) => {
       database.pragma("journal_mode = WAL");
       database.pragma("foreign_keys = ON");

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile, mkdir, chmod, access } from "fs/promises";
 import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import { buildCurlAuthHeader } from "@/lib/hookAuth";
 
 /**
  * Gemini CLI hooks는 stdout에 반드시 JSON만 출력해야 한다.
@@ -8,7 +9,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  */
 
 /** BeforeAgent hook bash 스크립트를 생성한다 */
-function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
+export function generatePromptHookScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: BeforeAgent
@@ -20,7 +21,7 @@ TASK_ID="${taskId}"
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"progress\\\"}" \\
+${buildCurlAuthHeader(authToken)}  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"progress\\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -29,7 +30,7 @@ exit 0
 }
 
 /** AfterAgent hook bash 스크립트를 생성한다 */
-function generateStopHookScript(kanvibeUrl: string, taskId: string): string {
+export function generateStopHookScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
   return `#!/bin/bash
 
 # KanVibe Gemini CLI Hook: AfterAgent
@@ -41,7 +42,7 @@ TASK_ID="${taskId}"
 
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
+${buildCurlAuthHeader(authToken)}  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
   > /dev/null 2>&1
 
 echo '{}'
@@ -93,7 +94,8 @@ function hasKanvibeHook(hookEntries: unknown[], scriptName: string): boolean {
 export async function setupGeminiHooks(
   repoPath: string,
   taskId: string,
-  kanvibeUrl: string
+  kanvibeUrl: string,
+  authToken?: string,
 ): Promise<void> {
   const geminiDir = path.join(repoPath, ".gemini");
   const hooksDir = path.join(geminiDir, "hooks");
@@ -104,8 +106,8 @@ export async function setupGeminiHooks(
   const promptScriptPath = path.join(hooksDir, "kanvibe-prompt-hook.sh");
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
 
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId), "utf-8");
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId, authToken), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId, authToken), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
 

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -74,6 +74,19 @@ async function execRemote(sshHost: string, command: string): Promise<string> {
   });
 }
 
+export function resolvePathForShell(targetPath: string, sshHost?: string | null): string {
+  if (!targetPath.startsWith("~")) {
+    return `"${targetPath}"`;
+  }
+
+  if (sshHost) {
+    const suffix = targetPath.slice(1);
+    return `"$HOME${suffix}"`;
+  }
+
+  return `"${targetPath.replace(/^~/, homedir())}"`;
+}
+
 /** 로컬 또는 SSH에서 명령을 실행한다. sshHost가 null이면 로컬 실행 */
 export async function execGit(command: string, sshHost?: string | null): Promise<string> {
   if (sshHost) {
@@ -171,13 +184,11 @@ export async function scanGitRepos(
   rootPath: string,
   sshHost?: string | null
 ): Promise<string[]> {
-  const resolvedPath = rootPath.startsWith("~")
-    ? rootPath.replace(/^~/, homedir())
-    : rootPath;
+  const resolvedPath = resolvePathForShell(rootPath, sshHost);
 
   try {
     const output = await execGit(
-      `find "${resolvedPath}" -maxdepth 4 -name ".git" -type d 2>/dev/null`,
+      `find ${resolvedPath} -maxdepth 4 -name ".git" -type d 2>/dev/null`,
       sshHost
     );
 

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -1,10 +1,12 @@
-import { exec } from "child_process";
+import { exec, execFile } from "child_process";
 import { promisify } from "util";
 import { readFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
+import { buildSSHArgs, type SSHHostConfig } from "@/lib/sshConfig";
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /** 로컬에서 셸 명령을 실행하고 stdout을 반환한다 */
 async function execLocal(command: string): Promise<string> {
@@ -14,7 +16,6 @@ async function execLocal(command: string): Promise<string> {
 
 /** SSH를 통해 원격에서 명령을 실행하고 stdout을 반환한다 */
 async function execRemote(sshHost: string, command: string): Promise<string> {
-  const { Client } = await import("ssh2");
   const { parseSSHConfig } = await import("@/lib/sshConfig");
 
   const configs = await parseSSHConfig();
@@ -24,54 +25,37 @@ async function execRemote(sshHost: string, command: string): Promise<string> {
     throw new Error(`SSH 호스트를 찾을 수 없습니다: ${sshHost}`);
   }
 
-  return new Promise((resolve, reject) => {
-    const conn = new Client();
+  const sshArgs = [
+    ...buildSSHArgs(hostConfig, { disableTty: true }),
+    buildRemoteShellCommand(command),
+  ];
 
-    conn.on("ready", () => {
-      conn.exec(command, (err, stream) => {
-        if (err) {
-          conn.end();
-          return reject(err);
-        }
-
-        let output = "";
-        let errorOutput = "";
-
-        stream.on("data", (data: Buffer) => {
-          output += data.toString();
-        });
-
-        stream.stderr.on("data", (data: Buffer) => {
-          errorOutput += data.toString();
-        });
-
-        stream.on("close", (code: number) => {
-          conn.end();
-          if (code !== 0) {
-            reject(new Error(`SSH 명령 실패 (exit ${code}): ${errorOutput}`));
-          } else {
-            resolve(output.trim());
-          }
-        });
-      });
+  try {
+    const { stdout } = await execFileAsync("ssh", sshArgs, {
+      maxBuffer: 10 * 1024 * 1024,
     });
+    return stdout.trim();
+  } catch (error) {
+    throw normalizeSSHExecError(error, sshHost);
+  }
+}
 
-    conn.on("error", reject);
+function buildRemoteShellCommand(command: string): string {
+  return `sh -lc ${quoteForPosixShell(command)}`;
+}
 
-    let privateKey: Buffer;
-    try {
-      privateKey = require("fs").readFileSync(hostConfig.privateKeyPath);
-    } catch {
-      return reject(new Error(`SSH 키를 읽을 수 없습니다: ${hostConfig.privateKeyPath}`));
-    }
+function quoteForPosixShell(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
 
-    conn.connect({
-      host: hostConfig.hostname,
-      port: hostConfig.port,
-      username: hostConfig.username,
-      privateKey,
-    });
-  });
+function normalizeSSHExecError(error: unknown, sshHost: string): Error {
+  if (error && typeof error === "object" && "stderr" in error) {
+    const stderr = String((error as { stderr?: string }).stderr || "").trim();
+    const message = stderr || (error instanceof Error ? error.message : "SSH 명령 실패");
+    return new Error(`${sshHost} 원격 명령 실패: ${message}`);
+  }
+
+  return error instanceof Error ? error : new Error(`${sshHost} 원격 명령 실패`);
 }
 
 export function resolvePathForShell(targetPath: string, sshHost?: string | null): string {

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -36,6 +36,12 @@ async function execRemote(sshHost: string, command: string): Promise<string> {
     });
     return stdout.trim();
   } catch (error) {
+    console.error("[remote-ssh] command failed", {
+      sshHost,
+      command,
+      sshArgs,
+      error: error instanceof Error ? error.message : String(error),
+    });
     throw normalizeSSHExecError(error, sshHost);
   }
 }
@@ -169,12 +175,10 @@ export async function scanGitRepos(
   sshHost?: string | null
 ): Promise<string[]> {
   const resolvedPath = resolvePathForShell(rootPath, sshHost);
+  const command = `find ${resolvedPath} -maxdepth 4 -name ".git" -type d 2>/dev/null`;
 
   try {
-    const output = await execGit(
-      `find ${resolvedPath} -maxdepth 4 -name ".git" -type d 2>/dev/null`,
-      sshHost
-    );
+    const output = await execGit(command, sshHost);
 
     if (!output) return [];
 
@@ -182,7 +186,14 @@ export async function scanGitRepos(
       .split("\n")
       .filter(Boolean)
       .map((gitDir) => gitDir.replace(/\/\.git$/, ""));
-  } catch {
+  } catch (error) {
+    console.error("[remote-scan] git repository scan failed", {
+      sshHost: sshHost || null,
+      rootPath,
+      resolvedPath,
+      command,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return [];
   }
 }

--- a/src/lib/hookAuth.ts
+++ b/src/lib/hookAuth.ts
@@ -1,0 +1,15 @@
+export function buildCurlAuthHeader(authToken?: string): string {
+  if (!authToken) {
+    return "";
+  }
+
+  return `  -H "X-Kanvibe-Token: ${authToken}" \\\n+`;
+}
+
+export function buildFetchAuthHeaders(authToken?: string): string {
+  if (!authToken) {
+    return '{ "Content-Type": "application/json" }';
+  }
+
+  return `{ "Content-Type": "application/json", "X-Kanvibe-Token": "${authToken}" }`;
+}

--- a/src/lib/hookEndpoint.ts
+++ b/src/lib/hookEndpoint.ts
@@ -1,0 +1,55 @@
+import os from "node:os";
+
+export const KANVIBE_HOOK_SERVER_PORT = 9736;
+
+export function getHookServerToken(): string {
+  return process.env.KANVIBE_HOOK_TOKEN || "";
+}
+
+export function getLocalHookServerUrl(): string {
+  return `http://localhost:${KANVIBE_HOOK_SERVER_PORT}`;
+}
+
+export function getRemoteHookServerUrl(): string {
+  const preferredHost = process.env.KANVIBE_EXTERNAL_HOST || getPreferredIpv4Address();
+
+  if (!preferredHost) {
+    throw new Error("로컬 Hook 서버에 접근할 수 있는 IP를 찾지 못했습니다. KANVIBE_EXTERNAL_HOST를 설정해 주세요.");
+  }
+
+  return `http://${preferredHost}:${KANVIBE_HOOK_SERVER_PORT}`;
+}
+
+export function getHookServerUrl(sshHost?: string | null): string {
+  return sshHost ? getRemoteHookServerUrl() : getLocalHookServerUrl();
+}
+
+function getPreferredIpv4Address(): string | null {
+  const interfaces = os.networkInterfaces();
+
+  for (const addresses of Object.values(interfaces)) {
+    for (const address of addresses || []) {
+      if (address.family !== "IPv4" || address.internal) {
+        continue;
+      }
+
+      if (
+        address.address.startsWith("10.") ||
+        address.address.startsWith("192.168.") ||
+        /^172\.(1[6-9]|2\d|3[0-1])\./.test(address.address)
+      ) {
+        return address.address;
+      }
+    }
+  }
+
+  for (const addresses of Object.values(interfaces)) {
+    for (const address of addresses || []) {
+      if (address.family === "IPv4" && !address.internal) {
+        return address.address;
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -1,0 +1,173 @@
+import path from "node:path";
+import { execGit } from "@/lib/gitOperations";
+import { setupClaudeHooks, generatePromptHookScript as generateClaudePromptHookScript, generateStopHookScript as generateClaudeStopHookScript, generateQuestionHookScript as generateClaudeQuestionHookScript } from "@/lib/claudeHooksSetup";
+import { setupGeminiHooks, generatePromptHookScript as generateGeminiPromptHookScript, generateStopHookScript as generateGeminiStopHookScript } from "@/lib/geminiHooksSetup";
+import { setupCodexHooks, generateNotifyHookScript, HOOK_SCRIPT_NAME, CONFIG_FILE_NAME } from "@/lib/codexHooksSetup";
+import { setupOpenCodeHooks, generatePluginScript, PLUGIN_DIR_NAME, PLUGIN_FILE_NAME } from "@/lib/openCodeHooksSetup";
+import { getHookServerToken, getHookServerUrl } from "@/lib/hookEndpoint";
+
+export async function installKanvibeHooks(
+  targetPath: string,
+  taskId: string,
+  sshHost?: string | null,
+): Promise<void> {
+  const hookServerUrl = getHookServerUrl(sshHost);
+  const hookServerToken = getHookServerToken();
+
+  if (!sshHost) {
+    const results = await Promise.allSettled([
+      setupClaudeHooks(targetPath, taskId, hookServerUrl, hookServerToken),
+      setupGeminiHooks(targetPath, taskId, hookServerUrl, hookServerToken),
+      setupCodexHooks(targetPath, taskId, hookServerUrl, hookServerToken),
+      setupOpenCodeHooks(targetPath, taskId, hookServerUrl, hookServerToken),
+    ]);
+    assertHookInstallResults(results);
+    return;
+  }
+
+  const results = await Promise.allSettled([
+    setupRemoteClaudeHooks(targetPath, taskId, hookServerUrl, hookServerToken, sshHost),
+    setupRemoteGeminiHooks(targetPath, taskId, hookServerUrl, hookServerToken, sshHost),
+    setupRemoteCodexHooks(targetPath, taskId, hookServerUrl, hookServerToken, sshHost),
+    setupRemoteOpenCodeHooks(targetPath, taskId, hookServerUrl, hookServerToken, sshHost),
+  ]);
+  assertHookInstallResults(results);
+}
+
+async function setupRemoteClaudeHooks(repoPath: string, taskId: string, hookServerUrl: string, hookServerToken: string, sshHost: string) {
+  const claudeDir = path.posix.join(repoPath, ".claude");
+  const hooksDir = path.posix.join(claudeDir, "hooks");
+  const settingsPath = path.posix.join(claudeDir, "settings.json");
+  await execGit(`mkdir -p "${hooksDir}"`, sshHost);
+
+  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"), generateClaudePromptHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
+  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-stop-hook.sh"), generateClaudeStopHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
+  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-question-hook.sh"), generateClaudeQuestionHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
+
+  const settings = await readRemoteJsonFile(settingsPath, sshHost);
+  const hooks = ((settings.hooks as Record<string, unknown[]>) || {});
+  settings.hooks = hooks;
+
+  upsertHookEntry(hooks, "UserPromptSubmit", "kanvibe-prompt-hook.sh", {
+    hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh', timeout: 10 }],
+  });
+  upsertHookEntry(hooks, "PreToolUse", "kanvibe-question-hook.sh", {
+    matcher: "AskUserQuestion",
+    hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-question-hook.sh', timeout: 10 }],
+  });
+  upsertHookEntry(hooks, "PostToolUse", "kanvibe-prompt-hook.sh", {
+    matcher: "AskUserQuestion",
+    hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh', timeout: 10 }],
+  });
+  upsertHookEntry(hooks, "Stop", "kanvibe-stop-hook.sh", {
+    hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-stop-hook.sh', timeout: 10 }],
+  });
+
+  await writeRemoteTextFile(settingsPath, JSON.stringify(settings, null, 2) + "\n", sshHost);
+}
+
+async function setupRemoteGeminiHooks(repoPath: string, taskId: string, hookServerUrl: string, hookServerToken: string, sshHost: string) {
+  const geminiDir = path.posix.join(repoPath, ".gemini");
+  const hooksDir = path.posix.join(geminiDir, "hooks");
+  const settingsPath = path.posix.join(geminiDir, "settings.json");
+  await execGit(`mkdir -p "${hooksDir}"`, sshHost);
+
+  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"), generateGeminiPromptHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
+  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-stop-hook.sh"), generateGeminiStopHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
+
+  const settings = await readRemoteJsonFile(settingsPath, sshHost);
+  const hooks = ((settings.hooks as Record<string, unknown[]>) || {});
+  settings.hooks = hooks;
+
+  upsertHookEntry(hooks, "BeforeAgent", "kanvibe-prompt-hook.sh", {
+    matcher: "*",
+    hooks: [{ type: "command", command: '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-prompt-hook.sh', timeout: 10000 }],
+  });
+  upsertHookEntry(hooks, "AfterAgent", "kanvibe-stop-hook.sh", {
+    matcher: "*",
+    hooks: [{ type: "command", command: '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-stop-hook.sh', timeout: 10000 }],
+  });
+
+  await writeRemoteTextFile(settingsPath, JSON.stringify(settings, null, 2) + "\n", sshHost);
+}
+
+async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServerUrl: string, hookServerToken: string, sshHost: string) {
+  const codexDir = path.posix.join(repoPath, ".codex");
+  const hooksDir = path.posix.join(codexDir, "hooks");
+  const configPath = path.posix.join(codexDir, CONFIG_FILE_NAME);
+  await execGit(`mkdir -p "${hooksDir}"`, sshHost);
+
+  await writeRemoteTextFile(path.posix.join(hooksDir, HOOK_SCRIPT_NAME), generateNotifyHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
+
+  const configContent = await readRemoteTextFile(configPath, sshHost);
+  const notifyLine = `notify = [".codex/hooks/${HOOK_SCRIPT_NAME}"]\n`;
+  const nextConfig = configContent.includes(HOOK_SCRIPT_NAME)
+    ? configContent.replace(/^notify\s*=.*$/m, `notify = [".codex/hooks/${HOOK_SCRIPT_NAME}"]`)
+    : configContent.trim().length === 0
+      ? notifyLine
+      : `${configContent.trimEnd()}\n${notifyLine}`;
+  await writeRemoteTextFile(configPath, nextConfig, sshHost);
+}
+
+async function setupRemoteOpenCodeHooks(repoPath: string, taskId: string, hookServerUrl: string, hookServerToken: string, sshHost: string) {
+  const pluginDir = path.posix.join(repoPath, ".opencode", PLUGIN_DIR_NAME);
+  await execGit(`mkdir -p "${pluginDir}"`, sshHost);
+  await writeRemoteTextFile(
+    path.posix.join(pluginDir, PLUGIN_FILE_NAME),
+    generatePluginScript(hookServerUrl, taskId, hookServerToken),
+    sshHost,
+  );
+}
+
+async function readRemoteJsonFile(filePath: string, sshHost: string): Promise<Record<string, unknown>> {
+  const content = await readRemoteTextFile(filePath, sshHost);
+  if (!content) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+async function readRemoteTextFile(filePath: string, sshHost: string): Promise<string> {
+  try {
+    return await execGit(`test -f "${filePath}" && cat "${filePath}" || true`, sshHost);
+  } catch {
+    return "";
+  }
+}
+
+async function writeRemoteTextFile(filePath: string, content: string, sshHost: string, mode?: number): Promise<void> {
+  const encodedContent = Buffer.from(content, "utf-8").toString("base64");
+  const chmodCommand = mode ? ` && chmod ${mode.toString(8)} "${filePath}"` : "";
+  await execGit(
+    `mkdir -p "${path.posix.dirname(filePath)}" && printf '%s' '${encodedContent}' | (base64 -d 2>/dev/null || base64 -D) > "${filePath}"${chmodCommand}`,
+    sshHost,
+  );
+}
+
+function upsertHookEntry(
+  hooks: Record<string, unknown[]>,
+  bucket: string,
+  scriptName: string,
+  entry: Record<string, unknown>,
+) {
+  if (!hooks[bucket]) {
+    hooks[bucket] = [];
+  }
+
+  const hasEntry = hooks[bucket].some((value) => JSON.stringify(value).includes(scriptName));
+  if (!hasEntry) {
+    hooks[bucket].push(entry);
+  }
+}
+
+function assertHookInstallResults(results: PromiseSettledResult<unknown>[]) {
+  const failure = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+  if (failure) {
+    throw failure.reason instanceof Error ? failure.reason : new Error("hooks 설정 실패");
+  }
+}

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -1,6 +1,7 @@
 import { writeFile, mkdir, access, readFile } from "fs/promises";
 import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import { buildFetchAuthHeaders } from "@/lib/hookAuth";
 
 /**
  * OpenCode는 `.opencode/plugins/` 디렉토리에 TypeScript 플러그인을 배치하여 hooks를 등록한다.
@@ -8,11 +9,11 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
  * question.replied → progress, session.idle → review, session.deleted → done 상태를 전송한다.
  */
 
-const PLUGIN_FILE_NAME = "kanvibe-plugin.ts";
-const PLUGIN_DIR_NAME = "plugins";
+export const PLUGIN_FILE_NAME = "kanvibe-plugin.ts";
+export const PLUGIN_DIR_NAME = "plugins";
 
 /** OpenCode plugin TypeScript 파일 내용을 생성한다 */
-function generatePluginScript(kanvibeUrl: string, taskId: string): string {
+export function generatePluginScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
   return `import type { Plugin } from "@opencode-ai/plugin";
 
 /**
@@ -28,7 +29,7 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
     try {
       await fetch(\`\${KANVIBE_URL}/api/hooks/status\`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: ${buildFetchAuthHeaders(authToken)},
         body: JSON.stringify({ taskId: TASK_ID, status }),
       });
     } catch {
@@ -146,7 +147,8 @@ function hasKanvibePlugin(pluginContent: string): boolean {
 export async function setupOpenCodeHooks(
   repoPath: string,
   taskId: string,
-  kanvibeUrl: string
+  kanvibeUrl: string,
+  authToken?: string,
 ): Promise<void> {
   const openCodeDir = path.join(repoPath, ".opencode");
   const pluginsDir = path.join(openCodeDir, PLUGIN_DIR_NAME);
@@ -154,7 +156,7 @@ export async function setupOpenCodeHooks(
   await mkdir(pluginsDir, { recursive: true });
 
   const pluginPath = path.join(pluginsDir, PLUGIN_FILE_NAME);
-  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, taskId), "utf-8");
+  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, taskId, authToken), "utf-8");
 
   try {
     await addAiToolPatternsToGitExclude(repoPath);

--- a/src/lib/remoteSessionDependency.ts
+++ b/src/lib/remoteSessionDependency.ts
@@ -1,0 +1,95 @@
+import { SessionType } from "@/entities/KanbanTask";
+import { execGit } from "@/lib/gitOperations";
+
+const blockedHosts = new Map<string, string>();
+
+export function getBlockedRemoteHostReason(sshHost: string): string | null {
+  return blockedHosts.get(sshHost) ?? null;
+}
+
+export async function ensureRemoteSessionDependency(
+  sessionType: SessionType,
+  sshHost?: string | null,
+): Promise<void> {
+  if (!sshHost) {
+    return;
+  }
+
+  const blockedReason = getBlockedRemoteHostReason(sshHost);
+  if (blockedReason) {
+    throw new Error(blockedReason);
+  }
+
+  const toolName = sessionType === SessionType.TMUX ? "tmux" : "zellij";
+
+  try {
+    await execGit(`command -v ${toolName} >/dev/null 2>&1`, sshHost);
+    return;
+  } catch {
+    // 설치 시도로 진행한다.
+  }
+
+  try {
+    await execGit(buildInstallCommand(toolName), sshHost);
+    await execGit(`command -v ${toolName} >/dev/null 2>&1`, sshHost);
+  } catch (error) {
+    const reason = `${sshHost} 호스트에서 ${toolName} 설치를 완료하지 못해 원격 접근을 차단했습니다. ${error instanceof Error ? error.message : "원격 설치 실패"}`;
+    blockedHosts.set(sshHost, reason);
+    throw new Error(reason);
+  }
+}
+
+function buildInstallCommand(toolName: string): string {
+  const installWithPrivilege = toolName === "zellij"
+    ? [
+        "cargo install --locked zellij",
+        "brew install zellij",
+        "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y zellij",
+        "dnf install -y zellij",
+        "yum install -y zellij",
+        "pacman -Sy --noconfirm zellij",
+        "zypper --non-interactive install zellij",
+        "apk add zellij",
+      ]
+    : [
+        "brew install tmux",
+        "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y tmux",
+        "dnf install -y tmux",
+        "yum install -y tmux",
+        "pacman -Sy --noconfirm tmux",
+        "zypper --non-interactive install tmux",
+        "apk add tmux",
+      ];
+
+  const installBranches = installWithPrivilege.map((command) => buildPackageManagerBranch(command));
+
+  return [
+    `if command -v ${toolName} >/dev/null 2>&1; then exit 0; fi`,
+    'run_install() {',
+    '  if [ "$(id -u)" -eq 0 ]; then',
+    '    sh -lc "$1"',
+    '    return $? ',
+    '  fi',
+    '  if command -v sudo >/dev/null 2>&1; then',
+    '    sudo -n sh -lc "$1"',
+    '    return $? ',
+    '  fi',
+    '  return 1',
+    '}',
+    ...installBranches,
+    `command -v ${toolName} >/dev/null 2>&1 || { echo "${toolName} 설치에 실패했습니다." >&2; exit 1; }`,
+  ].join("; ");
+}
+
+function buildPackageManagerBranch(command: string): string {
+  const executable = command.split(" ")[0];
+  if (executable === "cargo") {
+    return `if command -v cargo >/dev/null 2>&1; then ${command}; fi`;
+  }
+
+  if (executable === "brew") {
+    return `if command -v brew >/dev/null 2>&1; then ${command}; fi`;
+  }
+
+  return `if command -v ${executable} >/dev/null 2>&1; then run_install '${command}' && exit 0; fi`;
+}

--- a/src/lib/remoteSessionDependency.ts
+++ b/src/lib/remoteSessionDependency.ts
@@ -77,8 +77,11 @@ function buildInstallCommand(toolName: string): string {
     '  return 1',
     '}',
     ...installBranches,
-    `command -v ${toolName} >/dev/null 2>&1 || { echo "${toolName} 설치에 실패했습니다." >&2; exit 1; }`,
-  ].join("; ");
+    `if ! command -v ${toolName} >/dev/null 2>&1; then`,
+    `  echo "${toolName} 설치에 실패했습니다." >&2`,
+    '  exit 1',
+    'fi',
+  ].join("\n");
 }
 
 function buildPackageManagerBranch(command: string): string {

--- a/src/lib/sshConfig.ts
+++ b/src/lib/sshConfig.ts
@@ -10,6 +10,38 @@ export interface SSHHostConfig {
   privateKeyPath: string;
 }
 
+export function getSSHDestination(config: Pick<SSHHostConfig, "hostname" | "username">): string {
+  return `${config.username}@${config.hostname}`;
+}
+
+export function buildSSHArgs(
+  config: Pick<SSHHostConfig, "hostname" | "port" | "username" | "privateKeyPath">,
+  options?: {
+    forceTty?: boolean;
+    disableTty?: boolean;
+  },
+): string[] {
+  const args = [
+    "-i",
+    config.privateKeyPath,
+    "-p",
+    String(config.port),
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "IdentitiesOnly=yes",
+  ];
+
+  if (options?.forceTty) {
+    args.push("-tt");
+  } else if (options?.disableTty) {
+    args.push("-T");
+  }
+
+  args.push(getSSHDestination(config));
+  return args;
+}
+
 /**
  * ~/.ssh/config 파일을 파싱하여 호스트 목록을 반환한다.
  * Host, HostName, User, IdentityFile, Port 필드를 추출한다.

--- a/src/lib/sshConfig.ts
+++ b/src/lib/sshConfig.ts
@@ -10,12 +10,16 @@ export interface SSHHostConfig {
   privateKeyPath: string;
 }
 
-export function getSSHDestination(config: Pick<SSHHostConfig, "hostname" | "username">): string {
+export function getSSHDestination(config: Pick<SSHHostConfig, "host" | "hostname" | "username">): string {
+  if (config.host) {
+    return config.host;
+  }
+
   return `${config.username}@${config.hostname}`;
 }
 
 export function buildSSHArgs(
-  config: Pick<SSHHostConfig, "hostname" | "port" | "username" | "privateKeyPath">,
+  config: Pick<SSHHostConfig, "host" | "hostname" | "port" | "username" | "privateKeyPath">,
   options?: {
     forceTty?: boolean;
     disableTty?: boolean;
@@ -57,7 +61,7 @@ export async function parseSSHConfig(): Promise<SSHHostConfig[]> {
   }
 
   const hosts: SSHHostConfig[] = [];
-  let current: Partial<SSHHostConfig> | null = null;
+  let current: (Partial<SSHHostConfig> & { aliases?: string[] }) | null = null;
 
   for (const rawLine of content.split("\n")) {
     const line = rawLine.trim();
@@ -67,10 +71,10 @@ export async function parseSSHConfig(): Promise<SSHHostConfig[]> {
     const value = valueParts.join(" ");
 
     if (key.toLowerCase() === "host") {
-      if (current?.host && current.hostname) {
-        hosts.push(fillDefaults(current));
+      if (current?.aliases?.length && current.hostname) {
+        hosts.push(...expandHostAliases(current));
       }
-      current = { host: value };
+      current = { aliases: valueParts };
     } else if (current) {
       switch (key.toLowerCase()) {
         case "hostname":
@@ -89,8 +93,8 @@ export async function parseSSHConfig(): Promise<SSHHostConfig[]> {
     }
   }
 
-  if (current?.host && current.hostname) {
-    hosts.push(fillDefaults(current));
+  if (current?.aliases?.length && current.hostname) {
+    hosts.push(...expandHostAliases(current));
   }
 
   return hosts;
@@ -104,6 +108,14 @@ function fillDefaults(partial: Partial<SSHHostConfig>): SSHHostConfig {
     username: partial.username || "root",
     privateKeyPath: partial.privateKeyPath || path.join(homedir(), ".ssh", "id_rsa"),
   };
+}
+
+function expandHostAliases(
+  partial: Partial<SSHHostConfig> & { aliases?: string[] },
+): SSHHostConfig[] {
+  return (partial.aliases || [])
+    .filter((alias) => alias && !/[*!?]/.test(alias))
+    .map((alias) => fillDefaults({ ...partial, host: alias }));
 }
 
 /** 사용 가능한 SSH 호스트 이름 목록을 반환한다 */

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -220,6 +220,7 @@ export async function attachRemoteSession(
   sessionName: string,
   ws: WebSocket,
   sshConfig: {
+    host: string;
     hostname: string;
     port: number;
     username: string;

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -4,6 +4,7 @@ import { SessionType } from "@/entities/KanbanTask";
 import { ZELLIJ_LAYOUT_FILENAME } from "@/lib/worktree";
 import { execSync } from "child_process";
 import type { WebSocket } from "ws";
+import { buildSSHArgs } from "@/lib/sshConfig";
 
 /**
  * 활성 터미널 세션을 관리하는 레지스트리.
@@ -230,84 +231,90 @@ export async function attachRemoteSession(
   const initialCols = cols ?? 120;
   const initialRows = rows ?? 30;
 
-  const { Client } = await import("ssh2");
-  const fs = await import("fs");
+  const existing = activeTerminals.get(taskId);
+  if (existing) {
+    existing.clients.add(ws);
+    ws.on("message", (message) => handleTerminalMessage(existing.pty, message.toString()));
+    ws.on("close", () => {
+      existing.clients.delete(ws);
+      if (existing.clients.size === 0) {
+        detachSession(taskId);
+      }
+    });
+    return;
+  }
 
-  const conn = new Client();
+  const pty = await import("node-pty");
+  const remoteCommand = sessionType === SessionType.TMUX
+    ? [`tmux has-session -t "${sessionName}" 2>/dev/null || tmux new-session -d -s "${sessionName}"`, `exec tmux attach-session -t "${sessionName}"`].join("; ")
+    : `exec zellij attach "${sessionName}"`;
+  const args = [
+    ...buildSSHArgs(sshConfig, { forceTty: true }),
+    `sh -lc '${remoteCommand.replace(/'/g, `'"'"'`)}'`,
+  ];
 
-  conn.on("ready", () => {
-    /** 세션에 직접 attach한다 */
-    let command: string;
-    if (sessionType === SessionType.TMUX) {
-      command = [
-        `tmux has-session -t "${sessionName}" 2>/dev/null || tmux new-session -d -s "${sessionName}"`,
-        `tmux attach-session -t "${sessionName}"`,
-      ].join("; ");
-    } else {
-      command = `zellij attach "${sessionName}"`;
-    }
+  console.log(`[터미널] Remote PTY spawn: shell=ssh, args=${JSON.stringify(args)}`);
 
-    conn.shell(
-      { term: "xterm-256color", cols: initialCols, rows: initialRows },
-      (err, stream) => {
-        if (err) {
-          ws.close(1011, "SSH shell 오류");
-          conn.end();
-          return;
-        }
-
-        stream.write(command + "\n");
-
-        stream.on("data", (data: Buffer) => {
-          if (ws.readyState === ws.OPEN) {
-            ws.send(data);
-          }
-        });
-
-        stream.on("close", () => {
-          ws.close();
-          conn.end();
-          activeTerminals.delete(taskId);
-        });
-
-        ws.on("message", (message) => {
-          const data = message.toString();
-
-          if (data.startsWith("\x01")) {
-            try {
-              const parsed = JSON.parse(data.slice(1));
-              if (parsed.type === "resize" && parsed.cols && parsed.rows) {
-                stream.setWindow(parsed.rows, parsed.cols, 0, 0);
-              }
-            } catch {
-              stream.write(data);
-            }
-            return;
-          }
-
-          stream.write(data);
-        });
-
-        ws.on("close", () => {
-          stream.close();
-          conn.end();
-          activeTerminals.delete(taskId);
-        });
-      },
-    );
-  });
-
-  conn.on("error", (err) => {
-    console.error("SSH 연결 오류:", err.message);
+  let ptyProcess: import("node-pty").IPty;
+  try {
+    ptyProcess = pty.spawn("ssh", args, {
+      name: "xterm-256color",
+      cols: initialCols,
+      rows: initialRows,
+      cwd: process.env.HOME || "/",
+      env: {
+        ...process.env,
+        LANG: process.env.LANG || "en_US.UTF-8",
+        LC_ALL: process.env.LC_ALL || "en_US.UTF-8",
+      } as Record<string, string>,
+    });
+  } catch (error) {
+    console.error("[터미널] Remote PTY spawn 실패:", error);
     ws.close(1011, "SSH 연결 실패");
+    return;
+  }
+
+  const entry: TerminalEntry = { pty: ptyProcess, clients: new Set([ws]), sessionType, sessionName };
+  activeTerminals.set(taskId, entry);
+
+  ptyProcess.onData((data) => {
+    for (const client of entry.clients) {
+      if (client.readyState === client.OPEN) {
+        client.send(data);
+      }
+    }
   });
 
-  conn.connect({
-    host: sshConfig.hostname,
-    port: sshConfig.port,
-    username: sshConfig.username,
-    privateKey: fs.readFileSync(sshConfig.privateKeyPath),
+  ptyProcess.onExit(() => {
+    detachSession(taskId);
   });
+
+  ws.on("message", (message) => {
+    handleTerminalMessage(ptyProcess, message.toString());
+  });
+
+  ws.on("close", () => {
+    entry.clients.delete(ws);
+    if (entry.clients.size === 0) {
+      detachSession(taskId);
+    }
+  });
+}
+
+function handleTerminalMessage(ptyProcess: import("node-pty").IPty, data: string): void {
+  if (data.startsWith("\x01")) {
+    try {
+      const parsed = JSON.parse(data.slice(1));
+      if (parsed.type === "resize" && parsed.cols && parsed.rows) {
+        ptyProcess.resize(parsed.cols, parsed.rows);
+      }
+    } catch {
+      ptyProcess.write(data);
+    }
+    return;
+  }
+
+  ptyProcess.write(data);
 }
 
 /** 탭 전환 시 해당 태스크의 세션으로 포커스를 이동한다 */

--- a/src/lib/typeorm-cli.config.ts
+++ b/src/lib/typeorm-cli.config.ts
@@ -15,7 +15,7 @@ export default new DataSource({
   database: getRuntimeDatabasePath(),
   entities: [KanbanTask, Project, PaneLayoutConfig, AppSettings],
   synchronize: false,
-  logging: true,
+  logging: process.env.TYPEORM_LOGGING === "true",
   prepareDatabase: (database) => {
     database.pragma("journal_mode = WAL");
     database.pragma("foreign_keys = ON");

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -3,6 +3,7 @@ import { writeFile } from "fs/promises";
 import { SessionType } from "@/entities/KanbanTask";
 import { PaneLayoutType, type PaneCommand } from "@/entities/PaneLayoutConfig";
 import { execGit } from "@/lib/gitOperations";
+import { ensureRemoteSessionDependency } from "@/lib/remoteSessionDependency";
 import { getEffectivePaneLayout } from "@/desktop/main/services/paneLayoutService";
 
 interface WorktreeSession {
@@ -225,6 +226,8 @@ export async function createWorktreeWithSession(
   sshHost?: string | null,
   projectId?: string | null,
 ): Promise<WorktreeSession> {
+  await ensureRemoteSessionDependency(sessionType, sshHost);
+
   const projectName = path.basename(projectPath);
   const worktreeBase = path.posix.join(
     path.dirname(projectPath),
@@ -301,6 +304,8 @@ export async function createSessionWithoutWorktree(
   sshHost?: string | null,
   workingDir?: string,
 ): Promise<{ sessionName: string }> {
+  await ensureRemoteSessionDependency(sessionType, sshHost);
+
   const projectName = path.basename(projectPath);
   const sessionName = formatSessionName(projectName, branchName);
   const cwd = workingDir || projectPath;


### PR DESCRIPTION
## Summary
- preserve SSH host aliases when invoking the system `ssh` binary so remote discovery and terminal attachment reuse the same `~/.ssh/config` rules as manual `ssh <alias>` commands
- expand concrete aliases from `~/.ssh/config`, add regression coverage for alias parsing, and keep remote `~` path handling compatible with the remote `$HOME`
- add focused diagnostics for remote subdirectory and repository scans so SSH host, resolved path, and command failures are visible during investigation
- disable noisy default TypeORM SQL logging and keep it opt-in via `TYPEORM_LOGGING=true` so remote scan failures are easier to analyze
- stop blocking remote repository scans and project registration on tmux or zellij availability, so SSH discovery can reach actual Git repositories before session setup
- fix the generated remote install shell script syntax and keep project registration intact even when default remote session bootstrap fails

## Testing
- pnpm exec vitest run src/lib/__tests__/gitOperations.test.ts src/lib/__tests__/terminal.test.ts src/lib/__tests__/sshConfig.test.ts src/desktop/main/services/__tests__/projectService.test.ts
- pnpm exec vitest run src/lib/__tests__/remoteSessionDependency.test.ts src/desktop/main/services/__tests__/projectService.test.ts
- pnpm exec tsc --noEmit