### PR TITLE
fix(pr): restore remote task PR link resolution

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -314,6 +314,7 @@ describe("kanbanService.createTask", () => {
       id: "task-4",
       prUrl: "https://github.com/kanvibe/kanvibe/pull/1",
     }));
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
     expect(result).toBe("https://github.com/kanvibe/kanvibe/pull/1");
   });
 
@@ -352,12 +353,12 @@ describe("kanbanService.createTask", () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
-  it("원격 프로젝트는 task의 worktree 경로와 SSH를 사용해 gh CLI로 PR URL을 조회한다", async () => {
+  it("원격 프로젝트는 프로젝트 repo 경로와 SSH를 사용해 gh CLI로 PR URL을 조회한다", async () => {
     mocks.taskRepo.findOneBy.mockResolvedValue({
       id: "task-6",
       projectId: "project-remote",
       branchName: "feature/remote-pr",
-      worktreePath: "/remote/repo__worktrees/feature-remote-pr",
+      worktreePath: "/Users/local/repo__worktrees/feature-remote-pr",
       sshHost: "remote-host",
       prUrl: null,
     });
@@ -374,7 +375,7 @@ describe("kanbanService.createTask", () => {
     const result = await fetchAndSavePrUrl("task-6");
 
     expect(mocks.execGit).toHaveBeenCalledWith(
-      "cd '/remote/repo__worktrees/feature-remote-pr' && gh pr list --head 'feature/remote-pr' --json url -q '.[0].url'",
+      "cd '/remote/repo' && gh pr list --head 'feature/remote-pr' --json url -q '.[0].url'",
       "remote-host",
     );
     expect(mocks.execFile).not.toHaveBeenCalled();
@@ -382,16 +383,46 @@ describe("kanbanService.createTask", () => {
       id: "task-6",
       prUrl: "https://github.com/kanvibe/kanvibe/pull/99",
     }));
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
     expect(result).toBe("https://github.com/kanvibe/kanvibe/pull/99");
+  });
+
+  it("프로젝트를 찾을 수 없으면 task의 worktree 경로로 PR URL을 조회한다", async () => {
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-7",
+      projectId: "missing-project",
+      branchName: "feature/fallback-path",
+      worktreePath: "/remote/repo__worktrees/feature-fallback-path",
+      sshHost: "remote-host",
+      prUrl: null,
+    });
+    mocks.projectRepo.findOneBy.mockResolvedValue(null);
+    mocks.taskRepo.save.mockImplementation(async (value) => value);
+    mocks.execGit.mockResolvedValue("https://github.com/kanvibe/kanvibe/pull/101");
+
+    const { fetchAndSavePrUrl } = await import("@/desktop/main/services/kanbanService");
+
+    const result = await fetchAndSavePrUrl("task-7");
+
+    expect(mocks.execGit).toHaveBeenCalledWith(
+      "cd '/remote/repo__worktrees/feature-fallback-path' && gh pr list --head 'feature/fallback-path' --json url -q '.[0].url'",
+      "remote-host",
+    );
+    expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
+      id: "task-7",
+      prUrl: "https://github.com/kanvibe/kanvibe/pull/101",
+    }));
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+    expect(result).toBe("https://github.com/kanvibe/kanvibe/pull/101");
   });
 
   it("원격에 gh CLI가 없으면 PR URL 조회를 조용히 건너뛴다", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     mocks.taskRepo.findOneBy.mockResolvedValue({
-      id: "task-7",
+      id: "task-8",
       projectId: "project-remote",
       branchName: "feature/no-gh",
-      worktreePath: "/remote/repo__worktrees/feature-no-gh",
+      worktreePath: "/Users/local/repo__worktrees/feature-no-gh",
       sshHost: "remote-host",
       prUrl: null,
     });
@@ -404,14 +435,15 @@ describe("kanbanService.createTask", () => {
 
     const { fetchAndSavePrUrl } = await import("@/desktop/main/services/kanbanService");
 
-    const result = await fetchAndSavePrUrl("task-7");
+    const result = await fetchAndSavePrUrl("task-8");
 
     expect(result).toBeNull();
     expect(mocks.execGit).toHaveBeenCalledWith(
-      "cd '/remote/repo__worktrees/feature-no-gh' && gh pr list --head 'feature/no-gh' --json url -q '.[0].url'",
+      "cd '/remote/repo' && gh pr list --head 'feature/no-gh' --json url -q '.[0].url'",
       "remote-host",
     );
     expect(mocks.taskRepo.save).not.toHaveBeenCalled();
+    expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -551,24 +551,25 @@ export async function fetchAndSavePrUrl(taskId: string): Promise<string | null> 
   const task = await repo.findOneBy({ id: taskId });
   if (!task?.branchName) return null;
 
-  let repoPath: string | null = task.worktreePath || null;
+  let repoPath: string | null = null;
   let sshHost: string | null = task.sshHost || null;
   if (task.projectId) {
     const projectRepo = await getProjectRepository();
     const project = await projectRepo.findOneBy({ id: task.projectId });
     if (project) {
-      repoPath = repoPath ?? project.repoPath;
+      repoPath = project.repoPath;
       sshHost = sshHost ?? project.sshHost ?? null;
     }
   }
 
   try {
-    const cwd = repoPath ?? process.cwd();
+    const cwd = repoPath ?? task.worktreePath ?? process.cwd();
     const prUrl = await getPrUrlFromGitHubCli(task.branchName, cwd, sshHost);
 
     if (prUrl) {
       task.prUrl = prUrl;
       await repo.save(task);
+      broadcastBoardUpdate();
       return prUrl;
     }
   } catch (error) {


### PR DESCRIPTION
Prefer the remote project repository path when resolving PR URLs so stale task worktree paths do not break SSH-based gh lookups. Broadcast a board update after saving prUrl so remote task cards and detail screens can render the link without a manual reload.