### PR TITLE
fix(worktree): align tmux session tests with deferred remote attach

### DIFF
--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -348,6 +348,9 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
         username: "tester",
         privateKeyPath: "/tmp/test-key",
       },
+      120,
+      30,
+      "/remote/worktree",
     );
 
     // Then
@@ -369,6 +372,9 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     );
     expect(mockPtyWrite).toHaveBeenCalledWith(
       expect.stringContaining('tmux has-session -t "remote-session"'),
+    );
+    expect(mockPtyWrite).toHaveBeenCalledWith(
+      expect.stringContaining('tmux new-session -d -s "remote-session" -c "/remote/worktree"'),
     );
   });
 });

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -299,22 +299,10 @@ describe("createSessionWithoutWorktree", () => {
     );
   });
 
-  it("should retry remote tmux creation with TERM when detached startup fails", async () => {
+  it("should defer remote tmux creation until terminal attach", async () => {
     // Given
     mockExecGit.mockImplementation((command: string, sshHost?: string | null) => {
       if (command === "command -v tmux >/dev/null 2>&1" && sshHost === "remote-host") {
-        return Promise.resolve("");
-      }
-
-      if (command === 'tmux has-session -t "path-main" 2>/dev/null' && sshHost === "remote-host") {
-        return Promise.reject(new Error("no session"));
-      }
-
-      if (command === 'tmux new-session -d -s "path-main" -c "/custom/dir"' && sshHost === "remote-host") {
-        return Promise.reject(new Error("remote-host 원격 명령 실패: server exited unexpectedly"));
-      }
-
-      if (command === 'env TERM=xterm-256color tmux new-session -d -s "path-main" -c "/custom/dir"' && sshHost === "remote-host") {
         return Promise.resolve("");
       }
 
@@ -333,14 +321,13 @@ describe("createSessionWithoutWorktree", () => {
     );
 
     // Then
+    expect(mockExecGit).toHaveBeenCalledTimes(1);
     expect(mockExecGit).toHaveBeenCalledWith(
-      'tmux new-session -d -s "path-main" -c "/custom/dir"',
+      "command -v tmux >/dev/null 2>&1",
       "remote-host",
     );
-    expect(mockExecGit).toHaveBeenCalledWith(
-      'env TERM=xterm-256color tmux new-session -d -s "path-main" -c "/custom/dir"',
-      "remote-host",
-    );
+    expect(filterCalls("tmux has-session")).toHaveLength(0);
+    expect(filterCalls("tmux new-session")).toHaveLength(0);
   });
 });
 

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -40,8 +40,12 @@ function buildTmuxCreateSessionCommand(sessionName: string, workingDir: string):
   return `tmux new-session -d -s "${sessionName}" -c "${workingDir}"`;
 }
 
-async function createTmuxSession(sessionName: string, workingDir: string): Promise<void> {
-  await execGit(buildTmuxCreateSessionCommand(sessionName, workingDir));
+async function createTmuxSession(
+  sessionName: string,
+  workingDir: string,
+  sshHost?: string | null,
+): Promise<void> {
+  await execGit(buildTmuxCreateSessionCommand(sessionName, workingDir), sshHost);
 }
 
 
@@ -265,9 +269,9 @@ export async function createWorktreeWithSession(
        * 세션 생성을 터미널 연결 시 PTY가 확보된 후로 미룬다.
        */
       if (!sshHost) {
-        const hasSession = await isSessionAlive(sessionType, sessionName, null);
+        const hasSession = await isSessionAlive(sessionType, sessionName, sshHost);
         if (!hasSession) {
-          await createTmuxSession(sessionName, worktreePath);
+          await createTmuxSession(sessionName, worktreePath, sshHost);
         }
         applyPaneLayoutAsync(sessionName, worktreePath, projectId ?? undefined);
       }
@@ -326,9 +330,9 @@ export async function createSessionWithoutWorktree(
 
   if (sessionType === SessionType.TMUX) {
     if (!sshHost) {
-      const hasSession = await isSessionAlive(sessionType, sessionName, null);
+      const hasSession = await isSessionAlive(sessionType, sessionName, sshHost);
       if (!hasSession) {
-        await createTmuxSession(sessionName, cwd);
+        await createTmuxSession(sessionName, cwd, sshHost);
       }
     }
 


### PR DESCRIPTION
## What
- Align the worktree tmux session tests with the current deferred remote attach behavior.
- Keep local tmux session creation behavior stable while preserving the optional `sshHost` argument through the helper path.

## How
**Preserve local tmux helper call semantics**
- Pass the existing `sshHost` value through `createTmuxSession` so local calls keep the expected `null`/`undefined` contract.
- Continue skipping eager remote tmux creation during worktree/session setup.

**Move remote tmux coverage to the attach path**
- Update worktree tests to assert that remote tmux creation is deferred until terminal attach.
- Extend terminal attach tests to verify that the remote tmux session is created with the task worktree directory.

## Important changes
### Remote tmux session lifecycle

**Deferred remote creation remains the source of truth**
- **Reason**: remote tmux startup needs a real PTY, which is available in the terminal attach path rather than non-interactive worktree setup.
- **Files**: `src/lib/worktree.ts`, `src/lib/__tests__/worktree.test.ts`, `src/lib/__tests__/terminal.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>