### PR TITLE
feat(board): batch merged PR confirmations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -38,6 +38,7 @@
     "prMergeAlert": {
       "title": "PR merge detected",
       "message": "Kanvibe detected that worktree PR {branchName} was merged. Move the task \"{taskTitle}\" to Done?",
+      "batchMessage": "These PRs were detected as merged during the latest scan. Check the tasks you want to move to Done and handle them together.",
       "prLinkLabel": "PR Link"
     }
   },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -38,6 +38,7 @@
     "prMergeAlert": {
       "title": "PR merge 감지",
       "message": "worktree PR {branchName} 가 merge 된 것을 확인했습니다. \"{taskTitle}\" task를 Done으로 옮길까요?",
+      "batchMessage": "이번 탐색에서 merge가 확인된 PR 목록입니다. Done으로 옮길 task를 체크해서 한 번에 처리하세요.",
       "prLinkLabel": "PR 링크"
     }
   },

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -18,7 +18,7 @@ import type { Project } from "@/entities/Project";
 import { useAutoRefresh } from "@/desktop/renderer/hooks/useAutoRefresh";
 import { useProjectFilterParams } from "@/desktop/renderer/hooks/useProjectFilterParams";
 import { computeProjectColor } from "@/lib/projectColor";
-import type { BoardEventPayload } from "@/lib/boardNotifier";
+import type { BoardEventPayload, TaskPrMergedDetectedPayload } from "@/lib/boardNotifier";
 
 interface BoardProps {
   initialTasks: TasksByStatus;
@@ -105,8 +105,25 @@ function isTaskPrMergedDetectedEvent(
   return event.type === "task-pr-merged-detected";
 }
 
+function isTaskPrMergedDetectedBatchEvent(
+  event: BoardEventPayload,
+): event is Extract<BoardEventPayload, { type: "task-pr-merged-detected-batch" }> {
+  return event.type === "task-pr-merged-detected-batch";
+}
+
 function buildMergedPrEventKey(taskId: string, prUrl: string, mergedAt: string) {
   return `${taskId}:${prUrl}:${mergedAt}`;
+}
+
+function createPrMergeAlertState(payload: TaskPrMergedDetectedPayload): PrMergeAlertState {
+  return {
+    eventKey: buildMergedPrEventKey(payload.taskId, payload.prUrl, payload.mergedAt),
+    taskId: payload.taskId,
+    taskTitle: payload.taskTitle,
+    branchName: payload.branchName,
+    prUrl: payload.prUrl,
+    mergedAt: payload.mergedAt,
+  };
 }
 
 interface DragMovePlan {
@@ -226,6 +243,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const [, startDragPersistenceTransition] = useTransition();
   const [isPrMergeActionPending, startPrMergeActionTransition] = useTransition();
   const [prMergeAlerts, setPrMergeAlerts] = useState<PrMergeAlertState[]>([]);
+  const [selectedPrMergeEventKeys, setSelectedPrMergeEventKeys] = useState<string[]>([]);
   const dismissedPrMergeEventKeysRef = useRef<Set<string>>(new Set());
 
   /** projectId → 표시할 프로젝트 이름 매핑. worktree 프로젝트는 메인 프로젝트 이름으로 resolve한다 */
@@ -377,34 +395,42 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
     }
 
     return window.kanvibeDesktop.onBoardEvent((event: BoardEventPayload) => {
-      if (!isTaskPrMergedDetectedEvent(event)) {
-        return;
-      }
+      const incomingAlerts = isTaskPrMergedDetectedBatchEvent(event)
+        ? event.mergedPullRequests.map(createPrMergeAlertState)
+        : isTaskPrMergedDetectedEvent(event)
+          ? [createPrMergeAlertState(event)]
+          : null;
 
-      const eventKey = buildMergedPrEventKey(event.taskId, event.prUrl, event.mergedAt);
-      if (dismissedPrMergeEventKeysRef.current.has(eventKey)) {
+      if (!incomingAlerts) {
         return;
       }
 
       setPrMergeAlerts((current) => {
-        if (current.some((alert) => alert.eventKey === eventKey)) {
-          return current;
+        const knownEventKeys = new Set(current.map((alert) => alert.eventKey));
+        const nextAlerts = [...current];
+
+        for (const alert of incomingAlerts) {
+          if (dismissedPrMergeEventKeysRef.current.has(alert.eventKey) || knownEventKeys.has(alert.eventKey)) {
+            continue;
+          }
+
+          knownEventKeys.add(alert.eventKey);
+          nextAlerts.push(alert);
         }
 
-        return [
-          ...current,
-          {
-            eventKey,
-            taskId: event.taskId,
-            taskTitle: event.taskTitle,
-            branchName: event.branchName,
-            prUrl: event.prUrl,
-            mergedAt: event.mergedAt,
-          },
-        ];
+        return nextAlerts;
       });
     });
   }, []);
+
+  useEffect(() => {
+    if (prMergeAlerts.length === 0) {
+      setSelectedPrMergeEventKeys([]);
+      return;
+    }
+
+    setSelectedPrMergeEventKeys(prMergeAlerts.map((alert) => alert.eventKey));
+  }, [prMergeAlerts]);
 
   const handleLoadMoreDone = useCallback(async () => {
     if (isLoadingMore) return;
@@ -489,32 +515,52 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
     setPendingDoneResult(null);
   }, []);
 
-  const activePrMergeAlert = prMergeAlerts[0] ?? null;
+  const selectedPrMergeEventKeySet = useMemo(
+    () => new Set(selectedPrMergeEventKeys),
+    [selectedPrMergeEventKeys],
+  );
 
-  const dismissActivePrMergeAlert = useCallback(() => {
-    setPrMergeAlerts((current) => current.slice(1));
+  const togglePrMergeSelection = useCallback((eventKey: string) => {
+    setSelectedPrMergeEventKeys((current) => (
+      current.includes(eventKey)
+        ? current.filter((key) => key !== eventKey)
+        : [...current, eventKey]
+    ));
   }, []);
 
   const handlePrMergeCancel = useCallback(() => {
-    if (activePrMergeAlert) {
-      dismissedPrMergeEventKeysRef.current.add(activePrMergeAlert.eventKey);
+    for (const alert of prMergeAlerts) {
+      dismissedPrMergeEventKeysRef.current.add(alert.eventKey);
     }
-    dismissActivePrMergeAlert();
-  }, [activePrMergeAlert, dismissActivePrMergeAlert]);
+    setPrMergeAlerts([]);
+  }, [prMergeAlerts]);
 
   const handlePrMergeConfirm = useCallback(() => {
-    if (!activePrMergeAlert) {
+    if (prMergeAlerts.length === 0) {
       return;
     }
 
-    dismissedPrMergeEventKeysRef.current.add(activePrMergeAlert.eventKey);
-    const { taskId } = activePrMergeAlert;
-    dismissActivePrMergeAlert();
+    const selectedEventKeys = new Set(selectedPrMergeEventKeys);
+    const selectedTaskIds = prMergeAlerts
+      .filter((alert) => selectedEventKeys.has(alert.eventKey))
+      .map((alert) => alert.taskId);
+
+    for (const alert of prMergeAlerts) {
+      dismissedPrMergeEventKeysRef.current.add(alert.eventKey);
+    }
+
+    setPrMergeAlerts([]);
+
+    if (selectedTaskIds.length === 0) {
+      return;
+    }
 
     startPrMergeActionTransition(async () => {
-      await updateTaskStatus(taskId, TaskStatus.DONE);
+      for (const taskId of selectedTaskIds) {
+        await updateTaskStatus(taskId, TaskStatus.DONE);
+      }
     });
-  }, [activePrMergeAlert, dismissActivePrMergeAlert, startPrMergeActionTransition]);
+  }, [prMergeAlerts, selectedPrMergeEventKeys, startPrMergeActionTransition]);
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent, task: KanbanTask) => {
@@ -692,27 +738,48 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         onCancel={handleDoneCancel}
       />
 
-      {activePrMergeAlert && (
+      {prMergeAlerts.length > 0 && (
         <div className="fixed inset-0 z-[520] flex items-center justify-center bg-bg-overlay">
-          <div className="w-full max-w-md rounded-xl border border-border-default bg-bg-surface p-6 shadow-lg">
+          <div className="w-full max-w-2xl rounded-xl border border-border-default bg-bg-surface p-6 shadow-lg">
             <h2 className="mb-2 text-lg font-semibold text-text-primary">
               {tm("title")}
             </h2>
             <p className="text-sm text-text-secondary">
-              {tm("message", {
-                branchName: activePrMergeAlert.branchName,
-                taskTitle: activePrMergeAlert.taskTitle,
-              })}
+              {tm("batchMessage")}
             </p>
-            <a
-              href={activePrMergeAlert.prUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-4 inline-flex max-w-full items-center gap-1 rounded bg-tag-pr-bg px-2 py-1 text-xs text-tag-pr-text hover:opacity-80 transition-opacity"
-            >
-              <span className="shrink-0">{tm("prLinkLabel")}</span>
-              <span className="truncate">{activePrMergeAlert.prUrl}</span>
-            </a>
+            <div className="mt-4 max-h-[360px] space-y-3 overflow-y-auto pr-1">
+              {prMergeAlerts.map((alert) => (
+                <label
+                  key={alert.eventKey}
+                  className="flex cursor-pointer items-start gap-3 rounded-lg border border-border-default bg-bg-page px-4 py-3"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedPrMergeEventKeySet.has(alert.eventKey)}
+                    onChange={() => togglePrMergeSelection(alert.eventKey)}
+                    aria-label={alert.taskTitle}
+                    className="mt-0.5 h-4 w-4 rounded border-border-default text-brand-primary focus:ring-brand-primary"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-semibold text-text-primary">
+                      {alert.taskTitle}
+                    </p>
+                    <p className="mt-1 text-xs text-text-muted">
+                      {alert.branchName}
+                    </p>
+                    <a
+                      href={alert.prUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-3 inline-flex max-w-full items-center gap-1 rounded bg-tag-pr-bg px-2 py-1 text-xs text-tag-pr-text transition-opacity hover:opacity-80"
+                    >
+                      <span className="shrink-0">{tm("prLinkLabel")}</span>
+                      <span className="truncate">{alert.prUrl}</span>
+                    </a>
+                  </div>
+                </label>
+              ))}
+            </div>
             <div className="mt-5 flex justify-end gap-2">
               <button
                 type="button"

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -282,7 +282,7 @@ describe("Board defaultSessionType sync", () => {
     expect(screen.queryByRole("button", { name: "logout" })).toBeNull();
   });
 
-  it("PR merge 이벤트를 받으면 확인 모달을 띄우고 confirm 시 Done으로 이동한다", async () => {
+  it("PR merge batch 이벤트를 받으면 하나의 체크리스트 모달을 띄우고 체크된 task만 Done으로 이동한다", async () => {
     const listeners: Array<(event: unknown) => void> = [];
     window.kanvibeDesktop = {
       isDesktop: true,
@@ -304,6 +304,7 @@ describe("Board defaultSessionType sync", () => {
         doneAlertDismissed={false}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
         defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
       />,
     );
 
@@ -313,16 +314,32 @@ describe("Board defaultSessionType sync", () => {
 
     await act(async () => {
       listeners[0]({
-        type: "task-pr-merged-detected",
-        taskId: "task-1",
-        taskTitle: "Test Task",
-        branchName: "feature/pr-sync",
-        prUrl: "https://github.com/kanvibe/kanvibe/pull/210",
-        mergedAt: "2026-04-30T02:00:00Z",
+        type: "task-pr-merged-detected-batch",
+        mergedPullRequests: [
+          {
+            taskId: "task-1",
+            taskTitle: "Test Task",
+            branchName: "feature/pr-sync",
+            prUrl: "https://github.com/kanvibe/kanvibe/pull/210",
+            mergedAt: "2026-04-30T02:00:00Z",
+          },
+          {
+            taskId: "task-2",
+            taskTitle: "Docs Task",
+            branchName: "docs/pr-sync",
+            prUrl: "https://github.com/kanvibe/kanvibe/pull/211",
+            mergedAt: "2026-04-30T02:05:00Z",
+          },
+        ],
       });
     });
 
     expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/210")).toBeTruthy();
+    expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/211")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("checkbox", { name: "Docs Task" }));
+    });
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "confirm" }));
@@ -331,5 +348,6 @@ describe("Board defaultSessionType sync", () => {
     await waitFor(() => {
       expect(updateTaskStatus).toHaveBeenCalledWith("task-1", TaskStatus.DONE);
     });
+    expect(updateTaskStatus).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -555,6 +555,42 @@ describe("kanbanService.createTask", () => {
     expect(mocks.broadcastTaskPrMergedDetected).not.toHaveBeenCalled();
   });
 
+  it("active task PR sync는 메인 브랜치 root task를 merge 검사 대상에서 제외한다", async () => {
+    // Given
+    mocks.taskRepo.find.mockResolvedValue([
+      {
+        id: "task-main",
+        title: "Main branch task",
+        projectId: "project-1",
+        branchName: "main",
+        worktreePath: "/workspace/repo",
+        sshHost: null,
+        prUrl: null,
+        status: "review",
+      },
+    ]);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+
+    const { syncActiveTaskPullRequests } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await syncActiveTaskPullRequests(new Set());
+
+    // Then
+    expect(result).toEqual({
+      updatedTaskIds: [],
+      mergeEventKeys: [],
+    });
+    expect(mocks.execFile).not.toHaveBeenCalled();
+    expect(mocks.taskRepo.save).not.toHaveBeenCalled();
+    expect(mocks.broadcastTaskPrMergedDetected).not.toHaveBeenCalled();
+  });
+
   it("active task PR sync는 merged PR을 감지하면 중복 없이 merge 이벤트를 브로드캐스트한다", async () => {
     // Given
     const prUrl = "https://github.com/kanvibe/kanvibe/pull/211";

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -19,7 +19,7 @@ const mocks = vi.hoisted(() => ({
   broadcastBoardUpdate: vi.fn(),
   execGit: vi.fn(),
   broadcastTaskHookInstallFailed: vi.fn(),
-  broadcastTaskPrMergedDetected: vi.fn(),
+  broadcastTaskPrMergedDetectedBatch: vi.fn(),
 }));
 
 vi.mock("child_process", () => ({
@@ -67,7 +67,7 @@ vi.mock("@/lib/kanvibeHooksInstaller", () => ({
 vi.mock("@/lib/boardNotifier", () => ({
   broadcastBoardUpdate: mocks.broadcastBoardUpdate,
   broadcastTaskHookInstallFailed: mocks.broadcastTaskHookInstallFailed,
-  broadcastTaskPrMergedDetected: mocks.broadcastTaskPrMergedDetected,
+  broadcastTaskPrMergedDetectedBatch: mocks.broadcastTaskPrMergedDetectedBatch,
 }));
 
 vi.mock("@/lib/gitOperations", () => ({
@@ -552,7 +552,7 @@ describe("kanbanService.createTask", () => {
       id: "task-9",
       prUrl,
     }));
-    expect(mocks.broadcastTaskPrMergedDetected).not.toHaveBeenCalled();
+    expect(mocks.broadcastTaskPrMergedDetectedBatch).not.toHaveBeenCalled();
   });
 
   it("active task PR sync는 merged PR을 감지하면 중복 없이 merge 이벤트를 브로드캐스트한다", async () => {
@@ -594,13 +594,15 @@ describe("kanbanService.createTask", () => {
     await syncActiveTaskPullRequests(mergeEventKeys);
 
     // Then
-    expect(mocks.broadcastTaskPrMergedDetected).toHaveBeenCalledTimes(1);
-    expect(mocks.broadcastTaskPrMergedDetected).toHaveBeenCalledWith({
-      taskId: "task-10",
-      taskTitle: "Merged PR task",
-      branchName: "feature/merged-pr",
-      prUrl,
-      mergedAt: "2026-04-30T02:00:00Z",
+    expect(mocks.broadcastTaskPrMergedDetectedBatch).toHaveBeenCalledTimes(1);
+    expect(mocks.broadcastTaskPrMergedDetectedBatch).toHaveBeenCalledWith({
+      mergedPullRequests: [{
+        taskId: "task-10",
+        taskTitle: "Merged PR task",
+        branchName: "feature/merged-pr",
+        prUrl,
+        mergedAt: "2026-04-30T02:00:00Z",
+      }],
     });
   });
 });

--- a/src/desktop/main/services/desktopNotificationService.ts
+++ b/src/desktop/main/services/desktopNotificationService.ts
@@ -89,7 +89,10 @@ export async function deliverBoardEventNotification(
     return false;
   }
 
-  if (payload.type === "task-pr-merged-detected") {
+  if (
+    payload.type === "task-pr-merged-detected"
+    || payload.type === "task-pr-merged-detected-batch"
+  ) {
     return false;
   }
 

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -5,7 +5,7 @@ import { KanbanTask, TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
 import { createWorktreeWithSession, removeWorktreeAndBranch, createSessionWithoutWorktree, removeSessionOnly, buildManagedWorktreePath } from "@/lib/worktree";
 import { getProjectRepository } from "@/lib/database";
-import { broadcastBoardUpdate, broadcastTaskHookInstallFailed, broadcastTaskPrMergedDetected } from "@/lib/boardNotifier";
+import { broadcastBoardUpdate, broadcastTaskHookInstallFailed, broadcastTaskPrMergedDetectedBatch, type TaskPrMergedDetectedPayload } from "@/lib/boardNotifier";
 import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
 import { execGit } from "@/lib/gitOperations";
 
@@ -45,6 +45,7 @@ interface GitHubPullRequestInfo {
 export interface ActiveTaskPullRequestSyncResult {
   updatedTaskIds: string[];
   mergeEventKeys: string[];
+  mergedPullRequests: TaskPrMergedDetectedPayload[];
 }
 
 /** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
@@ -733,6 +734,7 @@ export async function syncActiveTaskPullRequests(
   const result: ActiveTaskPullRequestSyncResult = {
     updatedTaskIds: [],
     mergeEventKeys: [],
+    mergedPullRequests: [],
   };
 
   for (const task of tasks) {
@@ -762,7 +764,7 @@ export async function syncActiveTaskPullRequests(
 
         emittedMergeEventKeys.add(mergeEventKey);
         result.mergeEventKeys.push(mergeEventKey);
-        broadcastTaskPrMergedDetected({
+        result.mergedPullRequests.push({
           taskId: task.id,
           taskTitle: task.title,
           branchName: task.branchName,
@@ -777,6 +779,12 @@ export async function syncActiveTaskPullRequests(
         error: getErrorMessage(error),
       });
     }
+  }
+
+  if (result.mergedPullRequests.length > 0) {
+    broadcastTaskPrMergedDetectedBatch({
+      mergedPullRequests: result.mergedPullRequests,
+    });
   }
 
   return result;

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -210,19 +210,32 @@ async function getPrInfoFromGitHubCli(
   });
 }
 
-async function resolveTaskGitContext(task: Pick<KanbanTask, "projectId" | "worktreePath" | "sshHost">): Promise<{
+function isDefaultBranchTask(
+  task: Pick<KanbanTask, "branchName">,
+  project: { defaultBranch: string } | null,
+): boolean {
+  return Boolean(project && task.branchName && task.branchName === project.defaultBranch);
+}
+
+async function resolveTaskGitContext(
+  task: Pick<KanbanTask, "projectId" | "worktreePath" | "sshHost">,
+  project?: { repoPath: string; sshHost: string | null } | null,
+): Promise<{
   cwd: string;
   sshHost: string | null;
 }> {
   let repoPath: string | null = null;
   let sshHost: string | null = task.sshHost || null;
 
-  if (task.projectId) {
+  if (project) {
+    repoPath = project.repoPath;
+    sshHost = sshHost ?? project.sshHost ?? null;
+  } else if (task.projectId) {
     const projectRepo = await getProjectRepository();
-    const project = await projectRepo.findOneBy({ id: task.projectId });
-    if (project) {
-      repoPath = project.repoPath;
-      sshHost = sshHost ?? project.sshHost ?? null;
+    const resolvedProject = await projectRepo.findOneBy({ id: task.projectId });
+    if (resolvedProject) {
+      repoPath = resolvedProject.repoPath;
+      sshHost = sshHost ?? resolvedProject.sshHost ?? null;
     }
   }
 
@@ -726,6 +739,7 @@ export async function syncActiveTaskPullRequests(
   emittedMergeEventKeys: Set<string>,
 ): Promise<ActiveTaskPullRequestSyncResult> {
   const repo = await getTaskRepository();
+  const projectRepo = await getProjectRepository();
   const tasks = await repo.find({
     where: { status: Not(TaskStatus.DONE) },
     order: { updatedAt: "ASC" },
@@ -741,7 +755,15 @@ export async function syncActiveTaskPullRequests(
     }
 
     try {
-      const { cwd, sshHost } = await resolveTaskGitContext(task);
+      const project = task.projectId
+        ? await projectRepo.findOneBy({ id: task.projectId })
+        : null;
+
+      if (isDefaultBranchTask(task, project)) {
+        continue;
+      }
+
+      const { cwd, sshHost } = await resolveTaskGitContext(task, project);
       const prInfo = await getPrInfoFromGitHubCli(task.branchName, cwd, sshHost);
 
       if (!prInfo?.url) {

--- a/src/lib/boardNotifier.ts
+++ b/src/lib/boardNotifier.ts
@@ -33,12 +33,17 @@ export interface TaskPrMergedDetectedPayload {
   mergedAt: string;
 }
 
+export interface TaskPrMergedDetectedBatchPayload {
+  mergedPullRequests: TaskPrMergedDetectedPayload[];
+}
+
 export type BoardEventPayload =
   | BoardUpdatedPayload
   | ({ type: "task-status-changed" } & TaskStatusChangedPayload)
   | ({ type: "hook-status-target-missing" } & HookStatusTargetMissingPayload)
   | ({ type: "task-hook-install-failed" } & TaskHookInstallFailedPayload)
-  | ({ type: "task-pr-merged-detected" } & TaskPrMergedDetectedPayload);
+  | ({ type: "task-pr-merged-detected" } & TaskPrMergedDetectedPayload)
+  | ({ type: "task-pr-merged-detected-batch" } & TaskPrMergedDetectedBatchPayload);
 
 const boardEventEmitter = new EventEmitter();
 
@@ -78,4 +83,9 @@ export function broadcastTaskHookInstallFailed(payload: TaskHookInstallFailedPay
 /** background PR sync가 merge 완료를 감지하면 보드 확인 알럿으로 전달한다 */
 export function broadcastTaskPrMergedDetected(payload: TaskPrMergedDetectedPayload) {
   emitBoardEvent({ type: "task-pr-merged-detected", ...payload });
+}
+
+/** background PR sync 한 사이클에서 감지된 merged PR 목록을 한 번에 전달한다 */
+export function broadcastTaskPrMergedDetectedBatch(payload: TaskPrMergedDetectedBatchPayload) {
+  emitBoardEvent({ type: "task-pr-merged-detected-batch", ...payload });
 }


### PR DESCRIPTION
## Related Resources
- Issue: N/A

## What is this?
- Group merged PR detections from one sync pass into a single review dialog instead of showing one modal per merged PR.

## How did I solve it?
**Batch merge detection**
- Collect merged PR detections during a sync cycle and emit a single batch event after the scan completes.
- Keep duplicate suppression intact and ignore the new batch event in desktop notification delivery.

**Single checklist dialog**
- Replace the sequential merge confirmation modal with one checklist dialog that lists every merged PR found in the latest scan.
- Let users uncheck items they do not want to move to Done, and update localized copy plus tests for the new flow.

## What are the important changes?
### Batch event pipeline

**Emit merged PR results once per scan**
- **Reason**: match the desired post-scan UX and prevent modal spam when multiple PRs merge together.
- **Files**: `src/lib/boardNotifier.ts`, `src/desktop/main/services/kanbanService.ts`, `src/desktop/main/services/desktopNotificationService.ts`

### Board merge confirmation flow

**Replace sequential confirmations with checklist selection**
- **Reason**: allow users to review all merged tasks in one place and confirm only the ones they want to close.
- **Files**: `src/components/Board.tsx`, `messages/ko.json`, `messages/en.json`

**Cover the batch flow with tests**
- **Reason**: keep renderer behavior and service broadcasting aligned as the event contract changes.
- **Files**: `src/components/__tests__/Board.test.tsx`, `src/desktop/main/services/__tests__/kanbanService.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>
