### PR TITLE
Fix terminal focus and macOS Shift-drag selection in task detail

### DIFF
--- a/src/desktop/renderer/components/Terminal.tsx
+++ b/src/desktop/renderer/components/Terminal.tsx
@@ -18,6 +18,7 @@ interface TerminalCloseEvent {
 export default function Terminal({ taskId }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<import("@xterm/xterm").Terminal | null>(null);
+  const isMac = navigator.userAgent.includes("Mac") || navigator.platform.toLowerCase().includes("mac");
 
   const focusTerminal = useCallback(() => {
     xtermRef.current?.focus();
@@ -50,6 +51,7 @@ export default function Terminal({ taskId }: TerminalProps) {
       cursorBlink: true,
       fontSize: 14,
       fontFamily,
+      macOptionClickForcesSelection: true,
       rescaleOverlappingGlyphs: true,
       theme: {
         background: "#0a0a0a",
@@ -119,11 +121,47 @@ export default function Terminal({ taskId }: TerminalProps) {
       focusTerminal();
     };
 
+    const handleMouseDownCapture = (event: MouseEvent) => {
+      if (!isMac || !event.isTrusted || event.button !== 0 || !event.shiftKey || event.altKey) {
+        return;
+      }
+
+      const eventTarget = event.target instanceof EventTarget ? event.target : containerRef.current;
+      if (!eventTarget) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const remappedEvent = new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        button: event.button,
+        buttons: event.buttons,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        screenX: event.screenX,
+        screenY: event.screenY,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+        shiftKey: false,
+        altKey: true,
+        detail: event.detail,
+      });
+
+      focusTerminal();
+      eventTarget.dispatchEvent(remappedEvent);
+    };
+
     containerRef.current.addEventListener("pointerdown", handlePointerDown);
+    containerRef.current.addEventListener("mousedown", handleMouseDownCapture, true);
 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       containerRef.current?.removeEventListener("pointerdown", handlePointerDown);
+      containerRef.current?.removeEventListener("mousedown", handleMouseDownCapture, true);
       resizeObserver.disconnect();
       unsubscribeData();
       unsubscribeClose();
@@ -131,7 +169,7 @@ export default function Terminal({ taskId }: TerminalProps) {
       xtermRef.current = null;
       terminal.dispose();
     };
-  }, [focusTerminal, taskId]);
+  }, [focusTerminal, isMac, taskId]);
 
   useEffect(() => {
     let cleanup: (() => void) | undefined;

--- a/src/desktop/renderer/components/Terminal.tsx
+++ b/src/desktop/renderer/components/Terminal.tsx
@@ -5,8 +5,24 @@ interface TerminalProps {
   taskId: string;
 }
 
+interface TerminalDataEvent {
+  taskId: string;
+  data: string;
+}
+
+interface TerminalCloseEvent {
+  taskId: string;
+  reason: string | null;
+}
+
 export default function Terminal({ taskId }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const xtermRef = useRef<import("@xterm/xterm").Terminal | null>(null);
+
+  const focusTerminal = useCallback(() => {
+    xtermRef.current?.focus();
+    window.kanvibeDesktop?.focusTerminal(taskId);
+  }, [taskId]);
 
   const connect = useCallback(async () => {
     if (!containerRef.current) {
@@ -47,6 +63,7 @@ export default function Terminal({ taskId }: TerminalProps) {
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(new WebLinksAddon());
     terminal.open(containerRef.current);
+    xtermRef.current = terminal;
     terminal.options.fontFamily = "monospace";
     terminal.options.fontFamily = fontFamily;
 
@@ -62,13 +79,15 @@ export default function Terminal({ taskId }: TerminalProps) {
       terminal.writeln(`\r\n\x1b[31m${terminalReady.error || "터미널 연결 실패"}\x1b[0m`);
     }
 
-    const unsubscribeData = window.kanvibeDesktop!.onTerminalData((event: any) => {
+    focusTerminal();
+
+    const unsubscribeData = window.kanvibeDesktop!.onTerminalData((event: TerminalDataEvent) => {
       if (event.taskId === taskId) {
         terminal.write(event.data);
       }
     });
 
-    const unsubscribeClose = window.kanvibeDesktop!.onTerminalClose((event: any) => {
+    const unsubscribeClose = window.kanvibeDesktop!.onTerminalClose((event: TerminalCloseEvent) => {
       if (event.taskId === taskId) {
         terminal.writeln(`\r\n\x1b[31m${event.reason || "연결이 종료되었습니다."}\x1b[0m`);
       }
@@ -90,21 +109,29 @@ export default function Terminal({ taskId }: TerminalProps) {
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
-        window.kanvibeDesktop!.focusTerminal(taskId);
+        focusTerminal();
       }
     };
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
+    const handlePointerDown = () => {
+      focusTerminal();
+    };
+
+    containerRef.current.addEventListener("pointerdown", handlePointerDown);
+
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+      containerRef.current?.removeEventListener("pointerdown", handlePointerDown);
       resizeObserver.disconnect();
       unsubscribeData();
       unsubscribeClose();
       window.kanvibeDesktop!.closeTerminal(taskId);
+      xtermRef.current = null;
       terminal.dispose();
     };
-  }, [taskId]);
+  }, [focusTerminal, taskId]);
 
   useEffect(() => {
     let cleanup: (() => void) | undefined;

--- a/src/desktop/renderer/components/Terminal.tsx
+++ b/src/desktop/renderer/components/Terminal.tsx
@@ -15,6 +15,18 @@ interface TerminalCloseEvent {
   reason: string | null;
 }
 
+interface XTermSelectionService {
+  shouldForceSelection: (event: MouseEvent) => boolean;
+}
+
+interface XTermCore {
+  _selectionService?: XTermSelectionService;
+}
+
+interface XTermWithCore {
+  _core?: XTermCore;
+}
+
 export default function Terminal({ taskId }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<import("@xterm/xterm").Terminal | null>(null);
@@ -66,6 +78,16 @@ export default function Terminal({ taskId }: TerminalProps) {
     terminal.loadAddon(new WebLinksAddon());
     terminal.open(containerRef.current);
     xtermRef.current = terminal;
+
+    if (isMac) {
+      const terminalCore = terminal as unknown as XTermWithCore;
+      const selectionService = terminalCore._core?._selectionService;
+      if (selectionService) {
+        const defaultShouldForceSelection = selectionService.shouldForceSelection.bind(selectionService);
+        selectionService.shouldForceSelection = (event: MouseEvent) => event.shiftKey || defaultShouldForceSelection(event);
+      }
+    }
+
     terminal.options.fontFamily = "monospace";
     terminal.options.fontFamily = fontFamily;
 
@@ -121,47 +143,11 @@ export default function Terminal({ taskId }: TerminalProps) {
       focusTerminal();
     };
 
-    const handleMouseDownCapture = (event: MouseEvent) => {
-      if (!isMac || !event.isTrusted || event.button !== 0 || !event.shiftKey || event.altKey) {
-        return;
-      }
-
-      const eventTarget = event.target instanceof EventTarget ? event.target : containerRef.current;
-      if (!eventTarget) {
-        return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-
-      const remappedEvent = new MouseEvent("mousedown", {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        button: event.button,
-        buttons: event.buttons,
-        clientX: event.clientX,
-        clientY: event.clientY,
-        screenX: event.screenX,
-        screenY: event.screenY,
-        ctrlKey: event.ctrlKey,
-        metaKey: event.metaKey,
-        shiftKey: false,
-        altKey: true,
-        detail: event.detail,
-      });
-
-      focusTerminal();
-      eventTarget.dispatchEvent(remappedEvent);
-    };
-
     containerRef.current.addEventListener("pointerdown", handlePointerDown);
-    containerRef.current.addEventListener("mousedown", handleMouseDownCapture, true);
 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       containerRef.current?.removeEventListener("pointerdown", handlePointerDown);
-      containerRef.current?.removeEventListener("mousedown", handleMouseDownCapture, true);
       resizeObserver.disconnect();
       unsubscribeData();
       unsubscribeClose();

--- a/src/desktop/renderer/components/TerminalLoader.tsx
+++ b/src/desktop/renderer/components/TerminalLoader.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import Terminal from "@/desktop/renderer/components/Terminal";
 
 interface TerminalLoaderProps {
@@ -6,26 +5,9 @@ interface TerminalLoaderProps {
 }
 
 export default function TerminalLoader({ taskId }: TerminalLoaderProps) {
-  const [shouldMountTerminal, setShouldMountTerminal] = useState(false);
-
-  useEffect(() => {
-    const scheduleMount = window.requestIdleCallback
-      ? window.requestIdleCallback(() => setShouldMountTerminal(true))
-      : window.setTimeout(() => setShouldMountTerminal(true), 0);
-
-    return () => {
-      if (typeof scheduleMount === "number") {
-        window.clearTimeout(scheduleMount);
-        return;
-      }
-
-      window.cancelIdleCallback?.(scheduleMount);
-    };
-  }, []);
-
   return (
     <div className="h-full">
-      {shouldMountTerminal ? <Terminal taskId={taskId} /> : <div className="h-full bg-terminal-bg" />}
+      <Terminal taskId={taskId} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- mount the terminal immediately when opening task detail so it can receive interaction right away
- focus the xterm instance and desktop session as soon as the terminal connects and when the window becomes active again
- restore terminal focus on pointer interaction so keyboard shortcuts are delivered reliably
- support macOS Shift-drag selection by patching xterm's force-selection decision instead of relying on synthetic mouse events

## Testing
- pnpm check
- pnpm test src/lib/__tests__/terminal.test.ts