### PR TITLE
feat(codex): support hooks.json-based status hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@
 /.tooling/
 /.omc/
 /.codex/hooks/
+/.codex/hooks.json
+/.codex/config.toml
 /resources/database/app.seed.db
 
 # debug

--- a/README.md
+++ b/README.md
@@ -190,12 +190,13 @@ AfterAgent (agent done)    → REVIEW
 
 > Gemini CLI does not have an equivalent to Claude Code's `AskUserQuestion`, so the PENDING state is not available.
 
-#### Codex CLI (Partial Support)
+#### Codex CLI
 ```
-agent-turn-complete (agent done) → REVIEW
+UserPromptSubmit (user prompt) → PROGRESS
+Stop (turn stops)              → REVIEW
 ```
 
-> Codex CLI currently only supports the `agent-turn-complete` notification event via the `notify` config. PROGRESS and PENDING transitions are not yet available. OpenAI is [actively designing a hooks system](https://github.com/openai/codex/discussions/2150) — full support will be added when it ships.
+> KanVibe enables Codex hooks with `[features] codex_hooks = true` in `.codex/config.toml` and writes repo-local `.codex/hooks.json`. Codex hooks are experimental, currently disabled on Windows, and do not expose a Claude Code `AskUserQuestion` equivalent, so PENDING is not available.
 
 #### OpenCode
 ```

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -190,12 +190,13 @@ AfterAgent (에이전트 완료)   → REVIEW
 
 > Gemini CLI에는 Claude Code의 `AskUserQuestion`에 대응하는 이벤트가 없어 PENDING 상태는 지원되지 않습니다.
 
-#### Codex CLI (부분 지원)
+#### Codex CLI
 ```
-agent-turn-complete (에이전트 완료) → REVIEW
+UserPromptSubmit (사용자 프롬프트) → PROGRESS
+Stop (턴 종료)                    → REVIEW
 ```
 
-> Codex CLI는 현재 `notify` 설정의 `agent-turn-complete` 이벤트만 지원합니다. PROGRESS, PENDING 전환은 아직 불가합니다. OpenAI가 [hooks 시스템을 설계 중](https://github.com/openai/codex/discussions/2150)이며, 출시되면 전체 지원을 추가할 예정입니다.
+> KanVibe는 `.codex/config.toml`의 `[features] codex_hooks = true`와 repo-local `.codex/hooks.json`으로 Codex hooks를 활성화합니다. Codex hooks는 실험 기능이고 현재 Windows에서는 비활성화되어 있으며, Claude Code의 `AskUserQuestion`에 대응하는 이벤트가 없어 PENDING 상태는 지원되지 않습니다.
 
 #### OpenCode
 ```

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -190,12 +190,13 @@ AfterAgent（代理完成）       → REVIEW
 
 > Gemini CLI 没有与 Claude Code 的 `AskUserQuestion` 对应的事件，因此不支持 PENDING 状态。
 
-#### Codex CLI（部分支持）
+#### Codex CLI
 ```
-agent-turn-complete（代理完成） → REVIEW
+UserPromptSubmit（用户提示词） → PROGRESS
+Stop（回合结束）              → REVIEW
 ```
 
-> Codex CLI 目前仅支持 `notify` 配置的 `agent-turn-complete` 事件。PROGRESS 和 PENDING 转换尚不可用。OpenAI 正在[设计 hooks 系统](https://github.com/openai/codex/discussions/2150)，发布后将添加完整支持。
+> KanVibe 通过 `.codex/config.toml` 中的 `[features] codex_hooks = true` 和仓库本地 `.codex/hooks.json` 启用 Codex hooks。Codex hooks 仍是实验功能，目前在 Windows 上禁用，并且没有与 Claude Code 的 `AskUserQuestion` 对应的事件，因此不支持 PENDING 状态。
 
 #### OpenCode
 ```

--- a/src/components/HooksStatusDialog.tsx
+++ b/src/components/HooksStatusDialog.tsx
@@ -199,7 +199,9 @@ export default function HooksStatusDialog({
       status: localCodexStatus,
       files: [
         TASK_ID_FILE_PATH,
-        ".codex/hooks/kanvibe-notify-hook.sh",
+        ".codex/hooks/kanvibe-prompt-hook.sh",
+        ".codex/hooks/kanvibe-stop-hook.sh",
+        ".codex/hooks.json",
         ".codex/config.toml",
       ],
       onInstall: () => runInstall("codex", () => installTaskCodexHooks(taskId), applyCodexResult),

--- a/src/components/__tests__/HooksStatusCard.test.tsx
+++ b/src/components/__tests__/HooksStatusCard.test.tsx
@@ -88,7 +88,7 @@ describe("HooksStatusCard", () => {
       taskId: "task-1",
       initialClaudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
       initialGeminiStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasSettingsEntry: true },
-      initialCodexStatus: { installed: true, hasNotifyHook: true, hasConfigEntry: true },
+      initialCodexStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasHooksJsonEntry: true, hasFeatureFlag: true },
       initialOpenCodeStatus: { installed: true, hasPlugin: true },
       isRemote: false,
     };

--- a/src/components/__tests__/HooksStatusDialog.test.tsx
+++ b/src/components/__tests__/HooksStatusDialog.test.tsx
@@ -66,11 +66,12 @@ describe("HooksStatusDialog", () => {
 
   const verifiedCodexStatus = {
     installed: true,
-    hasNotifyHook: true,
-    hasConfigEntry: true,
+    hasPromptHook: true,
+    hasStopHook: true,
+    hasHooksJsonEntry: true,
+    hasFeatureFlag: true,
     hasTaskIdBinding: true,
-    hasReviewStatus: true,
-    hasAgentTurnCompleteFilter: true,
+    hasStatusMappings: true,
   };
 
   const verifiedOpenCodeStatus = {

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, readFile, rm } from "fs/promises";
+import { mkdtemp, readFile, rm, mkdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
+import { execSync } from "child_process";
 import { setupCodexHooks, getCodexHooksStatus } from "../codexHooksSetup";
 
 describe("codexHooksSetup", () => {
@@ -9,6 +10,7 @@ describe("codexHooksSetup", () => {
 
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "codex-test-"));
+    execSync("git init", { cwd: tempDir, stdio: "ignore" });
   });
 
   afterEach(async () => {
@@ -16,29 +18,41 @@ describe("codexHooksSetup", () => {
   });
 
   describe("setupCodexHooks - file operations", () => {
-    it("should create hook script file", async () => {
+    it("should create prompt and stop hook script files", async () => {
       const repoPath = tempDir;
 
       await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
 
       const status = await getCodexHooksStatus(repoPath);
-      expect(status.hasNotifyHook).toBe(true);
+      expect(status.hasPromptHook).toBe(true);
+      expect(status.hasStopHook).toBe(true);
     });
 
-    it("should create config.toml with notify entry", async () => {
+    it("should create hooks.json and config.toml with Codex hooks entries", async () => {
       const repoPath = tempDir;
 
       await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
 
       const status = await getCodexHooksStatus(repoPath);
-      expect(status.hasConfigEntry).toBe(true);
+      expect(status.hasHooksJsonEntry).toBe(true);
+      expect(status.hasFeatureFlag).toBe(true);
 
-      const hookContent = await readFile(join(repoPath, ".codex", "hooks", "kanvibe-notify-hook.sh"), "utf-8");
-      expect(hookContent).toContain('TASK_ID="task-1"');
-      expect(hookContent).toContain("taskId");
+      const promptHookContent = await readFile(join(repoPath, ".codex", "hooks", "kanvibe-prompt-hook.sh"), "utf-8");
+      const stopHookContent = await readFile(join(repoPath, ".codex", "hooks", "kanvibe-stop-hook.sh"), "utf-8");
+      const hooksJsonContent = await readFile(join(repoPath, ".codex", "hooks.json"), "utf-8");
+      const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
+
+      expect(promptHookContent).toContain('TASK_ID="task-1"');
+      expect(promptHookContent).toContain('\\"status\\": \\"progress\\"');
+      expect(stopHookContent).toContain('\\"status\\": \\"review\\"');
+      expect(hooksJsonContent).toContain("UserPromptSubmit");
+      expect(hooksJsonContent).toContain("Stop");
+      expect(hooksJsonContent).toContain("$(git rev-parse --show-toplevel)/.codex/hooks/kanvibe-prompt-hook.sh");
+      expect(configContent).toContain("[features]");
+      expect(configContent).toContain("codex_hooks = true");
     });
 
-    it("should mark as installed when both hook and config exist", async () => {
+    it("should mark as installed when scripts, hooks.json, and feature flag exist", async () => {
       const repoPath = tempDir;
 
       await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
@@ -47,14 +61,50 @@ describe("codexHooksSetup", () => {
       expect(status.installed).toBe(true);
     });
 
-    it("should not add duplicate notify entry", async () => {
+    it("should not add duplicate hooks.json entries", async () => {
       const repoPath = tempDir;
       await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
 
       await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
 
-      const status = await getCodexHooksStatus(repoPath);
-      expect(status.installed).toBe(true);
+      const hooksJson = JSON.parse(await readFile(join(repoPath, ".codex", "hooks.json"), "utf-8"));
+      expect(hooksJson.hooks.UserPromptSubmit).toHaveLength(1);
+      expect(hooksJson.hooks.Stop).toHaveLength(1);
+      expect(await getCodexHooksStatus(repoPath)).toMatchObject({ installed: true });
+    });
+
+    it("should preserve existing config while enabling codex hooks", async () => {
+      const repoPath = tempDir;
+      await mkdir(join(repoPath, ".codex"), { recursive: true });
+      await writeFile(
+        join(repoPath, ".codex", "config.toml"),
+        "model = \"gpt-5.4\"\n\n[features]\ncodex_hooks = false\n",
+        "utf-8",
+      );
+
+      await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
+
+      const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
+      expect(configContent).toContain('model = "gpt-5.4"');
+      expect(configContent).toContain("[features]");
+      expect(configContent).toContain("codex_hooks = true");
+      expect(configContent).not.toContain("codex_hooks = false");
+    });
+
+    it("should remove legacy KanVibe notify config to avoid duplicate review updates", async () => {
+      const repoPath = tempDir;
+      await mkdir(join(repoPath, ".codex"), { recursive: true });
+      await writeFile(
+        join(repoPath, ".codex", "config.toml"),
+        'notify = [".codex/hooks/kanvibe-notify-hook.sh"]\n',
+        "utf-8",
+      );
+
+      await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
+
+      const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
+      expect(configContent).not.toContain("kanvibe-notify-hook.sh");
+      expect(configContent).toContain("codex_hooks = true");
     });
   });
 
@@ -65,8 +115,10 @@ describe("codexHooksSetup", () => {
       const status = await getCodexHooksStatus(repoPath);
 
       expect(status.installed).toBe(false);
-      expect(status.hasNotifyHook).toBe(false);
-      expect(status.hasConfigEntry).toBe(false);
+      expect(status.hasPromptHook).toBe(false);
+      expect(status.hasStopHook).toBe(false);
+      expect(status.hasHooksJsonEntry).toBe(false);
+      expect(status.hasFeatureFlag).toBe(false);
     });
 
     it("should detect installed status correctly", async () => {
@@ -77,11 +129,12 @@ describe("codexHooksSetup", () => {
 
       expect(status).toEqual({
         installed: true,
-        hasNotifyHook: true,
-        hasConfigEntry: true,
+        hasPromptHook: true,
+        hasStopHook: true,
+        hasHooksJsonEntry: true,
+        hasFeatureFlag: true,
         hasTaskIdBinding: true,
-        hasReviewStatus: true,
-        hasAgentTurnCompleteFilter: true,
+        hasStatusMappings: true,
         hasExpectedHookServerUrl: true,
         hasReachableHookServer: true,
         boundTaskId: "task-1",

--- a/src/lib/__tests__/gitExclude.test.ts
+++ b/src/lib/__tests__/gitExclude.test.ts
@@ -34,6 +34,7 @@ describe("gitExclude", () => {
       expect(content).toContain(".gemini/hooks/");
       expect(content).toContain(".gemini/settings.json");
       expect(content).toContain(".codex/hooks/");
+      expect(content).toContain(".codex/hooks.json");
       expect(content).toContain(".codex/config.toml");
       expect(content).toContain(".opencode/plugins/");
     });

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -23,9 +23,14 @@ vi.mock("@/lib/geminiHooksSetup", () => ({
 
 vi.mock("@/lib/codexHooksSetup", () => ({
   setupCodexHooks: (...args: unknown[]) => mockSetupCodexHooks(...args),
-  generateNotifyHookScript: vi.fn(() => "codex notify"),
-  HOOK_SCRIPT_NAME: "kanvibe-notify-hook.sh",
+  generatePromptHookScript: vi.fn(() => "codex prompt"),
+  generateStopHookScript: vi.fn(() => "codex stop"),
+  PROMPT_HOOK_SCRIPT_NAME: "kanvibe-prompt-hook.sh",
+  STOP_HOOK_SCRIPT_NAME: "kanvibe-stop-hook.sh",
+  HOOKS_FILE_NAME: "hooks.json",
   CONFIG_FILE_NAME: "config.toml",
+  buildCodexConfigToml: vi.fn(() => "[features]\ncodex_hooks = true\n"),
+  buildCodexHooksJsonContent: vi.fn(() => "{\"hooks\":{}}\n"),
 }));
 
 vi.mock("@/lib/openCodeHooksSetup", () => ({

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -7,40 +7,70 @@ import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/li
 import { KANVIBE_TASK_ID_RELATIVE_PATH, buildShellTaskIdResolver, readHookTaskIdFile, writeHookTaskIdFile } from "@/lib/hookTaskBinding";
 
 /**
- * Codex CLI는 현재 notify 설정의 agent-turn-complete 이벤트만 지원한다.
- * config.toml에 notify 명령을 등록하고, hook 스크립트를 생성한다.
+ * Codex hooks는 `.codex/hooks.json`과 `[features].codex_hooks`를 사용한다.
+ * UserPromptSubmit은 PROGRESS, Stop은 REVIEW 상태로 매핑한다.
  */
 
-/** notify hook bash 스크립트를 생성한다 (agent-turn-complete → REVIEW) */
-export function generateNotifyHookScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
+export const PROMPT_HOOK_SCRIPT_NAME = "kanvibe-prompt-hook.sh";
+export const STOP_HOOK_SCRIPT_NAME = "kanvibe-stop-hook.sh";
+export const HOOKS_FILE_NAME = "hooks.json";
+export const CONFIG_FILE_NAME = "config.toml";
+
+const LEGACY_NOTIFY_SCRIPT_NAME = "kanvibe-notify-hook.sh";
+const CODEX_PROMPT_COMMAND = `/usr/bin/env bash "$(git rev-parse --show-toplevel)/.codex/hooks/${PROMPT_HOOK_SCRIPT_NAME}"`;
+const CODEX_STOP_COMMAND = `/usr/bin/env bash "$(git rev-parse --show-toplevel)/.codex/hooks/${STOP_HOOK_SCRIPT_NAME}"`;
+
+interface CodexHooksFile {
+  hooks?: Record<string, unknown[]>;
+  [key: string]: unknown;
+}
+
+interface CodexCommandHook {
+  type: string;
+  command: string;
+  timeout: number;
+  statusMessage?: string;
+}
+
+interface CodexHookEntry {
+  hooks: CodexCommandHook[];
+}
+
+function generateStatusHookScript(
+  hookName: string,
+  status: "progress" | "review",
+  kanvibeUrl: string,
+  taskId: string,
+  authToken?: string,
+): string {
   return `#!/bin/bash
 
-# KanVibe Codex CLI Hook: notify (agent-turn-complete)
-# Codex 응답이 완료되면 현재 task를 REVIEW로 변경한다.
-# Codex notify 스크립트는 첫 번째 인자로 JSON payload를 받는다.
+# KanVibe Codex Hook: ${hookName}
+# Codex hook 이벤트에 맞춰 현재 task를 ${status.toUpperCase()}로 변경한다.
+# Codex command hooks는 stdin으로 JSON payload를 받지만 이 스크립트는 상태 갱신만 수행한다.
 
 KANVIBE_URL="${kanvibeUrl}"
 ${buildShellTaskIdResolver(taskId)}
 
-JSON_PAYLOAD="$1"
-
-# agent-turn-complete 이벤트만 처리
-EVENT_TYPE=$(echo "$JSON_PAYLOAD" | grep -o '"type":"[^"]*"' | head -1 | cut -d'"' -f4)
-if [ "$EVENT_TYPE" != "agent-turn-complete" ]; then
-  exit 0
-fi
-
 curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
   -H "Content-Type: application/json" \\
-${buildCurlAuthHeader(authToken)}  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
+${buildCurlAuthHeader(authToken)}  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"${status}\\\"}" \\
   > /dev/null 2>&1
 
+printf '{"continue":true}\\n'
 exit 0
 `;
 }
 
-export const HOOK_SCRIPT_NAME = "kanvibe-notify-hook.sh";
-export const CONFIG_FILE_NAME = "config.toml";
+/** UserPromptSubmit hook bash 스크립트를 생성한다 */
+export function generatePromptHookScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
+  return generateStatusHookScript("UserPromptSubmit", "progress", kanvibeUrl, taskId, authToken);
+}
+
+/** Stop hook bash 스크립트를 생성한다 */
+export function generateStopHookScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
+  return generateStatusHookScript("Stop", "review", kanvibeUrl, taskId, authToken);
+}
 
 function hasTaskIdPayloadBinding(content: string, taskId?: string, boundTaskId?: string | null): boolean {
   const hasDynamicTaskIdResolver = content.includes(`TASK_ID_FILE="${KANVIBE_TASK_ID_RELATIVE_PATH}"`);
@@ -58,11 +88,149 @@ function hasTaskIdPayloadBinding(content: string, taskId?: string, boundTaskId?:
   return content.includes(`TASK_ID="${taskId}"`);
 }
 
-function hasLegacyBranchPayloadBinding(content: string): boolean {
-  return content.includes('BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD')
-    && content.includes('PROJECT_NAME="')
-    && content.includes('\\\"branchName\\\": \\\"${BRANCH_NAME}\\\"')
-    && content.includes('\\\"projectName\\\": \\\"${PROJECT_NAME}\\\"');
+function parseCodexHooksJson(content: string): CodexHooksFile {
+  if (!content.trim()) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(content) as CodexHooksFile;
+  } catch {
+    return {};
+  }
+}
+
+function readHookEntries(config: CodexHooksFile, eventName: string): unknown[] {
+  const hooks = config.hooks;
+  if (!hooks || typeof hooks !== "object" || Array.isArray(hooks)) {
+    return [];
+  }
+
+  const entries = hooks[eventName];
+  return Array.isArray(entries) ? entries : [];
+}
+
+function hasCodexCommandHook(hookEntries: unknown[], command: string): boolean {
+  return hookEntries.some((entry) => {
+    const typed = entry as CodexHookEntry;
+    return typed.hooks?.some((hook) => hook.type === "command" && hook.command === command);
+  });
+}
+
+function referencesScriptName(entry: unknown, scriptName: string): boolean {
+  return JSON.stringify(entry).includes(scriptName);
+}
+
+function upsertHookEntries(
+  hookEntries: unknown[] | undefined,
+  scriptName: string,
+  nextEntry: CodexHookEntry,
+): CodexHookEntry[] {
+  const preservedEntries = Array.isArray(hookEntries)
+    ? hookEntries.filter((entry) => !referencesScriptName(entry, scriptName)) as CodexHookEntry[]
+    : [];
+  preservedEntries.push(nextEntry);
+  return preservedEntries;
+}
+
+/** 기존 hooks.json 내용에 KanVibe Codex hooks를 멱등적으로 반영한다 */
+export function buildCodexHooksJsonContent(hooksJsonContent: string): string {
+  const config = parseCodexHooksJson(hooksJsonContent);
+  if (!config.hooks || typeof config.hooks !== "object" || Array.isArray(config.hooks)) {
+    config.hooks = {};
+  }
+
+  const hooks = config.hooks as Record<string, unknown[]>;
+
+  hooks.UserPromptSubmit = upsertHookEntries(hooks.UserPromptSubmit, PROMPT_HOOK_SCRIPT_NAME, {
+    hooks: [
+      {
+        type: "command",
+        command: CODEX_PROMPT_COMMAND,
+        timeout: 10,
+        statusMessage: "Updating KanVibe task status",
+      },
+    ],
+  });
+
+  hooks.Stop = upsertHookEntries(hooks.Stop, STOP_HOOK_SCRIPT_NAME, {
+    hooks: [
+      {
+        type: "command",
+        command: CODEX_STOP_COMMAND,
+        timeout: 10,
+        statusMessage: "Updating KanVibe task status",
+      },
+    ],
+  });
+
+  return JSON.stringify(config, null, 2) + "\n";
+}
+
+function removeLegacyNotifyConfig(configContent: string): string {
+  return configContent
+    .split(/\r?\n/)
+    .filter((line) => !new RegExp(`^\\s*notify\\s*=\\s*\\[\\s*["']\\.codex/hooks/${LEGACY_NOTIFY_SCRIPT_NAME}["']\\s*\\]\\s*$`).test(line))
+    .join("\n");
+}
+
+function findTomlSectionRange(lines: string[], sectionName: string) {
+  const start = lines.findIndex((line) => new RegExp(`^\\s*\\[${sectionName}\\]\\s*$`).test(line));
+  if (start === -1) {
+    return null;
+  }
+
+  const nextSection = lines.findIndex((line, index) => index > start && /^\s*\[[^\]]+\]\s*$/.test(line));
+  return {
+    start,
+    end: nextSection === -1 ? lines.length : nextSection,
+  };
+}
+
+function upsertCodexHooksFeatureFlag(configContent: string): string {
+  const trimmedContent = configContent.trimEnd();
+  if (!trimmedContent) {
+    return "[features]\ncodex_hooks = true\n";
+  }
+
+  const lines = trimmedContent.split(/\r?\n/);
+  const featuresRange = findTomlSectionRange(lines, "features");
+  if (!featuresRange) {
+    return `${trimmedContent}\n\n[features]\ncodex_hooks = true\n`;
+  }
+
+  const flagIndex = lines.findIndex((line, index) => (
+    index > featuresRange.start &&
+    index < featuresRange.end &&
+    /^\s*codex_hooks\s*=/.test(line)
+  ));
+
+  if (flagIndex === -1) {
+    lines.splice(featuresRange.start + 1, 0, "codex_hooks = true");
+  } else {
+    lines[flagIndex] = "codex_hooks = true";
+  }
+
+  return lines.join("\n").trimEnd() + "\n";
+}
+
+/** 기존 config.toml 내용에 Codex hooks feature flag를 반영하고 구형 KanVibe notify 설정은 제거한다 */
+export function buildCodexConfigToml(configContent: string): string {
+  return upsertCodexHooksFeatureFlag(removeLegacyNotifyConfig(configContent));
+}
+
+function hasCodexHooksFeatureFlag(configContent: string): boolean {
+  const lines = configContent.split(/\r?\n/);
+  const featuresRange = findTomlSectionRange(lines, "features");
+  if (!featuresRange) {
+    return false;
+  }
+
+  return lines.some((line, index) => (
+    index > featuresRange.start &&
+    index < featuresRange.end &&
+    /^\s*codex_hooks\s*=\s*true\s*$/.test(line)
+  ));
 }
 
 /** 기존 config.toml 내용을 읽거나 빈 문자열을 반환한다 */
@@ -70,15 +238,7 @@ async function readConfigToml(configPath: string, sshHost?: string | null): Prom
   return readTextFile(configPath, sshHost);
 }
 
-/** config.toml에 kanvibe notify hook이 등록되어 있는지 확인한다 */
-function hasKanvibeNotify(configContent: string): boolean {
-  return /^notify\s*=\s*\["\.codex\/hooks\/kanvibe-notify-hook\.sh"\]$/m.test(configContent);
-}
-
-/**
- * 지정된 repo에 Codex CLI hooks를 설정한다.
- * config.toml의 notify 설정에 hook 스크립트를 등록한다.
- */
+/** 지정된 repo에 Codex hooks를 설정한다 */
 export async function setupCodexHooks(
   repoPath: string,
   taskId: string,
@@ -88,30 +248,23 @@ export async function setupCodexHooks(
   const codexDir = path.join(repoPath, ".codex");
   const hooksDir = path.join(codexDir, "hooks");
   const configPath = path.join(codexDir, CONFIG_FILE_NAME);
+  const hooksJsonPath = path.join(codexDir, HOOKS_FILE_NAME);
 
   await mkdir(hooksDir, { recursive: true });
 
-  const notifyScriptPath = path.join(hooksDir, HOOK_SCRIPT_NAME);
+  const promptScriptPath = path.join(hooksDir, PROMPT_HOOK_SCRIPT_NAME);
+  const stopScriptPath = path.join(hooksDir, STOP_HOOK_SCRIPT_NAME);
   await writeHookTaskIdFile(repoPath, taskId);
-  await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, taskId, authToken), "utf-8");
-  await chmod(notifyScriptPath, 0o755);
+  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId, authToken), "utf-8");
+  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId, authToken), "utf-8");
+  await chmod(promptScriptPath, 0o755);
+  await chmod(stopScriptPath, 0o755);
+
+  const hooksJsonContent = await readTextFile(hooksJsonPath);
+  await writeFile(hooksJsonPath, buildCodexHooksJsonContent(hooksJsonContent), "utf-8");
 
   const configContent = await readConfigToml(configPath);
