### PR TITLE
fix(desktop): stabilize hook setup and route caching

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -115,6 +115,7 @@ describe("kanbanService.createTask", () => {
         null,
       );
     } finally {
+      vi.clearAllTimers();
       vi.useRealTimers();
     }
   });
@@ -158,6 +159,61 @@ describe("kanbanService.createTask", () => {
         "task-1",
         null,
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("원격 worktree 태스크 생성은 hooks 설치 완료를 기다린다", async () => {
+    vi.useFakeTimers();
+
+    try {
+      // Given
+      mocks.projectRepo.findOneBy.mockResolvedValue({
+        id: "project-1",
+        repoPath: "/remote/repo",
+        defaultBranch: "main",
+        sshHost: "remote-host",
+      });
+      mocks.createWorktreeWithSession.mockResolvedValue({
+        worktreePath: "/remote/repo-worktrees/task-1",
+        sessionName: "task-1",
+      });
+      let resolveInstall: (() => void) | undefined;
+      mocks.installKanvibeHooks.mockImplementation(() => new Promise<void>((resolve) => {
+        resolveInstall = resolve;
+      }));
+      mocks.taskRepo.save.mockImplementation(async (value) => ({ id: "task-1", ...value }));
+
+      const { createTask } = await import("@/desktop/main/services/kanbanService");
+
+      // When
+      let settled = false;
+      const resultPromise = createTask({
+        title: "원격 hooks 보장",
+        branchName: "fix/remote-hooks",
+        projectId: "project-1",
+        sessionType: "tmux" as never,
+      }).then((result) => {
+        settled = true;
+        return result;
+      });
+      for (let index = 0; index < 6; index += 1) {
+        await Promise.resolve();
+      }
+
+      // Then
+      expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
+        "/remote/repo-worktrees/task-1",
+        "task-1",
+        "remote-host",
+      );
+      expect(settled).toBe(false);
+
+      if (resolveInstall) {
+        resolveInstall();
+      }
+      await expect(resultPromise).resolves.toEqual(expect.objectContaining({ id: "task-1" }));
     } finally {
       vi.useRealTimers();
     }

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -246,15 +246,19 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
 
   const saved = await repo.save(task);
 
-  broadcastBoardUpdate();
-
   if (shouldInstallHooks && hookTargetPath) {
-    scheduleTaskHookInstall(hookTargetPath, {
-      id: saved.id,
-      title: saved.title,
-      sshHost: saved.sshHost,
-    });
+    if (saved.sshHost) {
+      await installKanvibeHooks(hookTargetPath, saved.id, saved.sshHost);
+    } else {
+      scheduleTaskHookInstall(hookTargetPath, {
+        id: saved.id,
+        title: saved.title,
+        sshHost: saved.sshHost,
+      });
+    }
   }
+
+  broadcastBoardUpdate();
 
   return serialize(saved);
 }

--- a/src/desktop/renderer/routes/BoardRoute.tsx
+++ b/src/desktop/renderer/routes/BoardRoute.tsx
@@ -3,6 +3,7 @@ import Board from "@/components/Board";
 import { getDoneAlertDismissed, getDefaultSessionType, getNotificationSettings, getSidebarDefaultCollapsed } from "@/desktop/renderer/actions/appSettings";
 import { getTasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { getAllProjects, getAvailableHosts } from "@/desktop/renderer/actions/project";
+import { buildRouteCacheKey, readRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
 
 interface BoardData {
@@ -15,9 +16,11 @@ interface BoardData {
   defaultSessionType: Awaited<ReturnType<typeof getDefaultSessionType>>;
 }
 
+const BOARD_ROUTE_CACHE_KEY = buildRouteCacheKey("board");
+
 export default function BoardRoute() {
   const refreshSignal = useRefreshSignal(["all", "board"]);
-  const [data, setData] = useState<BoardData | null>(null);
+  const [data, setData] = useState<BoardData | null>(() => readRouteCache<BoardData>(BOARD_ROUTE_CACHE_KEY));
 
   useEffect(() => {
     document.title = "";
@@ -36,7 +39,7 @@ export default function BoardRoute() {
       getDefaultSessionType(),
     ]).then(([tasks, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings, defaultSessionType]) => {
       if (!cancelled) {
-        setData({
+        const nextData = {
           tasks,
           sshHosts,
           projects,
@@ -44,7 +47,10 @@ export default function BoardRoute() {
           doneAlertDismissed,
           notificationSettings,
           defaultSessionType,
-        });
+        };
+
+        writeRouteCache(BOARD_ROUTE_CACHE_KEY, nextData);
+        setData(nextData);
       }
     });
 

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/desktop/renderer/actions/project";
 import TerminalLoader from "@/desktop/renderer/components/TerminalLoader";
 import { fetchPrUrlWithPrompt } from "@/desktop/renderer/utils/fetchPrUrlWithPrompt";
+import { buildRouteCacheKey, readRouteCache, removeRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
 import { TaskStatus } from "@/entities/KanbanTask";
 
@@ -74,13 +75,21 @@ const DEFAULT_DETAIL_STATE: Omit<TaskDetailState, "task"> = {
   doneAlertDismissed: false,
 };
 
+function getTaskDetailRouteCacheKey(taskId: string) {
+  return buildRouteCacheKey("task-detail", taskId);
+}
+
 export default function TaskDetailRoute() {
   const { id = "" } = useParams();
   const router = useRouter();
   const t = useTranslations("taskDetail");
   const tc = useTranslations("common");
   const refreshSignal = useRefreshSignal(["all", "task-detail"]);
-  const [state, setState] = useState<TaskDetailState | null | undefined>(undefined);
+  const cachedState = useMemo(
+    () => (id ? readRouteCache<TaskDetailState>(getTaskDetailRouteCacheKey(id)) : null),
+    [id],
+  );
+  const [state, setState] = useState<TaskDetailState | null | undefined>(cachedState ?? undefined);
   const [needsMacDesktopHeaderOffset, setNeedsMacDesktopHeaderOffset] = useState(false);
 
   useEffect(() => {
@@ -88,6 +97,34 @@ export default function TaskDetailRoute() {
     const isMacDesktop = navigator.userAgent.includes("Mac") || navigator.platform.toLowerCase().includes("mac");
     setNeedsMacDesktopHeaderOffset(isDesktopApp && isMacDesktop);
   }, []);
+
+  useEffect(() => {
+    setState(cachedState ?? undefined);
+  }, [cachedState, id]);
+
+  useEffect(() => {
+    if (!state || state === null) {
+      return;
+    }
+
+    document.title = [state.task.branchName, state.task.project?.name].filter(Boolean).join(" - ");
+  }, [state]);
+
+  useEffect(() => {
+    if (!id) {
+      return;
+    }
+
+    const cacheKey = getTaskDetailRouteCacheKey(id);
+    if (state === null) {
+      removeRouteCache(cacheKey);
+      return;
+    }
+
+    if (state !== undefined) {
+      writeRouteCache(cacheKey, state);
+    }
+  }, [id, state]);
 
   useEffect(() => {
     let cancelled = false;
@@ -105,11 +142,18 @@ export default function TaskDetailRoute() {
         return;
       }
 
-      document.title = [task.branchName, task.project?.name].filter(Boolean).join(" - ");
-      setState({
-        task,
-        ...DEFAULT_DETAIL_STATE,
-      });
+      setState((current) => current && current.task.id === task.id
+        ? {
+            ...current,
+            task: {
+              ...current.task,
+              ...task,
+            },
+          }
+        : {
+            task,
+            ...DEFAULT_DETAIL_STATE,
+          });
 
       if (task.branchName && !task.prUrl) {
         void (async () => {

--- a/src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import BoardRoute from "@/desktop/renderer/routes/BoardRoute";
+
+const BOARD_CACHE_KEY = "kanvibe:route-cache:board";
+
+const mocks = vi.hoisted(() => ({
+  getTasksByStatus: vi.fn(),
+  getAvailableHosts: vi.fn(),
+  getAllProjects: vi.fn(),
+  getSidebarDefaultCollapsed: vi.fn(),
+  getDoneAlertDismissed: vi.fn(),
+  getNotificationSettings: vi.fn(),
+  getDefaultSessionType: vi.fn(),
+  useRefreshSignal: vi.fn(() => 0),
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+vi.mock("@/components/Board", () => ({
+  default: ({ initialTasks }: { initialTasks: Record<string, Array<{ title: string }>> }) => (
+    <div data-testid="board-titles">{Object.values(initialTasks).flat().map((task) => task.title).join(",")}</div>
+  ),
+}));
+
+vi.mock("@/desktop/renderer/actions/kanban", () => ({
+  getTasksByStatus: (...args: unknown[]) => mocks.getTasksByStatus(...args),
+}));
+
+vi.mock("@/desktop/renderer/actions/project", () => ({
+  getAvailableHosts: (...args: unknown[]) => mocks.getAvailableHosts(...args),
+  getAllProjects: (...args: unknown[]) => mocks.getAllProjects(...args),
+}));
+
+vi.mock("@/desktop/renderer/actions/appSettings", () => ({
+  getSidebarDefaultCollapsed: (...args: unknown[]) => mocks.getSidebarDefaultCollapsed(...args),
+  getDoneAlertDismissed: (...args: unknown[]) => mocks.getDoneAlertDismissed(...args),
+  getNotificationSettings: (...args: unknown[]) => mocks.getNotificationSettings(...args),
+  getDefaultSessionType: (...args: unknown[]) => mocks.getDefaultSessionType(...args),
+}));
+
+vi.mock("@/desktop/renderer/utils/refresh", () => ({
+  useRefreshSignal: () => mocks.useRefreshSignal(),
+}));
+
+describe("BoardRoute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mocks.getAvailableHosts.mockResolvedValue([]);
+    mocks.getAllProjects.mockResolvedValue([]);
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(false);
+    mocks.getDoneAlertDismissed.mockResolvedValue(false);
+    mocks.getNotificationSettings.mockResolvedValue({ isEnabled: true, enabledStatuses: [] });
+    mocks.getDefaultSessionType.mockResolvedValue("tmux");
+  });
+
+  it("캐시가 있으면 stale board를 즉시 렌더링하고 이후 최신 데이터로 갱신한다", async () => {
+    // Given
+    sessionStorage.setItem(BOARD_CACHE_KEY, JSON.stringify({
+      tasks: {
+        tasks: {
+          todo: [{ id: "cached-task", title: "cached board task" }],
+          progress: [],
+          pending: [],
+          review: [],
+          done: [],
+        },
+        doneTotal: 0,
+        doneLimit: 20,
+      },
+      sshHosts: [],
+      projects: [],
+      sidebarDefaultCollapsed: false,
+      doneAlertDismissed: false,
+      notificationSettings: { isEnabled: true, enabledStatuses: [] },
+      defaultSessionType: "tmux",
+    }));
+    const deferredTasks = createDeferred<{
+      tasks: {
+        todo: Array<{ id: string; title: string }>;
+        progress: never[];
+        pending: never[];
+        review: never[];
+        done: never[];
+      };
+      doneTotal: number;
+      doneLimit: number;
+    }>();
+    mocks.getTasksByStatus.mockReturnValue(deferredTasks.promise);
+
+    // When
+    render(<BoardRoute />);
+
+    // Then
+    expect(screen.queryByText("Loading...")).toBeNull();
+    expect(screen.getByTestId("board-titles").textContent).toBe("cached board task");
+
+    deferredTasks.resolve({
+      tasks: {
+        todo: [{ id: "fresh-task", title: "fresh board task" }],
+        progress: [],
+        pending: [],
+        review: [],
+        done: [],
+      },
+      doneTotal: 0,
+      doneLimit: 20,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("board-titles").textContent).toBe("fresh board task");
+    });
+  });
+});

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -1,0 +1,235 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TaskDetailRoute from "@/desktop/renderer/routes/TaskDetailRoute";
+
+const TASK_DETAIL_CACHE_KEY = "kanvibe:route-cache:task-detail:task-1";
+
+const mocks = vi.hoisted(() => ({
+  getTaskById: vi.fn(),
+  getTaskIdByProjectAndBranch: vi.fn(),
+  updateTaskStatus: vi.fn(),
+  deleteTask: vi.fn(),
+  getGitDiffFiles: vi.fn(),
+  getTaskHooksStatus: vi.fn(),
+  getTaskGeminiHooksStatus: vi.fn(),
+  getTaskCodexHooksStatus: vi.fn(),
+  getTaskOpenCodeHooksStatus: vi.fn(),
+  getTaskAiSessions: vi.fn(),
+  getSidebarDefaultCollapsed: vi.fn(),
+  getSidebarHintDismissed: vi.fn(),
+  getDoneAlertDismissed: vi.fn(),
+  fetchPrUrlWithPrompt: vi.fn(),
+  useRefreshSignal: vi.fn(() => 0),
+  push: vi.fn(),
+  back: vi.fn(),
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("react-router-dom", () => ({
+  useParams: () => ({ id: "task-1" }),
+}));
+
+vi.mock("@/desktop/renderer/navigation", () => ({
+  Link: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  useRouter: () => ({ push: mocks.push, back: mocks.back }),
+}));
+
+vi.mock("@/desktop/renderer/utils/refresh", () => ({
+  useRefreshSignal: () => mocks.useRefreshSignal(),
+}));
+
+vi.mock("@/desktop/renderer/actions/kanban", () => ({
+  getTaskById: (...args: unknown[]) => mocks.getTaskById(...args),
+  getTaskIdByProjectAndBranch: (...args: unknown[]) => mocks.getTaskIdByProjectAndBranch(...args),
+  updateTaskStatus: (...args: unknown[]) => mocks.updateTaskStatus(...args),
+  deleteTask: (...args: unknown[]) => mocks.deleteTask(...args),
+}));
+
+vi.mock("@/desktop/renderer/actions/diff", () => ({
+  getGitDiffFiles: (...args: unknown[]) => mocks.getGitDiffFiles(...args),
+}));
+
+vi.mock("@/desktop/renderer/actions/project", () => ({
+  getTaskHooksStatus: (...args: unknown[]) => mocks.getTaskHooksStatus(...args),
+  getTaskGeminiHooksStatus: (...args: unknown[]) => mocks.getTaskGeminiHooksStatus(...args),
+  getTaskCodexHooksStatus: (...args: unknown[]) => mocks.getTaskCodexHooksStatus(...args),
+  getTaskOpenCodeHooksStatus: (...args: unknown[]) => mocks.getTaskOpenCodeHooksStatus(...args),
+  getTaskAiSessions: (...args: unknown[]) => mocks.getTaskAiSessions(...args),
+}));
+
+vi.mock("@/desktop/renderer/actions/appSettings", () => ({
+  getSidebarDefaultCollapsed: (...args: unknown[]) => mocks.getSidebarDefaultCollapsed(...args),
+  getSidebarHintDismissed: (...args: unknown[]) => mocks.getSidebarHintDismissed(...args),
+  getDoneAlertDismissed: (...args: unknown[]) => mocks.getDoneAlertDismissed(...args),
+}));
+
+vi.mock("@/desktop/renderer/utils/fetchPrUrlWithPrompt", () => ({
+  fetchPrUrlWithPrompt: (...args: unknown[]) => mocks.fetchPrUrlWithPrompt(...args),
+}));
+
+vi.mock("@/components/AiSessionsCard", () => ({
+  default: () => <div data-testid="ai-sessions-card" />,
+}));
+
+vi.mock("@/components/CollapsibleSidebar", () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ConnectTerminalForm", () => ({
+  default: () => <div data-testid="connect-terminal-form" />,
+}));
+
+vi.mock("@/components/DeleteTaskButton", () => ({
+  default: () => <button type="button">delete</button>,
+}));
+
+vi.mock("@/components/DoneStatusButton", () => ({
+  default: () => <button type="button">done</button>,
+}));
+
+vi.mock("@/components/HooksStatusCard", () => ({
+  default: () => <div data-testid="hooks-status-card" />,
+}));
+
+vi.mock("@/components/NotificationCenterButton", () => ({
+  default: () => <div data-testid="notification-center" />,
+}));
+
+vi.mock("@/components/TaskDetailInfoCard", () => ({
+  default: ({ task }: { task: { branchName: string | null } }) => (
+    <div data-testid="task-info">{task.branchName ?? "no-branch"}</div>
+  ),
+}));
+
+vi.mock("@/components/TaskDetailTitleCard", () => ({
+  default: ({ task }: { task: { title: string } }) => (
+    <div data-testid="task-title">{task.title}</div>
+  ),
+}));
+
+vi.mock("@/desktop/renderer/components/TerminalLoader", () => ({
+  default: () => <div data-testid="terminal-loader" />,
+}));
+
+describe("TaskDetailRoute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mocks.getTaskIdByProjectAndBranch.mockResolvedValue(null);
+    mocks.getGitDiffFiles.mockResolvedValue([]);
+    mocks.getTaskHooksStatus.mockResolvedValue(null);
+    mocks.getTaskGeminiHooksStatus.mockResolvedValue(null);
+    mocks.getTaskCodexHooksStatus.mockResolvedValue(null);
+    mocks.getTaskOpenCodeHooksStatus.mockResolvedValue(null);
+    mocks.getTaskAiSessions.mockResolvedValue({
+      isRemote: false,
+      targetPath: null,
+      repoPath: null,
+      sessions: [],
+      sources: [],
+    });
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(false);
+    mocks.getSidebarHintDismissed.mockResolvedValue(false);
+    mocks.getDoneAlertDismissed.mockResolvedValue(false);
+    mocks.updateTaskStatus.mockResolvedValue(null);
+    mocks.deleteTask.mockResolvedValue(true);
+    mocks.fetchPrUrlWithPrompt.mockResolvedValue(null);
+  });
+
+  it("캐시가 있으면 stale task detail을 즉시 렌더링하고 이후 최신 데이터로 갱신한다", async () => {
+    // Given
+    sessionStorage.setItem(TASK_DETAIL_CACHE_KEY, JSON.stringify({
+      task: {
+        id: "task-1",
+        title: "cached task title",
+        description: null,
+        branchName: "feat/cached",
+        baseBranch: "main",
+        prUrl: "https://example.com/cached",
+        sessionType: null,
+        sessionName: null,
+        sshHost: null,
+        projectId: "project-1",
+        project: { id: "project-1", name: "kanvibe" },
+        status: "todo",
+        agentType: null,
+        worktreePath: "/repo__worktrees/cached",
+      },
+      baseBranchTaskId: null,
+      diffFiles: [],
+      claudeHooksStatus: null,
+      geminiHooksStatus: null,
+      codexHooksStatus: null,
+      openCodeHooksStatus: null,
+      aiSessions: {
+        isRemote: false,
+        targetPath: null,
+        repoPath: null,
+        sessions: [],
+        sources: [],
+      },
+      sidebarDefaultCollapsed: false,
+      sidebarHintDismissed: false,
+      doneAlertDismissed: false,
+    }));
+    const deferredTask = createDeferred<{
+      id: string;
+      title: string;
+      description: null;
+      branchName: string;
+      baseBranch: string;
+      prUrl: string;
+      sessionType: null;
+      sessionName: null;
+      sshHost: null;
+      projectId: string;
+      project: { id: string; name: string };
+      status: string;
+      agentType: null;
+      worktreePath: string;
+    } | null>();
+    mocks.getTaskById.mockReturnValue(deferredTask.promise);
+
+    // When
+    render(<TaskDetailRoute />);
+
+    // Then
+    expect(screen.queryByText("Loading...")).toBeNull();
+    expect(screen.getByTestId("task-title").textContent).toBe("cached task title");
+
+    deferredTask.resolve({
+      id: "task-1",
+      title: "fresh task title",
+      description: null,
+      branchName: "feat/fresh",
+      baseBranch: "main",
+      prUrl: "https://example.com/fresh",
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/fresh",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-title").textContent).toBe("fresh task title");
+    });
+  });
+});

--- a/src/desktop/renderer/utils/routeCache.ts
+++ b/src/desktop/renderer/utils/routeCache.ts
@@ -1,0 +1,34 @@
+const ROUTE_CACHE_PREFIX = "kanvibe:route-cache";
+
+export function buildRouteCacheKey(scope: string, id?: string): string {
+  return id ? `${ROUTE_CACHE_PREFIX}:${scope}:${id}` : `${ROUTE_CACHE_PREFIX}:${scope}`;
+}
+
+export function readRouteCache<T>(key: string): T | null {
+  try {
+    const raw = sessionStorage.getItem(key);
+    if (!raw) {
+      return null;
+    }
+
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function writeRouteCache<T>(key: string, value: T): void {
+  try {
+    sessionStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* sessionStorage 접근 실패 시 캐시를 건너뛴다 */
+  }
+}
+
+export function removeRouteCache(key: string): void {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    /* sessionStorage 접근 실패 시 캐시 삭제를 건너뛴다 */
+  }
+}

--- a/src/lib/__tests__/gitExclude.test.ts
+++ b/src/lib/__tests__/gitExclude.test.ts
@@ -73,6 +73,54 @@ describe("gitExclude", () => {
       expect(content).toContain(".claude/hooks/");
     });
 
+    it("should restore missing patterns when only the marker block remains", async () => {
+      // Given
+      const excludePath = join(tempDir, ".git", "info", "exclude");
+      await writeFile(excludePath, "# KanVibe AI hooks (auto-generated)\n", "utf-8");
+
+      // When
+      await addAiToolPatternsToGitExclude(tempDir);
+
+      // Then
+      const content = await readFile(excludePath, "utf-8");
+      expect(content).toContain("# KanVibe AI hooks (auto-generated)");
+      expect(content).toContain(".claude/hooks/");
+      expect(content).toContain(".codex/config.toml");
+      expect(content).toContain(".opencode/plugins/");
+    });
+
+    it("should update the shared common-dir exclude when called from a linked worktree", async () => {
+      // Given
+      execSync('git config user.name "KanVibe Test"', { cwd: tempDir, stdio: "ignore" });
+      execSync('git config user.email "kanvibe@example.com"', { cwd: tempDir, stdio: "ignore" });
+      await writeFile(join(tempDir, "README.md"), "# test\n", "utf-8");
+      execSync("git add README.md", { cwd: tempDir, stdio: "ignore" });
+      execSync('git commit -m "init"', { cwd: tempDir, stdio: "ignore" });
+
+      const worktreeDir = await mkdtemp(join(tmpdir(), "git-exclude-worktree-"));
+      execSync(`git worktree add -b feature/test "${worktreeDir}" HEAD`, { cwd: tempDir, stdio: "ignore" });
+
+      const commonDir = execSync("git rev-parse --path-format=absolute --git-common-dir", {
+        cwd: worktreeDir,
+        encoding: "utf-8",
+      }).trim();
+      const commonExcludePath = join(commonDir, "info", "exclude");
+      await writeFile(commonExcludePath, "# KanVibe AI hooks (auto-generated)\n", "utf-8");
+
+      try {
+        // When
+        await addAiToolPatternsToGitExclude(worktreeDir);
+
+        // Then
+        const content = await readFile(commonExcludePath, "utf-8");
+        expect(content).toContain(".claude/hooks/");
+        expect(content).toContain(".gemini/settings.json");
+        expect(content).toContain(".codex/hooks.json");
+      } finally {
+        await rm(worktreeDir, { recursive: true, force: true });
+      }
+    });
+
     it("should throw when path is not a git repository", async () => {
       // Given
       const nonGitDir = await mkdtemp(join(tmpdir(), "non-git-"));

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -120,6 +120,20 @@ describe("kanvibeHooksInstaller", () => {
     expect(mockGetHookServerUrl).toHaveBeenCalledWith("remote-host");
   });
 
+  it("원격 프로젝트면 hooks 파일 설치 전에 git exclude도 함께 갱신한다", async () => {
+    // Given
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledWith(
+      expect.stringContaining('git -C "/remote/repo" rev-parse --path-format=absolute --git-common-dir'),
+      "remote-host",
+    );
+  });
+
   it("원격 Claude/Gemini stale hook entry도 재설치 시 현재 project 경로로 덮어쓴다", async () => {
     mockExecGit.mockImplementation(async (command: string) => {
       if (command.includes('cat "/remote/repo/.claude/settings.json"')) {
@@ -202,7 +216,7 @@ describe("kanvibeHooksInstaller", () => {
 
     // Then
     await expect(result).rejects.toThrow("remote host unavailable");
-    expect(mockExecGit).toHaveBeenCalledTimes(1);
+    expect(mockExecGit).toHaveBeenCalledTimes(2);
   });
 
   it("로컬 hook 설치 중 하나라도 실패하면 예외를 전파한다", async () => {

--- a/src/lib/gitExclude.ts
+++ b/src/lib/gitExclude.ts
@@ -1,7 +1,8 @@
-import { exec } from "child_process";
-import { promisify } from "util";
 import { readFile, writeFile, mkdir } from "fs/promises";
 import path from "path";
+import { exec } from "child_process";
+import { promisify } from "util";
+import { execGit } from "@/lib/gitOperations";
 
 const execAsync = promisify(exec);
 
@@ -18,41 +19,133 @@ const EXCLUDE_PATTERNS = [
   ".opencode/plugins/",
 ];
 
-/**
- * AI 코딩 도구의 hooks 설정 파일을 .git/info/excluded에 추가하여 git tracking에서 제외한다.
- * 마커 블록을 사용해 멱등성을 보장하며, 실패해도 예외를 던지지 않는다.
- * @param repoPath - worktree 또는 저장소 경로
- */
-export async function addAiToolPatternsToGitExclude(
-  repoPath: string
-): Promise<void> {
-  const { stdout } = await execAsync("git rev-parse --git-dir", {
-    cwd: repoPath,
-  });
-  const gitDir = stdout.trim();
-  const absoluteGitDir = path.isAbsolute(gitDir)
-    ? gitDir
-    : path.join(repoPath, gitDir);
-
-  const infoDir = path.join(absoluteGitDir, "info");
-  await mkdir(infoDir, { recursive: true });
-
-  const excludedPath = path.join(infoDir, "exclude");
-
-  let content = "";
-  try {
-    content = await readFile(excludedPath, "utf-8");
-  } catch {
-    /* 파일이 없으면 새로 생성 */
+function resolveAbsoluteGitPath(repoPath: string, gitPath: string, pathModule: typeof path | typeof path.posix): string {
+  const trimmed = gitPath.trim();
+  if (!trimmed) {
+    return repoPath;
   }
 
-  if (content.includes(MARKER)) return;
+  if (pathModule.isAbsolute(trimmed)) {
+    return trimmed;
+  }
 
-  const block = [
-    "",
-    MARKER,
-    ...EXCLUDE_PATTERNS,
-  ].join("\n") + "\n";
+  return pathModule.join(repoPath, trimmed);
+}
 
-  await writeFile(excludedPath, content.trimEnd() + "\n" + block, "utf-8");
+function buildExcludeContent(currentContent: string): string {
+  const lines = currentContent.replace(/\r\n/g, "\n").split("\n");
+  const preservedLines: string[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line !== MARKER) {
+      preservedLines.push(line);
+      continue;
+    }
+
+    index += 1;
+    while (index < lines.length && (EXCLUDE_PATTERNS.includes(lines[index]) || lines[index] === "")) {
+      index += 1;
+    }
+    index -= 1;
+  }
+
+  const preservedContent = preservedLines.join("\n").trimEnd();
+  const block = [MARKER, ...EXCLUDE_PATTERNS].join("\n");
+
+  if (!preservedContent) {
+    return `${block}\n`;
+  }
+
+  return `${preservedContent}\n\n${block}\n`;
+}
+
+async function readOptionalFile(filePath: string): Promise<string> {
+  try {
+    return await readFile(filePath, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+async function writeExcludeFile(filePath: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+
+  const currentContent = await readOptionalFile(filePath);
+  const nextContent = buildExcludeContent(currentContent);
+  if (currentContent === nextContent) {
+    return;
+  }
+
+  await writeFile(filePath, nextContent, "utf-8");
+}
+
+async function getLocalExcludePaths(repoPath: string): Promise<string[]> {
+  const [{ stdout: gitDirOutput }, { stdout: commonDirOutput }] = await Promise.all([
+    execAsync("git rev-parse --git-dir", { cwd: repoPath }),
+    execAsync("git rev-parse --git-common-dir", { cwd: repoPath }),
+  ]);
+
+  const gitDir = resolveAbsoluteGitPath(repoPath, gitDirOutput, path);
+  const commonDir = resolveAbsoluteGitPath(repoPath, commonDirOutput, path);
+
+  return [...new Set([
+    path.join(gitDir, "info", "exclude"),
+    path.join(commonDir, "info", "exclude"),
+  ])];
+}
+
+async function readRemoteTextFile(filePath: string, sshHost: string): Promise<string> {
+  return execGit(`test -f "${filePath}" && cat "${filePath}" || true`, sshHost);
+}
+
+async function writeRemoteTextFile(filePath: string, content: string, sshHost: string): Promise<void> {
+  const encodedContent = Buffer.from(content, "utf-8").toString("base64");
+  await execGit(
+    `mkdir -p "${path.posix.dirname(filePath)}" && printf '%s' '${encodedContent}' | (base64 -d 2>/dev/null || base64 -D) > "${filePath}"`,
+    sshHost,
+  );
+}
+
+async function getRemoteExcludePaths(repoPath: string, sshHost: string): Promise<string[]> {
+  const [gitDirOutput, commonDirOutput] = await Promise.all([
+    execGit(`git -C "${repoPath}" rev-parse --path-format=absolute --git-dir`, sshHost),
+    execGit(`git -C "${repoPath}" rev-parse --path-format=absolute --git-common-dir`, sshHost),
+  ]);
+
+  const gitDir = resolveAbsoluteGitPath(repoPath, gitDirOutput, path.posix);
+  const commonDir = resolveAbsoluteGitPath(repoPath, commonDirOutput, path.posix);
+
+  return [...new Set([
+    path.posix.join(gitDir, "info", "exclude"),
+    path.posix.join(commonDir, "info", "exclude"),
+  ])];
+}
+
+/**
+ * AI 코딩 도구의 hooks 설정 파일을 .git/info/exclude에 추가하여 git tracking에서 제외한다.
+ * worktree 저장소에서는 현재 gitdir과 공용 git common dir 둘 다 갱신한다.
+ * @param repoPath - worktree 또는 저장소 경로
+ */
+export async function addAiToolPatternsToGitExclude(repoPath: string): Promise<void> {
+  const excludePaths = await getLocalExcludePaths(repoPath);
+  await Promise.all(excludePaths.map((excludePath) => writeExcludeFile(excludePath)));
+}
+
+/**
+ * 원격 저장소의 현재 gitdir과 공용 git common dir exclude 파일을 갱신한다.
+ * linked worktree와 main worktree 모두에서 동일한 ignore 규칙이 적용되도록 한다.
+ */
+export async function addAiToolPatternsToGitExcludeRemote(repoPath: string, sshHost: string): Promise<void> {
+  const excludePaths = await getRemoteExcludePaths(repoPath, sshHost);
+
+  for (const excludePath of excludePaths) {
+    const currentContent = await readRemoteTextFile(excludePath, sshHost);
+    const nextContent = buildExcludeContent(currentContent);
+    if (currentContent === nextContent) {
+      continue;
+    }
+
+    await writeRemoteTextFile(excludePath, nextContent, sshHost);
+  }
 }

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -21,6 +21,7 @@ import {
 } from "@/lib/codexHooksSetup";
 import { setupOpenCodeHooks, getOpenCodeHooksStatus, generatePluginScript, PLUGIN_DIR_NAME, PLUGIN_FILE_NAME, type OpenCodeHooksStatus } from "@/lib/openCodeHooksSetup";
 import { getHookServerToken, getHookServerUrl } from "@/lib/hookEndpoint";
+import { addAiToolPatternsToGitExcludeRemote } from "@/lib/gitExclude";
 
 export async function installKanvibeHooks(
   targetPath: string,
@@ -29,6 +30,10 @@ export async function installKanvibeHooks(
 ): Promise<void> {
   const hookServerUrl = await getHookServerUrl(sshHost);
   const hookServerToken = getHookServerToken();
+
+  if (sshHost) {
+    await addAiToolPatternsToGitExcludeRemote(targetPath, sshHost);
+  }
 
   const installers = [
     {


### PR DESCRIPTION
## Related
- None

## What is this?
- Fix desktop hook setup regressions and reduce perceived loading latency on back navigation and refresh.

## How does it work?
**Hook setup reliability**
- Rewrite the KanVibe git exclude block instead of stopping on marker-only files.
- Update both the linked-worktree git metadata and the shared git common dir, and apply the same exclude repair before remote hook installation.
- Wait for remote task hook installation during task creation while keeping local task installation asynchronous.

**Desktop route cache**
- Add a sessionStorage-backed stale-while-revalidate cache for the Board and Task Detail routes.
- Render cached data immediately on back navigation or refresh, then update it in the background.

## Important changes
### Hook setup reliability

**Repair exclude updates for linked worktrees and remote installs**
- **Why**: hook and config artifacts could still appear in `git status` and `git diff` when the shared exclude block was incomplete.
- **Files**: `src/lib/gitExclude.ts`, `src/lib/kanvibeHooksInstaller.ts`, `src/lib/__tests__/gitExclude.test.ts`, `src/lib/__tests__/kanvibeHooksInstaller.test.ts`

**Guarantee remote task hook installation before returning**
- **Why**: remote task creation could finish before background hook setup completed.
- **Files**: `src/desktop/main/services/kanbanService.ts`, `src/desktop/main/services/__tests__/kanbanService.test.ts`

### Desktop loading performance

**Cache board and task detail route state**
- **Why**: back navigation and refresh showed a full-screen loading state even when fresh data had just been fetched.
- **Files**: `src/desktop/renderer/routes/BoardRoute.tsx`, `src/desktop/renderer/routes/TaskDetailRoute.tsx`, `src/desktop/renderer/utils/routeCache.ts`, `src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx`, `src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx`

Co-Authored-By: OpenAI Codex <codex@openai.com>
