### PR TITLE
fix(hooks): speed up remote hook installation and reduce PR lookup noise

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -215,4 +215,52 @@ describe("kanbanService.createTask", () => {
     }));
     expect(result).toBe("https://github.com/kanvibe/kanvibe/pull/1");
   });
+
+  it("gh CLI가 없으면 PR URL 조회를 조용히 건너뛴다", async () => {
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-5",
+      projectId: "project-1",
+      branchName: "main",
+      prUrl: null,
+    });
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      sshHost: null,
+    });
+    mocks.execFile.mockImplementation((file, args, options, callback) => {
+      const error = Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" });
+      callback(error, "", "");
+      return {} as never;
+    });
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { fetchAndSavePrUrl, __testing__ } = await import("@/desktop/main/services/kanbanService");
+    __testing__.clearPrLookupStateForTests();
+
+    await expect(fetchAndSavePrUrl("task-5")).resolves.toBeNull();
+    await expect(fetchAndSavePrUrl("task-5")).resolves.toBeNull();
+
+    expect(mocks.execFile).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith("PR URL 조회 실패:", expect.anything());
+  });
+
+  it("원격 프로젝트는 로컬 gh로 PR URL 조회를 시도하지 않는다", async () => {
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-6",
+      projectId: "project-remote",
+      branchName: "main",
+      prUrl: null,
+    });
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-remote",
+      repoPath: "/remote/repo",
+      sshHost: "remote-host",
+    });
+
+    const { fetchAndSavePrUrl } = await import("@/desktop/main/services/kanbanService");
+
+    await expect(fetchAndSavePrUrl("task-6")).resolves.toBeNull();
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
 });

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -733,6 +733,89 @@ describe("projectService local hook installation", () => {
     }
   });
 
