### PR TITLE
fix(sync): skip default branch tasks during PR merge sync

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -555,6 +555,42 @@ describe("kanbanService.createTask", () => {
     expect(mocks.broadcastTaskPrMergedDetected).not.toHaveBeenCalled();
   });
 
+  it("active task PR sync는 메인 브랜치 root task를 merge 검사 대상에서 제외한다", async () => {
+    // Given
+    mocks.taskRepo.find.mockResolvedValue([
+      {
+        id: "task-main",
+        title: "Main branch task",
+        projectId: "project-1",
+        branchName: "main",
+        worktreePath: "/workspace/repo",
+        sshHost: null,
+        prUrl: null,
+        status: "review",
+      },
+    ]);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+
+    const { syncActiveTaskPullRequests } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await syncActiveTaskPullRequests(new Set());
+
+    // Then
+    expect(result).toEqual({
+      updatedTaskIds: [],
+      mergeEventKeys: [],
+    });
+    expect(mocks.execFile).not.toHaveBeenCalled();
+    expect(mocks.taskRepo.save).not.toHaveBeenCalled();
+    expect(mocks.broadcastTaskPrMergedDetected).not.toHaveBeenCalled();
+  });
+
   it("active task PR sync는 merged PR을 감지하면 중복 없이 merge 이벤트를 브로드캐스트한다", async () => {
     // Given
     const prUrl = "https://github.com/kanvibe/kanvibe/pull/211";

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -210,19 +210,32 @@ async function getPrInfoFromGitHubCli(
   });
 }
 
-async function resolveTaskGitContext(task: Pick<KanbanTask, "projectId" | "worktreePath" | "sshHost">): Promise<{
+function isDefaultBranchTask(
+  task: Pick<KanbanTask, "branchName">,
+  project: { defaultBranch: string } | null,
+): boolean {
+  return Boolean(project && task.branchName && task.branchName === project.defaultBranch);
+}
+
+async function resolveTaskGitContext(
+  task: Pick<KanbanTask, "projectId" | "worktreePath" | "sshHost">,
+  project?: { repoPath: string; sshHost: string | null } | null,
+): Promise<{
   cwd: string;
   sshHost: string | null;
 }> {
   let repoPath: string | null = null;
   let sshHost: string | null = task.sshHost || null;
 
-  if (task.projectId) {
+  if (project) {
+    repoPath = project.repoPath;
+    sshHost = sshHost ?? project.sshHost ?? null;
+  } else if (task.projectId) {
     const projectRepo = await getProjectRepository();
-    const project = await projectRepo.findOneBy({ id: task.projectId });
-    if (project) {
-      repoPath = project.repoPath;
-      sshHost = sshHost ?? project.sshHost ?? null;
+    const resolvedProject = await projectRepo.findOneBy({ id: task.projectId });
+    if (resolvedProject) {
+      repoPath = resolvedProject.repoPath;
+      sshHost = sshHost ?? resolvedProject.sshHost ?? null;
     }
   }
 
@@ -726,6 +739,7 @@ export async function syncActiveTaskPullRequests(
   emittedMergeEventKeys: Set<string>,
 ): Promise<ActiveTaskPullRequestSyncResult> {
   const repo = await getTaskRepository();
+  const projectRepo = await getProjectRepository();
   const tasks = await repo.find({
     where: { status: Not(TaskStatus.DONE) },
     order: { updatedAt: "ASC" },
@@ -741,7 +755,15 @@ export async function syncActiveTaskPullRequests(
     }
 
     try {
-      const { cwd, sshHost } = await resolveTaskGitContext(task);
+      const project = task.projectId
+        ? await projectRepo.findOneBy({ id: task.projectId })
+        : null;
+
+      if (isDefaultBranchTask(task, project)) {
+        continue;
+      }
+
+      const { cwd, sshHost } = await resolveTaskGitContext(task, project);
       const prInfo = await getPrInfoFromGitHubCli(task.branchName, cwd, sshHost);
 
       if (!prInfo?.url) {


### PR DESCRIPTION
## Related
- Issue: none

## What does this PR do?
- Prevent background PR merge sync from treating the project root default-branch task as a merge candidate.

## How is it solved?
**Skip default branch root tasks**
- Resolve the owning project before PR sync and skip tasks whose branch matches the project's default branch.
- Reuse the resolved project context when deriving git cwd and SSH information.

**Add regression coverage**
- Add a regression test that proves the default-branch root task does not call `gh`, does not save a PR URL, and does not emit merge events.

## Key changes
### Background PR sync

**Exclude default branch tasks from merge detection**
- **Why**: The main worktree task should not be nudged toward Done by worktree PR merge checks.
- **Files changed**: `src/desktop/main/services/kanbanService.ts`

### Regression test

**Protect the default-branch root task path**
- **Why**: Prevent future regressions where the project root task is treated like a worktree PR task.
- **Files changed**: `src/desktop/main/services/__tests__/kanbanService.test.ts`

Co-authored-by: OpenAI Codex <codex@openai.com>
