### PR TITLE
Fix remote worktree discovery and hook setup reliability

### DIFF
--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -616,7 +616,8 @@ describe("projectService local hook installation", () => {
       ]);
 
       expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
-      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+      const syncBroadcastCount = mocks.broadcastBoardUpdate.mock.calls.length;
+      expect(syncBroadcastCount).toBeGreaterThanOrEqual(1);
 
       await vi.runAllTimersAsync();
 
@@ -625,7 +626,7 @@ describe("projectService local hook installation", () => {
         "task-main",
         null,
       );
-      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(2);
+      expect(mocks.broadcastBoardUpdate.mock.calls.length).toBeGreaterThan(syncBroadcastCount);
     } finally {
       vi.useRealTimers();
     }
@@ -972,6 +973,81 @@ describe("projectService local hook installation", () => {
       "task-worktree",
       "remote-host",
     );
+  });
+
+  it("원격 스캔은 root hook 상태 조회 실패와 무관하게 worktree 등록을 계속 진행한다", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const remoteConnectionError = new Error("remote-host 원격 명령 실패: Connection reset by 100.73.171.123 port 22");
+
+      mocks.scanGitRepos.mockResolvedValue(["/remote/repo"]);
+      mocks.getDefaultBranch.mockResolvedValue("main");
+      mocks.getClaudeHooksStatus.mockRejectedValue(remoteConnectionError);
+      mocks.getGeminiHooksStatus.mockRejectedValue(remoteConnectionError);
+      mocks.getCodexHooksStatus.mockRejectedValue(remoteConnectionError);
+      mocks.getOpenCodeHooksStatus.mockRejectedValue(remoteConnectionError);
+      mocks.listWorktrees.mockResolvedValue([
+        {
+          path: "/remote/repo__worktrees/feature-login",
+          branch: "feature-login",
+          isBare: false,
+        },
+      ]);
+      mocks.formatSessionName.mockReturnValue("repo-feature-login");
+      mocks.isSessionAlive.mockResolvedValue(false);
+
+      mocks.getProjectRepository.mockResolvedValue({
+        find: vi.fn()
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([
+            {
+              id: "project-1",
+              name: "repo",
+              repoPath: "/remote/repo",
+              defaultBranch: "main",
+              sshHost: "remote-host",
+            },
+          ]),
+        create: vi.fn((value) => value),
+        save: vi.fn(async (value) => ({ id: "project-1", ...value })),
+        remove: vi.fn(),
+      });
+
+      let rootTask: Record<string, unknown> | null = null;
+      const taskSave = vi.fn(async (value) => {
+        if (value.branchName === "main") {
+          rootTask = { id: "task-main", ...value };
+          return rootTask;
+        }
+
+        return { id: "task-worktree", ...value };
+      });
+
+      mocks.getTaskRepository.mockResolvedValue({
+        findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => {
+          if (criteria.projectId === "project-1" && criteria.branchName === "main") {
+            return rootTask;
+          }
+
+          return null;
+        }),
+        create: vi.fn((value) => value),
+        save: taskSave,
+      });
+
+      const { scanAndRegisterProjects } = await import("@/desktop/main/services/projectService");
+
+      const result = await scanAndRegisterProjects("/remote/workspace", "remote-host");
+
+      expect(result.worktreeTasks).toContain("feature-login");
+      expect(mocks.getClaudeHooksStatus).not.toHaveBeenCalled();
+      expect(mocks.getGeminiHooksStatus).not.toHaveBeenCalled();
+      expect(mocks.getCodexHooksStatus).not.toHaveBeenCalled();
+      expect(mocks.getOpenCodeHooksStatus).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("프로젝트 스캔 후 worktree 후속 처리는 현재 스캔에서 찾은 저장소만 대상으로 한다", async () => {

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -405,9 +405,12 @@ export async function registerProject(
   const saved = await repo.save(project);
   try {
     await ensureProjectRootTask(saved, {
-      repairHooks: true,
+      repairHooks: !saved.sshHost,
       throwOnHookRepairFailure: false,
     });
+    if (saved.sshHost) {
+      scheduleProjectRootHookRepair(saved);
+    }
   } catch (error) {
     await repo.remove(saved);
     return {
@@ -494,11 +497,12 @@ export async function scanAndRegisterProjects(
       result.registered.push(projectName);
 
       let defaultTask = null;
+      const shouldRepairHooksSynchronously = !saved.sshHost;
 
       /** 기본 브랜치 태스크 생성 실패는 프로젝트 등록 결과에 영향을 주지 않는다 */
       try {
         const ensured = await ensureProjectRootTask(saved, {
-          repairHooks: true,
+          repairHooks: shouldRepairHooksSynchronously,
           throwOnHookRepairFailure: false,
         });
         defaultTask = ensured.task;
@@ -514,8 +518,11 @@ export async function scanAndRegisterProjects(
       }
 
       /** 기본 브랜치 작업이 준비되면 hooks가 보장된다 */
-      if (defaultTask) {
+      if (defaultTask && shouldRepairHooksSynchronously) {
         result.hooksSetup.push(projectName);
+      }
+      if (saved.sshHost) {
+        scheduleProjectRootHookRepair(saved);
       }
     } catch (error) {
       result.errors.push(
@@ -532,12 +539,16 @@ export async function scanAndRegisterProjects(
 
   for (const project of scannedProjects) {
     try {
+      const shouldRepairHooksSynchronously = !project.sshHost;
       const { repaired } = await ensureProjectRootTask(project, {
-        repairHooks: true,
+        repairHooks: shouldRepairHooksSynchronously,
         throwOnHookRepairFailure: false,
       });
-      if (repaired && !result.hooksSetup.includes(project.name)) {
+      if (shouldRepairHooksSynchronously && repaired && !result.hooksSetup.includes(project.name)) {
         result.hooksSetup.push(project.name);
+      }
+      if (project.sshHost) {
+        scheduleProjectRootHookRepair(project);
       }
 
       const worktrees = await listWorktrees(project.repoPath, project.sshHost);

--- a/src/desktop/main/terminalBridge.ts
+++ b/src/desktop/main/terminalBridge.ts
@@ -5,6 +5,7 @@ import { SessionType } from "@/entities/KanbanTask";
 import { attachLocalSession, attachRemoteSession, focusSession } from "@/lib/terminal";
 import { parseSSHConfig } from "@/lib/sshConfig";
 import { ensureRemoteSessionDependency } from "@/lib/remoteSessionDependency";
+import { getEffectivePaneLayout } from "@/desktop/main/services/paneLayoutService";
 
 const OPEN = 1;
 const CLOSED = 3;
@@ -106,6 +107,10 @@ export async function openTerminal(
         return { ok: false, error: `SSH 호스트를 찾을 수 없습니다: ${task.sshHost}` };
       }
 
+      const tmuxPaneLayout = task.sessionType === SessionType.TMUX
+        ? await getEffectivePaneLayout(task.projectId ?? undefined)
+        : null;
+
       await attachRemoteSession(
         taskId,
         task.sshHost,
@@ -116,6 +121,7 @@ export async function openTerminal(
         cols,
         rows,
         task.worktreePath,
+        tmuxPaneLayout,
       );
     } else {
       await attachLocalSession(

--- a/src/lib/__tests__/claudeHooksSetup.test.ts
+++ b/src/lib/__tests__/claudeHooksSetup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -83,5 +83,20 @@ describe("claudeHooksSetup", () => {
     const repairedStatus = await getClaudeHooksStatus(repoPath);
     expect(repairedStatus.hasSettingsEntry).toBe(true);
     expect(repairedStatus.installed).toBe(true);
+  });
+
+  it("keeps Claude installed when hook server reachability fails but configuration is correct", async () => {
+    const repoPath = tempDir;
+    const mockFetch = vi.fn().mockRejectedValue(new Error("connection refused"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await setupClaudeHooks(repoPath, "task-1", "http://localhost:9736");
+    const status = await getClaudeHooksStatus(repoPath, "task-1");
+
+    expect(status.installed).toBe(true);
+    expect(status.hasExpectedHookServerUrl).toBe(true);
+    expect(status.hasReachableHookServer).toBe(false);
+
+    vi.unstubAllGlobals();
   });
 });

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, readFile, rm, writeFile, mkdir } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -173,6 +173,21 @@ describe("codexHooksSetup", () => {
         configuredHookServerUrl: "http://localhost:3000",
         expectedHookServerUrl: null,
       });
+    });
+
+    it("should keep installed true when reachability fails but the hook configuration matches", async () => {
+      const repoPath = tempDir;
+      const mockFetch = vi.fn().mockRejectedValue(new Error("connection refused"));
+      vi.stubGlobal("fetch", mockFetch);
+
+      await setupCodexHooks(repoPath, "task-1", "http://localhost:9736");
+      const status = await getCodexHooksStatus(repoPath, "task-1");
+
+      expect(status.installed).toBe(true);
+      expect(status.hasExpectedHookServerUrl).toBe(true);
+      expect(status.hasReachableHookServer).toBe(false);
+
+      vi.unstubAllGlobals();
     });
   });
 });

--- a/src/lib/__tests__/gitExclude.remote.test.ts
+++ b/src/lib/__tests__/gitExclude.remote.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockExecGit,
+  mockReadTextFile,
+  mockWriteTextFile,
+} = vi.hoisted(() => ({
+  mockExecGit: vi.fn(),
+  mockReadTextFile: vi.fn(),
+  mockWriteTextFile: vi.fn(),
+}));
+
+vi.mock("@/lib/gitOperations", () => ({
+  execGit: (...args: unknown[]) => mockExecGit(...args),
+}));
+
+vi.mock("@/lib/hostFileAccess", () => ({
+  readTextFile: (...args: unknown[]) => mockReadTextFile(...args),
+  writeTextFile: (...args: unknown[]) => mockWriteTextFile(...args),
+  quoteShellArgument: (value: string) => `'${value.replaceAll("'", `'\\''`)}'`,
+}));
+
+describe("gitExclude remote", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecGit.mockResolvedValue("/remote/main/.git");
+    mockReadTextFile.mockResolvedValue("# existing\n");
+    mockWriteTextFile.mockResolvedValue(undefined);
+  });
+
+  it("writes AI hook patterns to the remote common git exclude", async () => {
+    const { addAiToolPatternsToGitExclude } = await import("@/lib/gitExclude");
+
+    await addAiToolPatternsToGitExclude("/remote/worktree/task-1", "remote-host");
+
+    expect(mockExecGit).toHaveBeenCalledWith(
+      "git -C '/remote/worktree/task-1' rev-parse --path-format=absolute --git-common-dir",
+      "remote-host",
+    );
+    expect(mockWriteTextFile).toHaveBeenCalledWith(
+      "/remote/main/.git/info/exclude",
+      expect.stringContaining(".codex/config.toml"),
+      "remote-host",
+    );
+  });
+});

--- a/src/lib/__tests__/gitExclude.test.ts
+++ b/src/lib/__tests__/gitExclude.test.ts
@@ -98,5 +98,30 @@ describe("gitExclude", () => {
       );
       expect(content).toContain("# KanVibe AI hooks (auto-generated)");
     });
+
+    it("should update the common git exclude when called from a worktree", async () => {
+      // Given
+      execSync("git config user.name 'Kanvibe Test'", { cwd: tempDir, stdio: "ignore" });
+      execSync("git config user.email 'kanvibe@example.com'", { cwd: tempDir, stdio: "ignore" });
+      await writeFile(join(tempDir, "README.md"), "# test\n", "utf-8");
+      execSync("git add README.md", { cwd: tempDir, stdio: "ignore" });
+      execSync("git commit -m 'init'", { cwd: tempDir, stdio: "ignore" });
+
+      const worktreePath = join(
+        tmpdir(),
+        `git-exclude-worktree-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      execSync(`git worktree add ${JSON.stringify(worktreePath)} -b worktree-test`, { cwd: tempDir, stdio: "ignore" });
+
+      // When
+      await addAiToolPatternsToGitExclude(worktreePath);
+
+      // Then
+      const content = await readFile(join(tempDir, ".git", "info", "exclude"), "utf-8");
+      expect(content).toContain("# KanVibe AI hooks (auto-generated)");
+      expect(content).toContain(".claude/hooks/");
+
+      await rm(worktreePath, { recursive: true, force: true });
+    });
   });
 });

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   homedir: vi.fn(() => "/home/local-user"),
   exec: vi.fn(),
   execFile: vi.fn(),
+  mkdir: vi.fn(async () => undefined),
 }));
 
 vi.mock("child_process", () => ({
@@ -20,6 +21,15 @@ vi.mock("os", () => ({
     homedir: mocks.homedir,
   },
   homedir: mocks.homedir,
+}));
+
+vi.mock("fs/promises", () => ({
+  default: {
+    mkdir: mocks.mkdir,
+    readFile: vi.fn(),
+  },
+  mkdir: mocks.mkdir,
+  readFile: vi.fn(),
 }));
 
 describe("gitOperations.resolvePathForShell", () => {
@@ -76,22 +86,38 @@ describe("gitOperations.resolvePathForShell", () => {
     const result = await execGit("pwd", "remote-host");
 
     // Then
+    const expectedArgs = [
+      "-i",
+      "/tmp/test-key",
+      "-p",
+      "2202",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "IdentitiesOnly=yes",
+      "-T",
+    ];
+
+    if (process.platform !== "win32") {
+      expectedArgs.push(
+        "-o",
+        "ControlMaster=auto",
+        "-o",
+        "ControlPersist=60",
+        "-o",
+        "ControlPath=/home/local-user/.kanvibe/ssh-%C",
+      );
+    }
+
+    expectedArgs.push(
+      "remote-host",
+      "sh -lc 'pwd'",
+    );
+
     expect(result).toBe("ok");
     expect(mocks.execFile).toHaveBeenCalledWith(
       "ssh",
-      [
-        "-i",
-        "/tmp/test-key",
-        "-p",
-        "2202",
-        "-o",
-        "BatchMode=yes",
-        "-o",
-        "IdentitiesOnly=yes",
-        "-T",
-        "remote-host",
-        "sh -lc 'pwd'",
-      ],
+      expectedArgs,
       expect.objectContaining({ maxBuffer: 10 * 1024 * 1024 }),
       expect.any(Function),
     );

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -11,6 +11,7 @@ const mockGetOpenCodeHooksStatus = vi.fn();
 const mockExecGit = vi.fn();
 const mockGetHookServerUrl = vi.fn();
 const mockGetHookServerToken = vi.fn();
+const mockAddAiToolPatternsToGitExclude = vi.fn();
 
 vi.mock("@/lib/claudeHooksSetup", () => ({
   setupClaudeHooks: (...args: unknown[]) => mockSetupClaudeHooks(...args),
@@ -61,14 +62,22 @@ vi.mock("@/lib/hookEndpoint", () => ({
   getHookServerToken: (...args: unknown[]) => mockGetHookServerToken(...args),
 }));
 
+vi.mock("@/lib/gitExclude", () => ({
+  addAiToolPatternsToGitExclude: (...args: unknown[]) => mockAddAiToolPatternsToGitExclude(...args),
+}));
+
 function extractWrittenContent(calls: unknown[][], filePath: string): string {
-  const targetCall = calls.find(([command]) => typeof command === "string" && command.includes(`> "${filePath}"`));
+  const targetCall = calls.find(([command]) => typeof command === "string"
+    && (command.includes(`> "${filePath}"`) || command.includes(`> '${filePath}'`)));
   if (!targetCall) {
     throw new Error(`write command not found for ${filePath}`);
   }
 
   const command = targetCall[0] as string;
-  const encodedMatch = command.match(/printf '%s' '([^']+)' \|/);
+  const escapedFilePath = filePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const encodedMatch = command.match(new RegExp(
+    `printf '%s' ['"]([^'"]+)['"] \\| \\(base64 -d 2>/dev/null \\|\\| base64 -D\\) > ['"]${escapedFilePath}['"]`,
+  ));
   if (!encodedMatch) {
     throw new Error(`base64 payload not found for ${filePath}`);
   }
@@ -83,6 +92,7 @@ describe("kanvibeHooksInstaller", () => {
     mockGetHookServerUrl.mockReturnValue("http://192.168.0.8:9736");
     mockGetHookServerToken.mockReturnValue("token-123");
     mockExecGit.mockResolvedValue("");
+    mockAddAiToolPatternsToGitExclude.mockResolvedValue(undefined);
     mockGetClaudeHooksStatus.mockResolvedValue({ installed: true });
     mockGetGeminiHooksStatus.mockResolvedValue({ installed: true });
     mockGetCodexHooksStatus.mockResolvedValue({ installed: true });
@@ -118,6 +128,7 @@ describe("kanvibeHooksInstaller", () => {
     expect(mockSetupClaudeHooks).not.toHaveBeenCalled();
     expect(mockExecGit).toHaveBeenCalled();
     expect(mockGetHookServerUrl).toHaveBeenCalledWith("remote-host");
+    expect(mockAddAiToolPatternsToGitExclude).toHaveBeenCalledWith("/remote/repo", "remote-host");
   });
 
   it("원격 Claude/Gemini stale hook entry도 재설치 시 현재 project 경로로 덮어쓴다", async () => {
@@ -194,7 +205,13 @@ describe("kanvibeHooksInstaller", () => {
 
   it("원격 hook 설치 중 첫 SSH 쓰기가 실패하면 추가 설치를 진행하지 않는다", async () => {
     // Given
-    mockExecGit.mockRejectedValueOnce(new Error("remote host unavailable"));
+    mockExecGit.mockImplementation(async (command: string) => {
+      if (command.includes("printf '%s'")) {
+        throw new Error("remote host unavailable");
+      }
+
+      return "";
+    });
     const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
 
     // When
@@ -202,7 +219,7 @@ describe("kanvibeHooksInstaller", () => {
 
     // Then
     await expect(result).rejects.toThrow("remote host unavailable");
-    expect(mockExecGit).toHaveBeenCalledTimes(1);
+    expect(mockExecGit).toHaveBeenCalledTimes(2);
   });
 
   it("로컬 hook 설치 중 하나라도 실패하면 예외를 전파한다", async () => {
@@ -241,5 +258,20 @@ describe("kanvibeHooksInstaller", () => {
       failedChecks: ["hasConfigEntry"],
       targetPath: "/repo",
     }));
+  });
+
+  it("원격 설치는 후속 검증을 기다리지 않고 반환한다", async () => {
+    const pendingVerification = new Promise(() => {});
+    mockGetClaudeHooksStatus.mockReturnValue(pendingVerification);
+    mockGetGeminiHooksStatus.mockReturnValue(pendingVerification);
+    mockGetCodexHooksStatus.mockReturnValue(pendingVerification);
+    mockGetOpenCodeHooksStatus.mockReturnValue(pendingVerification);
+
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    await expect(Promise.race([
+      installKanvibeHooks("/remote/repo", "task-2", "remote-host").then(() => "resolved"),
+      new Promise((resolve) => setTimeout(() => resolve("timed-out"), 50)),
+    ])).resolves.toBe("resolved");
   });
 });

--- a/src/lib/__tests__/sshConfig.test.ts
+++ b/src/lib/__tests__/sshConfig.test.ts
@@ -47,4 +47,15 @@ describe("sshConfig.parseSSHConfig", () => {
       },
     ]);
   });
+
+  it("reuses parsed SSH config on repeated calls", async () => {
+    mocks.readFile.mockResolvedValue(`Host app-prod\n  HostName example.com\n  User tester\n`);
+
+    const { parseSSHConfig } = await import("@/lib/sshConfig");
+
+    await parseSSHConfig();
+    await parseSSHConfig();
+
+    expect(mocks.readFile).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -4,6 +4,7 @@
 import path from "path";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SessionType } from "@/entities/KanbanTask";
+import { PaneLayoutType } from "@/entities/PaneLayoutConfig";
 
 // --- Mocks ---
 
@@ -375,6 +376,45 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     );
     expect(mockPtyWrite).toHaveBeenCalledWith(
       expect.stringContaining('tmux new-session -d -s "remote-session" -c "/remote/worktree"'),
+    );
+  });
+
+  it("should apply tmux pane layout commands when creating a remote session", async () => {
+    const { attachRemoteSession } = await import("@/lib/terminal");
+
+    await attachRemoteSession(
+      "task-r2",
+      "remote-host",
+      SessionType.TMUX,
+      "remote-session",
+      createMockWs(),
+      {
+        host: "remote-host",
+        hostname: "example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/tmp/test-key",
+      },
+      120,
+      30,
+      "/remote/worktree",
+      {
+        layoutType: PaneLayoutType.VERTICAL_2,
+        panes: [
+          { position: 0, command: "pnpm dev" },
+          { position: 1, command: "pnpm test" },
+        ],
+      },
+    );
+
+    expect(mockPtyWrite).toHaveBeenCalledWith(
+      expect.stringContaining('tmux split-window -h -t "remote-session":0 -c "/remote/worktree"'),
+    );
+    expect(mockPtyWrite).toHaveBeenCalledWith(
+      expect.stringContaining('tmux send-keys -t "remote-session":0.0 "pnpm dev" Enter'),
+    );
+    expect(mockPtyWrite).toHaveBeenCalledWith(
+      expect.stringContaining('tmux send-keys -t "remote-session":0.1 "pnpm test" Enter'),
     );
   });
 });

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -299,8 +299,7 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
     && hasSettingsEntry
     && hasTaskIdBinding
     && hasStatusMappings
-    && hookServerValidation.hasExpectedHookServerUrl
-    && hookServerValidation.hasReachableHookServer;
+    && hookServerValidation.hasExpectedHookServerUrl;
 
   return {
     installed,

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -413,8 +413,7 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
     && hasConfigEntry
     && hasTaskIdBinding
     && hasStatusMappings
-    && hookServerValidation.hasExpectedHookServerUrl
-    && hookServerValidation.hasReachableHookServer;
+    && hookServerValidation.hasExpectedHookServerUrl;
 
   return {
     installed,

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -254,8 +254,7 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
     && hasSettingsEntry
     && hasTaskIdBinding
     && hasStatusMappings
-    && hookServerValidation.hasExpectedHookServerUrl
-    && hookServerValidation.hasReachableHookServer;
+    && hookServerValidation.hasExpectedHookServerUrl;
 
   return {
     installed,

--- a/src/lib/gitExclude.ts
+++ b/src/lib/gitExclude.ts
@@ -1,9 +1,6 @@
-import { exec } from "child_process";
-import { promisify } from "util";
-import { readFile, writeFile, mkdir } from "fs/promises";
-import path from "path";
-
-const execAsync = promisify(exec);
+import path from "node:path";
+import { execGit } from "@/lib/gitOperations";
+import { quoteShellArgument, readTextFile, writeTextFile } from "@/lib/hostFileAccess";
 
 const MARKER = "# KanVibe AI hooks (auto-generated)";
 
@@ -19,40 +16,37 @@ const EXCLUDE_PATTERNS = [
 ];
 
 /**
- * AI 코딩 도구의 hooks 설정 파일을 .git/info/excluded에 추가하여 git tracking에서 제외한다.
- * 마커 블록을 사용해 멱등성을 보장하며, 실패해도 예외를 던지지 않는다.
+ * AI 코딩 도구의 hooks 설정 파일을 git common dir의 info/exclude에 추가하여
+ * 모든 worktree에서 공통으로 git tracking에서 제외한다.
+ * 마커 블록을 사용해 멱등성을 보장하며, 원격 저장소도 지원한다.
  * @param repoPath - worktree 또는 저장소 경로
  */
 export async function addAiToolPatternsToGitExclude(
-  repoPath: string
+  repoPath: string,
+  sshHost?: string | null,
 ): Promise<void> {
-  const { stdout } = await execAsync("git rev-parse --git-dir", {
-    cwd: repoPath,
-  });
-  const gitDir = stdout.trim();
-  const absoluteGitDir = path.isAbsolute(gitDir)
-    ? gitDir
-    : path.join(repoPath, gitDir);
+  const gitCommonDir = (await execGit(
+    `git -C ${quoteShellArgument(repoPath)} rev-parse --path-format=absolute --git-common-dir`,
+    sshHost,
+  )).trim();
 
-  const infoDir = path.join(absoluteGitDir, "info");
-  await mkdir(infoDir, { recursive: true });
-
-  const excludedPath = path.join(infoDir, "exclude");
-
-  let content = "";
-  try {
-    content = await readFile(excludedPath, "utf-8");
-  } catch {
-    /* 파일이 없으면 새로 생성 */
+  if (!gitCommonDir) {
+    throw new Error(`git common dir를 확인할 수 없습니다: ${repoPath}`);
   }
 
-  if (content.includes(MARKER)) return;
+  const excludePath = sshHost
+    ? path.posix.join(gitCommonDir, "info", "exclude")
+    : path.join(gitCommonDir, "info", "exclude");
 
-  const block = [
-    "",
-    MARKER,
-    ...EXCLUDE_PATTERNS,
-  ].join("\n") + "\n";
+  const content = await readTextFile(excludePath, sshHost);
+  if (content.includes(MARKER)) {
+    return;
+  }
 
-  await writeFile(excludedPath, content.trimEnd() + "\n" + block, "utf-8");
+  const markerBlock = [MARKER, ...EXCLUDE_PATTERNS].join("\n");
+  const nextContent = content.trimEnd().length > 0
+    ? `${content.trimEnd()}\n\n${markerBlock}\n`
+    : `${markerBlock}\n`;
+
+  await writeTextFile(excludePath, nextContent, sshHost);
 }

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -1,6 +1,6 @@
 import { exec, execFile } from "child_process";
 import { promisify } from "util";
-import { readFile } from "fs/promises";
+import { mkdir, readFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
 import { buildSSHArgs, type SSHHostConfig } from "@/lib/sshConfig";
@@ -98,7 +98,7 @@ async function execRemote(sshHost: string, command: string): Promise<string> {
   }
 
   const sshArgs = [
-    ...buildSSHArgs(hostConfig, { disableTty: true }),
+    ...await buildExecSSHArgs(hostConfig),
     buildRemoteShellCommand(command),
   ];
 
@@ -123,6 +123,29 @@ async function execRemote(sshHost: string, command: string): Promise<string> {
 
     throw normalizeSSHExecError(error, sshHost);
   }
+}
+
+async function buildExecSSHArgs(
+  hostConfig: SSHHostConfig,
+): Promise<string[]> {
+  const args = buildSSHArgs(hostConfig, { disableTty: true });
+  if (process.platform === "win32") {
+    return args;
+  }
+
+  const controlPath = path.join(homedir(), ".kanvibe", "ssh-%C");
+  await mkdir(path.dirname(controlPath), { recursive: true });
+
+  return [
+    ...args.slice(0, -1),
+    "-o",
+    "ControlMaster=auto",
+    "-o",
+    "ControlPersist=60",
+    "-o",
+    `ControlPath=${controlPath}`,
+    args.at(-1)!,
+  ];
 }
 
 function buildRemoteShellCommand(command: string): string {

--- a/src/lib/hookServerStatus.ts
+++ b/src/lib/hookServerStatus.ts
@@ -9,6 +9,10 @@ export interface HookServerValidation {
   configuredHookServerUrl: string | null;
 }
 
+const HOOK_SERVER_CACHE_TTL_MS = process.env.VITEST ? 0 : 5_000;
+const expectedHookServerUrlCache = new Map<string, { expiresAt: number; value: Promise<string> }>();
+const hookServerReachabilityCache = new Map<string, { expiresAt: number; value: Promise<boolean> }>();
+
 export function extractShellHookServerUrl(content: string): string | null {
   const matched = content.match(/^KANVIBE_URL="([^"]+)"/m);
   return matched?.[1] ?? null;
@@ -47,7 +51,11 @@ export async function validateHookServerConfiguration(
 
   let expectedHookServerUrl: string | null = null;
   try {
-    expectedHookServerUrl = await getHookServerUrl(sshHost);
+    expectedHookServerUrl = await getCachedValue(
+      expectedHookServerUrlCache,
+      sshHost ?? "local",
+      () => getHookServerUrl(sshHost),
+    );
   } catch {
     return {
       hasExpectedHookServerUrl: false,
@@ -72,7 +80,14 @@ export async function validateHookServerConfiguration(
 
 async function isHookServerReachable(baseUrl: string, sshHost?: string | null): Promise<boolean> {
   const healthCheckUrl = new URL("/api/hooks/health", ensureTrailingSlash(baseUrl)).toString();
+  return getCachedValue(
+    hookServerReachabilityCache,
+    `${sshHost ?? "local"}:${healthCheckUrl}`,
+    () => performHookServerReachabilityCheck(healthCheckUrl, sshHost),
+  );
+}
 
+async function performHookServerReachabilityCheck(healthCheckUrl: string, sshHost?: string | null): Promise<boolean> {
   if (!sshHost) {
     try {
       const response = await fetch(healthCheckUrl, {
@@ -100,6 +115,31 @@ async function isHookServerReachable(baseUrl: string, sshHost?: string | null): 
       return true;
     }
     return false;
+  }
+}
+
+async function getCachedValue<T>(
+  cache: Map<string, { expiresAt: number; value: Promise<T> }>,
+  key: string,
+  loader: () => Promise<T>,
+): Promise<T> {
+  const now = Date.now();
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > now) {
+    return cached.value;
+  }
+
+  const value = loader();
+  cache.set(key, {
+    expiresAt: now + HOOK_SERVER_CACHE_TTL_MS,
+    value,
+  });
+
+  try {
+    return await value;
+  } catch (error) {
+    cache.delete(key);
+    throw error;
   }
 }
 

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -21,6 +21,8 @@ import {
 } from "@/lib/codexHooksSetup";
 import { setupOpenCodeHooks, getOpenCodeHooksStatus, generatePluginScript, PLUGIN_DIR_NAME, PLUGIN_FILE_NAME, type OpenCodeHooksStatus } from "@/lib/openCodeHooksSetup";
 import { getHookServerToken, getHookServerUrl } from "@/lib/hookEndpoint";
+import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import { quoteShellArgument } from "@/lib/hostFileAccess";
 
 export async function installKanvibeHooks(
   targetPath: string,
@@ -61,6 +63,16 @@ export async function installKanvibeHooks(
     const results = await Promise.allSettled(installers.map(({ install }) => install()));
     assertHookInstallResults(results, installers.map(({ provider }) => provider));
   } else {
+    try {
+      await addAiToolPatternsToGitExclude(targetPath, sshHost);
+    } catch (error) {
+      console.warn("[hooks] remote git exclude update failed", {
+        targetPath,
+        sshHost,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
     for (const { provider, install } of installers) {
       try {
         await install();
@@ -76,6 +88,18 @@ export async function installKanvibeHooks(
     }
   }
 
+  if (sshHost) {
+    void logHookVerificationStatuses(targetPath, taskId, sshHost).catch((error) => {
+      console.warn("[hooks] remote verification failed", {
+        targetPath,
+        taskId,
+        sshHost,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+    return;
+  }
+
   await logHookVerificationStatuses(targetPath, taskId, sshHost);
 }
 
@@ -83,11 +107,6 @@ async function setupRemoteClaudeHooks(repoPath: string, taskId: string, hookServ
   const claudeDir = path.posix.join(repoPath, ".claude");
   const hooksDir = path.posix.join(claudeDir, "hooks");
   const settingsPath = path.posix.join(claudeDir, "settings.json");
-  await execGit(`mkdir -p "${hooksDir}"`, sshHost);
-
-  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"), generateClaudePromptHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-stop-hook.sh"), generateClaudeStopHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-question-hook.sh"), generateClaudeQuestionHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
 
   const settings = await readRemoteJsonFile(settingsPath, sshHost);
   const hooks = ((settings.hooks as Record<string, unknown[]>) || {});
@@ -108,17 +127,33 @@ async function setupRemoteClaudeHooks(repoPath: string, taskId: string, hookServ
     hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-stop-hook.sh', timeout: 10 }],
   });
 
-  await writeRemoteTextFile(settingsPath, JSON.stringify(settings, null, 2) + "\n", sshHost);
+  await writeRemoteTextFiles([
+    {
+      filePath: path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"),
+      content: generateClaudePromptHookScript(hookServerUrl, taskId, hookServerToken),
+      mode: 0o755,
+    },
+    {
+      filePath: path.posix.join(hooksDir, "kanvibe-stop-hook.sh"),
+      content: generateClaudeStopHookScript(hookServerUrl, taskId, hookServerToken),
+      mode: 0o755,
+    },
+    {
+      filePath: path.posix.join(hooksDir, "kanvibe-question-hook.sh"),
+      content: generateClaudeQuestionHookScript(hookServerUrl, taskId, hookServerToken),
+      mode: 0o755,
+    },
+    {
+      filePath: settingsPath,
+      content: JSON.stringify(settings, null, 2) + "\n",
+    },
+  ], sshHost);
 }
 
 async function setupRemoteGeminiHooks(repoPath: string, taskId: string, hookServerUrl: string, hookServerToken: string, sshHost: string) {
   const geminiDir = path.posix.join(repoPath, ".gemini");
   const hooksDir = path.posix.join(geminiDir, "hooks");
   const settingsPath = path.posix.join(geminiDir, "settings.json");
-  await execGit(`mkdir -p "${hooksDir}"`, sshHost);
-
-  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"), generateGeminiPromptHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-  await writeRemoteTextFile(path.posix.join(hooksDir, "kanvibe-stop-hook.sh"), generateGeminiStopHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
 
   const settings = await readRemoteJsonFile(settingsPath, sshHost);
   const hooks = ((settings.hooks as Record<string, unknown[]>) || {});
@@ -133,7 +168,22 @@ async function setupRemoteGeminiHooks(repoPath: string, taskId: string, hookServ
     hooks: [{ type: "command", command: '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-stop-hook.sh', timeout: 10000 }],
   });
 
-  await writeRemoteTextFile(settingsPath, JSON.stringify(settings, null, 2) + "\n", sshHost);
+  await writeRemoteTextFiles([
+    {
+      filePath: path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"),
+      content: generateGeminiPromptHookScript(hookServerUrl, taskId, hookServerToken),
+      mode: 0o755,
+    },
+    {
+      filePath: path.posix.join(hooksDir, "kanvibe-stop-hook.sh"),
+      content: generateGeminiStopHookScript(hookServerUrl, taskId, hookServerToken),
+      mode: 0o755,
+    },
+    {
+      filePath: settingsPath,
+      content: JSON.stringify(settings, null, 2) + "\n",
+    },
+  ], sshHost);
 }
 
 async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServerUrl: string, hookServerToken: string, sshHost: string) {
@@ -141,28 +191,50 @@ async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServe
   const hooksDir = path.posix.join(codexDir, "hooks");
   const configPath = path.posix.join(codexDir, CONFIG_FILE_NAME);
   const hooksPath = path.posix.join(codexDir, HOOKS_FILE_NAME);
-  await execGit(`mkdir -p "${hooksDir}"`, sshHost);
-
-  await writeRemoteTextFile(path.posix.join(hooksDir, PROMPT_HOOK_SCRIPT_NAME), generateCodexPromptHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-  await writeRemoteTextFile(path.posix.join(hooksDir, PERMISSION_HOOK_SCRIPT_NAME), generateCodexPermissionHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-  await writeRemoteTextFile(path.posix.join(hooksDir, PRE_TOOL_HOOK_SCRIPT_NAME), generateCodexPreToolHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
-  await writeRemoteTextFile(path.posix.join(hooksDir, STOP_HOOK_SCRIPT_NAME), generateCodexStopHookScript(hookServerUrl, taskId, hookServerToken), sshHost, 0o755);
 
   const configContent = await readRemoteTextFile(configPath, sshHost);
-  await writeRemoteTextFile(configPath, upsertCodexConfigToml(configContent), sshHost);
-
   const hooksContent = await readRemoteTextFile(hooksPath, sshHost);
-  await writeRemoteTextFile(hooksPath, upsertCodexHooksJson(hooksContent), sshHost);
+
+  await writeRemoteTextFiles([
+    {
+      filePath: path.posix.join(hooksDir, PROMPT_HOOK_SCRIPT_NAME),
+      content: generateCodexPromptHookScript(hookServerUrl, taskId, hookServerToken),
+      mode: 0o755,
+    },
+    {
+      filePath: path.posix.join(hooksDir, PERMISSION_HOOK_SCRIPT_NAME),
+      content: generateCodexPermissionHookScript(hookServerUrl, taskId, hookServerToken),
+      mode: 0o755,
+    },
+    {
+      filePath: path.posix.join(hooksDir, PRE_TOOL_HOOK_SCRIPT_NAME),
+      content: generateCodexPreToolHookScript(hookServerUrl, taskId, hookServerToken),
+      mode: 0o755,
+    },
+    {
+      filePath: path.posix.join(hooksDir, STOP_HOOK_SCRIPT_NAME),
+      content: generateCodexStopHookScript(hookServerUrl, taskId, hookServerToken),
+      mode: 0o755,
+    },
+    {
+      filePath: configPath,
+      content: upsertCodexConfigToml(configContent),
+    },
+    {
+      filePath: hooksPath,
+      content: upsertCodexHooksJson(hooksContent),
+    },
+  ], sshHost);
 }
 
 async function setupRemoteOpenCodeHooks(repoPath: string, taskId: string, hookServerUrl: string, hookServerToken: string, sshHost: string) {
   const pluginDir = path.posix.join(repoPath, ".opencode", PLUGIN_DIR_NAME);
-  await execGit(`mkdir -p "${pluginDir}"`, sshHost);
-  await writeRemoteTextFile(
-    path.posix.join(pluginDir, PLUGIN_FILE_NAME),
-    generatePluginScript(hookServerUrl, taskId, hookServerToken),
-    sshHost,
-  );
+  await writeRemoteTextFiles([
+    {
+      filePath: path.posix.join(pluginDir, PLUGIN_FILE_NAME),
+      content: generatePluginScript(hookServerUrl, taskId, hookServerToken),
+    },
+  ], sshHost);
 }
 
 async function readRemoteJsonFile(filePath: string, sshHost: string): Promise<Record<string, unknown>> {
@@ -180,19 +252,37 @@ async function readRemoteJsonFile(filePath: string, sshHost: string): Promise<Re
 
 async function readRemoteTextFile(filePath: string, sshHost: string): Promise<string> {
   try {
-    return await execGit(`test -f "${filePath}" && cat "${filePath}" || true`, sshHost);
+    return await execGit(
+      `test -f ${quoteShellArgument(filePath)} && cat ${quoteShellArgument(filePath)} || true`,
+      sshHost,
+    );
   } catch {
     return "";
   }
 }
 
-async function writeRemoteTextFile(filePath: string, content: string, sshHost: string, mode?: number): Promise<void> {
-  const encodedContent = Buffer.from(content, "utf-8").toString("base64");
-  const chmodCommand = mode ? ` && chmod ${mode.toString(8)} "${filePath}"` : "";
-  await execGit(
-    `mkdir -p "${path.posix.dirname(filePath)}" && printf '%s' '${encodedContent}' | (base64 -d 2>/dev/null || base64 -D) > "${filePath}"${chmodCommand}`,
-    sshHost,
-  );
+interface RemoteTextFile {
+  filePath: string;
+  content: string;
+  mode?: number;
+}
+
+async function writeRemoteTextFiles(files: RemoteTextFile[], sshHost: string): Promise<void> {
+  const command = files.map(({ filePath, content, mode }) => {
+    const encodedContent = Buffer.from(content, "utf-8").toString("base64");
+    const parts = [
+      `mkdir -p ${quoteShellArgument(path.posix.dirname(filePath))}`,
+      `printf '%s' ${quoteShellArgument(encodedContent)} | (base64 -d 2>/dev/null || base64 -D) > ${quoteShellArgument(filePath)}`,
+    ];
+
+    if (mode) {
+      parts.push(`chmod ${mode.toString(8)} ${quoteShellArgument(filePath)}`);
+    }
+
+    return parts.join(" && ");
+  }).join(" && ");
+
+  await execGit(command, sshHost);
 }
 
 function upsertHookEntry(
@@ -257,6 +347,7 @@ function logHookVerificationStatus(
 ) {
   const failedChecks = Object.entries(status)
     .filter(([key, value]) => key.startsWith("has") && value === false)
+    .filter(([key]) => !(status.installed && key === "hasReachableHookServer"))
     .map(([key]) => key);
 
   const payload = {

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -298,8 +298,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
     && hasMainSessionGuard
     && hasDuplicateProgressGuard
     && hasRegisteredPlugin
-    && hookServerValidation.hasExpectedHookServerUrl
-    && hookServerValidation.hasReachableHookServer;
+    && hookServerValidation.hasExpectedHookServerUrl;
 
   return {
     installed,

--- a/src/lib/sshConfig.ts
+++ b/src/lib/sshConfig.ts
@@ -10,6 +10,11 @@ export interface SSHHostConfig {
   privateKeyPath: string;
 }
 
+const SSH_CONFIG_CACHE_TTL_MS = 5000;
+let cachedHosts: SSHHostConfig[] | null = null;
+let cacheExpiresAt = 0;
+let inFlightParse: Promise<SSHHostConfig[]> | null = null;
+
 export function getSSHDestination(config: Pick<SSHHostConfig, "host" | "hostname" | "username">): string {
   if (config.host) {
     return config.host;
@@ -51,53 +56,74 @@ export function buildSSHArgs(
  * Host, HostName, User, IdentityFile, Port 필드를 추출한다.
  */
 export async function parseSSHConfig(): Promise<SSHHostConfig[]> {
+  const now = Date.now();
+  if (cachedHosts && cacheExpiresAt > now) {
+    return cachedHosts;
+  }
+
+  if (inFlightParse) {
+    return inFlightParse;
+  }
+
   const configPath = path.join(homedir(), ".ssh", "config");
 
-  let content: string;
-  try {
-    content = await readFile(configPath, "utf-8");
-  } catch {
-    return [];
-  }
+  inFlightParse = (async () => {
+    let content: string;
+    try {
+      content = await readFile(configPath, "utf-8");
+    } catch {
+      cachedHosts = [];
+      cacheExpiresAt = Date.now() + SSH_CONFIG_CACHE_TTL_MS;
+      return [];
+    }
 
-  const hosts: SSHHostConfig[] = [];
-  let current: (Partial<SSHHostConfig> & { aliases?: string[] }) | null = null;
+    const hosts: SSHHostConfig[] = [];
+    let current: (Partial<SSHHostConfig> & { aliases?: string[] }) | null = null;
 
-  for (const rawLine of content.split("\n")) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith("#")) continue;
+    for (const rawLine of content.split("\n")) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith("#")) continue;
 
-    const [key, ...valueParts] = line.split(/\s+/);
-    const value = valueParts.join(" ");
+      const [key, ...valueParts] = line.split(/\s+/);
+      const value = valueParts.join(" ");
 
-    if (key.toLowerCase() === "host") {
-      if (current?.aliases?.length && current.hostname) {
-        hosts.push(...expandHostAliases(current));
-      }
-      current = { aliases: valueParts };
-    } else if (current) {
-      switch (key.toLowerCase()) {
-        case "hostname":
-          current.hostname = value;
-          break;
-        case "user":
-          current.username = value;
-          break;
-        case "port":
-          current.port = parseInt(value, 10);
-          break;
-        case "identityfile":
-          current.privateKeyPath = value.replace("~", homedir());
-          break;
+      if (key.toLowerCase() === "host") {
+        if (current?.aliases?.length && current.hostname) {
+          hosts.push(...expandHostAliases(current));
+        }
+        current = { aliases: valueParts };
+      } else if (current) {
+        switch (key.toLowerCase()) {
+          case "hostname":
+            current.hostname = value;
+            break;
+          case "user":
+            current.username = value;
+            break;
+          case "port":
+            current.port = parseInt(value, 10);
+            break;
+          case "identityfile":
+            current.privateKeyPath = value.replace("~", homedir());
+            break;
+        }
       }
     }
-  }
 
-  if (current?.aliases?.length && current.hostname) {
-    hosts.push(...expandHostAliases(current));
-  }
+    if (current?.aliases?.length && current.hostname) {
+      hosts.push(...expandHostAliases(current));
+    }
 
-  return hosts;
+    cachedHosts = hosts;
+    cacheExpiresAt = Date.now() + SSH_CONFIG_CACHE_TTL_MS;
+    return hosts;
+  })();
+
+  try {
+    return await inFlightParse;
+  } finally {
+    inFlightParse = null;
+  }
 }
 
 function fillDefaults(partial: Partial<SSHHostConfig>): SSHHostConfig {

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -1,10 +1,12 @@
 import path from "path";
 import { existsSync } from "fs";
 import { SessionType } from "@/entities/KanbanTask";
+import { PaneLayoutType } from "@/entities/PaneLayoutConfig";
 import { ZELLIJ_LAYOUT_FILENAME } from "@/lib/worktree";
 import { execSync } from "child_process";
 import type { WebSocket } from "ws";
 import { buildSSHArgs } from "@/lib/sshConfig";
+import { buildTmuxSessionBootstrapCommands, type TmuxPaneLayoutConfig } from "@/lib/worktree";
 
 /**
  * 활성 터미널 세션을 관리하는 레지스트리.
@@ -235,6 +237,7 @@ export async function attachRemoteSession(
   cols?: number,
   rows?: number,
   worktreePath?: string | null,
+  tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
 ): Promise<void> {
   const initialCols = cols ?? 120;
   const initialRows = rows ?? 30;
@@ -253,14 +256,8 @@ export async function attachRemoteSession(
   }
 
   const pty = await import("node-pty");
-  const tmuxNewSession = worktreePath
-    ? `tmux new-session -d -s "${sessionName}" -c "${worktreePath}"`
-    : `tmux new-session -d -s "${sessionName}"`;
   const attachCommand = sessionType === SessionType.TMUX
-    ? [
-        `tmux has-session -t "${sessionName}" 2>/dev/null || ${tmuxNewSession}`,
-        `exec tmux attach-session -t "${sessionName}"`,
-      ].join("; ")
+    ? buildRemoteTmuxAttachCommand(sessionName, worktreePath, tmuxPaneLayout)
     : `exec zellij attach "${sessionName}"`;
   const args = buildSSHArgs(sshConfig, { forceTty: true });
 
@@ -314,6 +311,31 @@ export async function attachRemoteSession(
       detachSession(taskId);
     }
   });
+}
+
+function buildRemoteTmuxAttachCommand(
+  sessionName: string,
+  worktreePath?: string | null,
+  tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
+): string {
+  const attachCommand = `exec tmux attach-session -t "${sessionName}"`;
+  const bootstrapCommands = worktreePath
+    ? buildTmuxSessionBootstrapCommands(
+        sessionName,
+        worktreePath,
+        tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
+          ? tmuxPaneLayout
+          : null,
+      )
+    : [`tmux new-session -d -s "${sessionName}"`];
+
+  return [
+    `if tmux has-session -t "${sessionName}" 2>/dev/null; then`,
+    `  ${attachCommand}`,
+    "fi",
+    ...bootstrapCommands,
+    attachCommand,
+  ].join("; ");
 }
 
 function handleTerminalMessage(ptyProcess: import("node-pty").IPty, data: string): void {

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -11,6 +11,11 @@ interface WorktreeSession {
   sessionName: string;
 }
 
+export interface TmuxPaneLayoutConfig {
+  layoutType: PaneLayoutType;
+  panes: PaneCommand[];
+}
+
 /** branchName을 세션 이름으로 변환한다. `/`를 `-`로 치환한다 */
 export function formatSessionName(projectName: string, branchName: string): string {
   return `${projectName}-${branchName}`.replace(/\//g, "-");
@@ -40,28 +45,18 @@ function buildTmuxCreateSessionCommand(sessionName: string, workingDir: string):
   return `tmux new-session -d -s "${sessionName}" -c "${workingDir}"`;
 }
 
-async function createTmuxSession(
-  sessionName: string,
-  workingDir: string,
-  sshHost?: string | null,
-): Promise<void> {
-  await execGit(buildTmuxCreateSessionCommand(sessionName, workingDir), sshHost);
+function buildTmuxTarget(sessionName: string): string {
+  return `"${sessionName}":0`;
 }
 
-
-/**
- * tmux 세션에 pane 레이아웃을 적용하고 각 pane에 시작 명령어를 실행한다.
- * 분할 실패 시에도 기본 window는 유지된다 (graceful fallback).
- */
-async function applyPaneLayout(
+export function buildTmuxPaneLayoutCommands(
   sessionName: string,
   layoutType: PaneLayoutType,
   panes: PaneCommand[],
   worktreePath: string,
-): Promise<void> {
-  const target = `"${sessionName}":0`;
+): string[] {
+  const target = buildTmuxTarget(sessionName);
 
-  /** 레이아웃 타입에 따른 tmux split 명령어 시퀀스 */
   const splitCommands: Record<PaneLayoutType, string[]> = {
     [PaneLayoutType.SINGLE]: [],
     [PaneLayoutType.HORIZONTAL_2]: [
@@ -85,18 +80,58 @@ async function applyPaneLayout(
     ],
   };
 
-  const commands = splitCommands[layoutType];
-  for (const cmd of commands) {
-    await execGit(cmd);
-  }
+  const sendKeysCommands = panes
+    .filter((pane) => pane.command.trim())
+    .map((pane) => (
+      `tmux send-keys -t ${target}.${pane.position} "${pane.command}" Enter`
+    ));
 
-  /** 각 pane에 시작 명령어 전송 */
-  for (const pane of panes) {
-    if (pane.command.trim()) {
-      await execGit(
-        `tmux send-keys -t ${target}.${pane.position} "${pane.command}" Enter`,
-      );
-    }
+  return [
+    ...splitCommands[layoutType],
+    ...sendKeysCommands,
+  ];
+}
+
+export function buildTmuxSessionBootstrapCommands(
+  sessionName: string,
+  workingDir: string,
+  paneLayout?: TmuxPaneLayoutConfig | null,
+): string[] {
+  return [
+    buildTmuxCreateSessionCommand(sessionName, workingDir),
+    ...(paneLayout && paneLayout.layoutType !== PaneLayoutType.SINGLE
+      ? buildTmuxPaneLayoutCommands(
+          sessionName,
+          paneLayout.layoutType,
+          paneLayout.panes,
+          workingDir,
+        )
+      : []),
+  ];
+}
+
+async function createTmuxSession(
+  sessionName: string,
+  workingDir: string,
+  sshHost?: string | null,
+): Promise<void> {
+  await execGit(buildTmuxCreateSessionCommand(sessionName, workingDir), sshHost);
+}
+
+
+/**
+ * tmux 세션에 pane 레이아웃을 적용하고 각 pane에 시작 명령어를 실행한다.
+ * 분할 실패 시에도 기본 window는 유지된다 (graceful fallback).
+ */
+async function applyPaneLayout(
+  sessionName: string,
+  layoutType: PaneLayoutType,
+  panes: PaneCommand[],
+  worktreePath: string,
+  sshHost?: string | null,
+): Promise<void> {
+  for (const command of buildTmuxPaneLayoutCommands(sessionName, layoutType, panes, worktreePath)) {
+    await execGit(command, sshHost);
   }
 }
 


### PR DESCRIPTION
## Related Materials
- Base branch: `refactor/nextron`
- Commit: `d7e5ada`

## What does this PR do?
- stabilizes remote project registration and worktree discovery so SSH scans are no longer blocked by root hook repair
- restores remote tmux pane bootstrapping for newly created tasks
- reduces remote command overhead across SSH execution and hook installation

## How is it fixed?
### Remote project and terminal reliability
- defer root hook repair for SSH-backed project registration and scan flows, then repair in the background
- pass the saved pane layout into remote tmux attach so the first attach recreates the expected pane split
- cache parsed SSH config entries and enable SSH control socket reuse for repeated remote commands

### Remote hook installation and verification
- write generated Claude, Gemini, Codex, and OpenCode artifacts into the repository common git exclude so remote worktrees stay untracked correctly
- batch remote hook file writes and move remote verification off the install critical path to cut SSH round-trips
- treat hook server reachability as diagnostic information instead of reporting the install itself as failed when files and config are already correct

## Important changes
### Remote scanning and worktree setup
- remote scan and register flows can keep discovering worktrees even if hook repair fails temporarily
- new remote tmux tasks start with the saved pane layout instead of a single default pane

### Hook setup performance and correctness
- remote hook installs now target the common git dir for ignore rules
- remote hook status no longer reports false negatives caused only by temporary health-check failures
- repeated remote SSH and hook validation lookups are cached to reduce latency

Co-Authored-By: OpenAI Codex <codex@openai.com>