+  it("hook server 도달 실패만으로는 원격 root hook 재설치를 반복하지 않는다", async () => {
+    vi.useFakeTimers();
+
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          id: "project-1",
+          name: "prompt",
+          repoPath: "/remote/prompt",
+          defaultBranch: "main",
+          sshHost: "remote-host",
+        },
+      ]),
+    });
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn().mockResolvedValue({
+        id: "task-main",
+        branchName: "main",
+        projectId: "project-1",
+        baseBranch: "main",
+        worktreePath: "/remote/prompt",
+        sshHost: "remote-host",
+      }),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => ({ id: "task-main", ...value })),
+    });
+    mocks.readHookTaskIdFile.mockResolvedValue("task-main");
+    mocks.getClaudeHooksStatus.mockResolvedValue({
+      installed: false,
+      hasPromptHook: true,
+      hasStopHook: true,
+      hasQuestionHook: true,
+      hasSettingsEntry: true,
+      hasTaskIdBinding: true,
+      hasStatusMappings: true,
+      hasExpectedHookServerUrl: true,
+      hasReachableHookServer: false,
+    });
+    mocks.getGeminiHooksStatus.mockResolvedValue({
+      installed: false,
+      hasPromptHook: true,
+      hasStopHook: true,
+      hasSettingsEntry: true,
+      hasTaskIdBinding: true,
+      hasStatusMappings: true,
+      hasExpectedHookServerUrl: true,
+      hasReachableHookServer: false,
+    });
+    mocks.getCodexHooksStatus.mockResolvedValue({
+      installed: false,
+      hasNotifyHook: true,
+      hasConfigEntry: true,
+      hasTaskIdBinding: true,
+      hasReviewStatus: true,
+      hasAgentTurnCompleteFilter: true,
+      hasExpectedHookServerUrl: true,
+      hasReachableHookServer: false,
+    });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({
+      installed: false,
+      hasPlugin: true,
+      hasRegisteredPlugin: true,
+      hasTaskIdBinding: true,
+      hasStatusEndpoint: true,
+      hasEventMappings: true,
+      hasMainSessionGuard: true,
+      hasDuplicateProgressGuard: true,
+      hasExpectedHookServerUrl: true,
+      hasReachableHookServer: false,
+    });
+
+    const { getAllProjects } = await import("@/desktop/main/services/projectService");
+
+    try {
+      await getAllProjects();
+      await vi.runAllTimersAsync();
+
+      expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("레거시 프로젝트에서 기본 브랜치 task가 없어도 project hook 재설치를 계속 진행한다", async () => {
     const project = {
       id: "project-1",

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -22,31 +22,130 @@ export interface LoadMoreDoneResponse {
 }
 
 const DONE_PAGE_SIZE = 20;
+const GITHUB_CLI_CANDIDATES = process.platform === "darwin"
+  ? ["gh", "/opt/homebrew/bin/gh", "/usr/local/bin/gh"]
+  : ["gh"];
+const prLookupWarnings = new Set<string>();
+let resolvedGitHubCliPath: string | null = null;
+let githubCliUnavailable = false;
 
 /** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
 function serialize<T>(data: T): T {
   return JSON.parse(JSON.stringify(data));
 }
 
-async function getPrUrlFromGitHubCli(branchName: string, cwd: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    execFile(
-      "gh",
-      ["pr", "list", "--head", branchName, "--json", "url", "-q", ".[0].url"],
-      { cwd },
-      (error, stdout) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-
-        resolve(stdout.trim());
-      },
-    );
-  });
+function isCommandNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error
+    && "code" in error
+    && (error as NodeJS.ErrnoException).code === "ENOENT";
 }
 
-/** 모든 작업을 상태별로 그룹핑하여 반환한다. Done 컬럼은 첫 페이지만 로드한다 */
+function warnPrLookupOnce(key: string, message: string) {
+  if (prLookupWarnings.has(key)) {
+    return;
+  }
+
+  prLookupWarnings.add(key);
+  console.warn(message);
+}
+
+async function execGitHubCli(args: string[], cwd: string): Promise<string | null> {
+  if (githubCliUnavailable) {
+    return null;
+  }
+
+  const candidates = resolvedGitHubCliPath ? [resolvedGitHubCliPath] : GITHUB_CLI_CANDIDATES;
+
+  for (const command of candidates) {
+    try {
+      const stdout = await new Promise<string>((resolve, reject) => {
+        execFile(command, args, { cwd }, (error, nextStdout) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve(nextStdout.trim());
+        });
+      });
+
+      resolvedGitHubCliPath = command;
+      return stdout;
+    } catch (error) {
+      if (isCommandNotFoundError(error)) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  githubCliUnavailable = true;
+  return null;
+}
+
+async function getPrUrlFromGitHubCli(branchName: string, cwd: string): Promise<string | null> {
+  return execGitHubCli(
+    ["pr", "list", "--head", branchName, "--json", "url", "-q", ".[0].url"],
+    cwd,
+  );
+}
+
+function getPrLookupErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isGitHubCliAuthOrRepoError(error: unknown): boolean {
+  const message = getPrLookupErrorMessage(error);
+  return /gh auth login|not logged into any GitHub hosts|could not resolve to a repository|not a git repository/i.test(message);
+}
+
+function handlePrLookupFailure(error: unknown) {
+  if (isCommandNotFoundError(error)) {
+    githubCliUnavailable = true;
+    warnPrLookupOnce(
+      "gh-missing",
+      "[kanvibe] gh CLI를 찾지 못해 PR URL 자동 조회를 건너뜁니다.",
+    );
+    return;
+  }
+
+  if (isGitHubCliAuthOrRepoError(error)) {
+    warnPrLookupOnce(
+      `gh-auth:${getPrLookupErrorMessage(error)}`,
+      `[kanvibe] ${getPrLookupErrorMessage(error)}. PR URL 자동 조회를 건너뜁니다.`,
+    );
+    return;
+  }
+
+  console.error("PR URL 조회 실패:", error);
+}
+
+function isRemoteProject(project: { sshHost?: string | null } | null): boolean {
+  return Boolean(project?.sshHost);
+}
+
+function normalizeRepoPath(project: { repoPath?: string | null } | null): string | null {
+  if (!project?.repoPath) {
+    return null;
+  }
+
+  return project.repoPath;
+}
+
+function canLookupPrUrl(project: { sshHost?: string | null } | null, repoPath: string | null): boolean {
+  return !isRemoteProject(project) && Boolean(repoPath ?? process.cwd());
+}
+
+function clearPrLookupStateForTests() {
+  resolvedGitHubCliPath = null;
+  githubCliUnavailable = false;
+  prLookupWarnings.clear();
+}
+
+export const __testing__ = { clearPrLookupStateForTests };
+
+/** 모든 작업을 상태별로 그룹핑하여 반환한다 */
 export async function getTasksByStatus(): Promise<TasksByStatusWithMeta> {
   const repo = await getTaskRepository();
 
@@ -482,10 +581,15 @@ export async function fetchAndSavePrUrl(taskId: string): Promise<string | null> 
   if (!task?.branchName) return null;
 
   let repoPath: string | null = null;
+  let project: { repoPath?: string | null; sshHost?: string | null } | null = null;
   if (task.projectId) {
     const projectRepo = await getProjectRepository();
-    const project = await projectRepo.findOneBy({ id: task.projectId });
-    if (project) repoPath = project.repoPath;
+    project = await projectRepo.findOneBy({ id: task.projectId });
+    repoPath = normalizeRepoPath(project);
+  }
+
+  if (!canLookupPrUrl(project, repoPath)) {
+    return null;
   }
 
   try {
@@ -498,7 +602,7 @@ export async function fetchAndSavePrUrl(taskId: string): Promise<string | null> 
       return prUrl;
     }
   } catch (error) {
-    console.error("PR URL 조회 실패:", error);
+    handlePrLookupFailure(error);
   }
 
   return null;

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -54,6 +54,21 @@ function isRemoteConnectionError(error: unknown): boolean {
 const projectRootHookRepairJobs = new Map<string, Promise<void>>();
 const projectRootHookRepairScheduled = new Set<string>();
 
+function hasRequiredHookConfiguration(
+  status:
+    | ClaudeHooksStatus
+    | GeminiHooksStatus
+    | CodexHooksStatus
+    | OpenCodeHooksStatus,
+  requiredChecks: string[],
+): boolean {
+  if (status.installed) {
+    return true;
+  }
+
+  return requiredChecks.every((key) => status[key as keyof typeof status] === true);
+}
+
 function scheduleProjectRootHookRepair(project: Project) {
   const projectPathKey = buildProjectPathKey(project.repoPath, project.sshHost);
   if (projectRootHookRepairScheduled.has(projectPathKey)) {
@@ -189,10 +204,41 @@ async function areProjectRootHooksInstalled(project: Project, taskId: string): P
     getOpenCodeHooksStatus(project.repoPath, taskId, project.sshHost),
   ]);
 
-  return claudeStatus.installed
-    && geminiStatus.installed
-    && codexStatus.installed
-    && openCodeStatus.installed;
+  return hasRequiredHookConfiguration(claudeStatus, [
+    "hasPromptHook",
+    "hasStopHook",
+    "hasQuestionHook",
+    "hasSettingsEntry",
+    "hasTaskIdBinding",
+    "hasStatusMappings",
+    "hasExpectedHookServerUrl",
+  ])
+    && hasRequiredHookConfiguration(geminiStatus, [
+      "hasPromptHook",
+      "hasStopHook",
+      "hasSettingsEntry",
+      "hasTaskIdBinding",
+      "hasStatusMappings",
+      "hasExpectedHookServerUrl",
+    ])
+    && hasRequiredHookConfiguration(codexStatus, [
+      "hasNotifyHook",
+      "hasConfigEntry",
+      "hasTaskIdBinding",
+      "hasReviewStatus",
+      "hasAgentTurnCompleteFilter",
+      "hasExpectedHookServerUrl",
+    ])
+    && hasRequiredHookConfiguration(openCodeStatus, [
+      "hasPlugin",
+      "hasRegisteredPlugin",
+      "hasTaskIdBinding",
+      "hasStatusEndpoint",
+      "hasEventMappings",
+      "hasMainSessionGuard",
+      "hasDuplicateProgressGuard",
+      "hasExpectedHookServerUrl",
+    ]);
 }
 
 async function ensureProjectRootTask(
@@ -440,6 +486,7 @@ export async function scanAndRegisterProjects(
     existing.map((project) => buildProjectPathKey(project.repoPath, project.sshHost))
   );
   const existingNames = new Set(existing.map((p) => p.name));
+  const rootHookRepairAttempted = new Set<string>();
 
   for (const repoPath of repoPaths) {
     const pathKey = buildProjectPathKey(repoPath, sshHost || null);
@@ -472,6 +519,7 @@ export async function scanAndRegisterProjects(
           repairHooks: true,
           throwOnHookRepairFailure: false,
         });
+        rootHookRepairAttempted.add(pathKey);
         defaultTask = ensured.task;
       } catch (taskError) {
         await repo.remove(saved);
@@ -503,10 +551,13 @@ export async function scanAndRegisterProjects(
 
   for (const project of scannedProjects) {
     try {
-      const { repaired } = await ensureProjectRootTask(project, {
-        repairHooks: true,
-        throwOnHookRepairFailure: false,
-      });
+      const projectPathKey = buildProjectPathKey(project.repoPath, project.sshHost);
+      const { repaired } = rootHookRepairAttempted.has(projectPathKey)
+        ? await ensureProjectRootTask(project)
+        : await ensureProjectRootTask(project, {
+          repairHooks: true,
+          throwOnHookRepairFailure: false,
+        });
       if (repaired && !result.hooksSetup.includes(project.name)) {
         result.hooksSetup.push(project.name);
       }

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -35,22 +35,22 @@ export async function installKanvibeHooks(
     () => setupRemoteOpenCodeHooks(targetPath, taskId, hookServerUrl, hookServerToken, sshHost),
   ];
 
-  for (const installRemoteHooks of remoteInstallers) {
-    await installRemoteHooks();
-  }
+  const results = await Promise.allSettled(remoteInstallers.map((installRemoteHooks) => installRemoteHooks()));
+  assertHookInstallResults(results);
 }
 
 async function setupRemoteClaudeHooks(repoPath: string, taskId: string, hookServerUrl: string, hookServerToken: string, sshHost: string) {
   const claudeDir = path.posix.join(repoPath, ".claude");
   const hooksDir = path.posix.join(claudeDir, "hooks");
   const settingsPath = path.posix.join(claudeDir, "settings.json");
-  await execGit(`mkdir -p "${hooksDir}"`, sshHost);
-
-  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"), generateClaudePromptHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-stop-hook.sh"), generateClaudeStopHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-question-hook.sh"), generateClaudeQuestionHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-
-  const settings = await readRemoteJsonFile(settingsPath, sshHost);
+  const [settings] = await Promise.all([
+    readRemoteJsonFile(settingsPath, sshHost),
+    Promise.all([
+      writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"), generateClaudePromptHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755),
+      writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-stop-hook.sh"), generateClaudeStopHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755),
+      writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-question-hook.sh"), generateClaudeQuestionHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755),
+    ]),
+  ]);
   const hooks = ((settings.hooks as Record<string, unknown[]>) || {});
   settings.hooks = hooks;
 
@@ -76,12 +76,13 @@ async function setupRemoteGeminiHooks(repoPath: string, taskId: string, hookServ
   const geminiDir = path.posix.join(repoPath, ".gemini");
   const hooksDir = path.posix.join(geminiDir, "hooks");
   const settingsPath = path.posix.join(geminiDir, "settings.json");
-  await execGit(`mkdir -p "${hooksDir}"`, sshHost);
-
-  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"), generateGeminiPromptHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-stop-hook.sh"), generateGeminiStopHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-
-  const settings = await readRemoteJsonFile(settingsPath, sshHost);
+  const [settings] = await Promise.all([
+    readRemoteJsonFile(settingsPath, sshHost),
+    Promise.all([
+      writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"), generateGeminiPromptHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755),
+      writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-stop-hook.sh"), generateGeminiStopHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755),
+    ]),
+  ]);
   const hooks = ((settings.hooks as Record<string, unknown[]>) || {});
   settings.hooks = hooks;
 
@@ -101,11 +102,10 @@ async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServe
   const codexDir = path.posix.join(repoPath, ".codex");
   const hooksDir = path.posix.join(codexDir, "hooks");
   const configPath = path.posix.join(codexDir, CONFIG_FILE_NAME);
-  await execGit(`mkdir -p "${hooksDir}"`, sshHost);
-
-  await writeRemoteTextFile(path.posix.join(hooksDir, HOOK_SCRIPT_NAME), generateNotifyHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-
-  const configContent = await readRemoteTextFile(configPath, sshHost);
+  const [configContent] = await Promise.all([
+    readRemoteTextFile(configPath, sshHost),
+    writeRemoteTextFile(path.posix.join(hooksDir, HOOK_SCRIPT_NAME), generateNotifyHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755),
+  ]);
   const notifyLine = `notify = [".codex/hooks/${HOOK_SCRIPT_NAME}"]\n`;
   const nextConfig = configContent.includes(HOOK_SCRIPT_NAME)
     ? configContent.replace(/^notify\s*=.*$/m, `notify = [".codex/hooks/${HOOK_SCRIPT_NAME}"]`)
@@ -117,7 +117,6 @@ async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServe
 
 async function setupRemoteOpenCodeHooks(repoPath: string, taskId: string, hookServerUrl: string, hookServerToken: string, sshHost: string) {
   const pluginDir = path.posix.join(repoPath, ".opencode", PLUGIN_DIR_NAME);
-  await execGit(`mkdir -p "${pluginDir}"`, sshHost);
   await writeRemoteTextFile(
     path.posix.join(pluginDir, PLUGIN_FILE_NAME),
     generatePluginScript(hookServerUrl, taskId, hookServerToken),


### PR DESCRIPTION
## What does this change?
- speed up remote hook installation by reducing SSH round-trips
- stop re-installing remote root hooks when only the hook server health check is temporarily unreachable
- make PR URL lookup best-effort and avoid repeated `gh` lookup noise

## How is it implemented?
### Remote hook installation
- run remote Claude, Gemini, Codex, and OpenCode hook setup in parallel
- parallelize remote script/config reads and writes inside each installer path
- avoid repeating root-hook repair work during project scans once the same project has already been repaired in that scan

### PR URL lookup resilience
- try common macOS `gh` install paths before treating the CLI as unavailable
- skip local `gh` PR lookup attempts for remote projects
- suppress repeated missing/authentication/repository lookup failures while keeping PR URL fetches non-blocking

### Regression coverage
- add regression coverage for the remote hook health-check fallback path
- add PR lookup tests for missing `gh` and remote-project behavior

Co-authored-by: Codex <noreply@openai.com>
