### PR TITLE
Add configurable task detail quick search

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Each pane can run a custom command (e.g., `vim`, `htop`, `lazygit`, test runner,
 - 5-status task management (TODO / PROGRESS / PENDING / REVIEW / DONE)
 - Custom task ordering with drag & drop
 - Multi-project filtering
+- Global quick search for task detail pages by branch or project name
 - Done column pagination
 - Real-time WebSocket updates
 
@@ -162,6 +163,12 @@ Each pane can run a custom command (e.g., `vim`, `htop`, `lazygit`, test runner,
 - Browser-based terminal via xterm.js + WebSocket
 - SSH remote terminal support (reads `~/.ssh/config`)
 - Nerd Font rendering support
+
+### Quick Task Search
+- Open a global search dialog from the configured keyboard shortcut
+- Search existing task detail pages by branch name or project name
+- Distinguish local tasks from SSH remote tasks directly in search results
+- Configure the shortcut in **Project Settings** → **Detail Page**
 
 ### AI Agent Hooks - Automatic Status Tracking
 KanVibe integrates with **Claude Code Hooks**, **Gemini CLI Hooks**, **Codex CLI**, and **OpenCode** to automatically track task status. Tasks are managed through 5 statuses:

--- a/messages/en.json
+++ b/messages/en.json
@@ -8,6 +8,7 @@
     "close": "Close",
     "confirm": "Confirm",
     "local": "Local",
+    "remote": "Remote",
     "settings": "Settings",
     "notifications": "Notifications",
     "markAllRead": "Mark all read",
@@ -142,6 +143,9 @@
     "detailPageSection": "Detail Page",
     "sidebarDefaultCollapsed": "Collapse sidebar by default",
     "sidebarDefaultCollapsedDescription": "Start with the left sidebar collapsed when entering the detail page.",
+    "taskSearchShortcut": "Quick search shortcut",
+    "taskSearchShortcutDescription": "Shortcut for finding a task detail page by branch or project name.",
+    "taskSearchShortcutRecording": "Press the shortcut",
     "notificationSection": "Notifications",
     "notificationEnabled": "Browser notifications",
     "notificationEnabledDescription": "Receive browser notifications when task status changes.",
@@ -150,6 +154,12 @@
     "taskCreationSection": "Task Creation",
     "defaultSessionType": "Default session type",
     "defaultSessionTypeDescription": "The default session type selected when creating a new task."
+  },
+  "taskSearch": {
+    "title": "Quick Task Search",
+    "placeholder": "Search by branch or project name...",
+    "empty": "No matching tasks found.",
+    "hint": "↑↓ Navigate · Enter Open · Esc Close"
   },
   "paneLayout": {
     "title": "Pane Layout Settings",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -8,6 +8,7 @@
     "close": "닫기",
     "confirm": "확인",
     "local": "로컬",
+    "remote": "원격",
     "settings": "설정",
     "notifications": "알림",
     "markAllRead": "모두 읽음 처리",
@@ -142,6 +143,9 @@
     "detailPageSection": "상세 페이지",
     "sidebarDefaultCollapsed": "사이드바 기본 접기",
     "sidebarDefaultCollapsedDescription": "상세 페이지 진입 시 왼쪽 사이드바를 접은 상태로 시작합니다.",
+    "taskSearchShortcut": "빠른 검색 단축키",
+    "taskSearchShortcutDescription": "브랜치명 또는 프로젝트명으로 태스크 상세 페이지를 빠르게 찾는 단축키입니다.",
+    "taskSearchShortcutRecording": "원하는 조합을 누르세요",
     "notificationSection": "알림",
     "notificationEnabled": "브라우저 알림",
     "notificationEnabledDescription": "작업 상태 변경 시 브라우저 알림을 받습니다.",
@@ -150,6 +154,12 @@
     "taskCreationSection": "작업 생성",
     "defaultSessionType": "기본 세션 타입",
     "defaultSessionTypeDescription": "새 작업 생성 시 기본으로 선택되는 세션 타입입니다."
+  },
+  "taskSearch": {
+    "title": "태스크 빠른 검색",
+    "placeholder": "브랜치명 또는 프로젝트명으로 검색...",
+    "empty": "일치하는 태스크가 없습니다.",
+    "hint": "↑↓ 이동 · Enter 이동 · Esc 닫기"
   },
   "paneLayout": {
     "title": "Pane 레이아웃 설정",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -8,6 +8,7 @@
     "close": "关闭",
     "confirm": "确认",
     "local": "本地",
+    "remote": "远程",
     "settings": "设置",
     "notifications": "通知",
     "markAllRead": "全部标记已读",
@@ -142,6 +143,9 @@
     "detailPageSection": "详情页",
     "sidebarDefaultCollapsed": "默认折叠侧栏",
     "sidebarDefaultCollapsedDescription": "进入详情页时左侧栏默认折叠。",
+    "taskSearchShortcut": "快速搜索快捷键",
+    "taskSearchShortcutDescription": "用于按分支名或项目名快速查找任务详情页的快捷键。",
+    "taskSearchShortcutRecording": "请按下快捷键组合",
     "notificationSection": "通知",
     "notificationEnabled": "浏览器通知",
     "notificationEnabledDescription": "任务状态变更时接收浏览器通知。",
@@ -150,6 +154,12 @@
     "taskCreationSection": "任务创建",
     "defaultSessionType": "默认会话类型",
     "defaultSessionTypeDescription": "创建新任务时默认选择的会话类型。"
+  },
+  "taskSearch": {
+    "title": "快速任务搜索",
+    "placeholder": "按分支名或项目名搜索...",
+    "empty": "没有找到匹配的任务。",
+    "hint": "↑↓ 移动 · Enter 打开 · Esc 关闭"
   },
   "paneLayout": {
     "title": "面板布局设置",

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -29,6 +29,7 @@ interface BoardProps {
   doneAlertDismissed: boolean;
   notificationSettings: { isEnabled: boolean; enabledStatuses: string[] };
   defaultSessionType: SessionType;
+  taskSearchShortcut: string;
 }
 
 const COLUMNS: { status: TaskStatus; labelKey: string; colorClass: string }[] = [
@@ -177,7 +178,7 @@ function buildDragMovePlan(
   };
 }
 
-export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings, defaultSessionType }: BoardProps) {
+export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings, defaultSessionType, taskSearchShortcut }: BoardProps) {
   useAutoRefresh();
   const t = useTranslations("board");
   const tt = useTranslations("task");
@@ -568,6 +569,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         sshHosts={sshHosts}
         sidebarDefaultCollapsed={sidebarDefaultCollapsed}
         defaultSessionType={currentDefaultSessionType}
+        taskSearchShortcut={taskSearchShortcut}
         onDefaultSessionTypeChange={(sessionType) => {
           setCurrentDefaultSessionType(sessionType);
         }}

--- a/src/components/ProjectSettings.tsx
+++ b/src/components/ProjectSettings.tsx
@@ -12,11 +12,16 @@ import {
   setNotificationEnabled,
   setNotificationStatuses,
   setDefaultSessionType,
+  setTaskSearchShortcut,
 } from "@/desktop/renderer/actions/appSettings";
 import { SessionType } from "@/entities/KanbanTask";
 import { Link } from "@/desktop/renderer/navigation";
 import type { Project } from "@/entities/Project";
 import FolderSearchInput from "@/components/FolderSearchInput";
+import {
+  captureShortcutFromEvent,
+  formatShortcutForDisplay,
+} from "@/desktop/renderer/utils/keyboardShortcut";
 
 /** 알림 대상 상태 목록 (사용자가 직접 설정하는 todo/done은 제외) */
 const STATUS_OPTIONS = [
@@ -32,6 +37,7 @@ interface ProjectSettingsProps {
   sshHosts: string[];
   sidebarDefaultCollapsed: boolean;
   defaultSessionType: SessionType;
+  taskSearchShortcut: string;
   onDefaultSessionTypeChange?: (sessionType: SessionType) => void;
   notificationSettings: { isEnabled: boolean; enabledStatuses: string[] };
 }
@@ -52,6 +58,7 @@ export default function ProjectSettings({
   sshHosts,
   sidebarDefaultCollapsed,
   defaultSessionType,
+  taskSearchShortcut,
   onDefaultSessionTypeChange,
   notificationSettings,
 }: ProjectSettingsProps) {
@@ -65,12 +72,30 @@ export default function ProjectSettings({
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
   const [scanSshHost, setScanSshHost] = useState("");
   const [selectedDefaultSessionType, setSelectedDefaultSessionType] = useState(defaultSessionType);
+  const [localTaskSearchShortcut, setLocalTaskSearchShortcut] = useState(taskSearchShortcut);
+  const [isCapturingTaskSearchShortcut, setIsCapturingTaskSearchShortcut] = useState(false);
+  const [pendingTaskSearchShortcut, setPendingTaskSearchShortcut] = useState<string | null>(null);
   const [localNotificationSettings, setLocalNotificationSettings] = useState(notificationSettings);
   const [pendingNotificationSettings, setPendingNotificationSettings] = useState<typeof notificationSettings | null>(null);
+  const isMacLike = typeof navigator !== "undefined"
+    && (navigator.userAgent.includes("Mac") || navigator.platform.toLowerCase().includes("mac"));
 
   useEffect(() => {
     setSelectedDefaultSessionType(defaultSessionType);
   }, [defaultSessionType]);
+
+  useEffect(() => {
+    if (isCapturingTaskSearchShortcut) {
+      return;
+    }
+
+    if (pendingTaskSearchShortcut && taskSearchShortcut !== pendingTaskSearchShortcut) {
+      return;
+    }
+
+    setLocalTaskSearchShortcut(taskSearchShortcut);
+    setPendingTaskSearchShortcut(null);
+  }, [isCapturingTaskSearchShortcut, pendingTaskSearchShortcut, taskSearchShortcut]);
 
   useEffect(() => {
     if (pendingNotificationSettings && !areNotificationSettingsEqual(notificationSettings, pendingNotificationSettings)) {
@@ -185,6 +210,55 @@ export default function ProjectSettings({
               />
             </button>
           </label>
+
+          <div className="mt-4 flex items-center justify-between gap-3">
+            <div>
+              <span className="text-sm text-text-primary">{t("taskSearchShortcut")}</span>
+              <p className="text-xs text-text-muted mt-0.5">{t("taskSearchShortcutDescription")}</p>
+            </div>
+            <button
+              type="button"
+              data-testid="task-search-shortcut-record"
+              data-shortcut-capture={isCapturingTaskSearchShortcut ? "true" : "false"}
+              onClick={() => setIsCapturingTaskSearchShortcut(true)}
+              onKeyDown={(event) => {
+                if (!isCapturingTaskSearchShortcut) {
+                  return;
+                }
+
+                event.preventDefault();
+                event.stopPropagation();
+
+                if (event.key === "Escape") {
+                  setIsCapturingTaskSearchShortcut(false);
+                  setLocalTaskSearchShortcut(taskSearchShortcut);
+                  return;
+                }
+
+                const capturedShortcut = captureShortcutFromEvent(event.nativeEvent);
+                if (!capturedShortcut) {
+                  return;
+                }
+
+                setLocalTaskSearchShortcut(capturedShortcut);
+                setPendingTaskSearchShortcut(capturedShortcut);
+                setIsCapturingTaskSearchShortcut(false);
+                startTransition(async () => {
+                  await setTaskSearchShortcut(capturedShortcut);
+                });
+              }}
+              disabled={isPending}
+              className={`min-w-[140px] rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
+                isCapturingTaskSearchShortcut
+                  ? "border-brand-primary bg-brand-primary/10 text-brand-primary"
+                  : "border-border-default bg-bg-page text-text-primary hover:border-brand-primary"
+              }`}
+            >
+              {isCapturingTaskSearchShortcut
+                ? t("taskSearchShortcutRecording")
+                : formatShortcutForDisplay(localTaskSearchShortcut, isMacLike)}
+            </button>
+          </div>
         </div>
 
         {/* 작업 생성 설정 */}

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -169,6 +169,7 @@ describe("Board defaultSessionType sync", () => {
       sidebarDefaultCollapsed: false,
       doneAlertDismissed: false,
       notificationSettings: { isEnabled: true, enabledStatuses: ["progress", "pending", "review"] },
+      taskSearchShortcut: "Mod+Shift+O",
     };
 
     const { rerender } = render(<Board {...baseProps} defaultSessionType={SessionType.TMUX} />);
@@ -196,6 +197,7 @@ describe("Board defaultSessionType sync", () => {
         doneAlertDismissed={false}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
         defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
       />,
     );
 
@@ -220,6 +222,7 @@ describe("Board defaultSessionType sync", () => {
         doneAlertDismissed={false}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
         defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
       />,
     );
 
@@ -245,6 +248,7 @@ describe("Board defaultSessionType sync", () => {
         doneAlertDismissed={false}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
         defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
       />,
     );
 
@@ -270,6 +274,7 @@ describe("Board defaultSessionType sync", () => {
         doneAlertDismissed={false}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
         defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
       />,
     );
 

--- a/src/components/__tests__/ProjectSettings.test.tsx
+++ b/src/components/__tests__/ProjectSettings.test.tsx
@@ -7,6 +7,7 @@ import type { Project } from "@/entities/Project";
 const mockSetDefaultSessionType = vi.fn().mockResolvedValue(undefined);
 const mockSetNotificationEnabled = vi.fn().mockResolvedValue(undefined);
 const mockSetNotificationStatuses = vi.fn().mockResolvedValue(undefined);
+const mockSetTaskSearchShortcut = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
@@ -43,6 +44,7 @@ vi.mock("@/desktop/renderer/actions/appSettings", () => ({
   setNotificationEnabled: (...args: unknown[]) => mockSetNotificationEnabled(...args),
   setNotificationStatuses: (...args: unknown[]) => mockSetNotificationStatuses(...args),
   setDefaultSessionType: (...args: unknown[]) => mockSetDefaultSessionType(...args),
+  setTaskSearchShortcut: (...args: unknown[]) => mockSetTaskSearchShortcut(...args),
 }));
 
 function createProject(): Project {
@@ -75,6 +77,7 @@ describe("ProjectSettings", () => {
         sshHosts={[]}
         sidebarDefaultCollapsed={false}
         defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
         onDefaultSessionTypeChange={onDefaultSessionTypeChange}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
       />,
@@ -101,6 +104,7 @@ describe("ProjectSettings", () => {
         sshHosts={[]}
         sidebarDefaultCollapsed={false}
         defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
       />,
     );
@@ -127,6 +131,7 @@ describe("ProjectSettings", () => {
         sshHosts={[]}
         sidebarDefaultCollapsed={false}
         defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
       />,
     );
@@ -155,6 +160,7 @@ describe("ProjectSettings", () => {
         sshHosts={[]}
         sidebarDefaultCollapsed={false}
         defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
         notificationSettings={initialSettings}
       />,
     );
@@ -169,6 +175,7 @@ describe("ProjectSettings", () => {
         sshHosts={[]}
         sidebarDefaultCollapsed={false}
         defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
         notificationSettings={{
           isEnabled: true,
           enabledStatuses: ["progress", "pending", "review"],
@@ -181,5 +188,37 @@ describe("ProjectSettings", () => {
       expect(mockSetNotificationStatuses).toHaveBeenCalledWith(["progress", "review"]);
     });
     expect(screen.getByText("pending").className).toContain("bg-bg-page");
+  });
+
+  it("검색 단축키를 캡처해서 즉시 저장한다", async () => {
+    // Given
+    render(
+      <ProjectSettings
+        isOpen
+        onClose={vi.fn()}
+        projects={[createProject()]}
+        sshHosts={[]}
+        sidebarDefaultCollapsed={false}
+        defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+      />,
+    );
+
+    const recordButton = screen.getByTestId("task-search-shortcut-record");
+
+    // When
+    fireEvent.click(recordButton);
+    fireEvent.keyDown(recordButton, {
+      key: "p",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    // Then
+    await waitFor(() => {
+      expect(mockSetTaskSearchShortcut).toHaveBeenCalledWith("Ctrl+Shift+P");
+    });
+    expect(screen.getByText("Ctrl+Shift+P")).toBeTruthy();
   });
 });

--- a/src/desktop/main/services/appSettingsService.ts
+++ b/src/desktop/main/services/appSettingsService.ts
@@ -107,6 +107,7 @@ export async function setNotificationStatuses(statuses: string[]): Promise<void>
 }
 
 const DEFAULT_SESSION_TYPE_KEY = "default_session_type";
+const TASK_SEARCH_SHORTCUT_KEY = "task_search_shortcut";
 
 /** 기본 세션 타입을 조회한다. 미설정 시 "tmux"를 반환한다 */
 export async function getDefaultSessionType(): Promise<SessionType> {
@@ -117,4 +118,16 @@ export async function getDefaultSessionType(): Promise<SessionType> {
 /** 기본 세션 타입을 저장한다 */
 export async function setDefaultSessionType(sessionType: SessionType): Promise<void> {
   await setAppSetting(DEFAULT_SESSION_TYPE_KEY, sessionType);
+}
+
+/** 태스크 빠른 검색 단축키를 조회한다. 미설정 시 기본값을 반환한다 */
+export async function getTaskSearchShortcut(): Promise<string> {
+  const value = await getAppSetting(TASK_SEARCH_SHORTCUT_KEY);
+  return value?.trim() || "Mod+Shift+O";
+}
+
+/** 태스크 빠른 검색 단축키를 저장한다 */
+export async function setTaskSearchShortcut(shortcut: string): Promise<void> {
+  const normalizedShortcut = shortcut.trim() || "Mod+Shift+O";
+  await setAppSetting(TASK_SEARCH_SHORTCUT_KEY, normalizedShortcut);
 }

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -22,6 +22,17 @@ export interface LoadMoreDoneResponse {
   doneTotal: number;
 }
 
+export interface SearchableTask {
+  id: string;
+  title: string;
+  branchName: string | null;
+  projectId: string | null;
+  projectName: string | null;
+  sshHost: string | null;
+  status: TaskStatus;
+  updatedAt: Date;
+}
+
 const DONE_PAGE_SIZE = 20;
 
 /** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
@@ -162,6 +173,26 @@ export async function getTaskById(taskId: string): Promise<KanbanTask | null> {
   const repo = await getTaskRepository();
   const task = await repo.findOne({ where: { id: taskId }, relations: ["project"] });
   return task ? serialize(task) : null;
+}
+
+/** 빠른 검색 오버레이에서 사용할 태스크 목록을 반환한다 */
+export async function getSearchableTasks(): Promise<SearchableTask[]> {
+  const repo = await getTaskRepository();
+  const tasks = await repo.find({
+    relations: ["project"],
+    order: { updatedAt: "DESC", createdAt: "DESC" },
+  });
+
+  return serialize(tasks.map((task) => ({
+    id: task.id,
+    title: task.title,
+    branchName: task.branchName,
+    projectId: task.projectId,
+    projectName: task.project?.name ?? null,
+    sshHost: task.sshHost ?? task.project?.sshHost ?? null,
+    status: task.status,
+    updatedAt: task.updatedAt,
+  })));
 }
 
 /** 같은 프로젝트 내에서 branchName이 일치하는 태스크 ID를 조회 */

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -5,6 +5,7 @@ import { HashRouter, Navigate, Outlet, Route, Routes, useParams } from "react-ro
 import LoginForm from "@/components/LoginForm";
 import BoardEventAlert from "@/desktop/renderer/components/BoardEventAlert";
 import NotificationListener from "@/desktop/renderer/components/NotificationListener";
+import TaskQuickSearchDialog from "@/desktop/renderer/components/TaskQuickSearchDialog";
 import { getSessionState } from "@/desktop/renderer/actions/auth";
 import { DEFAULT_LOCALE, getSafeLocale, isSupportedLocale, messagesByLocale } from "@/desktop/renderer/utils/locales";
 import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
@@ -18,7 +19,7 @@ interface SessionState {
   isAuthenticated: boolean;
 }
 
-function LocaleShell({ sessionLoading }: { sessionLoading: boolean }) {
+function LocaleShell({ sessionLoading, isAuthenticated }: { sessionLoading: boolean; isAuthenticated: boolean }) {
   const { locale } = useParams();
   const safeLocale = getSafeLocale(locale);
   const messages = useMemo(() => messagesByLocale[safeLocale], [safeLocale]);
@@ -31,6 +32,7 @@ function LocaleShell({ sessionLoading }: { sessionLoading: boolean }) {
     <IntlProvider locale={safeLocale} messages={messages}>
       {!sessionLoading && (
         <>
+          {isAuthenticated ? <TaskQuickSearchDialog /> : null}
           <NotificationListener />
           <BoardEventAlert />
         </>
@@ -113,7 +115,7 @@ export default function App() {
     <HashRouter>
       <Routes>
         <Route path="/" element={<Navigate to={`/${DEFAULT_LOCALE}${isAuthenticated ? "" : "/login"}`} replace />} />
-        <Route path="/:locale" element={<LocaleShell sessionLoading={sessionLoading} />}>
+        <Route path="/:locale" element={<LocaleShell sessionLoading={sessionLoading} isAuthenticated={isAuthenticated} />}>
           <Route index element={<ProtectedRoute isAuthenticated={isAuthenticated} sessionLoading={sessionLoading}><BoardRoute /></ProtectedRoute>} />
           <Route path="login" element={<AnonymousRoute isAuthenticated={isAuthenticated} sessionLoading={sessionLoading}><LoginForm /></AnonymousRoute>} />
           <Route path="pane-layout" element={<ProtectedRoute isAuthenticated={isAuthenticated} sessionLoading={sessionLoading}><PaneLayoutRoute /></ProtectedRoute>} />

--- a/src/desktop/renderer/actions/appSettings.ts
+++ b/src/desktop/renderer/actions/appSettings.ts
@@ -59,3 +59,11 @@ export function getDefaultSessionType(): Promise<SessionType> {
 export function setDefaultSessionType(sessionType: SessionType): Promise<void> {
   return invokeAndRefresh("setDefaultSessionType", sessionType);
 }
+
+export function getTaskSearchShortcut(): Promise<string> {
+  return invokeDesktop("appSettings", "getTaskSearchShortcut");
+}
+
+export function setTaskSearchShortcut(shortcut: string): Promise<void> {
+  return invokeAndRefresh("setTaskSearchShortcut", shortcut);
+}

--- a/src/desktop/renderer/actions/kanban.ts
+++ b/src/desktop/renderer/actions/kanban.ts
@@ -1,9 +1,9 @@
 import type { KanbanTask, TaskStatus } from "@/entities/KanbanTask";
 import type { SessionType } from "@/entities/KanbanTask";
-import type { LoadMoreDoneResponse, TasksByStatus, TasksByStatusWithMeta, CreateTaskInput } from "@/desktop/main/services/kanbanService";
+import type { LoadMoreDoneResponse, TasksByStatus, TasksByStatusWithMeta, CreateTaskInput, SearchableTask } from "@/desktop/main/services/kanbanService";
 import { invokeDesktop } from "@/desktop/renderer/ipc";
 
-export type { TasksByStatus, TasksByStatusWithMeta, LoadMoreDoneResponse, CreateTaskInput };
+export type { TasksByStatus, TasksByStatusWithMeta, LoadMoreDoneResponse, CreateTaskInput, SearchableTask };
 
 export function getTasksByStatus(): Promise<TasksByStatusWithMeta> {
   return invokeDesktop("kanban", "getTasksByStatus");
@@ -15,6 +15,10 @@ export function getMoreDoneTasks(offset: number, limit?: number): Promise<LoadMo
 
 export function getTaskById(taskId: string): Promise<KanbanTask | null> {
   return invokeDesktop("kanban", "getTaskById", taskId);
+}
+
+export function getSearchableTasks(): Promise<SearchableTask[]> {
+  return invokeDesktop("kanban", "getSearchableTasks");
 }
 
 export function getTaskIdByProjectAndBranch(projectId: string, branchName: string): Promise<string | null> {

--- a/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
+++ b/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import HighlightedText from "@/components/HighlightedText";
+import {
+  getSearchableTasks,
+  type SearchableTask,
+} from "@/desktop/renderer/actions/kanban";
+import { getTaskSearchShortcut } from "@/desktop/renderer/actions/appSettings";
+import { useRouter } from "@/desktop/renderer/navigation";
+import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
+import {
+  DEFAULT_TASK_SEARCH_SHORTCUT,
+  formatShortcutForDisplay,
+  matchShortcutEvent,
+} from "@/desktop/renderer/utils/keyboardShortcut";
+import { fuzzyMatch, type FuzzyMatch } from "@/utils/fuzzySearch";
+
+interface TaskQuickSearchDialogProps {
+  shortcut?: string;
+}
+
+interface SearchResult {
+  task: SearchableTask;
+  score: number;
+  branchMatch: FuzzyMatch | null;
+  projectMatch: FuzzyMatch | null;
+  titleMatch: FuzzyMatch | null;
+}
+
+function isMacLikePlatform() {
+  return typeof navigator !== "undefined"
+    && (navigator.userAgent.includes("Mac") || navigator.platform.toLowerCase().includes("mac"));
+}
+
+function buildSearchResults(tasks: SearchableTask[], query: string): SearchResult[] {
+  const trimmedQuery = query.trim();
+
+  if (!trimmedQuery) {
+    return tasks.map((task) => ({
+      task,
+      score: 0,
+      branchMatch: null,
+      projectMatch: null,
+      titleMatch: null,
+    }));
+  }
+
+  return tasks
+    .map((task) => {
+      const branchMatch = task.branchName ? fuzzyMatch(trimmedQuery, task.branchName) : null;
+      const projectMatch = task.projectName ? fuzzyMatch(trimmedQuery, task.projectName) : null;
+      const titleMatch = task.title ? fuzzyMatch(trimmedQuery, task.title) : null;
+      const matches = [branchMatch, projectMatch, titleMatch].filter(
+        (match): match is FuzzyMatch => match !== null,
+      );
+
+      if (matches.length === 0) {
+        return null;
+      }
+
+      const score = Math.max(...matches.map((match) => match.score))
+        + (branchMatch ? 3 : 0)
+        + (projectMatch ? 2 : 0)
+        + (titleMatch ? 1 : 0);
+
+      return {
+        task,
+        score,
+        branchMatch,
+        projectMatch,
+        titleMatch,
+      };
+    })
+    .filter((result): result is SearchResult => result !== null)
+    .sort((left, right) => right.score - left.score);
+}
+
+export default function TaskQuickSearchDialog({
+  shortcut,
+}: TaskQuickSearchDialogProps) {
+  const t = useTranslations("taskSearch");
+  const tc = useTranslations("common");
+  const router = useRouter();
+  const refreshSignal = useRefreshSignal(["all", "settings"]);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [resolvedShortcut, setResolvedShortcut] = useState(shortcut || DEFAULT_TASK_SEARCH_SHORTCUT);
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [tasks, setTasks] = useState<SearchableTask[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const isMacLike = isMacLikePlatform();
+
+  const effectiveShortcut = shortcut || resolvedShortcut;
+  const results = useMemo(() => buildSearchResults(tasks, query), [query, tasks]);
+
+  useEffect(() => {
+    if (shortcut) {
+      setResolvedShortcut(shortcut);
+      return;
+    }
+
+    let cancelled = false;
+
+    getTaskSearchShortcut().then((nextShortcut) => {
+      if (!cancelled) {
+        setResolvedShortcut(nextShortcut || DEFAULT_TASK_SEARCH_SHORTCUT);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshSignal, shortcut]);
+
+  useEffect(() => {
+    function handleGlobalKeyDown(event: KeyboardEvent) {
+      const eventTarget = event.target;
+      if (eventTarget instanceof Element && eventTarget.closest('[data-shortcut-capture="true"]')) {
+        return;
+      }
+
+      if (!matchShortcutEvent(event, effectiveShortcut, isMacLike)) {
+        return;
+      }
+
+      event.preventDefault();
+      setIsOpen((current) => !current);
+    }
+
+    window.addEventListener("keydown", handleGlobalKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleGlobalKeyDown);
+    };
+  }, [effectiveShortcut, isMacLike]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setQuery("");
+      setSelectedIndex(0);
+      return;
+    }
+
+    inputRef.current?.focus();
+
+    let cancelled = false;
+    setIsLoading(true);
+
+    getSearchableTasks()
+      .then((nextTasks) => {
+        if (!cancelled) {
+          setTasks(nextTasks);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (selectedIndex >= results.length) {
+      setSelectedIndex(0);
+    }
+  }, [results.length, selectedIndex]);
+
+  function closeDialog() {
+    setIsOpen(false);
+  }
+
+  function moveToTask(taskId: string) {
+    router.push(`/task/${taskId}`);
+    closeDialog();
+  }
+
+  function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setSelectedIndex((current) => (results.length === 0 ? 0 : Math.min(current + 1, results.length - 1)));
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setSelectedIndex((current) => Math.max(current - 1, 0));
+        break;
+      case "Enter":
+        event.preventDefault();
+        if (results[selectedIndex]) {
+          moveToTask(results[selectedIndex].task.id);
+        }
+        break;
+      case "Escape":
+        event.preventDefault();
+        closeDialog();
+        break;
+    }
+  }
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[500] flex items-start justify-center bg-black/45 px-4 pt-24">
+      <button
+        type="button"
+        aria-label={tc("close")}
+        className="absolute inset-0 cursor-default"
+        onClick={closeDialog}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative z-10 w-full max-w-2xl overflow-hidden rounded-2xl border border-border-default bg-bg-surface shadow-2xl"
+      >
+        <div className="border-b border-border-default px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-semibold text-text-primary">{t("title")}</p>
+              <p className="text-xs text-text-muted">
+                {formatShortcutForDisplay(effectiveShortcut, isMacLike)}
+              </p>
+            </div>
+          </div>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleInputKeyDown}
+            placeholder={t("placeholder")}
+            className="mt-3 w-full rounded-md border border-border-default bg-bg-page px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-brand-primary"
+          />
+        </div>
+
+        <div className="max-h-[420px] overflow-y-auto">
+          {isLoading ? (
+            <div className="px-4 py-6 text-sm text-text-muted">{tc("loading")}</div>
+          ) : results.length === 0 ? (
+            <div className="px-4 py-6 text-sm text-text-muted">{t("empty")}</div>
+          ) : (
+            results.map((result, index) => {
+              const { task, branchMatch, projectMatch, titleMatch } = result;
+              const isRemote = Boolean(task.sshHost);
+              const primaryLabel = task.branchName || task.title;
+
+              return (
+                <button
+                  key={task.id}
+                  type="button"
+                  onClick={() => moveToTask(task.id)}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  className={`flex w-full items-start justify-between gap-4 border-b border-border-subtle px-4 py-3 text-left transition-colors ${
+                    index === selectedIndex
+                      ? "bg-brand-primary/10"
+                      : "hover:bg-bg-page"
+                  }`}
+                >
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-text-primary">
+                      {branchMatch ? (
+                        <HighlightedText
+                          text={primaryLabel}
+                          matchedIndices={branchMatch.matchedIndices}
+                        />
+                      ) : (
+                        primaryLabel
+                      )}
+                    </div>
+                    {task.branchName && task.title !== task.branchName ? (
+                      <div className="mt-1 truncate text-xs text-text-muted">
+                        {titleMatch ? (
+                          <HighlightedText
+                            text={task.title}
+                            matchedIndices={titleMatch.matchedIndices}
+                          />
+                        ) : (
+                          task.title
+                        )}
+                      </div>
+                    ) : null}
+                    {task.projectName ? (
+                      <div className="mt-1 truncate text-xs text-text-muted">
+                        {projectMatch ? (
+                          <HighlightedText
+                            text={task.projectName}
+                            matchedIndices={projectMatch.matchedIndices}
+                          />
+                        ) : (
+                          task.projectName
+                        )}
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <div className="flex shrink-0 items-center gap-2">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                        isRemote
+                          ? "bg-tag-gemini-bg text-tag-gemini-text"
+                          : "bg-tag-project-bg text-tag-project-text"
+                      }`}
+                    >
+                      {isRemote ? tc("remote") : tc("local")}
+                    </span>
+                    {task.sshHost ? (
+                      <span className="text-[11px] text-text-muted">{task.sshHost}</span>
+                    ) : null}
+                  </div>
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        <div className="border-t border-border-default px-4 py-2 text-xs text-text-muted">
+          {t("hint")}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TaskQuickSearchDialog from "@/desktop/renderer/components/TaskQuickSearchDialog";
+
+const mocks = vi.hoisted(() => ({
+  getSearchableTasks: vi.fn(),
+  push: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+}));
+
+vi.mock("@/desktop/renderer/actions/kanban", () => ({
+  getSearchableTasks: (...args: unknown[]) => mocks.getSearchableTasks(...args),
+}));
+
+vi.mock("@/desktop/renderer/navigation", () => ({
+  useRouter: () => ({
+    push: (...args: unknown[]) => mocks.push(...args),
+  }),
+}));
+
+describe("TaskQuickSearchDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSearchableTasks.mockResolvedValue([
+      {
+        id: "task-local",
+        title: "Local Task",
+        branchName: "feat/local-search",
+        projectId: "project-local",
+        projectName: "kanvibe-web",
+        sshHost: null,
+        status: "todo",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+      },
+      {
+        id: "task-remote",
+        title: "Remote API Task",
+        branchName: "feat/api-search",
+        projectId: "project-remote",
+        projectName: "api-server",
+        sshHost: "devbox",
+        status: "progress",
+        updatedAt: "2026-04-30T01:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("단축키를 누르면 검색 다이얼로그를 열고 태스크 목록을 불러온다", async () => {
+    render(<TaskQuickSearchDialog shortcut="Ctrl+K" />);
+
+    fireEvent.keyDown(window, {
+      key: "k",
+      ctrlKey: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeTruthy();
+    });
+    expect(mocks.getSearchableTasks).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("feat/local-search")).toBeTruthy();
+    expect(screen.getByText("feat/api-search")).toBeTruthy();
+  });
+
+  it("검색 결과에 원격과 로컬을 구분해서 표시한다", async () => {
+    render(<TaskQuickSearchDialog shortcut="Ctrl+K" />);
+
+    fireEvent.keyDown(window, {
+      key: "k",
+      ctrlKey: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeTruthy();
+    });
+
+    expect(screen.getByText("common.local")).toBeTruthy();
+    expect(screen.getByText("common.remote")).toBeTruthy();
+    expect(screen.getByText("devbox")).toBeTruthy();
+  });
+
+  it("프로젝트명이나 브랜치명으로 검색한 뒤 Enter로 상세 페이지로 이동한다", async () => {
+    render(<TaskQuickSearchDialog shortcut="Ctrl+K" />);
+
+    fireEvent.keyDown(window, {
+      key: "k",
+      ctrlKey: true,
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, {
+      target: { value: "api" },
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mocks.push).toHaveBeenCalledWith("/task/task-remote");
+    });
+  });
+
+  it("Escape를 누르면 검색 다이얼로그를 닫는다", async () => {
+    render(<TaskQuickSearchDialog shortcut="Ctrl+K" />);
+
+    fireEvent.keyDown(window, {
+      key: "k",
+      ctrlKey: true,
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+});

--- a/src/desktop/renderer/routes/BoardRoute.tsx
+++ b/src/desktop/renderer/routes/BoardRoute.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import Board from "@/components/Board";
-import { getDoneAlertDismissed, getDefaultSessionType, getNotificationSettings, getSidebarDefaultCollapsed } from "@/desktop/renderer/actions/appSettings";
+import { getDoneAlertDismissed, getDefaultSessionType, getNotificationSettings, getSidebarDefaultCollapsed, getTaskSearchShortcut } from "@/desktop/renderer/actions/appSettings";
 import { getTasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { getAllProjects, getAvailableHosts } from "@/desktop/renderer/actions/project";
 import { buildRouteCacheKey, readRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
@@ -14,6 +14,7 @@ interface BoardData {
   doneAlertDismissed: boolean;
   notificationSettings: Awaited<ReturnType<typeof getNotificationSettings>>;
   defaultSessionType: Awaited<ReturnType<typeof getDefaultSessionType>>;
+  taskSearchShortcut: Awaited<ReturnType<typeof getTaskSearchShortcut>>;
 }
 
 const BOARD_ROUTE_CACHE_KEY = buildRouteCacheKey("board");
@@ -37,7 +38,8 @@ export default function BoardRoute() {
       getDoneAlertDismissed(),
       getNotificationSettings(),
       getDefaultSessionType(),
-    ]).then(([tasks, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings, defaultSessionType]) => {
+      getTaskSearchShortcut(),
+    ]).then(([tasks, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings, defaultSessionType, taskSearchShortcut]) => {
       if (!cancelled) {
         const nextData = {
           tasks,
@@ -47,6 +49,7 @@ export default function BoardRoute() {
           doneAlertDismissed,
           notificationSettings,
           defaultSessionType,
+          taskSearchShortcut,
         };
 
         writeRouteCache(BOARD_ROUTE_CACHE_KEY, nextData);
@@ -74,6 +77,7 @@ export default function BoardRoute() {
       doneAlertDismissed={data.doneAlertDismissed}
       notificationSettings={data.notificationSettings}
       defaultSessionType={data.defaultSessionType}
+      taskSearchShortcut={data.taskSearchShortcut}
     />
   );
 }

--- a/src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   getDoneAlertDismissed: vi.fn(),
   getNotificationSettings: vi.fn(),
   getDefaultSessionType: vi.fn(),
+  getTaskSearchShortcut: vi.fn(),
   useRefreshSignal: vi.fn(() => 0),
 }));
 
@@ -45,6 +46,7 @@ vi.mock("@/desktop/renderer/actions/appSettings", () => ({
   getDoneAlertDismissed: (...args: unknown[]) => mocks.getDoneAlertDismissed(...args),
   getNotificationSettings: (...args: unknown[]) => mocks.getNotificationSettings(...args),
   getDefaultSessionType: (...args: unknown[]) => mocks.getDefaultSessionType(...args),
+  getTaskSearchShortcut: (...args: unknown[]) => mocks.getTaskSearchShortcut(...args),
 }));
 
 vi.mock("@/desktop/renderer/utils/refresh", () => ({
@@ -61,6 +63,7 @@ describe("BoardRoute", () => {
     mocks.getDoneAlertDismissed.mockResolvedValue(false);
     mocks.getNotificationSettings.mockResolvedValue({ isEnabled: true, enabledStatuses: [] });
     mocks.getDefaultSessionType.mockResolvedValue("tmux");
+    mocks.getTaskSearchShortcut.mockResolvedValue("Mod+Shift+O");
   });
 
   it("캐시가 있으면 stale board를 즉시 렌더링하고 이후 최신 데이터로 갱신한다", async () => {
@@ -83,6 +86,7 @@ describe("BoardRoute", () => {
       doneAlertDismissed: false,
       notificationSettings: { isEnabled: true, enabledStatuses: [] },
       defaultSessionType: "tmux",
+      taskSearchShortcut: "Mod+Shift+O",
     }));
     const deferredTasks = createDeferred<{
       tasks: {

--- a/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
+++ b/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  captureShortcutFromEvent,
+  formatShortcutForDisplay,
+  matchShortcutEvent,
+} from "@/desktop/renderer/utils/keyboardShortcut";
+
+describe("keyboardShortcut", () => {
+  it("Mod 단축키는 macOS에서 Cmd로 표시한다", () => {
+    expect(formatShortcutForDisplay("Mod+Shift+o", true)).toBe("Cmd+Shift+O");
+  });
+
+  it("Mod 단축키는 비 macOS에서 Ctrl로 매칭한다", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "o",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(matchShortcutEvent(event, "Mod+Shift+O", false)).toBe(true);
+  });
+
+  it("추가 modifier가 있으면 단축키가 일치하지 않는다", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "o",
+      metaKey: true,
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(matchShortcutEvent(event, "Mod+Shift+O", true)).toBe(false);
+  });
+
+  it("키 입력으로 explicit shortcut 문자열을 캡처한다", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "p",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(captureShortcutFromEvent(event)).toBe("Ctrl+Shift+P");
+  });
+
+  it("modifier만 누른 경우는 캡처하지 않는다", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "Meta",
+      metaKey: true,
+    });
+
+    expect(captureShortcutFromEvent(event)).toBeNull();
+  });
+});

--- a/src/desktop/renderer/utils/keyboardShortcut.ts
+++ b/src/desktop/renderer/utils/keyboardShortcut.ts
@@ -1,0 +1,188 @@
+const MODIFIER_ORDER = ["Mod", "Meta", "Ctrl", "Alt", "Shift"] as const;
+const MODIFIER_KEYS = new Set(["Meta", "Control", "Ctrl", "Alt", "Shift"]);
+
+export const DEFAULT_TASK_SEARCH_SHORTCUT = "Mod+Shift+O";
+
+function normalizeModifierToken(token: string): string | null {
+  const normalizedToken = token.trim().toLowerCase();
+
+  switch (normalizedToken) {
+    case "mod":
+      return "Mod";
+    case "meta":
+    case "cmd":
+    case "command":
+      return "Meta";
+    case "ctrl":
+    case "control":
+      return "Ctrl";
+    case "alt":
+    case "option":
+      return "Alt";
+    case "shift":
+      return "Shift";
+    default:
+      return null;
+  }
+}
+
+function normalizeKeyToken(token: string): string {
+  const trimmedToken = token.trim();
+  if (!trimmedToken) {
+    return "";
+  }
+
+  if (trimmedToken.length === 1) {
+    return trimmedToken.toUpperCase();
+  }
+
+  if (trimmedToken === " ") {
+    return "Space";
+  }
+
+  const lowerToken = trimmedToken.toLowerCase();
+
+  switch (lowerToken) {
+    case "esc":
+      return "Escape";
+    case "space":
+      return "Space";
+    default:
+      return trimmedToken[0].toUpperCase() + trimmedToken.slice(1);
+  }
+}
+
+function normalizeShortcutParts(shortcut: string) {
+  const tokens = shortcut.split("+").map((token) => token.trim()).filter(Boolean);
+  const modifiers = new Set<string>();
+  let key = "";
+
+  for (const token of tokens) {
+    const normalizedModifier = normalizeModifierToken(token);
+    if (normalizedModifier) {
+      modifiers.add(normalizedModifier);
+      continue;
+    }
+
+    key = normalizeKeyToken(token);
+  }
+
+  return {
+    modifiers: MODIFIER_ORDER.filter((modifier) => modifiers.has(modifier)),
+    key,
+  };
+}
+
+function normalizeEventKey(key: string): string {
+  if (key === " ") {
+    return "Space";
+  }
+
+  if (key.length === 1) {
+    return key.toUpperCase();
+  }
+
+  if (key === "Control") {
+    return "Ctrl";
+  }
+
+  return normalizeKeyToken(key);
+}
+
+export function formatShortcutForDisplay(shortcut: string, isMacLike: boolean): string {
+  const { modifiers, key } = normalizeShortcutParts(shortcut);
+  const displayParts: string[] = modifiers.map((modifier) => {
+    if (modifier === "Mod") {
+      return isMacLike ? "Cmd" : "Ctrl";
+    }
+
+    if (modifier === "Meta") {
+      return isMacLike ? "Cmd" : "Meta";
+    }
+
+    return modifier;
+  });
+
+  if (key) {
+    displayParts.push(key);
+  }
+
+  return displayParts.join("+");
+}
+
+export function matchShortcutEvent(
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey">,
+  shortcut: string,
+  isMacLike: boolean,
+): boolean {
+  const { modifiers, key } = normalizeShortcutParts(shortcut);
+  const normalizedKey = normalizeEventKey(event.key);
+
+  if (!key || key !== normalizedKey) {
+    return false;
+  }
+
+  const requiresMod = modifiers.includes("Mod");
+  const requiresMeta = modifiers.includes("Meta");
+  const requiresCtrl = modifiers.includes("Ctrl");
+  const requiresAlt = modifiers.includes("Alt");
+  const requiresShift = modifiers.includes("Shift");
+
+  const expectedMeta = requiresMeta || (requiresMod && isMacLike);
+  const expectedCtrl = requiresCtrl || (requiresMod && !isMacLike);
+
+  if (event.metaKey !== expectedMeta) {
+    return false;
+  }
+
+  if (event.ctrlKey !== expectedCtrl) {
+    return false;
+  }
+
+  if (event.altKey !== requiresAlt) {
+    return false;
+  }
+
+  if (event.shiftKey !== requiresShift) {
+    return false;
+  }
+
+  return true;
+}
+
+export function captureShortcutFromEvent(
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey">,
+): string | null {
+  if (MODIFIER_KEYS.has(event.key)) {
+    return null;
+  }
+
+  const modifiers: string[] = [];
+
+  if (event.metaKey) {
+    modifiers.push("Meta");
+  }
+
+  if (event.ctrlKey) {
+    modifiers.push("Ctrl");
+  }
+
+  if (event.altKey) {
+    modifiers.push("Alt");
+  }
+
+  if (event.shiftKey) {
+    modifiers.push("Shift");
+  }
+
+  if (modifiers.length === 0) {
+    return null;
+  }
+
+  const key = normalizeEventKey(event.key);
+  if (!key) {
+    return null;
+  }
+
+  return [...modifiers, key].join("+");
+}


### PR DESCRIPTION
## Related Materials
- Local parent branch: `feat/git-branch-research`
- PR base branch: `refactor/nextron`
- Commit: `ab96884`

## What does this PR do?
- adds a global quick search entry point for existing task detail pages
- lets users search by branch or project name and navigate results entirely with the keyboard
- distinguishes SSH remote tasks from local tasks and adds a configurable default shortcut

## How is it fixed?
### Global search flow
- mount a renderer-level search dialog for authenticated screens
- fetch searchable task metadata from the desktop service and rank matches across branch, project, and title fields
- support arrow navigation, Enter to open `/task/:id`, and Escape to close the dialog

### Shortcut settings and task labeling
- persist the task search shortcut in app settings and expose a recorder in Project Settings -> Detail Page
- default the shortcut to `Cmd+Shift+O` on macOS through `Mod+Shift+O` normalization and `Ctrl+Shift+O` elsewhere
- label search results as local or remote based on `sshHost` and show the remote host name when present

### Wiring, copy, and coverage
- pass the configured shortcut through the board route and board shell so the dialog stays in sync with settings changes
- add localized copy and README documentation for the quick search workflow
- cover keyboard shortcut parsing, dialog behavior, board/settings integration, and route loading with tests

## Important changes
### New quick search surface
- **Change**: add a global dialog that can open task detail pages from anywhere in the authenticated desktop app
- **Files**: `src/desktop/renderer/components/TaskQuickSearchDialog.tsx`, `src/desktop/renderer/App.tsx`, `src/desktop/main/services/kanbanService.ts`, `src/desktop/renderer/actions/kanban.ts`

### Configurable shortcut handling
- **Change**: add normalized shortcut parsing, display formatting, persistence, and settings capture UI
- **Files**: `src/desktop/renderer/utils/keyboardShortcut.ts`, `src/desktop/main/services/appSettingsService.ts`, `src/desktop/renderer/actions/appSettings.ts`, `src/components/ProjectSettings.tsx`

### Supporting integration and tests
- **Change**: wire the shortcut through board loading and add regression coverage plus docs/localized strings
- **Files**: `src/desktop/renderer/routes/BoardRoute.tsx`, `src/components/Board.tsx`, `src/components/__tests__/Board.test.tsx`, `src/components/__tests__/ProjectSettings.test.tsx`, `src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx`, `src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts`, `README.md`, `messages/en.json`, `messages/ko.json`, `messages/zh.json`

Co-Authored-By: OpenAI Codex <codex@openai.com>
