### PR TITLE
fix(hooks): hardcode generated hook task IDs

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -239,9 +239,9 @@
     "hooksCurrentTaskId": "Current taskId: {taskId}",
     "hooksBoundTaskId": "Detected taskId: {taskId}",
     "hooksManualInstallGuide": "Manual install guide",
-    "hooksManualInstallDescription": "If the {tool} hook is bound to a different taskId or the taskId file is missing, rebind it manually with the command below.",
+    "hooksManualInstallDescription": "If the {tool} hook is bound to a different taskId, reinstall it here or update the generated hook file with the current taskId.",
     "hooksManualFiles": "Files to verify",
-    "hooksManualRecheck": "After applying the manual binding, reopen this dialog or press reinstall to verify the checks again.",
+    "hooksManualRecheck": "After applying manual changes, reopen this dialog or press reinstall to verify the checks again.",
     "taskNotFound": "Task not found.",
     "goBack": "Go back",
     "aiSessions": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -239,7 +239,7 @@
     "hooksCurrentTaskId": "현재 taskId: {taskId}",
     "hooksBoundTaskId": "감지된 taskId: {taskId}",
     "hooksManualInstallGuide": "수동 설치 가이드",
-    "hooksManualInstallDescription": "{tool} hook이 현재 taskId와 다르거나 taskId 파일이 없으면 아래 명령으로 수동 바인딩하세요.",
+    "hooksManualInstallDescription": "{tool} hook이 현재 taskId와 다르면 여기서 재설치하거나 생성된 hook 파일의 taskId를 현재 값으로 맞추세요.",
     "hooksManualFiles": "확인할 파일",
     "hooksManualRecheck": "수동 반영 후 다시 열거나 재설치를 눌러 검증 상태를 확인하세요.",
     "taskNotFound": "작업을 찾을 수 없습니다.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -239,7 +239,7 @@
     "hooksCurrentTaskId": "当前 taskId: {taskId}",
     "hooksBoundTaskId": "检测到的 taskId: {taskId}",
     "hooksManualInstallGuide": "手动安装指南",
-    "hooksManualInstallDescription": "如果 {tool} hook 绑定到了其他 taskId，或者 taskId 文件不存在，可以用下面的命令手动重新绑定。",
+    "hooksManualInstallDescription": "如果 {tool} hook 绑定到了其他 taskId，请在此重新安装，或更新生成的 hook 文件，使其包含当前 taskId。",
     "hooksManualFiles": "需要检查的文件",
     "hooksManualRecheck": "手动处理后，请重新打开此对话框或点击重新安装，再次确认校验状态。",
     "taskNotFound": "未找到任务。",

--- a/src/components/HooksStatusDialog.tsx
+++ b/src/components/HooksStatusDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   installTaskHooks,
@@ -31,8 +31,6 @@ interface HooksStatusDialogProps {
 }
 
 type HookToolKey = "claude" | "gemini" | "codex" | "openCode";
