### PR TITLE
fix(hooks): remove OpenCode duplicate plugin notice

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -234,7 +234,6 @@
     "codexHooksInstallSuccess": "Codex CLI hooks installed",
     "openCodeHooksInstallSuccess": "OpenCode hooks installed",
     "hooksInstallIncomplete": "Hooks were installed, but the required verification checks are not all passing yet.",
-    "hooksOpenCodeDuplicatePluginsNotice": "Two KanVibe plugins are registered, so both hooks may run. Check the logs for details.",
     "hooksInstallFailed": "Hooks installation failed",
     "hooksRemoteNotSupported": "Remote projects are not supported",
     "hooksCurrentTaskId": "Current taskId: {taskId}",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -234,7 +234,6 @@
     "codexHooksInstallSuccess": "Codex CLI hooks 설치 완료",
     "openCodeHooksInstallSuccess": "OpenCode hooks 설치 완료",
     "hooksInstallIncomplete": "Hooks는 설치됐지만 검증 항목이 아직 모두 맞지 않습니다.",
-    "hooksOpenCodeDuplicatePluginsNotice": "KanVibe plugin이 2개 등록되어 두 hook이 함께 실행될 수 있습니다. 상세 원인은 로그를 확인하세요.",
     "hooksInstallFailed": "Hooks 설치 실패",
     "hooksRemoteNotSupported": "원격 프로젝트는 지원하지 않습니다",
     "hooksCurrentTaskId": "현재 taskId: {taskId}",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -234,7 +234,6 @@
     "codexHooksInstallSuccess": "Codex CLI hooks 安装完成",
     "openCodeHooksInstallSuccess": "OpenCode hooks 安装完成",
     "hooksInstallIncomplete": "Hooks 已安装，但所需的校验项尚未全部通过。",
-    "hooksOpenCodeDuplicatePluginsNotice": "已注册两个 KanVibe plugin，因此两个 hook 都可能执行。详情请查看日志。",
     "hooksInstallFailed": "Hooks 安装失败",
     "hooksRemoteNotSupported": "不支持远程项目",
     "hooksCurrentTaskId": "当前 taskId: {taskId}",

--- a/src/components/HooksStatusDialog.tsx
+++ b/src/components/HooksStatusDialog.tsx
@@ -320,12 +320,6 @@ export default function HooksStatusDialog({
                   ) : null}
                 </div>
 
-                {item.key === "openCode" && item.status?.hasDuplicateKanvibePlugins ? (
-                  <p className="mt-4 rounded-md border border-status-warning/30 bg-status-warning/10 px-3 py-2 text-xs text-text-secondary">
-                    {t("hooksOpenCodeDuplicatePluginsNotice")}
-                  </p>
-                ) : null}
-
                 {expandedManualTool === item.key && !isRemote && !isInstalled ? (
                   <div className="mt-4 rounded-lg border border-border-default bg-bg-surface p-3">
                     <p className="text-xs text-text-secondary">{t("hooksManualInstallDescription", { tool: item.title })}</p>

--- a/src/components/__tests__/HooksStatusDialog.test.tsx
+++ b/src/components/__tests__/HooksStatusDialog.test.tsx
@@ -515,7 +515,7 @@ describe("HooksStatusDialog", () => {
     });
   });
 
-  it("should keep OpenCode UI brief and show only a short duplicate plugin warning", async () => {
+  it("should keep OpenCode UI brief without showing the duplicate plugin warning", async () => {
     mockGetTaskOpenCodeHooksStatus.mockResolvedValue({
       ...verifiedOpenCodeStatus,
       hasDuplicateKanvibePlugins: true,
@@ -537,10 +537,11 @@ describe("HooksStatusDialog", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("hooksOpenCodeDuplicatePluginsNotice")).toBeTruthy();
+      expect(mockGetTaskOpenCodeHooksStatus).toHaveBeenCalledWith("task-1");
     });
 
     expect(screen.getAllByText("hooksInstalled").length).toBeGreaterThan(0);
+    expect(screen.queryByText("hooksOpenCodeDuplicatePluginsNotice")).toBeNull();
     expect(screen.queryByText("hooksOpenCodeDiagnosticsTitle")).toBeNull();
     expect(screen.queryByText("hooksDiagnosticTargetPath")).toBeNull();
     expect(screen.queryByText("hooksDiagnosticPluginPath")).toBeNull();

--- a/src/components/__tests__/HooksStatusDialog.test.tsx
+++ b/src/components/__tests__/HooksStatusDialog.test.tsx
@@ -541,7 +541,6 @@ describe("HooksStatusDialog", () => {
     });
 
     expect(screen.getAllByText("hooksInstalled").length).toBeGreaterThan(0);
-    expect(screen.queryByText("hooksOpenCodeDuplicatePluginsNotice")).toBeNull();
     expect(screen.queryByText("hooksOpenCodeDiagnosticsTitle")).toBeNull();
     expect(screen.queryByText("hooksDiagnosticTargetPath")).toBeNull();
     expect(screen.queryByText("hooksDiagnosticPluginPath")).toBeNull();


### PR DESCRIPTION
## What is this?
- Remove the OpenCode duplicate plugin notice from the hooks status flow, including the dialog UI and the now-unused translation copy.

## How did I fix it?
**Remove the visible warning**
- Drop the duplicate plugin warning block from the hooks status dialog so the OpenCode card stays quiet.

**Clean up unused copy**
- Delete the unused `hooksOpenCodeDuplicatePluginsNotice` entries from the locale files after the UI stopped referencing them.

**Keep regression coverage focused**
- Keep the dialog regression test centered on the rendered state without depending on the removed translation key.

## Important changes
### Hooks status dialog

**Remove the duplicate warning banner**
- **Reason**: the task detail dialog should no longer show the OpenCode duplicate plugin notice.
- **Files**: `src/components/HooksStatusDialog.tsx`

### Locale cleanup

**Delete the unused duplicate notice translations**
- **Reason**: remove dead copy once the warning is no longer rendered.
- **Files**: `messages/en.json`, `messages/ko.json`, `messages/zh.json`

### Regression coverage

**Remove the translation-key-specific assertion**
- **Reason**: keep the test aligned with the simplified UI and avoid asserting against a removed i18n key.
- **Files**: `src/components/__tests__/HooksStatusDialog.test.tsx`

Co-Authored-By: OpenAI Codex <codex@openai.com>
