### PR TITLE
Fix remote SSH transport handling for tmux checks

### DIFF
--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -161,6 +161,22 @@ describe("gitOperations.resolvePathForShell", () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
+  it("SSH transport 오류를 원격 명령 내부 실패와 구분한다", async () => {
+    // Given
+    const { isSSHTransportError } = await import("@/lib/gitOperations");
+
+    const connectionResetError = new Error("remote-host 원격 명령 실패: Connection reset by 100.73.171.123 port 22");
+    const keyExchangeError = {
+      stderr: "kex_exchange_identification: read: Connection reset by peer\n",
+    };
+    const commandError = new Error("remote-host 원격 명령 실패: tmux 설치에 실패했습니다.");
+
+    // Then
+    expect(isSSHTransportError(connectionResetError)).toBe(true);
+    expect(isSSHTransportError(keyExchangeError)).toBe(true);
+    expect(isSSHTransportError(commandError)).toBe(false);
+  });
+
   it("scanGitRepos는 일반 저장소와 worktree 저장소를 모두 찾는다", async () => {
     // Given
     mocks.exec.mockImplementation((

--- a/src/lib/__tests__/remoteSessionDependency.test.ts
+++ b/src/lib/__tests__/remoteSessionDependency.test.ts
@@ -5,6 +5,15 @@ const mockExecGit = vi.fn();
 
 vi.mock("@/lib/gitOperations", () => ({
   execGit: (...args: unknown[]) => mockExecGit(...args),
+  isSSHTransportError: (error: unknown) => {
+    const message = error instanceof Error
+      ? error.message
+      : error && typeof error === "object" && "stderr" in error
+        ? String((error as { stderr?: string }).stderr)
+        : "";
+
+    return /Connection (?:reset|closed)|kex_exchange_identification/.test(message);
+  },
 }));
 
 describe("remoteSessionDependency", () => {
@@ -60,6 +69,22 @@ describe("remoteSessionDependency", () => {
     expect(mockExecGit).toHaveBeenCalledWith("command -v tmux >/dev/null 2>&1", "remote-a");
   });
 
+  it("원격 의존성 확인 중 SSH 연결 실패가 발생하면 설치를 시도하거나 차단하지 않는다", async () => {
+    // Given
+    mockExecGit.mockRejectedValueOnce(new Error("remote-a 원격 명령 실패: Connection reset by 100.73.171.123 port 22"));
+    const { ensureRemoteSessionDependency } = await import("@/lib/remoteSessionDependency");
+
+    // When & Then
+    await expect(ensureRemoteSessionDependency(SessionType.TMUX, "remote-a")).rejects.toThrow(/Connection reset/);
+    expect(mockExecGit).toHaveBeenCalledTimes(1);
+    expect(mockExecGit).toHaveBeenCalledWith("command -v tmux >/dev/null 2>&1", "remote-a");
+
+    mockExecGit.mockClear();
+    mockExecGit.mockResolvedValueOnce("");
+    await expect(ensureRemoteSessionDependency(SessionType.TMUX, "remote-a")).resolves.toBeUndefined();
+    expect(mockExecGit).toHaveBeenCalledTimes(1);
+  });
+
   it("원격에 도구가 없으면 자동 설치 후 다시 검증한다", async () => {
     // Given
     mockExecGit
@@ -77,6 +102,22 @@ describe("remoteSessionDependency", () => {
     expect(mockExecGit.mock.calls[1]?.[0]).toContain("run_install() {");
     expect(mockExecGit.mock.calls[1]?.[0]).not.toContain("run_install() {;");
     expect(mockExecGit.mock.calls[2]).toEqual(["command -v zellij >/dev/null 2>&1", "remote-b"]);
+  });
+
+  it("자동 설치 중 SSH 연결 실패가 발생하면 호스트를 차단하지 않는다", async () => {
+    // Given
+    mockExecGit
+      .mockRejectedValueOnce(new Error("missing"))
+      .mockRejectedValueOnce(new Error("remote-b 원격 명령 실패: Connection closed by 100.73.171.123 port 22"));
+    const { ensureRemoteSessionDependency } = await import("@/lib/remoteSessionDependency");
+
+    // When & Then
+    await expect(ensureRemoteSessionDependency(SessionType.TMUX, "remote-b")).rejects.toThrow(/Connection closed/);
+
+    mockExecGit.mockClear();
+    mockExecGit.mockResolvedValueOnce("");
+    await expect(ensureRemoteSessionDependency(SessionType.TMUX, "remote-b")).resolves.toBeUndefined();
+    expect(mockExecGit).toHaveBeenCalledWith("command -v tmux >/dev/null 2>&1", "remote-b");
   });
 
   it("자동 설치에 실패하면 호스트를 차단하고 다음 요청도 즉시 실패시킨다", async () => {

--- a/src/lib/aiSessions/__tests__/shared.test.ts
+++ b/src/lib/aiSessions/__tests__/shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeText, sortMessagesDescending } from "@/lib/aiSessions/shared";
+import { mapWithConcurrency, normalizeText, sortMessagesDescending } from "@/lib/aiSessions/shared";
 
 describe("sortMessagesDescending", () => {
   it("should sort session detail messages from newest to oldest", () => {
@@ -18,5 +18,25 @@ describe("normalizeText", () => {
     const result = normalizeText(`Fix hook state\n[Pasted ~33 lines]\n[remote-ssh] command failed {\nsshHost: 'roky-home'\nerror: 'server exited unexpectedly'\n    at createSessionWithoutWorktree (/tmp/worktree.js:1:1)\nmain branch tmux session failed`);
 
     expect(result).toBe("Fix hook state main branch tmux session failed");
+  });
+});
+
+describe("mapWithConcurrency", () => {
+  it("should preserve result order while limiting concurrent work", async () => {
+    let activeCount = 0;
+    let maxActiveCount = 0;
+
+    const result = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (value, index) => {
+      activeCount += 1;
+      maxActiveCount = Math.max(maxActiveCount, activeCount);
+
+      await new Promise((resolve) => setTimeout(resolve, (5 - index) * 2));
+
+      activeCount -= 1;
+      return value * 10;
+    });
+
+    expect(result).toEqual([10, 20, 30, 40, 50]);
+    expect(maxActiveCount).toBeLessThanOrEqual(2);
   });
 });

--- a/src/lib/aiSessions/readClaudeSessions.ts
+++ b/src/lib/aiSessions/readClaudeSessions.ts
@@ -7,10 +7,12 @@ import {
   getCachedOrParse,
   getCachedOrParseHead,
   getCandidatePaths,
+  mapWithConcurrency,
   makePreviewMessage,
   paginateItems,
   readJsonLines,
   readJsonLinesHead,
+  REMOTE_SESSION_FILE_PARSE_CONCURRENCY,
   sortMessagesDescending,
   toIsoString,
   truncateText,
@@ -53,8 +55,11 @@ export async function readClaudeSessions(context: AiSessionReaderContext): Promi
     return createReaderResult("claude", { sessions: [], reason: "No Claude project session files matched this task" });
   }
 
-  const results = await Promise.all(
-    projectFiles.map((filePath) => parseClaudeSessionFromFile(filePath, context))
+  const parseConcurrency = context.sshHost ? REMOTE_SESSION_FILE_PARSE_CONCURRENCY : projectFiles.length || 1;
+  const results = await mapWithConcurrency(
+    projectFiles,
+    parseConcurrency,
+    (filePath) => parseClaudeSessionFromFile(filePath, context),
   );
 
   let sessions = results.filter((s): s is AggregatedAiSession => s !== null);

--- a/src/lib/aiSessions/readCodexSessions.ts
+++ b/src/lib/aiSessions/readCodexSessions.ts
@@ -5,9 +5,11 @@ import {
   determineMatchScope,
   extractPlainText,
   getCachedOrParse,
+  mapWithConcurrency,
   makePreviewMessage,
   paginateItems,
   readJsonLines,
+  REMOTE_SESSION_FILE_PARSE_CONCURRENCY,
   sortMessagesDescending,
   toIsoString,
   truncateText,
@@ -31,9 +33,12 @@ export async function readCodexSessions(context: AiSessionReaderContext): Promis
   }
 
   const rolloutFiles = await listFilesRecursivelyBySuffix(codexSessionsDirectory, ".jsonl", context.sshHost);
+  const parseConcurrency = context.sshHost ? REMOTE_SESSION_FILE_PARSE_CONCURRENCY : rolloutFiles.length || 1;
 
-  const results = await Promise.all(
-    rolloutFiles.map((filePath) => parseCodexSessionSummary(filePath, context))
+  const results = await mapWithConcurrency(
+    rolloutFiles,
+    parseConcurrency,
+    (filePath) => parseCodexSessionSummary(filePath, context),
   );
   let sessions = results.filter((s): s is AggregatedAiSession => s !== null);
 

--- a/src/lib/aiSessions/shared.ts
+++ b/src/lib/aiSessions/shared.ts
@@ -18,6 +18,7 @@ import type {
 
 const MAX_PREVIEW_MESSAGES = 12;
 const MAX_PREVIEW_TEXT_LENGTH = 240;
+export const REMOTE_SESSION_FILE_PARSE_CONCURRENCY = 3;
 
 export function createReaderResult(provider: AiSessionProvider, partial?: Partial<AiSessionReaderResult>): AiSessionReaderResult {
   return {
@@ -190,6 +191,31 @@ export async function listFilesRecursively(rootPath: string, matcher: (filePath:
   }));
 
   return files.flat();
+}
+
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const workerCount = Math.min(Math.max(1, Math.floor(concurrency)), items.length);
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function runWorker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await mapper(items[currentIndex], currentIndex);
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+  return results;
 }
 
 export async function readJsonLines(filePath: string, sshHost?: string | null): Promise<unknown[]> {

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -8,6 +8,52 @@ import { buildSSHArgs, type SSHHostConfig } from "@/lib/sshConfig";
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
+const SSH_TRANSPORT_ERROR_PATTERNS = [
+  /kex_exchange_identification/i,
+  /connection reset by peer/i,
+  /connection reset by /i,
+  /connection closed by /i,
+  /connection refused/i,
+  /connection timed out/i,
+  /operation timed out/i,
+  /no route to host/i,
+  /network is unreachable/i,
+  /could not resolve hostname/i,
+  /name or service not known/i,
+  /temporary failure in name resolution/i,
+  /host key verification failed/i,
+  /remote host identification has changed/i,
+  /permission denied \(publickey/i,
+  /too many authentication failures/i,
+  /bad owner or permissions/i,
+  /ssh: connect to host/i,
+];
+
+function collectErrorOutput(error: unknown): string {
+  const outputs: string[] = [];
+
+  if (error instanceof Error) {
+    outputs.push(error.message);
+  }
+
+  if (error && typeof error === "object") {
+    if ("stderr" in error) {
+      outputs.push(String((error as { stderr?: string }).stderr || ""));
+    }
+
+    if ("stdout" in error) {
+      outputs.push(String((error as { stdout?: string }).stdout || ""));
+    }
+  }
+
+  return outputs.filter(Boolean).join("\n");
+}
+
+export function isSSHTransportError(error: unknown): boolean {
+  const errorOutput = collectErrorOutput(error);
+  return SSH_TRANSPORT_ERROR_PATTERNS.some((pattern) => pattern.test(errorOutput));
+}
+
 function summarizeCommandFailure(errorOutput: string): string {
   const lines = errorOutput
     .split(/\r?\n/)

--- a/src/lib/remoteSessionDependency.ts
+++ b/src/lib/remoteSessionDependency.ts
@@ -1,5 +1,5 @@
 import { SessionType } from "@/entities/KanbanTask";
-import { execGit } from "@/lib/gitOperations";
+import { execGit, isSSHTransportError } from "@/lib/gitOperations";
 
 const blockedTargets = new Map<string, string>();
 
@@ -30,7 +30,11 @@ async function hasSessionDependency(toolName: string, sshHost?: string | null): 
   try {
     await execGit(`command -v ${toolName} >/dev/null 2>&1`, sshHost);
     return true;
-  } catch {
+  } catch (error) {
+    if (sshHost && isSSHTransportError(error)) {
+      throw error;
+    }
+
     return false;
   }
 }
@@ -77,6 +81,10 @@ export async function installSessionDependency(
     await execGit(buildInstallCommand(toolName), sshHost);
     await execGit(`command -v ${toolName} >/dev/null 2>&1`, sshHost);
   } catch (error) {
+    if (sshHost && isSSHTransportError(error)) {
+      throw error;
+    }
+
     const subject = sshHost ? `${sshHost} 호스트` : "로컬 환경";
     const reason = sshHost
       ? `${subject}에서 ${toolName} 설치를 완료하지 못해 원격 접근을 차단했습니다. ${error instanceof Error ? error.message : "원격 설치 실패"}`


### PR DESCRIPTION
## What is this PR?

This PR fixes a remote tmux dependency false negative where SSH transport failures, such as `Connection reset`, `Connection closed`, or `kex_exchange_identification`, could be mistaken for a missing tmux or zellij installation and poison the remote host blocklist.

## How did you solve it?

**Separate SSH transport failures from missing tools**
- Add reusable SSH transport error classification in `gitOperations`.
- Let remote dependency checks rethrow transport failures instead of treating them as missing session tools.
- Keep the existing blocklist behavior for real install failures.

**Reduce remote SSH connection bursts**
- Add a small concurrency helper for AI session file parsing.
- Limit remote Codex and Claude session JSONL parsing concurrency to avoid opening too many short-lived SSH commands at once.

**Cover the regression with tests**
- Add tests for SSH transport error classification.
- Add tests proving transport failures do not trigger auto-install or host blocking.
- Add tests for ordered, concurrency-limited mapping.

## Important Changes

### SSH transport failures no longer block remote hosts

**Transport-aware dependency checks**
- **Why**: `roky-home` can already have tmux installed, while a reset SSH connection should only surface as a connection failure.
- **Files**: `src/lib/gitOperations.ts`, `src/lib/remoteSessionDependency.ts`

**Host blocklist behavior**
- **Why**: transient SSH failures should not persist as a tmux/zellij installation failure after the host becomes reachable again.
- **Files**: `src/lib/remoteSessionDependency.ts`, `src/lib/__tests__/remoteSessionDependency.test.ts`

### Remote AI session loading is less aggressive

**Concurrency-limited parsing**
- **Why**: remote session aggregation can otherwise fan out many SSH commands in parallel and increase the chance of server-side connection resets.
- **Files**: `src/lib/aiSessions/shared.ts`, `src/lib/aiSessions/readCodexSessions.ts`, `src/lib/aiSessions/readClaudeSessions.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>