-
-const TASK_ID_FILE_PATH = ".kanvibe/task-id";
 
 export default function HooksStatusDialog({
   isOpen,
@@ -84,13 +82,6 @@ export default function HooksStatusDialog({
 
   function getInstallIncompleteText() {
     return t("hooksInstallIncomplete");
-  }
-
-  function buildManualBindingCommand(currentTaskId: string) {
-    return [
-      "mkdir -p .kanvibe",
-      `printf '%s\\n' '${currentTaskId}' > ${TASK_ID_FILE_PATH}`,
-    ].join("\n");
   }
 
   function applyClaudeResult(result: Awaited<ReturnType<typeof installTaskHooks>>) {
@@ -165,15 +156,12 @@ export default function HooksStatusDialog({
     }
   }
 
-  const manualBindingCommand = useMemo(() => buildManualBindingCommand(taskId), [taskId]);
-
   const hookItems = [
     {
       key: "claude" as const,
       title: "Claude",
       status: localClaudeStatus,
       files: [
-        TASK_ID_FILE_PATH,
         ".claude/hooks/kanvibe-prompt-hook.sh",
         ".claude/hooks/kanvibe-question-hook.sh",
         ".claude/hooks/kanvibe-stop-hook.sh",
@@ -186,7 +174,6 @@ export default function HooksStatusDialog({
       title: "Gemini",
       status: localGeminiStatus,
       files: [
-        TASK_ID_FILE_PATH,
         ".gemini/hooks/kanvibe-prompt-hook.sh",
         ".gemini/hooks/kanvibe-stop-hook.sh",
         ".gemini/settings.json",
@@ -198,7 +185,6 @@ export default function HooksStatusDialog({
       title: "Codex",
       status: localCodexStatus,
       files: [
-        TASK_ID_FILE_PATH,
         ".codex/hooks/kanvibe-notify-hook.sh",
         ".codex/config.toml",
       ],
@@ -209,7 +195,6 @@ export default function HooksStatusDialog({
       title: "OpenCode",
       status: localOpenCodeStatus,
       files: [
-        TASK_ID_FILE_PATH,
         ".opencode/plugins/kanvibe-plugin.ts",
       ],
       onInstall: () => runInstall("openCode", () => installTaskOpenCodeHooks(taskId), applyOpenCodeResult),
@@ -310,9 +295,6 @@ export default function HooksStatusDialog({
                 {expandedManualTool === item.key && !isRemote && !isInstalled ? (
                   <div className="mt-4 rounded-lg border border-border-default bg-bg-surface p-3">
                     <p className="text-xs text-text-secondary">{t("hooksManualInstallDescription", { tool: item.title })}</p>
-                    <pre className="mt-3 overflow-x-auto rounded-md bg-[#0f172a] px-3 py-2 text-[11px] text-white">
-                      <code>{manualBindingCommand}</code>
-                    </pre>
                     <p className="mt-3 text-[11px] font-medium text-text-secondary">{t("hooksManualFiles")}</p>
                     <div className="mt-2 flex flex-wrap gap-1.5">
                       {item.files.map((filePath) => (

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -27,7 +27,6 @@ const mocks = vi.hoisted(() => ({
   aggregateAiSessions: vi.fn(),
   getAiSessionDetail: vi.fn(),
   installKanvibeHooks: vi.fn(),
-  readHookTaskIdFile: vi.fn(),
   broadcastBoardUpdate: vi.fn(),
 }));
 
@@ -134,16 +133,15 @@ vi.mock("@/lib/kanvibeHooksInstaller", () => ({
   installKanvibeHooks: mocks.installKanvibeHooks,
 }));
 
-vi.mock("@/lib/hookTaskBinding", () => ({
-  readHookTaskIdFile: mocks.readHookTaskIdFile,
-}));
-
 describe("projectService.listSubdirectories", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.getDefaultSessionType.mockResolvedValue("tmux");
-    mocks.readHookTaskIdFile.mockResolvedValue(null);
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: false });
   });
 
   it("원격 호스트에서도 세션 도구 검증 없이 디렉토리를 스캔한다", async () => {
@@ -200,6 +198,10 @@ describe("projectService remote registration flow", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.getDefaultSessionType.mockResolvedValue("tmux");
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: false });
   });
 
   it("원격 스캔은 세션 의존성 검증 없이 git 저장소 검색을 진행한다", async () => {
@@ -344,6 +346,10 @@ describe("projectService local hook installation", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.getDefaultSessionType.mockResolvedValue("tmux");
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: false });
   });
 
   it("로컬 Claude hook 설치 시 서버 URL과 토큰을 함께 전달한다", async () => {
@@ -610,7 +616,6 @@ describe("projectService local hook installation", () => {
       create: vi.fn((value) => value),
       save: vi.fn(async (value) => ({ id: "task-main", ...value })),
     });
-    mocks.readHookTaskIdFile.mockResolvedValue(null);
     mocks.installKanvibeHooks
       .mockRejectedValueOnce(new Error("hook server offline"))
       .mockResolvedValueOnce(undefined);
@@ -668,7 +673,6 @@ describe("projectService local hook installation", () => {
       create: vi.fn((value) => value),
       save: vi.fn(async (value) => ({ id: "task-main", ...value })),
     });
-    mocks.readHookTaskIdFile.mockResolvedValue("task-main");
     mocks.getClaudeHooksStatus.mockRejectedValueOnce(remoteConnectionError);
 
     const { getAllProjects } = await import("@/desktop/main/services/projectService");
@@ -713,7 +717,6 @@ describe("projectService local hook installation", () => {
       create: vi.fn((value) => value),
       save: vi.fn(async (value) => ({ id: "task-main", ...value })),
     });
-    mocks.readHookTaskIdFile.mockResolvedValue(null);
     mocks.installKanvibeHooks.mockRejectedValueOnce(remoteConnectionError);
 
     const { getAllProjects } = await import("@/desktop/main/services/projectService");
@@ -776,7 +779,6 @@ describe("projectService local hook installation", () => {
     mocks.scanGitRepos.mockResolvedValue(["/workspace/api"]);
     mocks.getDefaultBranch.mockResolvedValue("main");
     mocks.createSessionWithoutWorktree.mockResolvedValue({ sessionName: "api-main" });
-    mocks.readHookTaskIdFile.mockResolvedValue("task-main");
     mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
     mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
     mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
@@ -850,7 +852,6 @@ describe("projectService local hook installation", () => {
     mocks.scanGitRepos.mockResolvedValue(["/workspace/api"]);
     mocks.getDefaultBranch.mockResolvedValue("main");
     mocks.createSessionWithoutWorktree.mockResolvedValue({ sessionName: "api-main" });
-    mocks.readHookTaskIdFile.mockResolvedValue("task-main");
     mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
     mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
     mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
@@ -910,7 +911,6 @@ describe("projectService local hook installation", () => {
     mocks.scanGitRepos.mockResolvedValue(["/workspace/api"]);
     mocks.getDefaultBranch.mockResolvedValue("main");
     mocks.createSessionWithoutWorktree.mockResolvedValue({ sessionName: "api-main" });
-    mocks.readHookTaskIdFile.mockResolvedValue("task-main");
     mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
     mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
     mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
@@ -994,6 +994,10 @@ describe("projectService remote hook and AI session support", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.getDefaultSessionType.mockResolvedValue("tmux");
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: false });
   });
 
   it("원격 태스크의 Claude hook 상태도 sshHost 기준으로 조회한다", async () => {

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -18,7 +18,6 @@ import { getAvailableHosts as readAvailableHosts } from "@/lib/sshConfig";
 import { getDefaultSessionType } from "@/desktop/main/services/appSettingsService";
 import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
 import { getHookServerToken, getHookServerUrl } from "@/lib/hookEndpoint";
-import { readHookTaskIdFile } from "@/lib/hookTaskBinding";
 
 function matchesTaskLocation(task: { worktreePath?: string | null; sshHost?: string | null }, expectedPath: string, sshHost?: string | null): boolean {
   return task.worktreePath === expectedPath && (task.sshHost || null) === (sshHost || null);
@@ -244,10 +243,7 @@ async function ensureProjectRootTask(
     return { task, repaired };
   }
 
-  const boundTaskId = await readHookTaskIdFile(project.repoPath, project.sshHost);
-  const hasInstalledHooks = boundTaskId === task.id
-    ? await areProjectRootHooksInstalled(project, task.id)
-    : false;
+  const hasInstalledHooks = await areProjectRootHooksInstalled(project, task.id);
 
   if (!hasInstalledHooks) {
     try {

--- a/src/lib/__tests__/gitExclude.test.ts
+++ b/src/lib/__tests__/gitExclude.test.ts
@@ -29,6 +29,7 @@ describe("gitExclude", () => {
       // Then
       const content = await readFile(excludePath, "utf-8");
       expect(content).toContain("# KanVibe AI hooks (auto-generated)");
+      expect(content).not.toContain(".kanvibe/task-id");
       expect(content).toContain(".claude/hooks/");
       expect(content).toContain(".claude/settings.json");
       expect(content).toContain(".gemini/hooks/");

--- a/src/lib/__tests__/hookTaskBinding.test.ts
+++ b/src/lib/__tests__/hookTaskBinding.test.ts
@@ -1,61 +1,33 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtemp, readFile, rm } from "fs/promises";
-import { join } from "path";
-import { tmpdir } from "os";
+import { describe, expect, it } from "vitest";
 import {
   buildShellTaskIdResolver,
-  getHookTaskIdFilePath,
-  readHookTaskIdFile,
-  writeHookTaskIdFile,
+  extractShellTaskId,
 } from "@/lib/hookTaskBinding";
 
 describe("hookTaskBinding", () => {
-  let tempDir: string;
-
-  beforeEach(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "hook-task-binding-"));
-  });
-
-  afterEach(async () => {
-    await rm(tempDir, { recursive: true, force: true });
-  });
-
-  it("작업 ID 파일을 쓰면 개행 포함 원본과 trim된 바인딩 값을 함께 유지한다", async () => {
-    // Given
-    const filePath = getHookTaskIdFilePath(tempDir);
-
-    // When
-    await writeHookTaskIdFile(tempDir, "task-123");
-    const stored = await readFile(filePath, "utf-8");
-    const taskId = await readHookTaskIdFile(tempDir);
-
-    // Then
-    expect(stored).toBe("task-123\n");
-    expect(taskId).toBe("task-123");
-  });
-
-  it("빈 작업 ID 파일은 바인딩되지 않은 상태로 처리한다", async () => {
-    // Given
-    await writeHookTaskIdFile(tempDir, "");
-
-    // When
-    const taskId = await readHookTaskIdFile(tempDir);
-
-    // Then
-    expect(taskId).toBeNull();
-  });
-
-  it("shell resolver는 파일 task id를 기본값보다 우선하도록 생성된다", () => {
+  it("shell resolver는 hook 파일 안에 task id를 직접 고정한다", () => {
     // Given
 
     // When
     const resolver = buildShellTaskIdResolver("fallback-task");
 
     // Then
-    expect(resolver).toContain('TASK_ID_FILE=".kanvibe/task-id"');
-    expect(resolver).toContain('TASK_ID="fallback-task"');
-    expect(resolver).toContain('if [ -f "$TASK_ID_FILE" ]; then');
-    expect(resolver).toContain('FILE_TASK_ID=$(tr -d \'\\r\\n\' < "$TASK_ID_FILE")');
-    expect(resolver).toContain('TASK_ID="$FILE_TASK_ID"');
+    expect(resolver).toBe('TASK_ID="fallback-task"');
+    expect(resolver).not.toContain(".kanvibe/task-id");
+  });
+
+  it("shell script에서 고정된 task id를 읽는다", () => {
+    // Given
+    const script = [
+      "#!/bin/bash",
+      'TASK_ID="task-123"',
+      'echo "$TASK_ID"',
+    ].join("\n");
+
+    // When
+    const taskId = extractShellTaskId(script);
+
+    // Then
+    expect(taskId).toBe("task-123");
   });
 });

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -50,11 +50,10 @@ describe("openCodeHooksSetup", () => {
 
       expect(pluginContent).toContain("KanvibePlugin");
       expect(pluginContent).toContain("/api/hooks/status");
-      expect(pluginContent).toContain('const DEFAULT_TASK_ID = "task-1";');
-      expect(pluginContent).toContain('const TASK_ID_FILE = ".kanvibe/task-id";');
-      expect(pluginContent).toContain("const repoPath = worktree || directory || process.cwd();");
-      expect(pluginContent).toContain('readFile(join(repoPath, TASK_ID_FILE), "utf-8")');
-      expect(pluginContent).toContain("taskId: resolvedTaskId");
+      expect(pluginContent).toContain('const TASK_ID = "task-1";');
+      expect(pluginContent).not.toContain(".kanvibe/task-id");
+      expect(pluginContent).not.toContain("readFile");
+      expect(pluginContent).toContain("taskId: TASK_ID");
     });
 
     it("should generate plugin with all event handlers for status tracking", async () => {

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -4,7 +4,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { buildCurlAuthHeader } from "@/lib/hookAuth";
 import { pathExists, readTextFile } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { KANVIBE_TASK_ID_RELATIVE_PATH, buildShellTaskIdResolver, readHookTaskIdFile, writeHookTaskIdFile } from "@/lib/hookTaskBinding";
+import { buildShellTaskIdResolver, extractShellTaskId } from "@/lib/hookTaskBinding";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
 export function generatePromptHookScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
@@ -80,20 +80,16 @@ const CLAUDE_PROMPT_COMMAND = '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-promp
 const CLAUDE_STOP_COMMAND = '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-stop-hook.sh';
 const CLAUDE_QUESTION_COMMAND = '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-question-hook.sh';
 
-function hasTaskIdPayloadBinding(content: string, taskId?: string, boundTaskId?: string | null): boolean {
-  const hasDynamicTaskIdResolver = content.includes(`TASK_ID_FILE="${KANVIBE_TASK_ID_RELATIVE_PATH}"`);
+function hasTaskIdPayloadBinding(content: string, taskId?: string): boolean {
+  const boundTaskId = extractShellTaskId(content);
   const hasTaskIdPayload = content.includes("taskId") && content.includes("${TASK_ID}");
   if (!hasTaskIdPayload) return false;
 
   if (!taskId) {
-    return hasDynamicTaskIdResolver || content.includes("TASK_ID=");
+    return boundTaskId !== null;
   }
 
-  if (hasDynamicTaskIdResolver) {
-    return boundTaskId === taskId;
-  }
-
-  return content.includes(`TASK_ID="${taskId}"`);
+  return boundTaskId === taskId;
 }
 
 function hasLegacyBranchPayloadBinding(content: string): boolean {
@@ -166,7 +162,6 @@ export async function setupClaudeHooks(
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
   const questionScriptPath = path.join(hooksDir, "kanvibe-question-hook.sh");
 
-  await writeHookTaskIdFile(repoPath, taskId);
   await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId, authToken), "utf-8");
   await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId, authToken), "utf-8");
   await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, taskId, authToken), "utf-8");
@@ -268,8 +263,11 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
   ]);
 
   const scriptContents = [promptContent, stopContent, questionContent];
-  const boundTaskId = await readHookTaskIdFile(repoPath, sshHost);
-  const hasTaskIdBinding = scriptContents.every((content) => hasTaskIdPayloadBinding(content, taskId, boundTaskId));
+  const boundTaskIds = scriptContents.map(extractShellTaskId).filter((value): value is string => value !== null);
+  const boundTaskId = boundTaskIds.length > 0 && boundTaskIds.every((value) => value === boundTaskIds[0])
+    ? boundTaskIds[0]
+    : null;
+  const hasTaskIdBinding = scriptContents.every((content) => hasTaskIdPayloadBinding(content, taskId));
   const hookServerValidation = await validateHookServerConfiguration(
     scriptContents.map(extractShellHookServerUrl),
     Boolean(taskId),

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -4,7 +4,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { buildCurlAuthHeader } from "@/lib/hookAuth";
 import { pathExists, readTextFile } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { KANVIBE_TASK_ID_RELATIVE_PATH, buildShellTaskIdResolver, readHookTaskIdFile, writeHookTaskIdFile } from "@/lib/hookTaskBinding";
+import { buildShellTaskIdResolver, extractShellTaskId } from "@/lib/hookTaskBinding";
 
 /**
  * Codex CLI는 현재 notify 설정의 agent-turn-complete 이벤트만 지원한다.
@@ -42,20 +42,16 @@ exit 0
 export const HOOK_SCRIPT_NAME = "kanvibe-notify-hook.sh";
 export const CONFIG_FILE_NAME = "config.toml";
 
-function hasTaskIdPayloadBinding(content: string, taskId?: string, boundTaskId?: string | null): boolean {
-  const hasDynamicTaskIdResolver = content.includes(`TASK_ID_FILE="${KANVIBE_TASK_ID_RELATIVE_PATH}"`);
+function hasTaskIdPayloadBinding(content: string, taskId?: string): boolean {
+  const boundTaskId = extractShellTaskId(content);
   const hasTaskIdPayload = content.includes("taskId") && content.includes("${TASK_ID}");
   if (!hasTaskIdPayload) return false;
 
   if (!taskId) {
-    return hasDynamicTaskIdResolver || content.includes("TASK_ID=");
+    return boundTaskId !== null;
   }
 
-  if (hasDynamicTaskIdResolver) {
-    return boundTaskId === taskId;
-  }
-
-  return content.includes(`TASK_ID="${taskId}"`);
+  return boundTaskId === taskId;
 }
 
 function hasLegacyBranchPayloadBinding(content: string): boolean {
@@ -92,7 +88,6 @@ export async function setupCodexHooks(
   await mkdir(hooksDir, { recursive: true });
 
   const notifyScriptPath = path.join(hooksDir, HOOK_SCRIPT_NAME);
-  await writeHookTaskIdFile(repoPath, taskId);
   await writeFile(notifyScriptPath, generateNotifyHookScript(kanvibeUrl, taskId, authToken), "utf-8");
   await chmod(notifyScriptPath, 0o755);
 
@@ -147,8 +142,8 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
   const notifyContent = notifyScriptExists
     ? await readTextFile(notifyScriptPath, sshHost)
     : "";
-  const boundTaskId = await readHookTaskIdFile(repoPath, sshHost);
-  const hasTaskIdBinding = hasTaskIdPayloadBinding(notifyContent, taskId, boundTaskId);
+  const boundTaskId = extractShellTaskId(notifyContent);
+  const hasTaskIdBinding = hasTaskIdPayloadBinding(notifyContent, taskId);
   const hasReviewStatus = notifyContent.includes('\\\"status\\\": \\\"review\\\"');
   const hasAgentTurnCompleteFilter = notifyContent.includes("EVENT_TYPE") && notifyContent.includes("agent-turn-complete");
   const hookServerValidation = await validateHookServerConfiguration(

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -4,7 +4,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { buildCurlAuthHeader } from "@/lib/hookAuth";
 import { pathExists, readTextFile } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { KANVIBE_TASK_ID_RELATIVE_PATH, buildShellTaskIdResolver, readHookTaskIdFile, writeHookTaskIdFile } from "@/lib/hookTaskBinding";
+import { buildShellTaskIdResolver, extractShellTaskId } from "@/lib/hookTaskBinding";
 
 /**
  * Gemini CLI hooks는 stdout에 반드시 JSON만 출력해야 한다.
@@ -74,20 +74,16 @@ interface GeminiHookEntry {
 const GEMINI_PROMPT_COMMAND = '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-prompt-hook.sh';
 const GEMINI_STOP_COMMAND = '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-stop-hook.sh';
 
-function hasTaskIdPayloadBinding(content: string, taskId?: string, boundTaskId?: string | null): boolean {
-  const hasDynamicTaskIdResolver = content.includes(`TASK_ID_FILE="${KANVIBE_TASK_ID_RELATIVE_PATH}"`);
+function hasTaskIdPayloadBinding(content: string, taskId?: string): boolean {
+  const boundTaskId = extractShellTaskId(content);
   const hasTaskIdPayload = content.includes("taskId") && content.includes("${TASK_ID}");
   if (!hasTaskIdPayload) return false;
 
   if (!taskId) {
-    return hasDynamicTaskIdResolver || content.includes("TASK_ID=");
+    return boundTaskId !== null;
   }
 
-  if (hasDynamicTaskIdResolver) {
-    return boundTaskId === taskId;
-  }
-
-  return content.includes(`TASK_ID="${taskId}"`);
+  return boundTaskId === taskId;
 }
 
 function hasLegacyBranchPayloadBinding(content: string): boolean {
@@ -151,7 +147,6 @@ export async function setupGeminiHooks(
   const promptScriptPath = path.join(hooksDir, "kanvibe-prompt-hook.sh");
   const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
 
-  await writeHookTaskIdFile(repoPath, taskId);
   await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId, authToken), "utf-8");
   await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId, authToken), "utf-8");
   await chmod(promptScriptPath, 0o755);
@@ -227,8 +222,11 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
   ]);
 
   const scriptContents = [promptContent, stopContent];
-  const boundTaskId = await readHookTaskIdFile(repoPath, sshHost);
-  const hasTaskIdBinding = scriptContents.every((content) => hasTaskIdPayloadBinding(content, taskId, boundTaskId));
+  const boundTaskIds = scriptContents.map(extractShellTaskId).filter((value): value is string => value !== null);
+  const boundTaskId = boundTaskIds.length > 0 && boundTaskIds.every((value) => value === boundTaskIds[0])
+    ? boundTaskIds[0]
+    : null;
+  const hasTaskIdBinding = scriptContents.every((content) => hasTaskIdPayloadBinding(content, taskId));
   const hookServerValidation = await validateHookServerConfiguration(
     scriptContents.map(extractShellHookServerUrl),
     Boolean(taskId),

--- a/src/lib/gitExclude.ts
+++ b/src/lib/gitExclude.ts
@@ -8,7 +8,6 @@ const execAsync = promisify(exec);
 const MARKER = "# KanVibe AI hooks (auto-generated)";
 
 const EXCLUDE_PATTERNS = [
-  ".kanvibe/task-id",
   ".claude/hooks/",
   ".claude/settings.json",
   ".gemini/hooks/",

--- a/src/lib/hookTaskBinding.ts
+++ b/src/lib/hookTaskBinding.ts
@@ -1,34 +1,20 @@
-import { mkdir, writeFile } from "fs/promises";
-import path from "path";
-import { readTextFile } from "@/lib/hostFileAccess";
-
-export const KANVIBE_TASK_ID_RELATIVE_PATH = ".kanvibe/task-id";
-
-export function getHookTaskIdFilePath(repoPath: string, sshHost?: string | null) {
-  return (sshHost ? path.posix : path).join(repoPath, KANVIBE_TASK_ID_RELATIVE_PATH);
+function escapeShellDoubleQuotedValue(value: string) {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`");
 }
 
-export async function writeHookTaskIdFile(repoPath: string, taskId: string) {
-  const filePath = getHookTaskIdFilePath(repoPath);
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, `${taskId}\n`, "utf-8");
-}
-
-export async function readHookTaskIdFile(repoPath: string, sshHost?: string | null): Promise<string | null> {
-  const taskId = (await readTextFile(getHookTaskIdFilePath(repoPath, sshHost), sshHost)).trim();
-  return taskId.length > 0 ? taskId : null;
+function unescapeShellDoubleQuotedValue(value: string) {
+  return value.replace(/\\([\\"$`])/g, "$1");
 }
 
 export function buildShellTaskIdResolver(defaultTaskId: string) {
-  return [
-    `TASK_ID_FILE="${KANVIBE_TASK_ID_RELATIVE_PATH}"`,
-    `TASK_ID="${defaultTaskId}"`,
-    "",
-    'if [ -f "$TASK_ID_FILE" ]; then',
-    "  FILE_TASK_ID=$(tr -d '\\r\\n' < \"$TASK_ID_FILE\")",
-    '  if [ -n "$FILE_TASK_ID" ]; then',
-    '    TASK_ID="$FILE_TASK_ID"',
-    "  fi",
-    "fi",
-  ].join("\n");
+  return `TASK_ID="${escapeShellDoubleQuotedValue(defaultTaskId)}"`;
+}
+
+export function extractShellTaskId(content: string): string | null {
+  const match = content.match(/^TASK_ID="((?:\\.|[^"\\])*)"$/m);
+  return match ? unescapeShellDoubleQuotedValue(match[1]) : null;
 }

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -5,7 +5,6 @@ import { setupGeminiHooks, generatePromptHookScript as generateGeminiPromptHookS
 import { setupCodexHooks, generateNotifyHookScript, HOOK_SCRIPT_NAME, CONFIG_FILE_NAME } from "@/lib/codexHooksSetup";
 import { setupOpenCodeHooks, generatePluginScript, PLUGIN_DIR_NAME, PLUGIN_FILE_NAME } from "@/lib/openCodeHooksSetup";
 import { getHookServerToken, getHookServerUrl } from "@/lib/hookEndpoint";
-import { KANVIBE_TASK_ID_RELATIVE_PATH } from "@/lib/hookTaskBinding";
 
 export async function installKanvibeHooks(
   targetPath: string,
@@ -25,8 +24,6 @@ export async function installKanvibeHooks(
     assertHookInstallResults(results);
     return;
   }
-
-  await writeRemoteTextFile(path.posix.join(targetPath, KANVIBE_TASK_ID_RELATIVE_PATH), `${taskId}\n`, sshHost);
 
   const remoteInstallers = [
     () => setupRemoteClaudeHooks(targetPath, taskId, hookServerUrl, hookServerToken, sshHost),

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -4,7 +4,6 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { buildFetchAuthHeaders } from "@/lib/hookAuth";
 import { pathExists, readTextFile } from "@/lib/hostFileAccess";
 import { extractPluginHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { KANVIBE_TASK_ID_RELATIVE_PATH, readHookTaskIdFile, writeHookTaskIdFile } from "@/lib/hookTaskBinding";
 import { isOpenCodePluginRegistered } from "@/lib/openCodePluginRegistry";
 
 /**
@@ -18,35 +17,18 @@ export const PLUGIN_DIR_NAME = "plugins";
 
 /** OpenCode plugin TypeScript 파일 내용을 생성한다 */
 export function generatePluginScript(kanvibeUrl: string, taskId: string, authToken?: string): string {
-  return `import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-import type { Plugin } from "@opencode-ai/plugin";
+  return `import type { Plugin } from "@opencode-ai/plugin";
 
 /**
  * KanVibe OpenCode Plugin
  * message.updated(user) → progress, question.asked → pending,
  * question.replied → progress, session.idle → review, session.deleted → done 상태 변경
  */
-export const KanvibePlugin: Plugin = async ({ client, directory, worktree }) => {
+export const KanvibePlugin: Plugin = async ({ client }) => {
   const KANVIBE_URL = "${kanvibeUrl}";
-  const DEFAULT_TASK_ID = "${taskId}";
-  const TASK_ID_FILE = "${KANVIBE_TASK_ID_RELATIVE_PATH}";
-  const repoPath = worktree || directory || process.cwd();
+  const TASK_ID = ${JSON.stringify(taskId)};
   const lastStatusBySession = new Map<string, string>();
   const lastUserMessageBySession = new Map<string, string>();
-
-  async function resolveTaskId(): Promise<string> {
-    try {
-      const taskId = (await readFile(join(repoPath, TASK_ID_FILE), "utf-8")).trim();
-      if (taskId.length > 0) {
-        return taskId;
-      }
-    } catch {
-      /* taskId 파일이 없으면 기본값 사용 */
-    }
-
-    return DEFAULT_TASK_ID;
-  }
 
   function getSessionID(source: any): string | undefined {
     return (
@@ -95,11 +77,10 @@ export const KanvibePlugin: Plugin = async ({ client, directory, worktree }) => 
     }
 
     try {
-      const resolvedTaskId = await resolveTaskId();
       await fetch(\`\${KANVIBE_URL}/api/hooks/status\`, {
         method: "POST",
         headers: ${buildFetchAuthHeaders(authToken)},
-        body: JSON.stringify({ taskId: resolvedTaskId, status }),
+        body: JSON.stringify({ taskId: TASK_ID, status }),
       });
       if (sessionID) {
         lastStatusBySession.set(sessionID, status);
@@ -200,6 +181,17 @@ function hasKanvibePlugin(pluginContent: string): boolean {
   return pluginContent.includes("KanvibePlugin") && pluginContent.includes("/api/hooks/status");
 }
 
+function extractPluginTaskId(pluginContent: string): string | null {
+  const match = pluginContent.match(/const TASK_ID = ("(?:\\.|[^"\\])*");/);
+  if (!match) return null;
+
+  try {
+    return JSON.parse(match[1]) as string;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * 지정된 repo에 OpenCode plugin을 설정한다.
  * `.opencode/plugins/kanvibe-plugin.ts` 파일을 생성한다.
@@ -216,7 +208,6 @@ export async function setupOpenCodeHooks(
   await mkdir(pluginsDir, { recursive: true });
 
   const pluginPath = path.join(pluginsDir, PLUGIN_FILE_NAME);
-  await writeHookTaskIdFile(repoPath, taskId);
   await writeFile(pluginPath, generatePluginScript(kanvibeUrl, taskId, authToken), "utf-8");
 
   try {
@@ -252,8 +243,8 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
   const pluginExists = await pathExists(pluginPath, sshHost);
 
   let hasPlugin = false;
-  const boundTaskId = await readHookTaskIdFile(repoPath, sshHost);
-  let hasTaskIdBinding = !taskId;
+  let boundTaskId: string | null = null;
+  let hasTaskIdBinding = false;
   let hasStatusEndpoint = false;
   let hasEventMappings = false;
   let hasMainSessionGuard = false;
@@ -265,16 +256,11 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
       const content = await readTextFile(pluginPath, sshHost);
       hasPlugin = hasKanvibePlugin(content);
       configuredHookServerUrl = extractPluginHookServerUrl(content);
+      boundTaskId = extractPluginTaskId(content);
       hasTaskIdBinding =
-        !taskId || (
-          content.includes(`const DEFAULT_TASK_ID = \"${taskId}\";`) &&
-          content.includes(`const TASK_ID_FILE = \"${KANVIBE_TASK_ID_RELATIVE_PATH}\";`) &&
-          content.includes("const repoPath = worktree || directory || process.cwd();") &&
-          content.includes("readFile(join(repoPath, TASK_ID_FILE), \"utf-8\")") &&
-          content.includes("resolveTaskId") &&
-          content.includes("taskId: resolvedTaskId") &&
-          boundTaskId === taskId
-        );
+        boundTaskId !== null
+        && content.includes("taskId: TASK_ID")
+        && (!taskId || boundTaskId === taskId);
       hasStatusEndpoint = content.includes("/api/hooks/status");
       hasEventMappings = ["progress", "pending", "review", "done", "message.updated", "question.asked", "question.replied", "session.idle", "session.deleted"].every((fragment) => content.includes(fragment));
       hasMainSessionGuard = content.includes("isMainSession(message)") && content.includes("isMainSession(event.properties)");


### PR DESCRIPTION
## What
- remove the `.kanvibe/task-id` file dependency from generated hook setup
- keep task bindings inside generated shell hooks and the OpenCode plugin
- align hook validation, repair flow, localized guidance, and tests with the direct binding approach

## How
### Embed task IDs directly in generated hooks
- shell hook generators now emit a fixed `TASK_ID="..."` assignment
- the OpenCode plugin posts the embedded task ID instead of resolving a repo file

### Simplify installation and validation
- local and remote installers no longer write `.kanvibe/task-id`
- project root hook repair now relies on hook status checks instead of a repo-level task-id file
- generated git exclude patterns stop treating `.kanvibe/task-id` as managed output

### Update user guidance and tests
- remove manual file-binding commands from the hooks status dialog
- refresh locale copy for reinstall guidance
- update tests to validate direct task binding behavior

Co-authored-by: OpenAI Codex <codex@openai.com>
