### PR TITLE
Adjust macOS board header spacing

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -465,11 +465,15 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
     handleCloseContextMenu();
   }, [contextMenu.task, handleCloseContextMenu, tt]);
 
+  const headerClassName = shouldUseMacTitlebarLayout
+    ? "flex items-center justify-end bg-bg-page px-6 pb-4 pl-20 pr-6 pt-10 [-webkit-app-region:drag]"
+    : "flex items-center justify-end border-b border-border-default bg-bg-surface px-6 pb-4 pt-4";
+
+  const mainClassName = shouldUseMacTitlebarLayout ? "px-6 pb-6" : "p-6";
+
   return (
-    <div className="min-h-screen">
-      <header
-        className={`flex items-center justify-end border-b border-border-default bg-bg-surface ${shouldUseMacTitlebarLayout ? "h-10 pl-20 pr-4 [-webkit-app-region:drag]" : "px-6 pb-4 pt-4"}`}
-      >
+    <div className="min-h-screen bg-bg-page">
+      <header className={headerClassName}>
         <div className="flex items-center gap-3 [-webkit-app-region:no-drag]">
           <div className="w-64">
             <ProjectSelector
@@ -502,7 +506,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         </div>
       </header>
 
-      <main className={shouldUseMacTitlebarLayout ? "px-6 pb-6 pt-4" : "p-6"}>
+      <main className={mainClassName}>
         {isMounted ? (
           <DragDropContext onDragEnd={handleDragEnd}>
             <div className="flex gap-4 overflow-x-auto">

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -250,9 +250,11 @@ describe("Board defaultSessionType sync", () => {
 
     await waitFor(() => {
       const headerClassName = container.querySelector("header")?.className;
-      expect(headerClassName).toContain("h-10");
+      expect(headerClassName).toContain("pt-10");
       expect(headerClassName).toContain("pl-20");
-      expect(headerClassName).not.toContain("pt-10");
+      expect(headerClassName).toContain("bg-bg-page");
+      expect(headerClassName).not.toContain("h-10");
+      expect(headerClassName).not.toContain("border-b");
     });
   });
 


### PR DESCRIPTION
## Related Materials
- None

## What does this PR do?
- Refines the macOS main board header so the traffic light area blends into the rest of the screen instead of reading as a separate top bar.
- Adds enough top padding to keep the project search control clear of the native window controls.
- Updates the macOS-specific board regression test to match the new layout contract.

## How was it solved?
**Board header layout**
- Move the macOS header styling into dedicated class variables so the desktop-specific branch is easier to read.
- Remove the fixed titlebar-height treatment and bottom border from the macOS board header.
- Reuse the page background color and shift the spacing into top padding to preserve separation from the traffic light controls.

**Regression coverage**
- Update the board test to assert the new macOS header padding and background rules.
- Ensure the test rejects the old fixed-height and bordered titlebar styling.

## Important changes
### macOS board header spacing

**Blend the header into the main page surface**
- **Reason**: The previous fixed-height header looked like a separate bar on macOS.
- **Files**: `src/components/Board.tsx`

**Reserve more space above the search control**
- **Reason**: The project selector needed extra clearance from the native window buttons.
- **Files**: `src/components/Board.tsx`

### macOS regression test update

**Lock in the new header contract**
- **Reason**: The layout change should stay protected against regressions.
- **Files**: `src/components/__tests__/Board.test.tsx`

Co-Authored-By: OpenAI Codex <codex@openai.com>
