### PR TITLE
Reduce noisy git exclude errors during hook setup

### DIFF
--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, mkdir, chmod, access } from "fs/promises";
 import path from "path";
-import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import { addAiToolPatternsToGitExclude, isNotGitRepositoryError } from "@/lib/gitExclude";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
 function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
@@ -191,6 +191,7 @@ export async function setupClaudeHooks(
   try {
     await addAiToolPatternsToGitExclude(repoPath);
   } catch (error) {
+    if (isNotGitRepositoryError(error)) return;
     console.error("git exclude 패턴 추가 실패:", error);
   }
 }

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, mkdir, chmod, access } from "fs/promises";
 import path from "path";
-import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import { addAiToolPatternsToGitExclude, isNotGitRepositoryError } from "@/lib/gitExclude";
 
 /**
  * Codex CLI는 현재 notify 설정의 agent-turn-complete 이벤트만 지원한다.
@@ -91,6 +91,7 @@ export async function setupCodexHooks(
   try {
     await addAiToolPatternsToGitExclude(repoPath);
   } catch (error) {
+    if (isNotGitRepositoryError(error)) return;
     console.error("git exclude 패턴 추가 실패:", error);
   }
 }

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, mkdir, chmod, access } from "fs/promises";
 import path from "path";
-import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import { addAiToolPatternsToGitExclude, isNotGitRepositoryError } from "@/lib/gitExclude";
 
 /**
  * Gemini CLI hooks는 stdout에 반드시 JSON만 출력해야 한다.
@@ -153,6 +153,7 @@ export async function setupGeminiHooks(
   try {
     await addAiToolPatternsToGitExclude(repoPath);
   } catch (error) {
+    if (isNotGitRepositoryError(error)) return;
     console.error("git exclude 패턴 추가 실패:", error);
   }
 }

--- a/src/lib/gitExclude.ts
+++ b/src/lib/gitExclude.ts
@@ -17,6 +17,14 @@ const EXCLUDE_PATTERNS = [
   ".opencode/plugins/",
 ];
 
+export function isNotGitRepositoryError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return /not a git repository/i.test(error.message);
+}
+
 /**
  * AI 코딩 도구의 hooks 설정 파일을 .git/info/excluded에 추가하여 git tracking에서 제외한다.
  * 마커 블록을 사용해 멱등성을 보장하며, 실패해도 예외를 던지지 않는다.

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -1,6 +1,6 @@
 import { writeFile, mkdir, access, readFile } from "fs/promises";
 import path from "path";
-import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import { addAiToolPatternsToGitExclude, isNotGitRepositoryError } from "@/lib/gitExclude";
 
 /**
  * OpenCode는 `.opencode/plugins/` 디렉토리에 TypeScript 플러그인을 배치하여 hooks를 등록한다.
@@ -159,6 +159,7 @@ export async function setupOpenCodeHooks(
   try {
     await addAiToolPatternsToGitExclude(repoPath);
   } catch (error) {
+    if (isNotGitRepositoryError(error)) return;
     console.error("git exclude 패턴 추가 실패:", error);
   }
 }


### PR DESCRIPTION
## Summary
- ignore `not a git repository` errors when hook setup tries to append AI tool paths to `.git/info/exclude`
- keep existing error logging for real git exclude failures so unexpected setup problems still surface
- reduce CI log noise from temporary test directories that are intentionally not git repositories

## Verification
- `pnpm vitest run src/lib/__tests__/gitExclude.test.ts src/lib/__tests__/openCodeHooksSetup.test.ts src/lib/__tests__/geminiHooksSetup.test.ts src/lib/__tests__/codexHooksSetup.test.ts`
- `pnpm vitest run src/components/__tests__/Board.test.tsx src/hooks/__tests__/useTaskNotification.test.ts`
- `pnpm test`
- `pnpm check`

## Notes
- `pnpm lint` still reports pre-existing repository-wide issues unrelated to this change.