### PR TITLE
Align board controls with the macOS titlebar

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -15,7 +15,6 @@ import { reorderTasks, deleteTask, getMoreDoneTasks, moveTaskToColumn } from "@/
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
-import { logoutAction } from "@/desktop/renderer/actions/auth";
 import { useAutoRefresh } from "@/desktop/renderer/hooks/useAutoRefresh";
 import { useProjectFilterParams } from "@/desktop/renderer/hooks/useProjectFilterParams";
 import { computeProjectColor } from "@/lib/projectColor";
@@ -201,7 +200,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const [isDoneAlertDismissed, setIsDoneAlertDismissed] = useState(doneAlertDismissed);
   const [pendingDoneResult, setPendingDoneResult] = useState<DropResult | null>(null);
   const [currentDefaultSessionType, setCurrentDefaultSessionType] = useState<SessionType>(defaultSessionType);
-  const [needsMacDesktopHeaderOffset, setNeedsMacDesktopHeaderOffset] = useState(false);
+  const [shouldUseMacTitlebarLayout, setShouldUseMacTitlebarLayout] = useState(false);
   const [, startDragPersistenceTransition] = useTransition();
 
   /** projectId → 표시할 프로젝트 이름 매핑. worktree 프로젝트는 메인 프로젝트 이름으로 resolve한다 */
@@ -344,7 +343,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   useEffect(() => {
     const isDesktopApp = window.kanvibeDesktop?.isDesktop === true;
     const isMacDesktop = navigator.userAgent.includes("Mac") || navigator.platform.toLowerCase().includes("mac");
-    setNeedsMacDesktopHeaderOffset(isDesktopApp && isMacDesktop);
+    setShouldUseMacTitlebarLayout(isDesktopApp && isMacDesktop);
   }, []);
 
   const handleLoadMoreDone = useCallback(async () => {
@@ -469,9 +468,9 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   return (
     <div className="min-h-screen">
       <header
-        className={`flex items-center justify-end px-6 pb-4 border-b border-border-default bg-bg-surface ${needsMacDesktopHeaderOffset ? "pt-10" : "pt-4"}`}
+        className={`flex items-center justify-end border-b border-border-default bg-bg-surface ${shouldUseMacTitlebarLayout ? "h-10 pl-20 pr-4 [-webkit-app-region:drag]" : "px-6 pb-4 pt-4"}`}
       >
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 [-webkit-app-region:no-drag]">
           <div className="w-64">
             <ProjectSelector
               multiple
@@ -500,18 +499,10 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
             </svg>
           </button>
           <NotificationCenterButton buttonClassName="hover:bg-bg-page" />
-          <form action={logoutAction}>
-            <button
-              type="submit"
-              className="px-3 py-1.5 text-sm text-text-muted hover:text-text-primary transition-colors"
-            >
-              {tc("logout")}
-            </button>
-          </form>
         </div>
       </header>
 
-      <main className="p-6">
+      <main className={shouldUseMacTitlebarLayout ? "px-6 pb-6 pt-4" : "p-6"}>
         {isMounted ? (
           <DragDropContext onDragEnd={handleDragEnd}>
             <div className="flex gap-4 overflow-x-auto">

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -44,10 +44,6 @@ vi.mock("@/desktop/renderer/actions/kanban", () => ({
   moveTaskToColumn: vi.fn(),
 }));
 
-vi.mock("@/desktop/renderer/actions/auth", () => ({
-  logoutAction: vi.fn(),
-}));
-
 vi.mock("@/desktop/renderer/hooks/useAutoRefresh", () => ({
   useAutoRefresh: vi.fn(),
 }));
@@ -62,6 +58,10 @@ vi.mock("../Column", () => ({
 
 vi.mock("../ProjectSelector", () => ({
   default: () => <div data-testid="project-selector" />,
+}));
+
+vi.mock("../NotificationCenterButton", () => ({
+  default: () => <button type="button" aria-label="notifications" />,
 }));
 
 vi.mock("../TaskContextMenu", () => ({
@@ -230,7 +230,7 @@ describe("Board defaultSessionType sync", () => {
     });
   });
 
-  it("맥 데스크톱 앱에서는 헤더 상단에 추가 여백을 준다", async () => {
+  it("맥 데스크톱 앱에서는 보드 컨트롤을 타이틀바 한 줄에 배치한다", async () => {
     window.kanvibeDesktop = { isDesktop: true };
     mockNavigatorPlatform("MacIntel");
 
@@ -249,7 +249,28 @@ describe("Board defaultSessionType sync", () => {
     );
 
     await waitFor(() => {
-      expect(container.querySelector("header")?.className).toContain("pt-10");
+      const headerClassName = container.querySelector("header")?.className;
+      expect(headerClassName).toContain("h-10");
+      expect(headerClassName).toContain("pl-20");
+      expect(headerClassName).not.toContain("pt-10");
     });
+  });
+
+  it("인증 UI가 없는 보드 상단에는 로그아웃 버튼을 표시하지 않는다", () => {
+    render(
+      <Board
+        initialTasks={createEmptyTasks()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "logout" })).toBeNull();
   });
 });


### PR DESCRIPTION
## Related Materials
- Issue: N/A

## What changed?
- Align the board project filter, new task action, settings action, and notifications action with the macOS titlebar row.
- Keep the Kanban board directly below the compact titlebar header.
- Remove the logout action from the board header because the current UI does not expose authentication controls.

## How was it solved?
**Board header layout**
- Replaced the macOS-only top padding offset with a compact titlebar-height header.
- Reserved left-side space for native macOS window controls and marked the header drag region appropriately.
- Kept the interactive controls in a no-drag region so filters and buttons remain clickable.

**Logout action removal**
- Removed the logout form and unused auth action import from the board header.

**Regression coverage**
- Updated the macOS desktop layout test to assert titlebar-row placement.
- Added coverage that the board header no longer renders a logout button.

## Important details
### macOS titlebar alignment

**Use a titlebar-height board header**
- **Reason**: The previous macOS offset pushed controls below the native window buttons and left extra vertical space before the board.
- **Files**: `src/components/Board.tsx`

**Preserve clickability inside the draggable header**
- **Reason**: Electron titlebar drag regions can block interaction unless controls are explicitly marked as no-drag.
- **Files**: `src/components/Board.tsx`

### Authentication action cleanup

**Remove the board logout button**
- **Reason**: The board does not currently expose an authentication workflow that needs a logout affordance in this header.
- **Files**: `src/components/Board.tsx`, `src/components/__tests__/Board.test.tsx`

Co-authored-by: Codex <codex@openai.com>