-
-  if (!hasKanvibeNotify(configContent)) {
-    const notifyLine = `notify = [".codex/hooks/${HOOK_SCRIPT_NAME}"]\n`;
-
-    if (configContent.trim().length === 0) {
-      await writeFile(configPath, notifyLine, "utf-8");
-    } else {
-      if (/^notify\s*=/m.test(configContent)) {
-        const updated = configContent.replace(/^notify\s*=.*$/m, `notify = [".codex/hooks/${HOOK_SCRIPT_NAME}"]`);
-        await writeFile(configPath, updated, "utf-8");
-      } else {
-        await writeFile(configPath, configContent.trimEnd() + "\n" + notifyLine, "utf-8");
-      }
-    }
-  }
+  await writeFile(configPath, buildCodexConfigToml(configContent), "utf-8");
 
   try {
     await addAiToolPatternsToGitExclude(repoPath);
@@ -122,11 +275,12 @@ export async function setupCodexHooks(
 
 export interface CodexHooksStatus {
   installed: boolean;
-  hasNotifyHook: boolean;
-  hasConfigEntry: boolean;
+  hasPromptHook: boolean;
+  hasStopHook: boolean;
+  hasHooksJsonEntry: boolean;
+  hasFeatureFlag: boolean;
   hasTaskIdBinding?: boolean;
-  hasReviewStatus?: boolean;
-  hasAgentTurnCompleteFilter?: boolean;
+  hasStatusMappings?: boolean;
   hasExpectedHookServerUrl?: boolean;
   hasReachableHookServer?: boolean;
   boundTaskId?: string | null;
@@ -134,52 +288,70 @@ export interface CodexHooksStatus {
   expectedHookServerUrl?: string | null;
 }
 
-/** 지정된 repo의 Codex CLI hooks 설치 상태를 확인한다 */
+/** 지정된 repo의 Codex hooks 설치 상태를 확인한다 */
 export async function getCodexHooksStatus(repoPath: string, taskId?: string, sshHost?: string | null): Promise<CodexHooksStatus> {
   const pathModule = sshHost ? path.posix : path;
   const codexDir = pathModule.join(repoPath, ".codex");
   const hooksDir = pathModule.join(codexDir, "hooks");
   const configPath = pathModule.join(codexDir, CONFIG_FILE_NAME);
-  const notifyScriptPath = pathModule.join(hooksDir, HOOK_SCRIPT_NAME);
+  const hooksJsonPath = pathModule.join(codexDir, HOOKS_FILE_NAME);
+  const promptScriptPath = pathModule.join(hooksDir, PROMPT_HOOK_SCRIPT_NAME);
+  const stopScriptPath = pathModule.join(hooksDir, STOP_HOOK_SCRIPT_NAME);
 
-  const notifyScriptExists = await pathExists(notifyScriptPath, sshHost);
+  const promptScriptExists = await pathExists(promptScriptPath, sshHost);
+  const stopScriptExists = await pathExists(stopScriptPath, sshHost);
 
-  const notifyContent = notifyScriptExists
-    ? await readTextFile(notifyScriptPath, sshHost)
-    : "";
+  const [promptContent, stopContent] = await Promise.all([
+    promptScriptExists ? readTextFile(promptScriptPath, sshHost) : Promise.resolve(""),
+    stopScriptExists ? readTextFile(stopScriptPath, sshHost) : Promise.resolve(""),
+  ]);
+
+  const scriptContents = [promptContent, stopContent];
   const boundTaskId = await readHookTaskIdFile(repoPath, sshHost);
-  const hasTaskIdBinding = hasTaskIdPayloadBinding(notifyContent, taskId, boundTaskId);
-  const hasReviewStatus = notifyContent.includes('\\\"status\\\": \\\"review\\\"');
-  const hasAgentTurnCompleteFilter = notifyContent.includes("EVENT_TYPE") && notifyContent.includes("agent-turn-complete");
+  const hasTaskIdBinding = scriptContents.every((content) => hasTaskIdPayloadBinding(content, taskId, boundTaskId));
+  const hasStatusMappings =
+    promptContent.includes('\\\"status\\\": \\\"progress\\\"') &&
+    stopContent.includes('\\\"status\\\": \\\"review\\\"');
   const hookServerValidation = await validateHookServerConfiguration(
-    [extractShellHookServerUrl(notifyContent)],
+    scriptContents.map(extractShellHookServerUrl),
     Boolean(taskId),
     sshHost,
   );
 
-  let hasConfigEntry = false;
+  let hasHooksJsonEntry = false;
+  let hasFeatureFlag = false;
   try {
-    const configContent = await readConfigToml(configPath, sshHost);
-    hasConfigEntry = hasKanvibeNotify(configContent);
+    const hooksJson = parseCodexHooksJson(await readTextFile(hooksJsonPath, sshHost));
+    hasHooksJsonEntry =
+      hasCodexCommandHook(readHookEntries(hooksJson, "UserPromptSubmit"), CODEX_PROMPT_COMMAND) &&
+      hasCodexCommandHook(readHookEntries(hooksJson, "Stop"), CODEX_STOP_COMMAND);
+  } catch {
+    /* hooks.json 없음 */
+  }
+
+  try {
+    hasFeatureFlag = hasCodexHooksFeatureFlag(await readConfigToml(configPath, sshHost));
   } catch {
     /* config.toml 없음 */
   }
 
-  const installed = notifyScriptExists
-    && hasConfigEntry
+  const installed = promptScriptExists
+    && stopScriptExists
+    && hasHooksJsonEntry
+    && hasFeatureFlag
     && hasTaskIdBinding
-    && hasReviewStatus
-    && hasAgentTurnCompleteFilter
+    && hasStatusMappings
     && hookServerValidation.hasExpectedHookServerUrl
     && hookServerValidation.hasReachableHookServer;
 
   return {
     installed,
-    hasNotifyHook: notifyScriptExists,
-    hasConfigEntry,
+    hasPromptHook: promptScriptExists,
+    hasStopHook: stopScriptExists,
+    hasHooksJsonEntry,
+    hasFeatureFlag,
     hasTaskIdBinding,
-    hasReviewStatus,
-    hasAgentTurnCompleteFilter,
+    hasStatusMappings,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
     hasReachableHookServer: hookServerValidation.hasReachableHookServer,
     boundTaskId,

--- a/src/lib/gitExclude.ts
+++ b/src/lib/gitExclude.ts
@@ -14,6 +14,7 @@ const EXCLUDE_PATTERNS = [
   ".gemini/hooks/",
   ".gemini/settings.json",
   ".codex/hooks/",
+  ".codex/hooks.json",
   ".codex/config.toml",
   ".opencode/plugins/",
 ];

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -2,7 +2,17 @@ import path from "node:path";
 import { execGit } from "@/lib/gitOperations";
 import { setupClaudeHooks, generatePromptHookScript as generateClaudePromptHookScript, generateStopHookScript as generateClaudeStopHookScript, generateQuestionHookScript as generateClaudeQuestionHookScript } from "@/lib/claudeHooksSetup";
 import { setupGeminiHooks, generatePromptHookScript as generateGeminiPromptHookScript, generateStopHookScript as generateGeminiStopHookScript } from "@/lib/geminiHooksSetup";
-import { setupCodexHooks, generateNotifyHookScript, HOOK_SCRIPT_NAME, CONFIG_FILE_NAME } from "@/lib/codexHooksSetup";
+import {
+  setupCodexHooks,
+  generatePromptHookScript as generateCodexPromptHookScript,
+  generateStopHookScript as generateCodexStopHookScript,
+  PROMPT_HOOK_SCRIPT_NAME as CODEX_PROMPT_HOOK_SCRIPT_NAME,
+  STOP_HOOK_SCRIPT_NAME as CODEX_STOP_HOOK_SCRIPT_NAME,
+  HOOKS_FILE_NAME as CODEX_HOOKS_FILE_NAME,
+  CONFIG_FILE_NAME as CODEX_CONFIG_FILE_NAME,
+  buildCodexConfigToml,
+  buildCodexHooksJsonContent,
+} from "@/lib/codexHooksSetup";
 import { setupOpenCodeHooks, generatePluginScript, PLUGIN_DIR_NAME, PLUGIN_FILE_NAME } from "@/lib/openCodeHooksSetup";
 import { getHookServerToken, getHookServerUrl } from "@/lib/hookEndpoint";
 import { KANVIBE_TASK_ID_RELATIVE_PATH } from "@/lib/hookTaskBinding";
@@ -100,19 +110,28 @@ async function setupRemoteGeminiHooks(repoPath: string, taskId: string, hookServ
 async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServerUrl: string, hookServerToken: string, sshHost: string) {
   const codexDir = path.posix.join(repoPath, ".codex");
   const hooksDir = path.posix.join(codexDir, "hooks");
-  const configPath = path.posix.join(codexDir, CONFIG_FILE_NAME);
+  const configPath = path.posix.join(codexDir, CODEX_CONFIG_FILE_NAME);
+  const hooksJsonPath = path.posix.join(codexDir, CODEX_HOOKS_FILE_NAME);
   await execGit(`mkdir -p "${hooksDir}"`, sshHost);
 
-  await writeRemoteTextFile(path.posix.join(hooksDir, HOOK_SCRIPT_NAME), generateNotifyHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
+  await writeRemoteTextFile(
+    path.posix.join(hooksDir, CODEX_PROMPT_HOOK_SCRIPT_NAME),
+    generateCodexPromptHookScript(hookServerUrl, taskId, hookServerToken),
+    sshHost,
+    0o755,
+  );
+  await writeRemoteTextFile(
+    path.posix.join(hooksDir, CODEX_STOP_HOOK_SCRIPT_NAME),
+    generateCodexStopHookScript(hookServerUrl, taskId, hookServerToken),
+    sshHost,
+    0o755,
+  );
+
+  const hooksJsonContent = await readRemoteTextFile(hooksJsonPath, sshHost);
+  await writeRemoteTextFile(hooksJsonPath, buildCodexHooksJsonContent(hooksJsonContent), sshHost);
 
   const configContent = await readRemoteTextFile(configPath, sshHost);
-  const notifyLine = `notify = [".codex/hooks/${HOOK_SCRIPT_NAME}"]\n`;
-  const nextConfig = configContent.includes(HOOK_SCRIPT_NAME)
-    ? configContent.replace(/^notify\s*=.*$/m, `notify = [".codex/hooks/${HOOK_SCRIPT_NAME}"]`)
-    : configContent.trim().length === 0
-      ? notifyLine
-      : `${configContent.trimEnd()}\n${notifyLine}`;
-  await writeRemoteTextFile(configPath, nextConfig, sshHost);
+  await writeRemoteTextFile(configPath, buildCodexConfigToml(configContent), sshHost);
 }
 
 async function setupRemoteOpenCodeHooks(repoPath: string, taskId: string, hookServerUrl: string, hookServerToken: string, sshHost: string) {


### PR DESCRIPTION
## Related resources
- No linked issue

## What is this change?
- Add Codex hooks support based on the current experimental `hooks.json` configuration model instead of the legacy `notify` event.

## How was it solved?
**Codex hook installation**
- Generate `UserPromptSubmit` and `Stop` hook scripts for KanVibe task status updates.
- Write repo-local `.codex/hooks.json` entries and enable `[features] codex_hooks = true` in `.codex/config.toml`.
- Remove the legacy KanVibe notify entry to avoid duplicate review updates.

**Installer and ignore handling**
- Update local and remote installers to create the same Codex hook files.
- Add `.codex/hooks.json` and `.codex/config.toml` to generated hook ignore patterns.
- Update the hooks status dialog manual file list for the new Codex setup.

**Docs and tests**
- Refresh README files to document Codex `UserPromptSubmit` and `Stop` behavior.
- Update Codex setup, installer, git exclude, and hooks status tests for the new contract.

## Important changes
### Codex hooks.json setup

**Feature flag and hook discovery**
- **Why**: Codex now discovers hooks through `hooks.json` next to active config layers, gated by `codex_hooks`.
- **Files**: `src/lib/codexHooksSetup.ts`, `src/lib/kanvibeHooksInstaller.ts`

**Generated file hygiene**
- **Why**: Repo-local hook configuration is machine/task specific and should not be committed accidentally.
- **Files**: `.gitignore`, `src/lib/gitExclude.ts`

**User-facing guidance**
- **Why**: The UI and docs should no longer describe Codex as notify-only partial support.
- **Files**: `src/components/HooksStatusDialog.tsx`, `README.md`, `docs/README.ko.md`, `docs/README.zh.md`

Co-Authored-By: OpenAI Codex <codex@openai.com>
