### PR TITLE
perf(task): 새 태스크 hook 설치를 비동기로 전환

### DIFF
--- a/.claude/plan/ui/2026-04/24-async-task-hook-install.plan.md
+++ b/.claude/plan/ui/2026-04/24-async-task-hook-install.plan.md
@@ -1,0 +1,92 @@
+# 새 태스크 생성 시 hooks 비동기 설치 및 실패 알럿
+
+## Business Goal
+새 태스크 생성 시 hooks 설치 대기 때문에 UI 응답이 느려지는 문제를 줄이고, 백그라운드 설치가 실패해도 사용자가 즉시 재설치 필요 상태를 인지할 수 있게 한다.
+
+## Scope
+- **In Scope**: 새 태스크 생성 경로에서 hooks 설치를 비동기로 전환, 실패 이벤트 브로드캐스트 추가, 앱 상단 실패 알럿 표시, 관련 회귀 테스트 추가
+- **Out of Scope**: 기존 수동 hooks 재설치 UX 변경, worktree/세션 생성 플로우 재설계, 프로젝트 스캔/복구 경로의 동작 변경
+
+## Codebase Analysis Summary
+태스크 생성은 `kanbanService.createTask`에서 worktree/세션 생성 후 `installKanvibeHooks`를 직접 기다린 뒤 보드 업데이트를 브로드캐스트한다. 렌더러는 `window.kanvibeDesktop.onBoardEvent`로 메인 프로세스 이벤트를 구독하고 있고, 현재는 상태 변경 알림과 보드 리프레시만 처리한다. 상단 전역 토스트 시스템은 없지만 고정 배너를 App 레벨에 추가하기 쉬운 구조다.
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/desktop/main/services/kanbanService.ts` | 새 태스크 생성 및 hooks 자동 설치 | Modify |
+| `src/lib/boardNotifier.ts` | 데스크톱 렌더러로 전달되는 board event 정의 | Modify |
+| `src/desktop/renderer/App.tsx` | 전역 렌더러 셸 | Modify |
+| `src/desktop/renderer/components/NotificationListener.tsx` | 기존 board event 구독 패턴 참고 | Reference |
+| `src/desktop/main/services/__tests__/kanbanService.test.ts` | 태스크 생성 서비스 회귀 테스트 | Modify |
+| `src/desktop/renderer/components/__tests__/NotificationListener.test.tsx` | board event 기반 컴포넌트 테스트 패턴 | Reference |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| Board event 브로드캐스트 | `src/lib/boardNotifier.ts` | 메인 서비스는 payload type을 명시하고 board event로 렌더러에 전달한다 |
+| 렌더러 경량 메시지 패턴 | `src/components/HooksStatusDialog.tsx` | 실패 메시지는 작은 배너/알럿 스타일로 간결하게 노출한다 |
+| 테스트 스타일 | `src/desktop/main/services/__tests__/kanbanService.test.ts` | Given/When/Then 주석과 vi mock 기반 단위 테스트를 유지한다 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| hooks 설치 실행 시점 | task 저장 후 백그라운드 `setTimeout`으로 스케줄 | 생성 응답을 막지 않으면서 기존 설치 로직 재사용 가능 | createTask 반환을 확장해 프론트에서 별도 후속 호출 |
+| 실패 피드백 전달 | `boardNotifier`에 실패 이벤트 추가 | 기존 Electron board event 채널을 재사용해 구현 범위를 최소화 | 별도 IPC 채널 추가 |
+| 사용자 피드백 UI | App 레벨 상단 고정 알럿 | 라우트 전환 후에도 보여줄 수 있고 “위에 살짝” 요구에 맞음 | 브라우저 notification 또는 각 페이지별 인라인 메시지 |
+
+## Implementation Todos
+
+### Todo 1: 비차단 hooks 설치 회귀 테스트 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: createTask가 hooks 설치 완료를 기다리지 않고 반환하는 동작과 실패 이벤트 방출을 테스트로 고정한다
+- **Work**:
+  - `src/desktop/main/services/__tests__/kanbanService.test.ts`에 background schedule 기준 기대값 추가
+  - hooks 설치 Promise가 pending이어도 `createTask`가 resolve되는 케이스 작성
+  - hooks 설치 reject 시 실패 이벤트 브로드캐스트 payload를 검증하는 테스트 작성
+- **Convention Notes**: 기존 vi mock 구조와 Given/When/Then 패턴을 유지한다
+- **Verification**: `pnpm test -- src/desktop/main/services/__tests__/kanbanService.test.ts`
+- **Exit Criteria**: 새 테스트가 실패 상태로 추가되고, 구현 후 green으로 돌아간다
+- **Status**: completed
+
+### Todo 2: 메인 프로세스 비동기 hooks 설치 및 실패 이벤트 구현
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 태스크 생성 응답을 block하지 않도록 hooks 설치를 백그라운드화한다
+- **Work**:
+  - `src/lib/boardNotifier.ts`에 hooks 설치 실패 payload/type 추가
+  - `src/desktop/main/services/kanbanService.ts`에서 `displayOrder` 조회를 앞당겨 병렬화
+  - task 저장 후 background hooks install helper를 스케줄하고 실패 시 이벤트/로그를 남긴다
+- **Convention Notes**: 기존 createTask 예외 처리 범위는 유지하고, 실패 로깅은 provider 에러를 그대로 살린다
+- **Verification**: `pnpm test -- src/desktop/main/services/__tests__/kanbanService.test.ts`
+- **Exit Criteria**: createTask 호출이 hooks 설치 완료와 분리되고 실패 시 event가 발행된다
+- **Status**: completed
+
+### Todo 3: 전역 상단 실패 알럿 렌더링
+- **Priority**: 2
+- **Dependencies**: Todo 2
+- **Goal**: 백그라운드 hooks 설치 실패를 사용자가 즉시 인지할 수 있게 한다
+- **Work**:
+  - App 레벨 렌더러 컴포넌트를 추가해 `task-hook-install-failed` board event를 구독
+  - 상단 고정 배너 스타일, 자동 숨김, 수동 닫기 동작을 구현
+  - 다국어 메시지와 렌더러 테스트를 추가
+- **Convention Notes**: 기존 Tailwind 토큰과 작은 인라인 메시지 톤을 유지한다
+- **Verification**: `pnpm test -- src/desktop/renderer/components/__tests__/BoardEventAlert.test.tsx`
+- **Exit Criteria**: 실패 이벤트 수신 시 상단 알럿이 노출되고 자동/수동 dismiss가 동작한다
+- **Status**: completed
+
+## Verification Strategy
+서비스와 렌더러 단위 테스트를 우선 검증하고, 타입체크로 이벤트/번역 추가에 따른 정합성을 확인한다.
+- `pnpm test -- src/desktop/main/services/__tests__/kanbanService.test.ts src/desktop/renderer/components/__tests__/BoardEventAlert.test.tsx`
+- `pnpm check`
+
+## Progress Tracking
+- Total Todos: 3
+- Completed: 3
+- Status: Execution complete
+
+## Change Log
+- 2026-04-24: Plan created
+- 2026-04-24: createTask 비차단 hooks 설치 및 실패 board event 추가
+- 2026-04-24: App 레벨 상단 hooks 실패 알럿과 다국어 메시지 추가
+- 2026-04-24: kanbanService 및 BoardEventAlert 회귀 테스트 검증

--- a/messages/en.json
+++ b/messages/en.json
@@ -74,6 +74,8 @@
     "sshHost": "SSH Host (optional)",
     "createTitle": "Create New Task",
     "createFailed": "Failed to create task.",
+    "createHooksBackgroundFailedTitle": "Automatic hooks install failed",
+    "createHooksBackgroundFailedBody": "Hooks installation failed after creating \"{taskTitle}\". You can reinstall it from the Hooks Status section.",
     "deleteConfirm": "Are you sure you want to delete this task?",
     "priority": "Priority",
     "priorityLow": "!",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -74,6 +74,8 @@
     "sshHost": "SSH 호스트 (선택)",
     "createTitle": "새 작업 생성",
     "createFailed": "작업 생성에 실패했습니다.",
+    "createHooksBackgroundFailedTitle": "Hooks 자동 설치 실패",
+    "createHooksBackgroundFailedBody": "\"{taskTitle}\" 생성 후 hooks 자동 설치에 실패했습니다. 상세 화면의 Hooks 상태에서 다시 설치할 수 있습니다.",
     "deleteConfirm": "이 작업을 삭제하시겠습니까?",
     "priority": "우선순위",
     "priorityLow": "!",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -74,6 +74,8 @@
     "sshHost": "SSH 主机（可选）",
     "createTitle": "创建新任务",
     "createFailed": "创建任务失败。",
+    "createHooksBackgroundFailedTitle": "自动安装 Hooks 失败",
+    "createHooksBackgroundFailedBody": "创建“{taskTitle}”后安装 hooks 失败。你可以在 Hooks 状态区域重新安装。",
     "deleteConfirm": "确定要删除此任务吗？",
     "priority": "优先级",
     "priorityLow": "!",

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   removeSessionOnly: vi.fn(),
   installKanvibeHooks: vi.fn(),
   broadcastBoardUpdate: vi.fn(),
+  broadcastTaskHookInstallFailed: vi.fn(),
 }));
 
 vi.mock("child_process", () => ({
@@ -58,6 +59,7 @@ vi.mock("@/lib/kanvibeHooksInstaller", () => ({
 
 vi.mock("@/lib/boardNotifier", () => ({
   broadcastBoardUpdate: mocks.broadcastBoardUpdate,
+  broadcastTaskHookInstallFailed: mocks.broadcastTaskHookInstallFailed,
 }));
 
 describe("kanbanService.createTask", () => {
@@ -65,6 +67,7 @@ describe("kanbanService.createTask", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.taskRepo.create.mockImplementation((value) => value);
+    mocks.installKanvibeHooks.mockResolvedValue(undefined);
     mocks.taskRepo.createQueryBuilder.mockReturnValue({
       select: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
@@ -73,35 +76,128 @@ describe("kanbanService.createTask", () => {
   });
 
   it("로컬 worktree 태스크를 만들면 hooks를 자동 설치한다", async () => {
-    // Given
-    mocks.projectRepo.findOneBy.mockResolvedValue({
-      id: "project-1",
-      repoPath: "/workspace/repo",
-      defaultBranch: "main",
-      sshHost: null,
-    });
-    mocks.createWorktreeWithSession.mockResolvedValue({
-      worktreePath: "/workspace/repo-worktrees/task-1",
-      sessionName: "task-1",
-    });
-    mocks.taskRepo.save.mockImplementation(async (value) => ({ id: "task-1", ...value }));
+    vi.useFakeTimers();
 
-    const { createTask } = await import("@/desktop/main/services/kanbanService");
+    try {
+      // Given
+      mocks.projectRepo.findOneBy.mockResolvedValue({
+        id: "project-1",
+        repoPath: "/workspace/repo",
+        defaultBranch: "main",
+        sshHost: null,
+      });
+      mocks.createWorktreeWithSession.mockResolvedValue({
+        worktreePath: "/workspace/repo-worktrees/task-1",
+        sessionName: "task-1",
+      });
+      mocks.taskRepo.save.mockImplementation(async (value) => ({ id: "task-1", ...value }));
 
-    // When
-    await createTask({
-      title: "알림 회귀 수정",
-      branchName: "fix/notifications",
-      projectId: "project-1",
-      sessionType: "tmux" as never,
-    });
+      const { createTask } = await import("@/desktop/main/services/kanbanService");
 
-    // Then
-    expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
-      "/workspace/repo-worktrees/task-1",
-      "task-1",
-      null,
-    );
+      // When
+      await createTask({
+        title: "알림 회귀 수정",
+        branchName: "fix/notifications",
+        projectId: "project-1",
+        sessionType: "tmux" as never,
+      });
+      await vi.runAllTimersAsync();
+
+      // Then
+      expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
+        "/workspace/repo-worktrees/task-1",
+        "task-1",
+        null,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("worktree 태스크 생성은 hooks 설치 완료를 기다리지 않고 즉시 반환한다", async () => {
+    vi.useFakeTimers();
+
+    try {
+      // Given
+      mocks.projectRepo.findOneBy.mockResolvedValue({
+        id: "project-1",
+        repoPath: "/workspace/repo",
+        defaultBranch: "main",
+        sshHost: null,
+      });
+      mocks.createWorktreeWithSession.mockResolvedValue({
+        worktreePath: "/workspace/repo-worktrees/task-1",
+        sessionName: "task-1",
+      });
+      mocks.installKanvibeHooks.mockReturnValue(new Promise(() => {}));
+      mocks.taskRepo.save.mockImplementation(async (value) => ({ id: "task-1", ...value }));
+
+      const { createTask } = await import("@/desktop/main/services/kanbanService");
+
+      // When
+      const result = await createTask({
+        title: "알림 회귀 수정",
+        branchName: "fix/notifications",
+        projectId: "project-1",
+        sessionType: "tmux" as never,
+      });
+
+      // Then
+      expect(result).toEqual(expect.objectContaining({ id: "task-1" }));
+      expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
+      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+
+      await vi.runAllTimersAsync();
+      expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
+        "/workspace/repo-worktrees/task-1",
+        "task-1",
+        null,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("백그라운드 hooks 설치 실패는 실패 이벤트로 브로드캐스트한다", async () => {
+    vi.useFakeTimers();
+
+    try {
+      // Given
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mocks.projectRepo.findOneBy.mockResolvedValue({
+        id: "project-1",
+        repoPath: "/workspace/repo",
+        defaultBranch: "main",
+        sshHost: null,
+      });
+      mocks.createWorktreeWithSession.mockResolvedValue({
+        worktreePath: "/workspace/repo-worktrees/task-1",
+        sessionName: "task-1",
+      });
+      mocks.installKanvibeHooks.mockRejectedValueOnce(new Error("codex config failed"));
+      mocks.taskRepo.save.mockImplementation(async (value) => ({ id: "task-1", ...value }));
+
+      const { createTask } = await import("@/desktop/main/services/kanbanService");
+
+      // When
+      await createTask({
+        title: "알림 회귀 수정",
+        branchName: "fix/notifications",
+        projectId: "project-1",
+        sessionType: "tmux" as never,
+      });
+      await vi.runAllTimersAsync();
+
+      // Then
+      expect(mocks.broadcastTaskHookInstallFailed).toHaveBeenCalledWith({
+        taskId: "task-1",
+        taskTitle: "알림 회귀 수정",
+        error: "codex config failed",
+      });
+      consoleErrorSpy.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("원격 stale task는 안전하지 않은 worktree/브랜치 삭제를 건너뛴다", async () => {

--- a/src/desktop/main/services/desktopNotificationService.ts
+++ b/src/desktop/main/services/desktopNotificationService.ts
@@ -85,6 +85,10 @@ export async function deliverBoardEventNotification(
     }).desktopPayload, options);
   }
 
+  if (payload.type === "task-hook-install-failed") {
+    return false;
+  }
+
   if (!settings.enabledStatuses.includes(payload.requestedStatus)) {
     return false;
   }

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -5,7 +5,7 @@ import { KanbanTask, TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
 import { createWorktreeWithSession, removeWorktreeAndBranch, createSessionWithoutWorktree, removeSessionOnly, buildManagedWorktreePath } from "@/lib/worktree";
 import { getProjectRepository } from "@/lib/database";
-import { broadcastBoardUpdate } from "@/lib/boardNotifier";
+import { broadcastBoardUpdate, broadcastTaskHookInstallFailed } from "@/lib/boardNotifier";
 import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
 
 export type TasksByStatus = Record<TaskStatus, KanbanTask[]>;
@@ -34,6 +34,35 @@ function isMissingGitHubCli(error: unknown): boolean {
   }
 
   return "code" in error && (error as { code?: string }).code === "ENOENT";
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function scheduleTaskHookInstall(
+  targetPath: string,
+  task: Pick<KanbanTask, "id" | "title" | "sshHost">,
+) {
+  setTimeout(() => {
+    void installKanvibeHooks(targetPath, task.id, task.sshHost).catch((error) => {
+      const errorMessage = getErrorMessage(error);
+
+      console.error("새 태스크 hooks 백그라운드 설치 실패:", {
+        taskId: task.id,
+        taskTitle: task.title,
+        targetPath,
+        sshHost: task.sshHost ?? null,
+        error: errorMessage,
+      });
+
+      broadcastTaskHookInstallFailed({
+        taskId: task.id,
+        taskTitle: task.title,
+        error: errorMessage,
+      });
+    });
+  }, 0);
 }
 
 async function getPrUrlFromGitHubCli(branchName: string, cwd: string): Promise<string | null> {
@@ -140,6 +169,11 @@ export interface CreateTaskInput {
 /** 새 작업을 생성한다. branchName + projectId가 있으면 worktree와 세션도 함께 생성한다 */
 export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
   const repo = await getTaskRepository();
+  const maxDisplayOrderPromise = repo
+    .createQueryBuilder("t")
+    .select("MAX(t.displayOrder)", "max")
+    .where("t.status = :status", { status: TaskStatus.TODO })
+    .getRawOne();
 
   const task = repo.create({
     title: input.title || input.branchName || "Untitled",
@@ -185,20 +219,21 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
     }
   }
 
-  const maxResult = await repo
-    .createQueryBuilder("t")
-    .select("MAX(t.displayOrder)", "max")
-    .where("t.status = :status", { status: task.status })
-    .getRawOne();
+  const maxResult = await maxDisplayOrderPromise;
   task.displayOrder = (maxResult?.max ?? -1) + 1;
 
   const saved = await repo.save(task);
 
+  broadcastBoardUpdate();
+
   if (shouldInstallHooks && hookTargetPath) {
-    await installKanvibeHooks(hookTargetPath, saved.id, task.sshHost);
+    scheduleTaskHookInstall(hookTargetPath, {
+      id: saved.id,
+      title: saved.title,
+      sshHost: saved.sshHost,
+    });
   }
 
-  broadcastBoardUpdate();
   return serialize(saved);
 }
 

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { IntlProvider } from "next-intl";
 import { HashRouter, Navigate, Outlet, Route, Routes, useParams } from "react-router-dom";
 import LoginForm from "@/components/LoginForm";
+import BoardEventAlert from "@/desktop/renderer/components/BoardEventAlert";
 import NotificationListener from "@/desktop/renderer/components/NotificationListener";
 import { getSessionState } from "@/desktop/renderer/actions/auth";
 import { DEFAULT_LOCALE, getSafeLocale, isSupportedLocale, messagesByLocale } from "@/desktop/renderer/utils/locales";
@@ -28,7 +29,12 @@ function LocaleShell({ sessionLoading }: { sessionLoading: boolean }) {
 
   return (
     <IntlProvider locale={safeLocale} messages={messages}>
-      {!sessionLoading && <NotificationListener />}
+      {!sessionLoading && (
+        <>
+          <NotificationListener />
+          <BoardEventAlert />
+        </>
+      )}
       <Outlet />
     </IntlProvider>
   );

--- a/src/desktop/renderer/components/BoardEventAlert.tsx
+++ b/src/desktop/renderer/components/BoardEventAlert.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import type { BoardEventPayload } from "@/lib/boardNotifier";
+
+const AUTO_DISMISS_MS = 5000;
+
+interface HookInstallAlertState {
+  taskId: string;
+  taskTitle: string;
+}
+
+function isTaskHookInstallFailedEvent(
+  event: BoardEventPayload,
+): event is Extract<BoardEventPayload, { type: "task-hook-install-failed" }> {
+  return event.type === "task-hook-install-failed";
+}
+
+export default function BoardEventAlert() {
+  const t = useTranslations("task");
+  const tc = useTranslations("common");
+  const [alert, setAlert] = useState<HookInstallAlertState | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    return window.kanvibeDesktop!.onBoardEvent((event: BoardEventPayload) => {
+      if (!isTaskHookInstallFailedEvent(event)) {
+        return;
+      }
+
+      setAlert({
+        taskId: event.taskId,
+        taskTitle: event.taskTitle,
+      });
+
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = window.setTimeout(() => {
+        timeoutRef.current = null;
+        setAlert(null);
+      }, AUTO_DISMISS_MS);
+    });
+  }, []);
+
+  function dismissAlert() {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    setAlert(null);
+  }
+
+  if (!alert) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-4 z-[700] flex justify-center px-4">
+      <div
+        role="alert"
+        className="pointer-events-auto w-full max-w-xl rounded-xl border border-status-error/20 bg-bg-surface/95 px-4 py-3 shadow-lg backdrop-blur"
+      >
+        <div className="flex items-start gap-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold text-status-error">
+              {t("createHooksBackgroundFailedTitle")}
+            </p>
+            <p className="mt-1 text-sm text-text-secondary">
+              {t("createHooksBackgroundFailedBody", { taskTitle: alert.taskTitle })}
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={dismissAlert}
+            aria-label={tc("close")}
+            className="text-base leading-none text-text-muted transition-colors hover:text-text-primary"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/desktop/renderer/components/__tests__/BoardEventAlert.test.tsx
+++ b/src/desktop/renderer/components/__tests__/BoardEventAlert.test.tsx
@@ -1,0 +1,88 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import BoardEventAlert from "@/desktop/renderer/components/BoardEventAlert";
+
+let boardEventListener: ((event: any) => void) | null = null;
+
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace: string) => (key: string, values?: Record<string, unknown>) => {
+    if (values?.taskTitle) {
+      return `${namespace}.${key}:${values.taskTitle}`;
+    }
+    return `${namespace}.${key}`;
+  },
+}));
+
+describe("BoardEventAlert", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    boardEventListener = null;
+
+    window.kanvibeDesktop = {
+      onBoardEvent: vi.fn((listener) => {
+        boardEventListener = listener;
+        return () => {};
+      }),
+    } as any;
+  });
+
+  it("hooks 자동 설치 실패 이벤트가 오면 상단 알럿을 표시한다", async () => {
+    // Given
+    render(<BoardEventAlert />);
+
+    // When
+    await act(async () => {
+      boardEventListener?.({
+        type: "task-hook-install-failed",
+        taskId: "task-1",
+        taskTitle: "로그인 개선",
+        error: "codex config failed",
+      });
+    });
+
+    // Then
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.getByText("task.createHooksBackgroundFailedTitle")).toBeTruthy();
+    expect(screen.getByText("task.createHooksBackgroundFailedBody:로그인 개선")).toBeTruthy();
+  });
+
+  it("알럿은 자동으로 사라진다", async () => {
+    // Given
+    render(<BoardEventAlert />);
+
+    // When
+    await act(async () => {
+      boardEventListener?.({
+        type: "task-hook-install-failed",
+        taskId: "task-1",
+        taskTitle: "로그인 개선",
+        error: "codex config failed",
+      });
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    // Then
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("닫기 버튼으로 즉시 dismiss 할 수 있다", async () => {
+    // Given
+    render(<BoardEventAlert />);
+    await act(async () => {
+      boardEventListener?.({
+        type: "task-hook-install-failed",
+        taskId: "task-1",
+        taskTitle: "로그인 개선",
+        error: "codex config failed",
+      });
+    });
+
+    // When
+    fireEvent.click(screen.getByRole("button", { name: "common.close" }));
+
+    // Then
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/src/lib/boardNotifier.ts
+++ b/src/lib/boardNotifier.ts
@@ -19,10 +19,17 @@ export interface HookStatusTargetMissingPayload {
   reason: "task-not-found";
 }
 
+export interface TaskHookInstallFailedPayload {
+  taskId: string;
+  taskTitle: string;
+  error: string;
+}
+
 export type BoardEventPayload =
   | BoardUpdatedPayload
   | ({ type: "task-status-changed" } & TaskStatusChangedPayload)
-  | ({ type: "hook-status-target-missing" } & HookStatusTargetMissingPayload);
+  | ({ type: "hook-status-target-missing" } & HookStatusTargetMissingPayload)
+  | ({ type: "task-hook-install-failed" } & TaskHookInstallFailedPayload);
 
 const boardEventEmitter = new EventEmitter();
 
@@ -52,4 +59,9 @@ export function broadcastTaskStatusChanged(payload: TaskStatusChangedPayload) {
 /** hooks 대상 조회 실패 시 미매칭 상황을 브로드캐스트한다 */
 export function broadcastHookStatusTargetMissing(payload: HookStatusTargetMissingPayload) {
   emitBoardEvent({ type: "hook-status-target-missing", ...payload });
+}
+
+/** 새 태스크 생성 후 hooks 자동 설치가 실패하면 렌더러에 안내를 브로드캐스트한다 */
+export function broadcastTaskHookInstallFailed(payload: TaskHookInstallFailedPayload) {
+  emitBoardEvent({ type: "task-hook-install-failed", ...payload });
 }


### PR DESCRIPTION
## 관련 자료
- 작업 계획: `.claude/plan/ui/2026-04/24-async-task-hook-install.plan.md`
- 이슈: 없음

## 어떤 작업인가요?
- 새 태스크 생성 시 hook 자동 설치 대기를 제거해 사용자 응답 속도를 높이고, 백그라운드 설치 실패를 상단 얼럿으로 즉시 안내하는 변경입니다.

## 어떻게 해결했나요?
**태스크 생성 응답 경로 단축**
- `createTask`가 task 저장 뒤 즉시 보드 업데이트를 보내고 hook 설치는 백그라운드로 스케줄하도록 변경했습니다.
- `displayOrder` 조회를 앞당겨 생성 경로의 대기 시간을 더 줄였습니다.

**실패 피드백 추가**
- `task-hook-install-failed` board event를 추가했습니다.
- App 전역에서 상단 얼럿을 띄워 실패 시 재설치 필요를 안내하고 자동/수동 dismiss를 지원합니다.
- 데스크톱 알림 서비스는 이 이벤트를 시스템 알림으로 중복 전달하지 않도록 분기했습니다.

**회귀 테스트 및 문구 보강**
- 생성 경로가 hook 설치를 기다리지 않는지와 실패 이벤트 방출을 테스트로 고정했습니다.
- 상단 알럿 컴포넌트 렌더링, 자동 닫힘, 수동 닫힘 테스트를 추가했습니다.
- ko/en/zh 메시지와 작업 계획 문서를 함께 정리했습니다.

## 중요한 변경 사항은 무엇인가요?
### 태스크 생성 응답 속도 개선

**hook 설치를 비동기 후속 작업으로 분리**
- **변경 이유**: worktree와 세션 생성 뒤 hook 설치까지 기다리면 새 태스크 생성 응답이 불필요하게 느려졌기 때문입니다.
- **수정 파일**: `src/desktop/main/services/kanbanService.ts`, `src/lib/boardNotifier.ts`

**displayOrder 조회를 앞당겨 생성 경로 대기 축소**
- **변경 이유**: 독립적인 조회를 worktree 생성과 겹쳐 처리해 생성 경로 자체를 더 줄이기 위해서입니다.
- **수정 파일**: `src/desktop/main/services/kanbanService.ts`

### 실패 안내 UX 추가

**전역 상단 얼럿으로 hook 설치 실패 안내**
- **변경 이유**: 백그라운드 실패가 조용히 묻히지 않도록 즉시 보이는 피드백이 필요했기 때문입니다.
- **수정 파일**: `src/desktop/renderer/App.tsx`, `src/desktop/renderer/components/BoardEventAlert.tsx`, `messages/ko.json`, `messages/en.json`, `messages/zh.json`

**데스크톱 알림 중복 방지**
- **변경 이유**: 상단 얼럿과 별도 시스템 알림이 동시에 뜨는 중복 UX를 피하기 위해서입니다.
- **수정 파일**: `src/desktop/main/services/desktopNotificationService.ts`

### 회귀 테스트 고정

**비차단 생성과 실패 알럿 동작 검증**
- **변경 이유**: 응답 속도 개선과 실패 피드백이 다시 동기화되거나 누락되지 않도록 회귀를 막기 위해서입니다.
- **수정 파일**: `src/desktop/main/services/__tests__/kanbanService.test.ts`, `src/desktop/renderer/components/__tests__/BoardEventAlert.test.tsx`

Co-Authored-By: OpenAI Codex <codex@openai.com>
