### PR TITLE
fix(hooks): overwrite stale hook state on reinstall

### DIFF
--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -397,7 +397,7 @@ describe("projectService local hook installation", () => {
     mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: false });
   });
 
-  it("로컬 Claude hook 설치 시 서버 URL과 토큰을 함께 전달한다", async () => {
+  it("로컬 Claude hook 설치 시 공통 installer로 모든 hooks를 다시 설치한다", async () => {
     const task = {
       id: "task-1",
       worktreePath: "/workspace/task-1",
@@ -417,17 +417,15 @@ describe("projectService local hook installation", () => {
 
     await installTaskHooks(task.id);
 
-    expect(mocks.getHookServerUrl).toHaveBeenCalledWith(null);
-    expect(mocks.getHookServerToken).toHaveBeenCalled();
-    expect(mocks.setupClaudeHooks).toHaveBeenCalledWith(
+    expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
       "/workspace/task-1",
       "task-1",
-      "http://localhost:9736",
-      "desktop-hook-token",
+      null,
     );
+    expect(mocks.setupClaudeHooks).not.toHaveBeenCalled();
   });
 
-  it("로컬 OpenCode hook 설치 시 서버 URL과 토큰을 함께 전달한다", async () => {
+  it("로컬 OpenCode hook 설치 시 공통 installer로 모든 hooks를 다시 설치한다", async () => {
     const task = {
       id: "task-2",
       worktreePath: null,
@@ -456,14 +454,12 @@ describe("projectService local hook installation", () => {
 
     await installTaskOpenCodeHooks(task.id);
 
-    expect(mocks.getHookServerUrl).toHaveBeenCalledWith(null);
-    expect(mocks.getHookServerToken).toHaveBeenCalled();
-    expect(mocks.setupOpenCodeHooks).toHaveBeenCalledWith(
+    expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
       "/workspace/repo",
       "task-main",
-      "http://localhost:9736",
-      "desktop-hook-token",
+      null,
     );
+    expect(mocks.setupOpenCodeHooks).not.toHaveBeenCalled();
   });
 
   it("프로젝트 루트 경로 task의 Claude hook 상태는 현재 root task 기준으로 조회한다", async () => {
@@ -502,7 +498,7 @@ describe("projectService local hook installation", () => {
     );
   });
 
-  it("프로젝트 루트 경로 task에서 Claude hook 재설치를 누르면 현재 root task에 다시 바인딩한다", async () => {
+  it("프로젝트 루트 경로 task에서 Claude hook 재설치를 누르면 공통 installer로 현재 root task에 다시 바인딩한다", async () => {
     const task = {
       id: "stale-task",
       worktreePath: "/workspace/repo",
@@ -531,12 +527,12 @@ describe("projectService local hook installation", () => {
 
     await installTaskHooks(task.id);
 
-    expect(mocks.setupClaudeHooks).toHaveBeenCalledWith(
+    expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
       "/workspace/repo",
       "task-main",
-      "http://localhost:9736",
-      "desktop-hook-token",
+      null,
     );
+    expect(mocks.setupClaudeHooks).not.toHaveBeenCalled();
   });
 
   it("로컬 기본 브랜치 태스크가 TODO로 남아도 repo 경로에 hooks를 자동 설치한다", async () => {
@@ -818,12 +814,12 @@ describe("projectService local hook installation", () => {
       status: { installed: true },
     });
 
-    expect(mocks.setupClaudeHooks).toHaveBeenCalledWith(
+    expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
       "/workspace/api",
       "task-main",
-      "http://localhost:9736",
-      "desktop-hook-token",
+      null,
     );
+    expect(mocks.setupClaudeHooks).not.toHaveBeenCalled();
   });
 
   it("스캔으로 발견한 로컬 TODO worktree 태스크에도 hooks를 자동 설치한다", async () => {

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -4,10 +4,10 @@ import { validateGitRepo, getDefaultBranch, listBranches, scanGitRepos, listWork
 import { TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { IsNull } from "typeorm";
 import { isSessionAlive, formatSessionName, createSessionWithoutWorktree } from "@/lib/worktree";
-import { setupClaudeHooks, getClaudeHooksStatus, type ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
-import { setupGeminiHooks, getGeminiHooksStatus, type GeminiHooksStatus } from "@/lib/geminiHooksSetup";
-import { setupCodexHooks, getCodexHooksStatus, type CodexHooksStatus } from "@/lib/codexHooksSetup";
-import { setupOpenCodeHooks, getOpenCodeHooksStatus, type OpenCodeHooksStatus } from "@/lib/openCodeHooksSetup";
+import { getClaudeHooksStatus, type ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
+import { getGeminiHooksStatus, type GeminiHooksStatus } from "@/lib/geminiHooksSetup";
+import { getCodexHooksStatus, type CodexHooksStatus } from "@/lib/codexHooksSetup";
+import { getOpenCodeHooksStatus, type OpenCodeHooksStatus } from "@/lib/openCodeHooksSetup";
 import { aggregateAiSessions, getAiSessionDetail } from "@/lib/aiSessions/aggregateAiSessions";
 import type { AggregatedAiSessionDetail, AggregatedAiSessionsResult, AiMessageRole, AiSessionProvider } from "@/lib/aiSessions/types";
 import { homedir } from "os";
@@ -17,7 +17,6 @@ import { broadcastBoardUpdate } from "@/lib/boardNotifier";
 import { getAvailableHosts as readAvailableHosts } from "@/lib/sshConfig";
 import { getDefaultSessionType } from "@/desktop/main/services/appSettingsService";
 import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
-import { getHookServerToken, getHookServerUrl } from "@/lib/hookEndpoint";
 
 function matchesTaskLocation(task: { worktreePath?: string | null; sshHost?: string | null }, expectedPath: string, sshHost?: string | null): boolean {
   return task.worktreePath === expectedPath && (task.sshHost || null) === (sshHost || null);
@@ -320,13 +319,6 @@ async function resolveTaskHookTarget(task: {
     targetPath,
     taskId: projectRootTask?.id ?? task.id,
     sshHost: task.project.sshHost,
-  };
-}
-
-async function getHookInstallConfig(sshHost?: string | null) {
-  return {
-    kanvibeUrl: await getHookServerUrl(sshHost),
-    authToken: getHookServerToken() || undefined,
   };
 }
 
@@ -732,13 +724,7 @@ export async function installProjectHooks(
   if (!task) return { success: false, error: "기본 브랜치 태스크를 찾을 수 없습니다." };
 
   try {
-    if (project.sshHost) {
-      await installKanvibeHooks(project.repoPath, task.id, project.sshHost);
-      return { success: true, status: await getClaudeHooksStatus(project.repoPath, task.id, project.sshHost) };
-    }
-
-    const { kanvibeUrl, authToken } = await getHookInstallConfig(project.sshHost);
-    await setupClaudeHooks(project.repoPath, task.id, kanvibeUrl, authToken);
+    await installKanvibeHooks(project.repoPath, task.id, project.sshHost);
     return { success: true, status: await getClaudeHooksStatus(project.repoPath, task.id, project.sshHost) };
   } catch (error) {
     return {
@@ -776,13 +762,7 @@ export async function installTaskHooks(
       return { success: false, error: "프로젝트를 찾을 수 없습니다." };
     }
 
-    if (hookTarget.sshHost) {
-      await installKanvibeHooks(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost);
-      return { success: true, status: await getClaudeHooksStatus(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost) };
-    }
-
-    const { kanvibeUrl, authToken } = await getHookInstallConfig(task.project.sshHost);
-    await setupClaudeHooks(hookTarget.targetPath, hookTarget.taskId, kanvibeUrl, authToken);
+    await installKanvibeHooks(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost);
     return { success: true, status: await getClaudeHooksStatus(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost) };
   } catch (error) {
     return {
@@ -816,13 +796,7 @@ export async function installProjectGeminiHooks(
   if (!task) return { success: false, error: "기본 브랜치 태스크를 찾을 수 없습니다." };
 
   try {
-    if (project.sshHost) {
-      await installKanvibeHooks(project.repoPath, task.id, project.sshHost);
-      return { success: true, status: await getGeminiHooksStatus(project.repoPath, task.id, project.sshHost) };
-    }
-
-    const { kanvibeUrl, authToken } = await getHookInstallConfig(project.sshHost);
-    await setupGeminiHooks(project.repoPath, task.id, kanvibeUrl, authToken);
+    await installKanvibeHooks(project.repoPath, task.id, project.sshHost);
     return { success: true, status: await getGeminiHooksStatus(project.repoPath, task.id, project.sshHost) };
   } catch (error) {
     return {
@@ -860,13 +834,7 @@ export async function installTaskGeminiHooks(
       return { success: false, error: "프로젝트를 찾을 수 없습니다." };
     }
 
-    if (hookTarget.sshHost) {
-      await installKanvibeHooks(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost);
-      return { success: true, status: await getGeminiHooksStatus(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost) };
-    }
-
-    const { kanvibeUrl, authToken } = await getHookInstallConfig(task.project.sshHost);
-    await setupGeminiHooks(hookTarget.targetPath, hookTarget.taskId, kanvibeUrl, authToken);
+    await installKanvibeHooks(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost);
     return { success: true, status: await getGeminiHooksStatus(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost) };
   } catch (error) {
     return {
@@ -898,13 +866,7 @@ export async function installProjectCodexHooks(
   if (!task) return { success: false, error: "기본 브랜치 태스크를 찾을 수 없습니다." };
 
   try {
-    if (project.sshHost) {
-      await installKanvibeHooks(project.repoPath, task.id, project.sshHost);
-      return { success: true, status: await getCodexHooksStatus(project.repoPath, task.id, project.sshHost) };
-    }
-
-    const { kanvibeUrl, authToken } = await getHookInstallConfig(project.sshHost);
-    await setupCodexHooks(project.repoPath, task.id, kanvibeUrl, authToken);
+    await installKanvibeHooks(project.repoPath, task.id, project.sshHost);
     return { success: true, status: await getCodexHooksStatus(project.repoPath, task.id, project.sshHost) };
   } catch (error) {
     return {
@@ -940,13 +902,7 @@ export async function installTaskCodexHooks(
       return { success: false, error: "프로젝트를 찾을 수 없습니다." };
     }
 
-    if (hookTarget.sshHost) {
-      await installKanvibeHooks(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost);
-      return { success: true, status: await getCodexHooksStatus(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost) };
-    }
-
-    const { kanvibeUrl, authToken } = await getHookInstallConfig(task.project.sshHost);
-    await setupCodexHooks(hookTarget.targetPath, hookTarget.taskId, kanvibeUrl, authToken);
+    await installKanvibeHooks(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost);
     return { success: true, status: await getCodexHooksStatus(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost) };
   } catch (error) {
     return {
@@ -968,13 +924,7 @@ export async function installProjectOpenCodeHooks(
   if (!task) return { success: false, error: "Default branch task not found" };
 
   try {
-    if (project.sshHost) {
-      await installKanvibeHooks(project.repoPath, task.id, project.sshHost);
-      return { success: true, status: await getOpenCodeHooksStatus(project.repoPath, task.id, project.sshHost) };
-    }
-
-    const { kanvibeUrl, authToken } = await getHookInstallConfig(project.sshHost);
-    await setupOpenCodeHooks(project.repoPath, task.id, kanvibeUrl, authToken);
+    await installKanvibeHooks(project.repoPath, task.id, project.sshHost);
     return { success: true, status: await getOpenCodeHooksStatus(project.repoPath, task.id, project.sshHost) };
   } catch (error) {
     return {
@@ -1001,13 +951,7 @@ export async function installTaskOpenCodeHooks(
       return { success: false, error: "Task or project not found" };
     }
 
-    if (hookTarget.sshHost) {
-      await installKanvibeHooks(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost);
-      return { success: true, status: await getOpenCodeHooksStatus(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost) };
-    }
-
-    const { kanvibeUrl, authToken } = await getHookInstallConfig(task.project.sshHost);
-    await setupOpenCodeHooks(hookTarget.targetPath, hookTarget.taskId, kanvibeUrl, authToken);
+    await installKanvibeHooks(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost);
     return { success: true, status: await getOpenCodeHooksStatus(hookTarget.targetPath, hookTarget.taskId, hookTarget.sshHost) };
   } catch (error) {
     return {

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, readFile, rm } from "fs/promises";
+import { mkdtemp, readFile, rm, mkdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import { setupOpenCodeHooks, getOpenCodeHooksStatus } from "../openCodeHooksSetup";
@@ -133,6 +133,50 @@ describe("openCodeHooksSetup", () => {
       // Then - should still be installed correctly
       const status = await getOpenCodeHooksStatus(repoPath);
       expect(status.installed).toBe(true);
+    });
+
+    it("should repair stale branch-bound plugin content on reinstall", async () => {
+      // Given
+      const repoPath = tempDir;
+      const pluginDir = join(repoPath, ".opencode", "plugins");
+      const pluginPath = join(pluginDir, "kanvibe-plugin.ts");
+      await mkdir(pluginDir, { recursive: true });
+      await writeFile(pluginPath, `import type { Plugin } from "@opencode-ai/plugin";
+
+export const KanvibePlugin: Plugin = async ({ $ }) => {
+  const KANVIBE_URL = "http://localhost:3000";
+  const PROJECT_NAME = "kanvibe";
+
+  async function updateStatus(status: string): Promise<void> {
+    const branchName = "feature/legacy";
+    await fetch(\`\${KANVIBE_URL}/api/hooks/status\`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ branchName, projectName: PROJECT_NAME, status }),
+    });
+  }
+
+  return {
+    event: async () => {
+      await updateStatus("review");
+    },
+  };
+};
+`, "utf-8");
+
+      // When
+      await setupOpenCodeHooks(repoPath, "task-2", "http://localhost:3000");
+
+      // Then
+      const pluginContent = await readFile(pluginPath, "utf-8");
+      const status = await getOpenCodeHooksStatus(repoPath);
+
+      expect(pluginContent).toContain('const TASK_ID = "task-2";');
+      expect(pluginContent).toContain("taskId: TASK_ID");
+      expect(pluginContent).not.toContain("branchName");
+      expect(pluginContent).not.toContain("projectName");
+      expect(status.boundTaskId).toBe("task-2");
+      expect(status.hasTaskIdBinding).toBe(true);
     });
   });
 

--- a/src/lib/__tests__/openCodePluginRegistry.test.ts
+++ b/src/lib/__tests__/openCodePluginRegistry.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { extractRegisteredPluginUrls } from "../openCodePluginRegistry";
+
+describe("openCodePluginRegistry", () => {
+  it("extracts plugin urls from valid JSON output", () => {
+    const output = JSON.stringify({
+      plugin: [
+        "file:///tmp/alpha.ts",
+        "file:///tmp/kanvibe-plugin.ts",
+      ],
+      agent: {},
+    });
+
+    expect(extractRegisteredPluginUrls(output)).toEqual([
+      "file:///tmp/alpha.ts",
+      "file:///tmp/kanvibe-plugin.ts",
+    ]);
+  });
+
+  it("falls back to the plugin block when opencode debug output is not valid JSON", () => {
+    const output = `{
+  "plugin": [
+    "file:///tmp/alpha.ts",
+    "file:///tmp/kanvibe-plugin.ts"
+  ],
+  "agent": {
+    "custom": {
+      "template": "line 1
+line 2"
+    }
+  }
+}`;
+
+    expect(extractRegisteredPluginUrls(output)).toEqual([
+      "file:///tmp/alpha.ts",
+      "file:///tmp/kanvibe-plugin.ts",
+    ]);
+  });
+});

--- a/src/lib/openCodePluginRegistry.ts
+++ b/src/lib/openCodePluginRegistry.ts
@@ -8,19 +8,42 @@ interface OpenCodeDebugConfig {
   plugin?: unknown;
 }
 
+function normalizePluginEntries(values: unknown): string[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  return values.filter((value): value is string => typeof value === "string");
+}
+
+export function extractRegisteredPluginUrls(output: string): string[] {
+  try {
+    const config = JSON.parse(output) as OpenCodeDebugConfig;
+    const pluginEntries = normalizePluginEntries(config.plugin);
+    if (pluginEntries.length > 0) {
+      return pluginEntries;
+    }
+  } catch {
+    // OpenCode debug output can embed invalid JSON in later sections. Fall back to the top-level plugin block.
+  }
+
+  const pluginBlockMatch = output.match(/"plugin"\s*:\s*\[([\s\S]*?)\]\s*,\s*"[^"]+"\s*:/);
+  const pluginBlock = pluginBlockMatch?.[1];
+  if (!pluginBlock) {
+    return [];
+  }
+
+  return Array.from(pluginBlock.matchAll(/"((?:\\.|[^"\\])*)"/g), ([, value]) => JSON.parse(`"${value}"`) as string);
+}
+
 export async function isOpenCodePluginRegistered(repoPath: string, pluginPath: string): Promise<boolean> {
   try {
     const { stdout } = await execFileAsync("opencode", ["debug", "config"], {
       cwd: repoPath,
       maxBuffer: 1024 * 1024,
     });
-    const config = JSON.parse(stdout) as OpenCodeDebugConfig;
-    if (!Array.isArray(config.plugin)) {
-      return false;
-    }
-
     const expectedPluginUrl = pathToFileURL(pluginPath).href;
-    return config.plugin.some((value) => value === expectedPluginUrl);
+    return extractRegisteredPluginUrls(stdout).some((value) => value === expectedPluginUrl);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Related materials
- None

## What work is this?
- Fix hook reinstall and validation regressions that left OpenCode hooks showing as incomplete and prevented reinstall from fully overwriting stale generated files.

## How did you solve it?
**Shared reinstall flow**
- Route project and task reinstall requests through the shared `installKanvibeHooks` path so Claude, Gemini, Codex, and OpenCode outputs are rewritten together.
- Keep provider-specific status checks after reinstall so the UI still reports the selected provider accurately.

**OpenCode validation hardening**
- Make OpenCode plugin registration parsing tolerate `opencode debug config` output that contains invalid JSON outside the top-level plugin array.
- Add regression coverage for stale branch-bound plugin content and for the shared local reinstall behavior.

## What are the important changes?
### Shared hook reinstall path

**Rewrite all hook outputs on local reinstall**
- **Reason**: reinstalling a single provider could leave stale files for the others, so generated hook state was not fully overwritten.
- **Files changed**: `src/desktop/main/services/projectService.ts`, `src/desktop/main/services/__tests__/projectService.test.ts`

### OpenCode hook validation

**Handle non-JSON OpenCode debug output**
- **Reason**: plugin registration checks were falling back to false when `opencode debug config` included invalid JSON in later sections.
- **Files changed**: `src/lib/openCodePluginRegistry.ts`, `src/lib/__tests__/openCodePluginRegistry.test.ts`

**Cover stale OpenCode plugin repair**
- **Reason**: reinstall needs regression coverage to confirm stale branch-bound plugin content is replaced with the current task-bound plugin.
- **Files changed**: `src/lib/__tests__/openCodeHooksSetup.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>
