### PR TITLE
fix(desktop): isolate multi-window closes and reuse existing routes

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -32,6 +32,7 @@ app.commandLine.appendSwitch("log-level", "3");
 
 let mainWindow = null;
 let hookServer = null;
+let windowOpenHelpers = null;
 
 function broadcastNotificationsChanged() {
   for (const window of BrowserWindow.getAllWindows()) {
@@ -51,6 +52,14 @@ function getRuntimeModulePath(relativePath) {
   }
 
   return path.join(app.getAppPath(), "build", "main", relativePath.replace(/\.ts$/, ".js"));
+}
+
+function getWindowOpenHelpers() {
+  if (!windowOpenHelpers) {
+    windowOpenHelpers = require(getRuntimeModulePath(path.join("src", "desktop", "main", "windowOpen.ts")));
+  }
+
+  return windowOpenHelpers;
 }
 
 function registerRuntimeAliases() {
@@ -145,23 +154,6 @@ function createBrowserWindowOptions() {
   };
 }
 
-function isKanvibeUrl(targetUrl) {
-  if (targetUrl.startsWith("file://")) {
-    return true;
-  }
-
-  if (!RENDERER_DEV_URL) {
-    return false;
-  }
-
-  try {
-    const parsedUrl = new URL(targetUrl);
-    return parsedUrl.origin === new URL(RENDERER_DEV_URL).origin;
-  } catch {
-    return false;
-  }
-}
-
 function normalizeNotificationLocale(locale) {
   if (typeof locale !== "string") {
     return DEFAULT_LOCALE;
@@ -204,7 +196,45 @@ function createDesktopNotificationOptions() {
   };
 }
 
+function getAvailableWindows() {
+  return BrowserWindow.getAllWindows().filter((window) => !window.isDestroyed());
+}
+
+function focusWindow(window) {
+  if (!window || window.isDestroyed()) {
+    return;
+  }
+
+  if (window.isMinimized()) {
+    window.restore();
+  }
+
+  window.show();
+  window.focus();
+}
+
+function registerAppWindow(browserWindow) {
+  mainWindow = browserWindow;
+  attachWindowHandlers(browserWindow);
+
+  browserWindow.on("focus", () => {
+    if (!browserWindow.isDestroyed()) {
+      mainWindow = browserWindow;
+    }
+  });
+
+  browserWindow.on("closed", () => {
+    if (mainWindow === browserWindow) {
+      mainWindow = getAvailableWindows()[0] || null;
+    }
+  });
+}
+
 async function focusMainWindow(relativePath) {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    mainWindow = getAvailableWindows()[0] || null;
+  }
+
   if (!mainWindow || mainWindow.isDestroyed()) {
     await createMainWindow();
   }
@@ -213,12 +243,7 @@ async function focusMainWindow(relativePath) {
     return;
   }
 
-  if (mainWindow.isMinimized()) {
-    mainWindow.restore();
-  }
-
-  mainWindow.show();
-  mainWindow.focus();
+  focusWindow(mainWindow);
 
   if (!relativePath) {
     return;
@@ -256,9 +281,25 @@ function registerNotificationHandlers() {
 
 function attachWindowHandlers(browserWindow) {
   browserWindow.webContents.setWindowOpenHandler(({ url }) => {
-    if (isKanvibeUrl(url)) {
+    const { resolveWindowOpenAction } = getWindowOpenHelpers();
+    const windowOpenAction = resolveWindowOpenAction({
+      targetUrl: url,
+      rendererDevUrl: RENDERER_DEV_URL,
+      openWindows: getAvailableWindows(),
+      getWindowUrl: (window) => window.webContents.getURL(),
+      excludeWindow: browserWindow,
+    });
+
+    if (windowOpenAction.type === "focus-existing") {
+      mainWindow = windowOpenAction.existingWindow;
+      focusWindow(windowOpenAction.existingWindow);
+      return { action: "deny" };
+    }
+
+    if (windowOpenAction.type === "open-internal") {
       return {
         action: "allow",
+        outlivesOpener: true,
         overrideBrowserWindowOptions: createBrowserWindowOptions(),
       };
     }
@@ -268,7 +309,7 @@ function attachWindowHandlers(browserWindow) {
   });
 
   browserWindow.webContents.on("did-create-window", (childWindow) => {
-    attachWindowHandlers(childWindow);
+    registerAppWindow(childWindow);
   });
 
   browserWindow.webContents.on("before-input-event", (event, input) => {
@@ -408,16 +449,9 @@ async function loadRenderer(window, targetUrl = getRendererNavigationUrl()) {
 
 async function createAppWindow(target = getRendererNavigationUrl()) {
   const browserWindow = new BrowserWindow(createBrowserWindowOptions());
-  mainWindow = browserWindow;
-  attachWindowHandlers(browserWindow);
+  registerAppWindow(browserWindow);
 
   await loadRenderer(browserWindow, getRendererNavigationUrl(target));
-
-  browserWindow.on("closed", () => {
-    if (mainWindow === browserWindow) {
-      mainWindow = null;
-    }
-  });
 
   return browserWindow;
 }

--- a/src/desktop/main/__tests__/windowOpen.test.ts
+++ b/src/desktop/main/__tests__/windowOpen.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { resolveWindowOpenAction } from "@/desktop/main/windowOpen";
+
+describe("resolveWindowOpenAction", () => {
+  it("file 기반 내부 URL은 독립적인 내부 창 열기로 판단한다", () => {
+    const result = resolveWindowOpenAction({
+      targetUrl: "file:///Applications/Kanvibe.app/Contents/Resources/app.asar/build/renderer/index.html#/ko/task/task-1",
+      rendererDevUrl: null,
+      openWindows: [],
+      getWindowUrl: (windowUrl) => windowUrl,
+    });
+
+    expect(result).toEqual({
+      type: "open-internal",
+      route: "/ko/task/task-1",
+      outlivesOpener: true,
+    });
+  });
+
+  it("이미 열린 동일 route 창이 있으면 새 창 대신 해당 창으로 포커스를 이동시킨다", () => {
+    const existingWindow = {
+      id: "window-2",
+      url: "http://localhost:3000/#/ko/task/task-1",
+    };
+
+    const result = resolveWindowOpenAction({
+      targetUrl: "http://localhost:3000/#/ko/task/task-1",
+      rendererDevUrl: "http://localhost:3000",
+      openWindows: [existingWindow],
+      getWindowUrl: (windowRecord) => windowRecord.url,
+    });
+
+    expect(result).toEqual({
+      type: "focus-existing",
+      route: "/ko/task/task-1",
+      existingWindow,
+    });
+  });
+
+  it("현재 창만 같은 route면 제외하고 새 내부 창을 연다", () => {
+    const sourceWindow = {
+      id: "window-1",
+      url: "http://localhost:3000/#/ko/task/task-1",
+    };
+
+    const result = resolveWindowOpenAction({
+      targetUrl: "/#/ko/task/task-1",
+      rendererDevUrl: "http://localhost:3000",
+      openWindows: [sourceWindow],
+      getWindowUrl: (windowRecord) => windowRecord.url,
+      excludeWindow: sourceWindow,
+    });
+
+    expect(result).toEqual({
+      type: "open-internal",
+      route: "/ko/task/task-1",
+      outlivesOpener: true,
+    });
+  });
+
+  it("외부 URL은 내부 창 정책 대상이 아니다", () => {
+    const result = resolveWindowOpenAction({
+      targetUrl: "https://example.com/docs",
+      rendererDevUrl: "http://localhost:3000",
+      openWindows: [],
+      getWindowUrl: (windowUrl) => windowUrl,
+    });
+
+    expect(result).toEqual({
+      type: "external",
+    });
+  });
+});

--- a/src/desktop/main/windowOpen.ts
+++ b/src/desktop/main/windowOpen.ts
@@ -1,0 +1,121 @@
+export type WindowOpenAction<T> =
+  | {
+      type: "external";
+    }
+  | {
+      type: "open-internal";
+      route: string;
+      outlivesOpener: true;
+    }
+  | {
+      type: "focus-existing";
+      route: string;
+      existingWindow: T;
+    };
+
+interface ResolveWindowOpenActionOptions<T> {
+  targetUrl: string;
+  rendererDevUrl: string | null;
+  openWindows: readonly T[];
+  getWindowUrl: (window: T) => string;
+  excludeWindow?: T | null;
+}
+
+function normalizeInternalRoute(route: string | null | undefined): string | null {
+  if (!route) {
+    return null;
+  }
+
+  if (route.startsWith("/#/")) {
+    return route.slice(2);
+  }
+
+  if (route.startsWith("#/")) {
+    return route.slice(1);
+  }
+
+  if (route.startsWith("/")) {
+    return route;
+  }
+
+  return `/${route}`;
+}
+
+function extractRouteFromParsedUrl(parsedUrl: URL, rendererDevUrl: string | null): string | null {
+  const hashRoute = normalizeInternalRoute(parsedUrl.hash);
+  if (parsedUrl.protocol === "file:") {
+    return hashRoute;
+  }
+
+  if (!rendererDevUrl) {
+    return null;
+  }
+
+  let rendererOrigin: string;
+  try {
+    rendererOrigin = new URL(rendererDevUrl).origin;
+  } catch {
+    return null;
+  }
+
+  if (parsedUrl.origin !== rendererOrigin) {
+    return null;
+  }
+
+  return hashRoute ?? normalizeInternalRoute(parsedUrl.pathname);
+}
+
+export function extractInternalRoute(targetUrl: string, rendererDevUrl: string | null): string | null {
+  if (!targetUrl) {
+    return null;
+  }
+
+  if (targetUrl.startsWith("/")) {
+    return normalizeInternalRoute(targetUrl);
+  }
+
+  if (targetUrl.startsWith("#")) {
+    return normalizeInternalRoute(targetUrl);
+  }
+
+  try {
+    return extractRouteFromParsedUrl(new URL(targetUrl), rendererDevUrl);
+  } catch {
+    return null;
+  }
+}
+
+export function resolveWindowOpenAction<T>({
+  targetUrl,
+  rendererDevUrl,
+  openWindows,
+  getWindowUrl,
+  excludeWindow = null,
+}: ResolveWindowOpenActionOptions<T>): WindowOpenAction<T> {
+  const route = extractInternalRoute(targetUrl, rendererDevUrl);
+  if (!route) {
+    return { type: "external" };
+  }
+
+  const existingWindow = openWindows.find((window) => {
+    if (window === excludeWindow) {
+      return false;
+    }
+
+    return extractInternalRoute(getWindowUrl(window), rendererDevUrl) === route;
+  });
+
+  if (existingWindow) {
+    return {
+      type: "focus-existing",
+      route,
+      existingWindow,
+    };
+  }
+
+  return {
+    type: "open-internal",
+    route,
+    outlivesOpener: true,
+  };
+}


### PR DESCRIPTION
## Related references
- Issue: N/A

## What is this?
- Prevent a desktop multi-window session from collapsing when the user closes only the active window.
- Reuse an already open Kanvibe window when the same internal route is opened with Cmd+click.

## How did I solve it?
**Stabilize Electron window reuse**
- Extract internal route parsing and reuse decisions into a dedicated helper used by `setWindowOpenHandler`.
- Focus an existing matching window instead of creating a duplicate one, and let internal child windows outlive their opener.

**Keep app-level focus on a live window**
- Reassign `mainWindow` when a window gains focus or when the tracked window closes.
- Reuse the shared focus helper for notification-driven navigation as well.

**Add regression coverage**
- Add focused node tests for packaged `file://` URLs, dev-server URLs, self-window exclusion, and external URLs.

## Important changes
### Window reuse and close isolation

**Match internal routes before opening a new window**
- **Why**: avoid duplicate task/detail windows for the same route.
- **Files**: `electron/main.js`, `src/desktop/main/windowOpen.ts`

**Keep child windows alive after the opener closes**
- **Why**: make `Cmd+W` close only the active window instead of taking related windows down with it.
- **Files**: `electron/main.js`

**Track the latest live app window**
- **Why**: keep desktop focus and navigation flows targeting an existing window.
- **Files**: `electron/main.js`

### Regression tests

**Cover the window-open policy with route-level tests**
- **Why**: lock the new reuse behavior without relying on a full Electron integration harness.
- **Files**: `src/desktop/main/__tests__/windowOpen.test.ts`

Co-authored-by: Codex <noreply@openai.com>
