### PR TITLE
fix(desktop): reuse existing detail windows on navigation

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -229,12 +229,27 @@ function registerAppWindow(browserWindow) {
 }
 
 async function focusMainWindow(relativePath) {
-  if (!mainWindow || mainWindow.isDestroyed()) {
-    mainWindow = getAvailableWindows()[0] || null;
+  const targetUrl = relativePath ? getRendererNavigationUrl(relativePath) : null;
+  const availableWindows = getAvailableWindows();
+  const fallbackWindow = mainWindow && !mainWindow.isDestroyed()
+    ? mainWindow
+    : availableWindows[0] || null;
+
+  if (targetUrl) {
+    const { resolveNavigationTargetWindow } = getWindowOpenHelpers();
+    mainWindow = resolveNavigationTargetWindow({
+      preferredWindow: fallbackWindow,
+      targetUrl,
+      rendererDevUrl: RENDERER_DEV_URL,
+      openWindows: availableWindows,
+      getWindowUrl: (window) => window.webContents.getURL(),
+    });
+  } else {
+    mainWindow = fallbackWindow;
   }
 
   if (!mainWindow || mainWindow.isDestroyed()) {
-    await createMainWindow();
+    await createMainWindow(relativePath);
   }
 
   if (!mainWindow) {
@@ -247,7 +262,6 @@ async function focusMainWindow(relativePath) {
     return;
   }
 
-  const targetUrl = getRendererNavigationUrl(relativePath);
   if (mainWindow.webContents.getURL() !== targetUrl) {
     await mainWindow.loadURL(targetUrl);
   }
@@ -454,8 +468,8 @@ async function createAppWindow(target = getRendererNavigationUrl()) {
   return browserWindow;
 }
 
-async function createMainWindow() {
-  return createAppWindow();
+async function createMainWindow(target) {
+  return createAppWindow(target);
 }
 
 app.whenReady().then(async () => {

--- a/src/desktop/main/__tests__/windowOpen.test.ts
+++ b/src/desktop/main/__tests__/windowOpen.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { resolveWindowOpenAction } from "@/desktop/main/windowOpen";
+import { resolveNavigationTargetWindow, resolveWindowOpenAction } from "@/desktop/main/windowOpen";
 
 describe("resolveWindowOpenAction", () => {
   it("file 기반 내부 URL은 독립적인 내부 창 열기로 판단한다", () => {
@@ -70,5 +70,49 @@ describe("resolveWindowOpenAction", () => {
     expect(result).toEqual({
       type: "external",
     });
+  });
+});
+
+describe("resolveNavigationTargetWindow", () => {
+  it("이동 대상과 같은 상세 route 창이 이미 열려 있으면 그 창을 선택한다", () => {
+    const preferredWindow = {
+      id: "window-1",
+      url: "http://localhost:3000/#/ko",
+    };
+    const detailWindow = {
+      id: "window-2",
+      url: "http://localhost:3000/#/ko/task/task-1",
+    };
+
+    const result = resolveNavigationTargetWindow({
+      preferredWindow,
+      targetUrl: "http://localhost:3000/#/ko/task/task-1",
+      rendererDevUrl: "http://localhost:3000",
+      openWindows: [preferredWindow, detailWindow],
+      getWindowUrl: (windowRecord) => windowRecord.url,
+    });
+
+    expect(result).toBe(detailWindow);
+  });
+
+  it("같은 route 창이 없으면 기존 선호 창을 유지한다", () => {
+    const preferredWindow = {
+      id: "window-1",
+      url: "http://localhost:3000/#/ko",
+    };
+    const anotherDetailWindow = {
+      id: "window-2",
+      url: "http://localhost:3000/#/ko/task/task-2",
+    };
+
+    const result = resolveNavigationTargetWindow({
+      preferredWindow,
+      targetUrl: "http://localhost:3000/#/ko/task/task-1",
+      rendererDevUrl: "http://localhost:3000",
+      openWindows: [preferredWindow, anotherDetailWindow],
+      getWindowUrl: (windowRecord) => windowRecord.url,
+    });
+
+    expect(result).toBe(preferredWindow);
   });
 });

--- a/src/desktop/main/windowOpen.ts
+++ b/src/desktop/main/windowOpen.ts
@@ -21,6 +21,14 @@ interface ResolveWindowOpenActionOptions<T> {
   excludeWindow?: T | null;
 }
 
+interface ResolveNavigationTargetWindowOptions<T> {
+  preferredWindow?: T | null;
+  targetUrl: string;
+  rendererDevUrl: string | null;
+  openWindows: readonly T[];
+  getWindowUrl: (window: T) => string;
+}
+
 function normalizeInternalRoute(route: string | null | undefined): string | null {
   if (!route) {
     return null;
@@ -85,16 +93,22 @@ export function extractInternalRoute(targetUrl: string, rendererDevUrl: string |
   }
 }
 
-export function resolveWindowOpenAction<T>({
+function findExistingInternalWindow<T>({
   targetUrl,
   rendererDevUrl,
   openWindows,
   getWindowUrl,
   excludeWindow = null,
-}: ResolveWindowOpenActionOptions<T>): WindowOpenAction<T> {
+}: ResolveWindowOpenActionOptions<T>): {
+  route: string | null;
+  existingWindow: T | null;
+} {
   const route = extractInternalRoute(targetUrl, rendererDevUrl);
   if (!route) {
-    return { type: "external" };
+    return {
+      route: null,
+      existingWindow: null,
+    };
   }
 
   const existingWindow = openWindows.find((window) => {
@@ -103,7 +117,49 @@ export function resolveWindowOpenAction<T>({
     }
 
     return extractInternalRoute(getWindowUrl(window), rendererDevUrl) === route;
+  }) ?? null;
+
+  return {
+    route,
+    existingWindow,
+  };
+}
+
+export function resolveNavigationTargetWindow<T>({
+  preferredWindow = null,
+  targetUrl,
+  rendererDevUrl,
+  openWindows,
+  getWindowUrl,
+}: ResolveNavigationTargetWindowOptions<T>): T | null {
+  const { existingWindow } = findExistingInternalWindow({
+    targetUrl,
+    rendererDevUrl,
+    openWindows,
+    getWindowUrl,
   });
+
+  return existingWindow ?? preferredWindow;
+}
+
+export function resolveWindowOpenAction<T>({
+  targetUrl,
+  rendererDevUrl,
+  openWindows,
+  getWindowUrl,
+  excludeWindow = null,
+}: ResolveWindowOpenActionOptions<T>): WindowOpenAction<T> {
+  const { route, existingWindow } = findExistingInternalWindow({
+    targetUrl,
+    rendererDevUrl,
+    openWindows,
+    getWindowUrl,
+    excludeWindow,
+  });
+
+  if (!route) {
+    return { type: "external" };
+  }
 
   if (existingWindow) {
     return {

--- a/src/desktop/renderer/components/Terminal.tsx
+++ b/src/desktop/renderer/components/Terminal.tsx
@@ -76,6 +76,17 @@ export default function Terminal({ taskId }: TerminalProps) {
       window.kanvibeDesktop!.resizeTerminal(taskId, cols, rows);
     });
 
+    const syncTerminalSize = () => {
+      fitAddon.fit();
+      window.kanvibeDesktop!.resizeTerminal(taskId, terminal.cols, terminal.rows);
+    };
+
+    const scheduleTerminalSync = () => {
+      requestAnimationFrame(() => {
+        syncTerminalSize();
+      });
+    };
+
     const focusCurrentTerminal = () => {
       terminal.focus();
     };
@@ -83,21 +94,28 @@ export default function Terminal({ taskId }: TerminalProps) {
     focusCurrentTerminal();
 
     const resizeObserver = new ResizeObserver(() => {
-      fitAddon.fit();
-      window.kanvibeDesktop!.resizeTerminal(taskId, terminal.cols, terminal.rows);
+      syncTerminalSize();
     });
     resizeObserver.observe(containerRef.current);
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
         focusCurrentTerminal();
+        scheduleTerminalSync();
       }
     };
 
+    const handleWindowFocus = () => {
+      focusCurrentTerminal();
+      scheduleTerminalSync();
+    };
+
     document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", handleWindowFocus);
 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", handleWindowFocus);
       disposeMacShiftSelectionPatch();
       resizeObserver.disconnect();
       unsubscribeData();

--- a/src/desktop/renderer/components/__tests__/Terminal.test.tsx
+++ b/src/desktop/renderer/components/__tests__/Terminal.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import Terminal from "../Terminal";
 
@@ -121,5 +121,28 @@ describe("Desktop Terminal", () => {
       expect(mockTerminalFocus).toHaveBeenCalledTimes(1);
     });
     expect(mockFocusTerminal).not.toHaveBeenCalled();
+  });
+
+  it("상세 창으로 다시 포커스되면 terminal fit과 resize를 다시 실행한다", async () => {
+    // Given
+    render(<Terminal taskId="task-1" />);
+
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", 80, 24);
+    });
+
+    mockFit.mockClear();
+    mockResizeTerminal.mockClear();
+
+    // When
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    // Then
+    await waitFor(() => {
+      expect(mockFit).toHaveBeenCalledTimes(1);
+    });
+    expect(mockResizeTerminal).toHaveBeenCalledWith("task-1", 80, 24);
   });
 });


### PR DESCRIPTION
## What does this change?
- reuse an already open task detail window when desktop navigation targets the same route
- keep the current preferred window behavior when no matching detail window exists
- refit and resize the embedded terminal when the detail window regains focus

## Why?
- prevent duplicate detail windows from opening on top of an existing terminal window
- keep the terminal size aligned after returning focus to the active detail window

## Important changes
### Desktop navigation reuse
- added a shared helper to resolve an existing internal window for a target route
- updated desktop navigation to focus the existing detail window instead of always falling back to the current main window

### Terminal resize on focus restore
- rerun xterm fit and desktop resize IPC when the detail window becomes visible or focused
- added regression coverage for window reuse and terminal refit behavior

Co-Authored-By: OpenAI Codex <codex@openai.com>
