### PR TITLE
build(desktop): macOS dmg 파일명을 kanvibe로 고정

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -26,4 +26,7 @@ mac:
     - dmg
     - zip
 
+dmg:
+  artifactName: "kanvibe.${ext}"
+
 publish: null


### PR DESCRIPTION
## 관련 자료
- 이슈 : 없음

## 어떤 작업인가요?
- macOS 배포 시 생성되는 DMG 파일명을 `kanvibe.dmg`로 고정합니다.

## 어떻게 해결했나요?
**DMG 산출물 이름 분리**
- `electron-builder.yml`에 `dmg.artifactName`을 추가해 `productName`과 무관하게 DMG 파일명이 생성되도록 했습니다.
- ZIP 타깃과 앱 표시 이름은 그대로 유지해 DMG 산출물에만 변경이 적용되도록 제한했습니다.

**기존 빌드 흐름 유지**
- 변경 후 `pnpm build`를 실행해 일반 빌드 흐름이 유지되는지 확인했습니다.
- macOS 전용 DMG 실생성은 현재 Linux 환경 한계로 확인 범위에서 제외했습니다.

## 중요한 변경 사항은 무엇인가요?
### DMG 파일명 고정

**Electron Builder DMG 설정 추가**
- **변경 이유**: 배포 결과물이 제품명 기반 기본 이름 대신 `kanvibe.dmg`로 생성되도록 맞추기 위해
- **수정 파일**: `electron-builder.yml`

Co-authored-by: OpenAI Codex <codex@openai.com>
