### PR TITLE
fix: exclude nested repos from project discovery

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   removeWorktreeAndBranch: vi.fn(),
   removeSessionOnly: vi.fn(),
   installKanvibeHooks: vi.fn(),
+  listWorktrees: vi.fn(),
   broadcastBoardUpdate: vi.fn(),
 }));
 
@@ -50,6 +51,10 @@ vi.mock("@/lib/worktree", () => ({
   createSessionWithoutWorktree: vi.fn(),
   removeSessionOnly: mocks.removeSessionOnly,
   buildManagedWorktreePath: vi.fn((projectPath: string, branchName: string) => `${projectPath}__worktrees/${branchName}`),
+}));
+
+vi.mock("@/lib/gitOperations", () => ({
+  listWorktrees: mocks.listWorktrees,
 }));
 
 vi.mock("@/lib/kanvibeHooksInstaller", () => ({
@@ -112,6 +117,7 @@ describe("kanbanService.createTask", () => {
       repoPath: "/remote/repo",
       sshHost: "remote-host",
     });
+    mocks.listWorktrees.mockResolvedValue([]);
 
     const { cleanupTaskResources } = await import("@/desktop/main/services/kanbanService");
 
@@ -129,6 +135,45 @@ describe("kanbanService.createTask", () => {
     // Then
     expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
     expect(consoleWarnSpy).toHaveBeenCalled();
+  });
+
+  it("TODO 삭제 시 git worktree 목록에서 확인한 실제 경로를 삭제한다", async () => {
+    // Given
+    const actualWorktreePath = "/workspace/repo/modules/api-worktree";
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+    mocks.listWorktrees.mockResolvedValue([
+      {
+        path: actualWorktreePath,
+        branch: "feature/login",
+        isBare: false,
+      },
+    ]);
+
+    const { cleanupTaskResources } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    await cleanupTaskResources({
+      id: "task-actual-path",
+      projectId: "project-1",
+      branchName: "feature/login",
+      worktreePath: actualWorktreePath,
+      sshHost: null,
+      sessionType: null,
+      sessionName: null,
+    } as never);
+
+    // Then
+    expect(mocks.removeWorktreeAndBranch).toHaveBeenCalledWith(
+      "/workspace/repo",
+      "feature/login",
+      null,
+      actualWorktreePath,
+    );
   });
 
   it("연결된 프로젝트를 찾을 수 없는 원격 stale task는 정리를 시도하지 않는다", async () => {

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -156,7 +156,7 @@ describe("projectService.listSubdirectories", () => {
 
     // Then
     expect(mocks.execGit).toHaveBeenCalledWith(
-      'find "/workspace" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort',
+      'if git -C "/workspace" rev-parse --is-inside-work-tree >/dev/null 2>&1; then find "/workspace" -maxdepth 1 -mindepth 1 -type d ! -exec test -e "{}/.git" \\; 2>/dev/null | sort; else find "/workspace" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort; fi',
       "remote-host",
     );
     expect(result).toEqual(["api", "web"]);
@@ -172,7 +172,7 @@ describe("projectService.listSubdirectories", () => {
 
     // Then
     expect(mocks.execGit).toHaveBeenCalledWith(
-      'find "/home/tester/" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort',
+      'if git -C "/home/tester/" rev-parse --is-inside-work-tree >/dev/null 2>&1; then find "/home/tester/" -maxdepth 1 -mindepth 1 -type d ! -exec test -e "{}/.git" \\; 2>/dev/null | sort; else find "/home/tester/" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort; fi',
       null,
     );
     expect(result).toEqual(["projects"]);
@@ -188,7 +188,7 @@ describe("projectService.listSubdirectories", () => {
 
     // Then
     expect(mocks.execGit).toHaveBeenCalledWith(
-      'find "$HOME/projects" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort',
+      'if git -C "$HOME/projects" rev-parse --is-inside-work-tree >/dev/null 2>&1; then find "$HOME/projects" -maxdepth 1 -mindepth 1 -type d ! -exec test -e "{}/.git" \\; 2>/dev/null | sort; else find "$HOME/projects" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort; fi',
       "remote-host",
     );
     expect(result).toEqual(["projects"]);

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -3,10 +3,11 @@ import { Not, Like } from "typeorm";
 import { getTaskRepository } from "@/lib/database";
 import { KanbanTask, TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
-import { createWorktreeWithSession, removeWorktreeAndBranch, createSessionWithoutWorktree, removeSessionOnly, buildManagedWorktreePath } from "@/lib/worktree";
+import { createWorktreeWithSession, removeWorktreeAndBranch, createSessionWithoutWorktree, removeSessionOnly } from "@/lib/worktree";
 import { getProjectRepository } from "@/lib/database";
 import { broadcastBoardUpdate } from "@/lib/boardNotifier";
 import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
+import { listWorktrees } from "@/lib/gitOperations";
 
 export type TasksByStatus = Record<TaskStatus, KanbanTask[]>;
 
@@ -22,6 +23,34 @@ export interface LoadMoreDoneResponse {
 }
 
 const DONE_PAGE_SIZE = 20;
+
+function isProjectRootTask(task: KanbanTask, project: { repoPath: string; defaultBranch?: string | null }): boolean {
+  if (task.worktreePath === project.repoPath) {
+    return true;
+  }
+
+  return task.branchName === project.defaultBranch && !task.worktreePath;
+}
+
+async function findActualWorktreePath(
+  projectPath: string,
+  branchName: string,
+  taskWorktreePath: string | null,
+  sshHost?: string | null,
+): Promise<string | null> {
+  if (!taskWorktreePath) {
+    return null;
+  }
+
+  const worktrees = await listWorktrees(projectPath, sshHost);
+  const matchingWorktree = worktrees.find((worktree) => (
+    !worktree.isBare
+    && worktree.branch === branchName
+    && worktree.path === taskWorktreePath
+  ));
+
+  return matchingWorktree?.path ?? null;
+}
 
 /** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
 function serialize<T>(data: T): T {
@@ -272,10 +301,7 @@ export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
     return;
   }
 
-  const isProjectRoot = project && task.worktreePath === project.repoPath;
-  const expectedWorktreePath = project?.repoPath && task.branchName
-    ? buildManagedWorktreePath(project.repoPath, task.branchName)
-    : null;
+  const isProjectRoot = project ? isProjectRootTask(task, project) : false;
 
   /** 브랜치별 독립 세션 정리 */
   if (task.sessionType && task.sessionName) {
@@ -292,12 +318,12 @@ export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
 
   /** worktree + 브랜치 정리 (프로젝트 루트 브랜치 제외) */
   if (task.branchName && !isProjectRoot) {
-    const canCleanupBranch = Boolean(project?.repoPath)
-      && Boolean(task.worktreePath)
-      && task.worktreePath === expectedWorktreePath;
+    const actualWorktreePath = project?.repoPath
+      ? await findActualWorktreePath(project.repoPath, task.branchName, task.worktreePath, sshHost)
+      : null;
 
-    if (!canCleanupBranch) {
-      console.warn("worktree/브랜치 정리 건너뜀: task 경로와 project 경로가 일치하지 않습니다.", {
+    if (!project?.repoPath || !actualWorktreePath) {
+      console.warn("worktree/브랜치 정리 건너뜀: git worktree 목록에서 task 경로를 찾을 수 없습니다.", {
         taskId: task.id,
         branchName: task.branchName,
         worktreePath: task.worktreePath,
@@ -309,9 +335,10 @@ export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
 
     try {
       await removeWorktreeAndBranch(
-        project?.repoPath || process.cwd(),
+        project.repoPath,
         task.branchName,
-        sshHost
+        sshHost,
+        actualWorktreePath,
       );
     } catch (error) {
       console.error("worktree/브랜치 정리 실패:", error);

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -37,6 +37,16 @@ function resolveDirectorySearchPath(targetPath: string, sshHost?: string): strin
   return `"${targetPath.replace(/^~/, homedir())}"`;
 }
 
+function buildSubdirectoryScanCommand(resolvedPath: string): string {
+  return [
+    `if git -C ${resolvedPath} rev-parse --is-inside-work-tree >/dev/null 2>&1; then`,
+    `find ${resolvedPath} -maxdepth 1 -mindepth 1 -type d ! -exec test -e "{}/.git" \\; 2>/dev/null | sort;`,
+    "else",
+    `find ${resolvedPath} -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort;`,
+    "fi",
+  ].join(" ");
+}
+
 /** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
 function serialize<T>(data: T): T {
   return JSON.parse(JSON.stringify(data));
@@ -637,7 +647,7 @@ export async function listSubdirectories(
   sshHost?: string
 ): Promise<string[]> {
   const resolvedPath = resolveDirectorySearchPath(parentPath, sshHost);
-  const command = `find ${resolvedPath} -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort`;
+  const command = buildSubdirectoryScanCommand(resolvedPath);
 
   try {
     const output = await execGit(command, sshHost || null);

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -161,7 +161,7 @@ describe("gitOperations.resolvePathForShell", () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
-  it("scanGitRepos는 일반 저장소와 worktree 저장소를 모두 찾는다", async () => {
+  it("scanGitRepos는 메인 저장소 내부의 submodule/worktree 후보를 제외한다", async () => {
     // Given
     mocks.exec.mockImplementation((
       _command: string,
@@ -170,7 +170,12 @@ describe("gitOperations.resolvePathForShell", () => {
       callback(
         null,
         {
-          stdout: "/workspace/api/.git\n/workspace/feature-worktree/.git\n",
+          stdout: [
+            "/workspace/api/.git",
+            "/workspace/api/packages/shared/.git",
+            "/workspace/api/.worktrees/feature-login/.git",
+            "/workspace/feature-worktree/.git",
+          ].join("\n"),
           stderr: "",
         },
       );

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -236,6 +236,36 @@ describe("removeSessionOnly", () => {
   });
 });
 
+describe("removeWorktreeAndBranch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should remove the explicitly resolved worktree path", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("");
+    const { removeWorktreeAndBranch } = await import("@/lib/worktree");
+
+    // When
+    await removeWorktreeAndBranch(
+      "/repo/path",
+      "feat/login",
+      null,
+      "/repo/modules/api-worktree",
+    );
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledWith(
+      'git -C "/repo/path" worktree remove "/repo/modules/api-worktree" --force',
+      null,
+    );
+    expect(mockExecGit).toHaveBeenCalledWith(
+      'git -C "/repo/path" branch -D "feat/login"',
+      null,
+    );
+  });
+});
+
 describe("createSessionWithoutWorktree", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -1,9 +1,7 @@
 import { exec, execFile } from "child_process";
 import { promisify } from "util";
-import { readFile } from "fs/promises";
 import { homedir } from "os";
-import path from "path";
-import { buildSSHArgs, type SSHHostConfig } from "@/lib/sshConfig";
+import { buildSSHArgs } from "@/lib/sshConfig";
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -199,9 +197,45 @@ export async function getDefaultBranch(
   }
 }
 
+function normalizeRepositoryPath(repoPath: string): string {
+  if (repoPath === "/") return repoPath;
+  return repoPath.replace(/\/+$/, "");
+}
+
+function isNestedRepositoryPath(repoPath: string, parentRepoPath: string): boolean {
+  const normalizedRepoPath = normalizeRepositoryPath(repoPath);
+  const normalizedParentPath = normalizeRepositoryPath(parentRepoPath);
+
+  if (normalizedParentPath === "/") {
+    return normalizedRepoPath !== "/";
+  }
+
+  return normalizedRepoPath !== normalizedParentPath
+    && normalizedRepoPath.startsWith(`${normalizedParentPath}/`);
+}
+
+function filterNestedRepositoryPaths(repoPaths: string[]): string[] {
+  const uniquePaths = repoPaths
+    .map(normalizeRepositoryPath)
+    .filter((value, index, self) => self.indexOf(value) === index);
+  const topLevelPaths: string[] = [];
+
+  for (const repoPath of [...uniquePaths].sort((a, b) => a.length - b.length)) {
+    if (topLevelPaths.some((parentPath) => isNestedRepositoryPath(repoPath, parentPath))) {
+      continue;
+    }
+
+    topLevelPaths.push(repoPath);
+  }
+
+  const topLevelPathSet = new Set(topLevelPaths);
+  return uniquePaths.filter((repoPath) => topLevelPathSet.has(repoPath));
+}
+
 /**
  * 지정 디렉토리 하위의 git 저장소 경로 목록을 반환한다.
  * 일반 저장소의 `.git` 디렉토리와 worktree의 `.git` 파일을 모두 탐색하여 상위 경로를 추출한다.
+ * 이미 발견한 메인 저장소 내부의 submodule/worktree는 별도 프로젝트 후보에서 제외한다.
  */
 export async function scanGitRepos(
   rootPath: string,
@@ -215,11 +249,13 @@ export async function scanGitRepos(
 
     if (!output) return [];
 
-    return output
+    const repoPaths = output
       .split("\n")
       .filter(Boolean)
       .map((gitDir) => gitDir.replace(/\/\.git$/, ""))
       .filter((value, index, self) => self.indexOf(value) === index);
+
+    return filterNestedRepositoryPaths(repoPaths);
   } catch (error) {
     console.error("[remote-scan] git repository scan failed", {
       sshHost: sshHost || null,

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -348,11 +348,12 @@ export async function removeWorktreeAndBranch(
   projectPath: string,
   branchName: string,
   sshHost?: string | null,
+  worktreePath?: string | null,
 ): Promise<void> {
   try {
-    const worktreePath = buildManagedWorktreePath(projectPath, branchName);
+    const removalTargetPath = worktreePath || buildManagedWorktreePath(projectPath, branchName);
     await execGit(
-      `git -C "${projectPath}" worktree remove "${worktreePath}" --force`,
+      `git -C "${projectPath}" worktree remove "${removalTargetPath}" --force`,
       sshHost,
     );
   } catch {


### PR DESCRIPTION
## What is this change?
- Prevent project discovery from registering nested git repositories inside a main module, including submodules and worktrees.
- Ensure task cleanup deletes the actual git worktree path recorded by git instead of relying on a hardcoded managed worktree path.

## How was it solved?
**Project discovery**
- Filter nested repository paths after `.git` discovery so only top-level project roots remain scan candidates.
- Update folder drill-down scanning to hide direct child directories that contain their own `.git` entry when browsing inside a git repository.

**Task cleanup**
- Resolve the task worktree through `git worktree list` before cleanup.
- Pass the resolved worktree path into the removal helper so module-specific worktree locations are deleted correctly.

## Important changes
### Nested repository filtering

**Skip submodules and internal worktrees during discovery**
- **Reason**: Scanning inside a main module should not register internal repositories as separate projects.
- **Files**: `src/lib/gitOperations.ts`, `src/desktop/main/services/projectService.ts`

### Actual worktree cleanup

**Delete the git-confirmed task worktree path**
- **Reason**: Hardcoded managed path construction does not work for worktrees created or stored at module-specific locations.
- **Files**: `src/desktop/main/services/kanbanService.ts`, `src/lib/worktree.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>