### PR TITLE
fix(remote): avoid aliased runtime imports in ssh checks

### DIFF
--- a/src/lib/__tests__/runtimeImportSafety.test.ts
+++ b/src/lib/__tests__/runtimeImportSafety.test.ts
@@ -1,0 +1,28 @@
+import { readFile } from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(currentDir, "../../..");
+
+describe("runtime import safety", () => {
+  it("런타임 라이브러리 코드에 aliased dynamic import를 두지 않는다", async () => {
+    const runtimeFiles = [
+      path.join(projectRoot, "src/lib/gitOperations.ts"),
+    ];
+
+    const offenders: string[] = [];
+
+    for (const filePath of runtimeFiles) {
+      const source = await readFile(filePath, "utf-8");
+      const matches = source.match(/import\(\s*["']@\/[^"']+["']\s*\)/g) ?? [];
+
+      if (matches.length > 0) {
+        offenders.push(`${path.relative(projectRoot, filePath)}: ${matches.join(", ")}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -3,7 +3,7 @@ import { promisify } from "util";
 import { mkdir, readFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
-import { buildSSHArgs, type SSHHostConfig } from "@/lib/sshConfig";
+import { buildSSHArgs, parseSSHConfig, type SSHHostConfig } from "@/lib/sshConfig";
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -88,8 +88,6 @@ async function execLocal(command: string): Promise<string> {
 
 /** SSH를 통해 원격에서 명령을 실행하고 stdout을 반환한다 */
 async function execRemote(sshHost: string, command: string): Promise<string> {
-  const { parseSSHConfig } = await import("@/lib/sshConfig");
-
   const configs = await parseSSHConfig();
   const hostConfig = configs.find((c) => c.host === sshHost);
 


### PR DESCRIPTION
## What is this?
- Prevent remote dependency checks from failing before SSH command probes run in the Electron runtime.

## How was it solved?
**Stabilize SSH config loading**
- Replace the aliased dynamic import in `gitOperations` with the existing static `parseSSHConfig` import so remote probes no longer depend on runtime alias resolution.

**Add regression coverage**
- Add a runtime safety test that fails if aliased dynamic imports are reintroduced in runtime library code.

## Important changes
### Stabilize remote dependency checks

**Remove the runtime-only alias dependency**
- **Reason**: Electron resolves the `@/` alias for the existing main-module path, but this dynamic import path could still fail and surface as false `gh` or `tmux` dependency errors.
- **Files**: `src/lib/gitOperations.ts`

### Guard against regressions

**Add import safety coverage**
- **Reason**: Catch the same runtime import pattern before it can break remote terminal access again.
- **Files**: `src/lib/__tests__/runtimeImportSafety.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>
