### PR TITLE
fix(desktop): route background sync review through notifications

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -33,11 +33,20 @@ let mainWindow = null;
 let hookServer = null;
 let windowOpenHelpers = null;
 let stopBackgroundTaskSync = null;
+let pendingNotificationActivation = null;
 
 function broadcastNotificationsChanged() {
   for (const window of BrowserWindow.getAllWindows()) {
     if (!window.isDestroyed()) {
       window.webContents.send("kanvibe:notifications-changed");
+    }
+  }
+}
+
+function broadcastNotificationActivated(appNotification) {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send("kanvibe:notification-activated", appNotification);
     }
   }
 }
@@ -187,12 +196,15 @@ function createDesktopNotificationOptions() {
   return {
     onNotificationsChanged: broadcastNotificationsChanged,
     onNotificationClick: async (appNotification) => {
-      const targetPath = appNotification.taskId
-        ? `/${appNotification.locale}/task/${appNotification.taskId}`
-        : appNotification.relativePath;
-      await focusMainWindow(targetPath);
+      await activateAppNotification(appNotification, { markAsRead: false });
     },
   };
+}
+
+function getNotificationTargetPath(appNotification) {
+  return appNotification.taskId
+    ? `/${appNotification.locale}/task/${appNotification.taskId}`
+    : appNotification.relativePath;
 }
 
 function getAvailableWindows() {
@@ -268,9 +280,32 @@ async function focusMainWindow(relativePath) {
   }
 }
 
+function getNotificationStore() {
+  return require(getRuntimeModulePath(path.join("src", "desktop", "main", "notificationStore.ts")));
+}
+
+async function activateAppNotification(appNotification, options = {}) {
+  const notificationStore = getNotificationStore();
+  const markAsRead = options.markAsRead !== false;
+  let activatedNotification = appNotification;
+
+  if (markAsRead && !appNotification.isRead) {
+    const updatedNotification = await notificationStore.markNotificationRead(appNotification.id);
+    if (updatedNotification) {
+      activatedNotification = updatedNotification;
+    }
+    broadcastNotificationsChanged();
+  }
+
+  pendingNotificationActivation = activatedNotification;
+  await focusMainWindow(getNotificationTargetPath(activatedNotification));
+  broadcastNotificationActivated(activatedNotification);
+  return true;
+}
+
 function registerNotificationHandlers() {
   const { deliverDesktopNotification } = require(getRuntimeModulePath(path.join("src", "desktop", "main", "services", "desktopNotificationService.ts")));
-  const { listNotifications, markAllNotificationsRead, markNotificationRead } = require(getRuntimeModulePath(path.join("src", "desktop", "main", "notificationStore.ts")));
+  const { listNotifications, markAllNotificationsRead, markNotificationRead, getNotificationById } = getNotificationStore();
 
   ipcMain.handle("kanvibe:show-notification", async (_event, payload) => {
     return deliverDesktopNotification(payload, createDesktopNotificationOptions());
@@ -289,6 +324,21 @@ function registerNotificationHandlers() {
   ipcMain.handle("kanvibe:notifications-mark-all-read", async () => {
     await markAllNotificationsRead();
     broadcastNotificationsChanged();
+  });
+
+  ipcMain.handle("kanvibe:notifications-activate", async (_event, notificationId) => {
+    const notification = await getNotificationById(notificationId);
+    if (!notification) {
+      return false;
+    }
+
+    return activateAppNotification(notification);
+  });
+
+  ipcMain.handle("kanvibe:notifications-consume-activation", async () => {
+    const nextActivation = pendingNotificationActivation;
+    pendingNotificationActivation = null;
+    return nextActivation;
   });
 }
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -53,11 +53,24 @@ contextBridge.exposeInMainWorld("kanvibeDesktop", {
   markAllNotificationsRead() {
     return ipcRenderer.invoke("kanvibe:notifications-mark-all-read");
   },
+  activateNotification(notificationId) {
+    return ipcRenderer.invoke("kanvibe:notifications-activate", notificationId);
+  },
+  consumePendingNotificationActivation() {
+    return ipcRenderer.invoke("kanvibe:notifications-consume-activation");
+  },
   onNotificationsChanged(listener) {
     const handler = () => listener();
     ipcRenderer.on("kanvibe:notifications-changed", handler);
     return () => {
       ipcRenderer.removeListener("kanvibe:notifications-changed", handler);
+    };
+  },
+  onNotificationActivated(listener) {
+    const handler = (_event, payload) => listener(payload);
+    ipcRenderer.on("kanvibe:notification-activated", handler);
+    return () => {
+      ipcRenderer.removeListener("kanvibe:notification-activated", handler);
     };
   },
 });

--- a/messages/en.json
+++ b/messages/en.json
@@ -40,6 +40,14 @@
       "message": "Kanvibe detected that worktree PR {branchName} was merged. Move the task \"{taskTitle}\" to Done?",
       "batchMessage": "These PRs were detected as merged during the latest scan. Check the tasks you want to move to Done and handle them together.",
       "prLinkLabel": "PR Link"
+    },
+    "backgroundSyncReview": {
+      "title": "Background Sync Review",
+      "message": "The latest background scan found items to review. Check merged PR tasks you want to move to Done, and review newly registered worktrees as well.",
+      "mergedSection": "Merged PRs",
+      "registeredSection": "New TODO worktrees",
+      "emptyMerged": "There are no merged PR tasks to move to Done in this review.",
+      "emptyRegistered": "There are no newly registered worktrees in this review."
     }
   },
   "login": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -40,6 +40,14 @@
       "message": "worktree PR {branchName} 가 merge 된 것을 확인했습니다. \"{taskTitle}\" task를 Done으로 옮길까요?",
       "batchMessage": "이번 탐색에서 merge가 확인된 PR 목록입니다. Done으로 옮길 task를 체크해서 한 번에 처리하세요.",
       "prLinkLabel": "PR 링크"
+    },
+    "backgroundSyncReview": {
+      "title": "백그라운드 sync 검토",
+      "message": "이번 백그라운드 탐색에서 정리하거나 확인할 항목을 찾았습니다. merge 완료 PR은 체크 후 Done으로 옮기고, 새로 등록된 worktree도 함께 확인하세요.",
+      "mergedSection": "Merge 완료 PR",
+      "registeredSection": "새 TODO worktree",
+      "emptyMerged": "이번 검토에서 Done으로 옮길 merge PR이 없습니다.",
+      "emptyRegistered": "이번 검토에서 새로 등록된 worktree가 없습니다."
     }
   },
   "login": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -39,6 +39,14 @@
       "title": "检测到 PR 已合并",
       "message": "已确认 worktree PR {branchName} 已被合并。要将任务“{taskTitle}”移动到 Done 吗？",
       "prLinkLabel": "PR 链接"
+    },
+    "backgroundSyncReview": {
+      "title": "后台同步检查",
+      "message": "最近一次后台扫描发现了需要检查的项目。请勾选要移动到 Done 的已合并 PR 任务，并同时确认新注册的 worktree。",
+      "mergedSection": "已合并 PR",
+      "registeredSection": "新 TODO worktree",
+      "emptyMerged": "本次检查中没有需要移动到 Done 的已合并 PR 任务。",
+      "emptyRegistered": "本次检查中没有新注册的 worktree。"
     }
   },
   "login": {

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useMemo, useRef, useTransition } from "react";
+import { useState, useCallback, useEffect, useMemo, useTransition } from "react";
 import { useTranslations } from "next-intl";
 import { DragDropContext, type DropResult } from "@hello-pangea/dnd";
 import BoardPageFindBar from "./BoardPageFindBar";
@@ -16,10 +16,15 @@ import { reorderTasks, deleteTask, getMoreDoneTasks, moveTaskToColumn, updateTas
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
+import type { AppNotification } from "@/desktop/shared/notifications";
 import { useAutoRefresh } from "@/desktop/renderer/hooks/useAutoRefresh";
 import { useProjectFilterParams } from "@/desktop/renderer/hooks/useProjectFilterParams";
 import { computeProjectColor } from "@/lib/projectColor";
-import type { BoardEventPayload, TaskPrMergedDetectedPayload } from "@/lib/boardNotifier";
+import type {
+  BackgroundSyncReviewPayload,
+  BackgroundSyncRegisteredWorktreePayload,
+  TaskPrMergedDetectedPayload,
+} from "@/lib/boardNotifier";
 
 interface BoardProps {
   initialTasks: TasksByStatus;
@@ -47,15 +52,6 @@ interface ContextMenuState {
   x: number;
   y: number;
   task: KanbanTask | null;
-}
-
-interface PrMergeAlertState {
-  eventKey: string;
-  taskId: string;
-  taskTitle: string;
-  branchName: string;
-  prUrl: string;
-  mergedAt: string;
 }
 
 /** worktree repoPath에서 메인 프로젝트 경로를 추출한다 */
@@ -100,31 +96,20 @@ function insertAtFilteredIndex(
   return arr;
 }
 
-function isTaskPrMergedDetectedEvent(
-  event: BoardEventPayload,
-): event is Extract<BoardEventPayload, { type: "task-pr-merged-detected" }> {
-  return event.type === "task-pr-merged-detected";
-}
-
-function isTaskPrMergedDetectedBatchEvent(
-  event: BoardEventPayload,
-): event is Extract<BoardEventPayload, { type: "task-pr-merged-detected-batch" }> {
-  return event.type === "task-pr-merged-detected-batch";
-}
-
 function buildMergedPrEventKey(taskId: string, prUrl: string, mergedAt: string) {
   return `${taskId}:${prUrl}:${mergedAt}`;
 }
 
-function createPrMergeAlertState(payload: TaskPrMergedDetectedPayload): PrMergeAlertState {
-  return {
-    eventKey: buildMergedPrEventKey(payload.taskId, payload.prUrl, payload.mergedAt),
-    taskId: payload.taskId,
-    taskTitle: payload.taskTitle,
-    branchName: payload.branchName,
-    prUrl: payload.prUrl,
-    mergedAt: payload.mergedAt,
-  };
+function getMergedPrEventKey(payload: TaskPrMergedDetectedPayload) {
+  return buildMergedPrEventKey(payload.taskId, payload.prUrl, payload.mergedAt);
+}
+
+function getBackgroundSyncReviewPayload(notification: AppNotification | null | undefined): BackgroundSyncReviewPayload | null {
+  if (notification?.action?.type !== "background-sync-review") {
+    return null;
+  }
+
+  return notification.action.payload;
 }
 
 interface DragMovePlan {
@@ -221,6 +206,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const t = useTranslations("board");
   const tt = useTranslations("task");
   const tc = useTranslations("common");
+  const tr = useTranslations("common.backgroundSyncReview");
   const tm = useTranslations("common.prMergeAlert");
   const [tasks, setTasks] = useState<TasksByStatus>(initialTasks);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -243,9 +229,8 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const [shouldUseMacTitlebarLayout, setShouldUseMacTitlebarLayout] = useState(false);
   const [, startDragPersistenceTransition] = useTransition();
   const [isPrMergeActionPending, startPrMergeActionTransition] = useTransition();
-  const [prMergeAlerts, setPrMergeAlerts] = useState<PrMergeAlertState[]>([]);
+  const [backgroundSyncReview, setBackgroundSyncReview] = useState<BackgroundSyncReviewPayload | null>(null);
   const [selectedPrMergeEventKeys, setSelectedPrMergeEventKeys] = useState<string[]>([]);
-  const dismissedPrMergeEventKeysRef = useRef<Set<string>>(new Set());
 
   /** projectId → 표시할 프로젝트 이름 매핑. worktree 프로젝트는 메인 프로젝트 이름으로 resolve한다 */
   const projectNameMap = useMemo(() => {
@@ -391,47 +376,47 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   }, []);
 
   useEffect(() => {
-    if (!window.kanvibeDesktop?.onBoardEvent) {
-      return;
-    }
+    let isActive = true;
 
-    return window.kanvibeDesktop.onBoardEvent((event: BoardEventPayload) => {
-      const incomingAlerts = isTaskPrMergedDetectedBatchEvent(event)
-        ? event.mergedPullRequests.map(createPrMergeAlertState)
-        : isTaskPrMergedDetectedEvent(event)
-          ? [createPrMergeAlertState(event)]
-          : null;
-
-      if (!incomingAlerts) {
+    const applyNotification = (notification: AppNotification | null | undefined) => {
+      if (!isActive) {
         return;
       }
 
-      setPrMergeAlerts((current) => {
-        const knownEventKeys = new Set(current.map((alert) => alert.eventKey));
-        const nextAlerts = [...current];
+      const payload = getBackgroundSyncReviewPayload(notification);
+      if (!payload) {
+        return;
+      }
 
-        for (const alert of incomingAlerts) {
-          if (dismissedPrMergeEventKeysRef.current.has(alert.eventKey) || knownEventKeys.has(alert.eventKey)) {
-            continue;
-          }
+      setBackgroundSyncReview(payload);
+    };
 
-          knownEventKeys.add(alert.eventKey);
-          nextAlerts.push(alert);
-        }
-
-        return nextAlerts;
+    void window.kanvibeDesktop?.consumePendingNotificationActivation?.()
+      .then((notification: AppNotification | null) => {
+        applyNotification(notification);
+      })
+      .catch(() => {
+        /* pending activation consume 실패는 무시 */
       });
+
+    const dispose = window.kanvibeDesktop?.onNotificationActivated?.((notification: AppNotification) => {
+      applyNotification(notification);
     });
+
+    return () => {
+      isActive = false;
+      dispose?.();
+    };
   }, []);
 
   useEffect(() => {
-    if (prMergeAlerts.length === 0) {
+    if (!backgroundSyncReview || backgroundSyncReview.mergedPullRequests.length === 0) {
       setSelectedPrMergeEventKeys([]);
       return;
     }
 
-    setSelectedPrMergeEventKeys(prMergeAlerts.map((alert) => alert.eventKey));
-  }, [prMergeAlerts]);
+    setSelectedPrMergeEventKeys(backgroundSyncReview.mergedPullRequests.map(getMergedPrEventKey));
+  }, [backgroundSyncReview]);
 
   const handleLoadMoreDone = useCallback(async () => {
     if (isLoadingMore) return;
@@ -530,27 +515,20 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   }, []);
 
   const handlePrMergeCancel = useCallback(() => {
-    for (const alert of prMergeAlerts) {
-      dismissedPrMergeEventKeysRef.current.add(alert.eventKey);
-    }
-    setPrMergeAlerts([]);
-  }, [prMergeAlerts]);
+    setBackgroundSyncReview(null);
+  }, []);
 
   const handlePrMergeConfirm = useCallback(() => {
-    if (prMergeAlerts.length === 0) {
+    if (!backgroundSyncReview) {
       return;
     }
 
     const selectedEventKeys = new Set(selectedPrMergeEventKeys);
-    const selectedTaskIds = prMergeAlerts
-      .filter((alert) => selectedEventKeys.has(alert.eventKey))
+    const selectedTaskIds = backgroundSyncReview.mergedPullRequests
+      .filter((alert) => selectedEventKeys.has(getMergedPrEventKey(alert)))
       .map((alert) => alert.taskId);
 
-    for (const alert of prMergeAlerts) {
-      dismissedPrMergeEventKeysRef.current.add(alert.eventKey);
-    }
-
-    setPrMergeAlerts([]);
+    setBackgroundSyncReview(null);
 
     if (selectedTaskIds.length === 0) {
       return;
@@ -561,7 +539,7 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         await updateTaskStatus(taskId, TaskStatus.DONE);
       }
     });
-  }, [prMergeAlerts, selectedPrMergeEventKeys, startPrMergeActionTransition]);
+  }, [backgroundSyncReview, selectedPrMergeEventKeys, startPrMergeActionTransition]);
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent, task: KanbanTask) => {
@@ -740,47 +718,86 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         onCancel={handleDoneCancel}
       />
 
-      {prMergeAlerts.length > 0 && (
+      {backgroundSyncReview && (
         <div className="fixed inset-0 z-[520] flex items-center justify-center bg-bg-overlay">
           <div className="w-full max-w-2xl rounded-xl border border-border-default bg-bg-surface p-6 shadow-lg">
             <h2 className="mb-2 text-lg font-semibold text-text-primary">
-              {tm("title")}
+              {tr("title")}
             </h2>
             <p className="text-sm text-text-secondary">
-              {tm("batchMessage")}
+              {tr("message")}
             </p>
-            <div className="mt-4 max-h-[360px] space-y-3 overflow-y-auto pr-1">
-              {prMergeAlerts.map((alert) => (
-                <label
-                  key={alert.eventKey}
-                  className="flex cursor-pointer items-start gap-3 rounded-lg border border-border-default bg-bg-page px-4 py-3"
-                >
-                  <input
-                    type="checkbox"
-                    checked={selectedPrMergeEventKeySet.has(alert.eventKey)}
-                    onChange={() => togglePrMergeSelection(alert.eventKey)}
-                    aria-label={alert.taskTitle}
-                    className="mt-0.5 h-4 w-4 rounded border-border-default text-brand-primary focus:ring-brand-primary"
-                  />
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm font-semibold text-text-primary">
-                      {alert.taskTitle}
-                    </p>
-                    <p className="mt-1 text-xs text-text-muted">
-                      {alert.branchName}
-                    </p>
-                    <a
-                      href={alert.prUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="mt-3 inline-flex max-w-full items-center gap-1 rounded bg-tag-pr-bg px-2 py-1 text-xs text-tag-pr-text transition-opacity hover:opacity-80"
-                    >
-                      <span className="shrink-0">{tm("prLinkLabel")}</span>
-                      <span className="truncate">{alert.prUrl}</span>
-                    </a>
+            <div className="mt-4 max-h-[360px] space-y-5 overflow-y-auto pr-1">
+              <section>
+                <h3 className="text-sm font-semibold text-text-primary">{tr("mergedSection")}</h3>
+                {backgroundSyncReview.mergedPullRequests.length === 0 ? (
+                  <p className="mt-2 text-sm text-text-muted">{tr("emptyMerged")}</p>
+                ) : (
+                  <div className="mt-3 space-y-3">
+                    {backgroundSyncReview.mergedPullRequests.map((alert) => {
+                      const eventKey = getMergedPrEventKey(alert);
+                      return (
+                        <label
+                          key={eventKey}
+                          className="flex cursor-pointer items-start gap-3 rounded-lg border border-border-default bg-bg-page px-4 py-3"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedPrMergeEventKeySet.has(eventKey)}
+                            onChange={() => togglePrMergeSelection(eventKey)}
+                            aria-label={alert.taskTitle}
+                            className="mt-0.5 h-4 w-4 rounded border-border-default text-brand-primary focus:ring-brand-primary"
+                          />
+                          <div className="min-w-0 flex-1">
+                            <p className="text-sm font-semibold text-text-primary">
+                              {alert.taskTitle}
+                            </p>
+                            <p className="mt-1 text-xs text-text-muted">
+                              {alert.branchName}
+                            </p>
+                            <a
+                              href={alert.prUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="mt-3 inline-flex max-w-full items-center gap-1 rounded bg-tag-pr-bg px-2 py-1 text-xs text-tag-pr-text transition-opacity hover:opacity-80"
+                            >
+                              <span className="shrink-0">{tm("prLinkLabel")}</span>
+                              <span className="truncate">{alert.prUrl}</span>
+                            </a>
+                          </div>
+                        </label>
+                      );
+                    })}
                   </div>
-                </label>
-              ))}
+                )}
+              </section>
+
+              <section>
+                <h3 className="text-sm font-semibold text-text-primary">{tr("registeredSection")}</h3>
+                {backgroundSyncReview.registeredWorktrees.length === 0 ? (
+                  <p className="mt-2 text-sm text-text-muted">{tr("emptyRegistered")}</p>
+                ) : (
+                  <div className="mt-3 space-y-3">
+                    {backgroundSyncReview.registeredWorktrees.map((worktree: BackgroundSyncRegisteredWorktreePayload) => (
+                      <div
+                        key={`${worktree.taskId}:${worktree.worktreePath}`}
+                        className="rounded-lg border border-border-default bg-bg-page px-4 py-3"
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <p className="text-sm font-semibold text-text-primary">
+                            {worktree.projectName}
+                          </p>
+                          <span className="rounded-full bg-bg-surface px-2 py-0.5 text-[11px] text-text-muted">
+                            {tc(worktree.sshHost ? "remote" : "local")}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-xs text-text-muted">{worktree.branchName}</p>
+                        <p className="mt-3 text-xs text-text-secondary">{worktree.worktreePath}</p>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </section>
             </div>
             <div className="mt-5 flex justify-end gap-2">
               <button

--- a/src/components/NotificationCenterButton.tsx
+++ b/src/components/NotificationCenterButton.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { getTaskById } from "@/desktop/renderer/actions/kanban";
-import { markAllNotificationsRead, markNotificationRead, listNotifications } from "@/desktop/renderer/actions/notifications";
+import {
+  activateNotification,
+  listNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from "@/desktop/renderer/actions/notifications";
 import { redirect } from "@/desktop/renderer/navigation";
 import type { AppNotification } from "@/desktop/shared/notifications";
 
@@ -54,6 +59,11 @@ export default function NotificationCenterButton({ buttonClassName = "", panelCl
     }
 
     setIsOpen(false);
+
+    if (notification.action?.type === "background-sync-review") {
+      await activateNotification(notification.id);
+      return;
+    }
 
     if (notification.taskId) {
       const task = await getTaskById(notification.taskId);

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -383,11 +383,52 @@ describe("Board defaultSessionType sync", () => {
   });
 
   it("PR merge batch 이벤트를 받으면 하나의 체크리스트 모달을 띄우고 체크된 task만 Done으로 이동한다", async () => {
-    const listeners: Array<(event: unknown) => void> = [];
+    const notificationActivationListeners: Array<(notification: unknown) => void> = [];
     window.kanvibeDesktop = {
       isDesktop: true,
-      onBoardEvent: vi.fn((listener) => {
-        listeners.push(listener);
+      consumePendingNotificationActivation: vi.fn().mockResolvedValue({
+        id: "n-review",
+        title: "Background sync review",
+        body: "Review pending items",
+        taskId: null,
+        relativePath: "/ko",
+        locale: "ko",
+        isRead: false,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        dedupeKey: "background-review-1",
+        action: {
+          type: "background-sync-review",
+          payload: {
+            mergedPullRequests: [
+              {
+                taskId: "task-1",
+                taskTitle: "Test Task",
+                branchName: "feature/pr-sync",
+                prUrl: "https://github.com/kanvibe/kanvibe/pull/210",
+                mergedAt: "2026-04-30T02:00:00Z",
+              },
+              {
+                taskId: "task-2",
+                taskTitle: "Docs Task",
+                branchName: "docs/pr-sync",
+                prUrl: "https://github.com/kanvibe/kanvibe/pull/211",
+                mergedAt: "2026-04-30T02:05:00Z",
+              },
+            ],
+            registeredWorktrees: [
+              {
+                taskId: "task-worktree",
+                projectName: "kanvibe",
+                branchName: "feature-sync",
+                worktreePath: "/repo/kanvibe__worktrees/feature-sync",
+                sshHost: null,
+              },
+            ],
+          },
+        },
+      }),
+      onNotificationActivated: vi.fn((listener) => {
+        notificationActivationListeners.push(listener);
         return () => {};
       }),
     } as never;
@@ -409,36 +450,45 @@ describe("Board defaultSessionType sync", () => {
     );
 
     await waitFor(() => {
-      expect(listeners).toHaveLength(1);
+      expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/210")).toBeTruthy();
     });
 
+    expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/211")).toBeTruthy();
+    expect(screen.getByText("/repo/kanvibe__worktrees/feature-sync")).toBeTruthy();
+
     await act(async () => {
-      listeners[0]({
-        type: "task-pr-merged-detected-batch",
-        mergedPullRequests: [
-          {
-            taskId: "task-1",
-            taskTitle: "Test Task",
-            branchName: "feature/pr-sync",
-            prUrl: "https://github.com/kanvibe/kanvibe/pull/210",
-            mergedAt: "2026-04-30T02:00:00Z",
+      notificationActivationListeners[0]?.({
+        id: "n-review-2",
+        title: "Background sync review",
+        body: "Review pending items",
+        taskId: null,
+        relativePath: "/ko",
+        locale: "ko",
+        isRead: false,
+        createdAt: "2026-05-01T00:10:00.000Z",
+        dedupeKey: "background-review-2",
+        action: {
+          type: "background-sync-review",
+          payload: {
+            mergedPullRequests: [
+              {
+                taskId: "task-3",
+                taskTitle: "Release Task",
+                branchName: "release/pr-sync",
+                prUrl: "https://github.com/kanvibe/kanvibe/pull/310",
+                mergedAt: "2026-04-30T02:10:00Z",
+              },
+            ],
+            registeredWorktrees: [],
           },
-          {
-            taskId: "task-2",
-            taskTitle: "Docs Task",
-            branchName: "docs/pr-sync",
-            prUrl: "https://github.com/kanvibe/kanvibe/pull/211",
-            mergedAt: "2026-04-30T02:05:00Z",
-          },
-        ],
+        },
       });
     });
 
-    expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/210")).toBeTruthy();
-    expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/211")).toBeTruthy();
+    expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/310")).toBeTruthy();
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("checkbox", { name: "Docs Task" }));
+      fireEvent.click(screen.getByRole("checkbox", { name: "Release Task" }));
     });
 
     await act(async () => {
@@ -446,8 +496,7 @@ describe("Board defaultSessionType sync", () => {
     });
 
     await waitFor(() => {
-      expect(updateTaskStatus).toHaveBeenCalledWith("task-1", TaskStatus.DONE);
+      expect(updateTaskStatus).not.toHaveBeenCalled();
     });
-    expect(updateTaskStatus).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/__tests__/NotificationCenterButton.test.tsx
+++ b/src/components/__tests__/NotificationCenterButton.test.tsx
@@ -2,10 +2,11 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import NotificationCenterButton from "@/components/NotificationCenterButton";
 
-const { mockListNotifications, mockMarkNotificationRead, mockMarkAllNotificationsRead, mockGetTaskById, mockRedirect } = vi.hoisted(() => ({
+const { mockListNotifications, mockMarkNotificationRead, mockMarkAllNotificationsRead, mockActivateNotification, mockGetTaskById, mockRedirect } = vi.hoisted(() => ({
   mockListNotifications: vi.fn(),
   mockMarkNotificationRead: vi.fn(),
   mockMarkAllNotificationsRead: vi.fn(),
+  mockActivateNotification: vi.fn(),
   mockGetTaskById: vi.fn(),
   mockRedirect: vi.fn(),
 }));
@@ -22,6 +23,7 @@ vi.mock("@/desktop/renderer/actions/notifications", () => ({
   listNotifications: mockListNotifications,
   markNotificationRead: mockMarkNotificationRead,
   markAllNotificationsRead: mockMarkAllNotificationsRead,
+  activateNotification: mockActivateNotification,
 }));
 
 vi.mock("@/desktop/renderer/actions/kanban", () => ({
@@ -103,5 +105,46 @@ describe("NotificationCenterButton", () => {
     await waitFor(() => {
       expect(mockRedirect).toHaveBeenCalledWith("/en/task/task-1");
     });
+  });
+
+  it("uses activation bridge for background sync review notifications", async () => {
+    mockListNotifications.mockResolvedValue([
+      {
+        id: "n-review",
+        title: "Background sync review",
+        body: "Review pending items",
+        taskId: null,
+        relativePath: "/en",
+        locale: "en",
+        isRead: false,
+        createdAt: new Date().toISOString(),
+        dedupeKey: "review-1",
+        action: {
+          type: "background-sync-review",
+          payload: {
+            mergedPullRequests: [],
+            registeredWorktrees: [],
+          },
+        },
+      },
+    ]);
+    mockMarkNotificationRead.mockResolvedValue(undefined);
+    mockActivateNotification.mockResolvedValue(true);
+
+    render(<NotificationCenterButton />);
+
+    await waitFor(() => {
+      expect(mockListNotifications).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "notifications" }));
+    fireEvent.click(screen.getByRole("button", { name: /Background sync review/i }));
+
+    await waitFor(() => {
+      expect(mockActivateNotification).toHaveBeenCalledWith("n-review");
+    });
+
+    expect(mockGetTaskById).not.toHaveBeenCalled();
+    expect(mockRedirect).not.toHaveBeenCalled();
   });
 });

--- a/src/desktop/main/notificationStore.ts
+++ b/src/desktop/main/notificationStore.ts
@@ -50,6 +50,11 @@ export async function listNotifications(): Promise<AppNotification[]> {
   return notifications.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
 }
 
+export async function getNotificationById(id: string): Promise<AppNotification | null> {
+  const notifications = await readNotifications();
+  return notifications.find((notification) => notification.id === id) ?? null;
+}
+
 export async function createNotification(payload: DesktopNotificationPayload): Promise<{ created: boolean; notification: AppNotification }> {
   const now = Date.now();
   const dedupeKey = payload.dedupeKey || [payload.title, payload.body, payload.taskId || "", payload.locale].join("::");
@@ -75,6 +80,7 @@ export async function createNotification(payload: DesktopNotificationPayload): P
     isRead: false,
     createdAt: new Date(now).toISOString(),
     dedupeKey,
+    action: payload.action ?? null,
   };
 
   await writeNotifications([notification, ...notifications]);

--- a/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
+++ b/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  syncRegisteredProjectWorktrees: vi.fn(),
+  syncActiveTaskPullRequests: vi.fn(),
+  broadcastBoardUpdate: vi.fn(),
+  broadcastBackgroundSyncReviewNeeded: vi.fn(),
+}));
+
+vi.mock("@/desktop/main/services/projectService", () => ({
+  syncRegisteredProjectWorktrees: mocks.syncRegisteredProjectWorktrees,
+}));
+
+vi.mock("@/desktop/main/services/kanbanService", () => ({
+  syncActiveTaskPullRequests: mocks.syncActiveTaskPullRequests,
+}));
+
+vi.mock("@/lib/boardNotifier", () => ({
+  broadcastBoardUpdate: mocks.broadcastBoardUpdate,
+  broadcastBackgroundSyncReviewNeeded: mocks.broadcastBackgroundSyncReviewNeeded,
+}));
+
+describe("backgroundTaskSyncService", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mocks.syncRegisteredProjectWorktrees.mockResolvedValue({
+      worktreeTasks: [],
+      registeredWorktrees: [],
+      hooksSetup: [],
+      errors: [],
+      changed: false,
+    });
+    mocks.syncActiveTaskPullRequests.mockResolvedValue({
+      updatedTaskIds: [],
+      mergeEventKeys: [],
+      mergedPullRequests: [],
+    });
+  });
+
+  it("background sync review 대상이 있으면 통합 review event를 브로드캐스트한다", async () => {
+    mocks.syncRegisteredProjectWorktrees.mockResolvedValue({
+      worktreeTasks: ["feature-sync"],
+      registeredWorktrees: [
+        {
+          taskId: "task-worktree",
+          projectName: "api",
+          branchName: "feature-sync",
+          worktreePath: "/workspace/api__worktrees/feature-sync",
+          sshHost: null,
+        },
+      ],
+      hooksSetup: [],
+      errors: [],
+      changed: true,
+    });
+    mocks.syncActiveTaskPullRequests.mockResolvedValue({
+      updatedTaskIds: [],
+      mergeEventKeys: ["task-10:https://github.com/kanvibe/kanvibe/pull/211:2026-04-30T02:00:00Z"],
+      mergedPullRequests: [
+        {
+          taskId: "task-10",
+          taskTitle: "Merged PR task",
+          branchName: "feature/merged-pr",
+          prUrl: "https://github.com/kanvibe/kanvibe/pull/211",
+          mergedAt: "2026-04-30T02:00:00Z",
+        },
+      ],
+    });
+
+    const { startBackgroundTaskSync } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    const stop = startBackgroundTaskSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mocks.broadcastBackgroundSyncReviewNeeded).toHaveBeenCalledWith({
+      registeredWorktrees: [
+        {
+          taskId: "task-worktree",
+          projectName: "api",
+          branchName: "feature-sync",
+          worktreePath: "/workspace/api__worktrees/feature-sync",
+          sshHost: null,
+        },
+      ],
+      mergedPullRequests: [
+        {
+          taskId: "task-10",
+          taskTitle: "Merged PR task",
+          branchName: "feature/merged-pr",
+          prUrl: "https://github.com/kanvibe/kanvibe/pull/211",
+          mergedAt: "2026-04-30T02:00:00Z",
+        },
+      ],
+    });
+
+    stop();
+  });
+});

--- a/src/desktop/main/services/__tests__/desktopNotificationService.test.ts
+++ b/src/desktop/main/services/__tests__/desktopNotificationService.test.ts
@@ -170,4 +170,86 @@ describe("desktopNotificationService", () => {
 
     expect(mocks.createNotification).not.toHaveBeenCalled();
   });
+
+  it("background sync review event는 review action metadata와 함께 알림을 생성한다", async () => {
+    mocks.getNotificationSettings.mockResolvedValue({
+      isEnabled: true,
+      enabledStatuses: ["progress"],
+    });
+    mocks.createNotification.mockResolvedValue({
+      created: true,
+      notification: {
+        id: "notification-review-1",
+        title: "Background sync review",
+        body: "1 merged PR\n1 registered worktree",
+        taskId: null,
+        relativePath: "/ko",
+        locale: "ko",
+        isRead: false,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        dedupeKey: "background-sync-review:test",
+        action: {
+          type: "background-sync-review",
+          payload: {
+            mergedPullRequests: [],
+            registeredWorktrees: [],
+          },
+        },
+      },
+    });
+
+    const { deliverBoardEventNotification } = await import("@/desktop/main/services/desktopNotificationService");
+
+    await expect(deliverBoardEventNotification({
+      type: "background-sync-review-needed",
+      mergedPullRequests: [
+        {
+          taskId: "task-10",
+          taskTitle: "Merged PR task",
+          branchName: "feature/merged-pr",
+          prUrl: "https://github.com/kanvibe/kanvibe/pull/211",
+          mergedAt: "2026-04-30T02:00:00Z",
+        },
+      ],
+      registeredWorktrees: [
+        {
+          taskId: "task-worktree",
+          projectName: "api",
+          branchName: "feature-sync",
+          worktreePath: "/workspace/api__worktrees/feature-sync",
+          sshHost: null,
+        },
+      ],
+    }, "ko", {
+      iconPath: "/icon.png",
+    })).resolves.toBe(true);
+
+    expect(mocks.createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      locale: "ko",
+      relativePath: "/ko",
+      action: {
+        type: "background-sync-review",
+        payload: {
+          mergedPullRequests: [
+            {
+              taskId: "task-10",
+              taskTitle: "Merged PR task",
+              branchName: "feature/merged-pr",
+              prUrl: "https://github.com/kanvibe/kanvibe/pull/211",
+              mergedAt: "2026-04-30T02:00:00Z",
+            },
+          ],
+          registeredWorktrees: [
+            {
+              taskId: "task-worktree",
+              projectName: "api",
+              branchName: "feature-sync",
+              worktreePath: "/workspace/api__worktrees/feature-sync",
+              sshHost: null,
+            },
+          ],
+        },
+      },
+    }));
+  });
 });

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -1250,6 +1250,15 @@ describe("projectService local hook installation", () => {
 
     // Then
     expect(result.worktreeTasks).toContain("feature-sync");
+    expect(result.registeredWorktrees).toEqual([
+      {
+        taskId: "task-worktree",
+        projectName: "api",
+        branchName: "feature-sync",
+        worktreePath: "/workspace/api__worktrees/feature-sync",
+        sshHost: null,
+      },
+    ]);
     expect(taskSave).toHaveBeenCalledWith(expect.objectContaining({
       branchName: "feature-sync",
       projectId: "project-1",

--- a/src/desktop/main/services/backgroundTaskSyncService.ts
+++ b/src/desktop/main/services/backgroundTaskSyncService.ts
@@ -1,6 +1,6 @@
 import { syncRegisteredProjectWorktrees } from "@/desktop/main/services/projectService";
 import { syncActiveTaskPullRequests } from "@/desktop/main/services/kanbanService";
-import { broadcastBoardUpdate } from "@/lib/boardNotifier";
+import { broadcastBackgroundSyncReviewNeeded, broadcastBoardUpdate } from "@/lib/boardNotifier";
 
 const INITIAL_SYNC_DELAY_MS = 20_000;
 const SYNC_INTERVAL_MS = 90_000;
@@ -32,6 +32,13 @@ export function startBackgroundTaskSync() {
     try {
       const worktreeSyncResult = await syncRegisteredProjectWorktrees();
       const prSyncResult = await syncActiveTaskPullRequests(emittedMergeEventKeys);
+
+      if (worktreeSyncResult.registeredWorktrees.length > 0 || prSyncResult.mergedPullRequests.length > 0) {
+        broadcastBackgroundSyncReviewNeeded({
+          registeredWorktrees: worktreeSyncResult.registeredWorktrees,
+          mergedPullRequests: prSyncResult.mergedPullRequests,
+        });
+      }
 
       if (worktreeSyncResult.changed || prSyncResult.updatedTaskIds.length > 0) {
         broadcastBoardUpdate();

--- a/src/desktop/main/services/desktopNotificationService.ts
+++ b/src/desktop/main/services/desktopNotificationService.ts
@@ -3,7 +3,11 @@ import type { AppNotification, DesktopNotificationPayload } from "@/desktop/shar
 import type { BoardEventPayload } from "@/lib/boardNotifier";
 import { createNotification, markNotificationRead } from "@/desktop/main/notificationStore";
 import { getNotificationSettings } from "@/desktop/main/services/appSettingsService";
-import { buildHookStatusTargetMissingNotification, buildTaskStatusNotification } from "@/desktop/shared/taskNotifications";
+import {
+  buildBackgroundSyncReviewNotification,
+  buildHookStatusTargetMissingNotification,
+  buildTaskStatusNotification,
+} from "@/desktop/shared/taskNotifications";
 
 const activeDesktopNotifications = new Set<InstanceType<typeof Notification>>();
 
@@ -87,6 +91,13 @@ export async function deliverBoardEventNotification(
 
   if (payload.type === "task-hook-install-failed") {
     return false;
+  }
+
+  if (payload.type === "background-sync-review-needed") {
+    return deliverDesktopNotification(buildBackgroundSyncReviewNotification({
+      ...payload,
+      locale,
+    }).desktopPayload, options);
   }
 
   if (

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -439,11 +439,21 @@ export interface ScanResult {
   skipped: string[];
   errors: string[];
   worktreeTasks: string[];
+  registeredWorktrees: RegisteredWorktreeSummary[];
   hooksSetup: string[];
+}
+
+export interface RegisteredWorktreeSummary {
+  taskId: string;
+  projectName: string;
+  branchName: string;
+  worktreePath: string;
+  sshHost: string | null;
 }
 
 export interface RegisteredProjectWorktreeSyncResult {
   worktreeTasks: string[];
+  registeredWorktrees: RegisteredWorktreeSummary[];
   hooksSetup: string[];
   errors: string[];
   changed: boolean;
@@ -452,6 +462,7 @@ export interface RegisteredProjectWorktreeSyncResult {
 function mergeRegisteredProjectWorktreeSyncResult(
   target: {
     worktreeTasks: string[];
+    registeredWorktrees: RegisteredWorktreeSummary[];
     hooksSetup: string[];
     errors: string[];
     changed?: boolean;
@@ -463,6 +474,7 @@ function mergeRegisteredProjectWorktreeSyncResult(
   }
   target.errors.push(...next.errors);
   target.worktreeTasks.push(...next.worktreeTasks);
+  target.registeredWorktrees.push(...next.registeredWorktrees);
   target.hooksSetup.push(...next.hooksSetup.filter((name) => !target.hooksSetup.includes(name)));
 }
 
@@ -472,6 +484,7 @@ async function syncProjectWorktrees(
 ): Promise<RegisteredProjectWorktreeSyncResult> {
   const result: RegisteredProjectWorktreeSyncResult = {
     worktreeTasks: [],
+    registeredWorktrees: [],
     hooksSetup: [],
     errors: [],
     changed: false,
@@ -540,6 +553,13 @@ async function syncProjectWorktrees(
           );
         }
         result.worktreeTasks.push(wt.branch);
+        result.registeredWorktrees.push({
+          taskId: savedTask.id,
+          projectName: project.name,
+          branchName: wt.branch,
+          worktreePath: wt.path,
+          sshHost: project.sshHost ?? null,
+        });
         continue;
       }
 
@@ -574,6 +594,13 @@ async function syncProjectWorktrees(
         );
       }
       result.worktreeTasks.push(wt.branch);
+      result.registeredWorktrees.push({
+        taskId: savedTask.id,
+        projectName: project.name,
+        branchName: wt.branch,
+        worktreePath: wt.path,
+        sshHost: project.sshHost ?? null,
+      });
     }
   } catch (error) {
     result.errors.push(
@@ -623,6 +650,7 @@ export async function syncRegisteredProjectWorktrees(
   const projects = projectsInput ?? await projectRepo.find({ order: { createdAt: "ASC" } });
   const mergedResult: RegisteredProjectWorktreeSyncResult = {
     worktreeTasks: [],
+    registeredWorktrees: [],
     hooksSetup: [],
     errors: [],
     changed: false,
@@ -646,7 +674,7 @@ export async function scanAndRegisterProjects(
   rootPath: string,
   sshHost?: string
 ): Promise<ScanResult> {
-  const result: ScanResult = { registered: [], skipped: [], errors: [], worktreeTasks: [], hooksSetup: [] };
+  const result: ScanResult = { registered: [], skipped: [], errors: [], worktreeTasks: [], registeredWorktrees: [], hooksSetup: [] };
 
   const discoveredRepoPaths = await scanGitRepos(rootPath, sshHost || null);
   const repoPaths = Array.from(

--- a/src/desktop/renderer/actions/notifications.ts
+++ b/src/desktop/renderer/actions/notifications.ts
@@ -11,3 +11,11 @@ export function markNotificationRead(notificationId: string): Promise<AppNotific
 export function markAllNotificationsRead(): Promise<void> {
   return window.kanvibeDesktop?.markAllNotificationsRead?.() ?? Promise.resolve();
 }
+
+export function activateNotification(notificationId: string): Promise<boolean> {
+  return window.kanvibeDesktop?.activateNotification?.(notificationId) ?? Promise.resolve(false);
+}
+
+export function consumePendingNotificationActivation(): Promise<AppNotification | null> {
+  return window.kanvibeDesktop?.consumePendingNotificationActivation?.() ?? Promise.resolve(null);
+}

--- a/src/desktop/renderer/components/NotificationListener.tsx
+++ b/src/desktop/renderer/components/NotificationListener.tsx
@@ -5,7 +5,11 @@ import { getNotificationSettings } from "@/desktop/renderer/actions/appSettings"
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
 
 export default function NotificationListener() {
-  const { notifyTaskStatusChanged, notifyHookStatusTargetMissing } = useTaskNotification();
+  const {
+    notifyTaskStatusChanged,
+    notifyHookStatusTargetMissing,
+    notifyBackgroundSyncReview,
+  } = useTaskNotification();
   const locale = useLocale();
   const refreshSignal = useRefreshSignal(["all", "settings"]);
   const [settings, setSettings] = useState({
@@ -42,8 +46,12 @@ export default function NotificationListener() {
 
         notifyHookStatusTargetMissing({ ...event, locale });
       }
+
+      if (event.type === "background-sync-review-needed") {
+        notifyBackgroundSyncReview({ ...event, locale });
+      }
     });
-  }, [locale, notifyHookStatusTargetMissing, notifyTaskStatusChanged, settings]);
+  }, [locale, notifyBackgroundSyncReview, notifyHookStatusTargetMissing, notifyTaskStatusChanged, settings]);
 
   return null;
 }

--- a/src/desktop/renderer/components/__tests__/NotificationListener.test.tsx
+++ b/src/desktop/renderer/components/__tests__/NotificationListener.test.tsx
@@ -5,6 +5,7 @@ import NotificationListener from "@/desktop/renderer/components/NotificationList
 const mocks = vi.hoisted(() => ({
   notifyTaskStatusChanged: vi.fn(),
   notifyHookStatusTargetMissing: vi.fn(),
+  notifyBackgroundSyncReview: vi.fn(),
   getNotificationSettings: vi.fn(),
   useRefreshSignal: vi.fn(() => 0),
 }));
@@ -19,6 +20,7 @@ vi.mock("@/hooks/useTaskNotification", () => ({
   useTaskNotification: () => ({
     notifyTaskStatusChanged: mocks.notifyTaskStatusChanged,
     notifyHookStatusTargetMissing: mocks.notifyHookStatusTargetMissing,
+    notifyBackgroundSyncReview: mocks.notifyBackgroundSyncReview,
   }),
 }));
 
@@ -108,5 +110,60 @@ describe("NotificationListener", () => {
 
     // Then
     expect(mocks.notifyTaskStatusChanged).not.toHaveBeenCalled();
+  });
+
+  it("background sync review 이벤트가 오면 review 알림 훅을 호출한다", async () => {
+    render(<NotificationListener />);
+    await waitFor(() => {
+      expect((window.kanvibeDesktop?.onBoardEvent as any).mock.calls.length).toBeGreaterThan(1);
+    });
+    mocks.notifyBackgroundSyncReview.mockClear();
+
+    await act(async () => {
+      boardEventListener?.({
+        type: "background-sync-review-needed",
+        mergedPullRequests: [
+          {
+            taskId: "task-10",
+            taskTitle: "Merged PR task",
+            branchName: "feature/merged-pr",
+            prUrl: "https://github.com/kanvibe/kanvibe/pull/211",
+            mergedAt: "2026-04-30T02:00:00Z",
+          },
+        ],
+        registeredWorktrees: [
+          {
+            taskId: "task-worktree",
+            projectName: "api",
+            branchName: "feature-sync",
+            worktreePath: "/workspace/api__worktrees/feature-sync",
+            sshHost: null,
+          },
+        ],
+      });
+    });
+
+    expect(mocks.notifyBackgroundSyncReview).toHaveBeenCalledWith({
+      type: "background-sync-review-needed",
+      mergedPullRequests: [
+        {
+          taskId: "task-10",
+          taskTitle: "Merged PR task",
+          branchName: "feature/merged-pr",
+          prUrl: "https://github.com/kanvibe/kanvibe/pull/211",
+          mergedAt: "2026-04-30T02:00:00Z",
+        },
+      ],
+      registeredWorktrees: [
+        {
+          taskId: "task-worktree",
+          projectName: "api",
+          branchName: "feature-sync",
+          worktreePath: "/workspace/api__worktrees/feature-sync",
+          sshHost: null,
+        },
+      ],
+      locale: "ko",
+    });
   });
 });

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -29,6 +29,9 @@ declare global {
       markNotificationRead?: (notificationId: string) => Promise<AppNotification | null>;
       markAllNotificationsRead?: () => Promise<void>;
       onNotificationsChanged?: (listener: () => void) => () => void;
+      activateNotification?: (notificationId: string) => Promise<boolean>;
+      consumePendingNotificationActivation?: () => Promise<AppNotification | null>;
+      onNotificationActivated?: (listener: (notification: AppNotification) => void) => () => void;
     };
   }
 }

--- a/src/desktop/shared/notifications.ts
+++ b/src/desktop/shared/notifications.ts
@@ -1,3 +1,12 @@
+import type { BackgroundSyncReviewPayload } from "@/lib/boardNotifier";
+
+export interface BackgroundSyncReviewNotificationAction {
+  type: "background-sync-review";
+  payload: BackgroundSyncReviewPayload;
+}
+
+export type AppNotificationAction = BackgroundSyncReviewNotificationAction;
+
 export interface AppNotification {
   id: string;
   title: string;
@@ -8,6 +17,7 @@ export interface AppNotification {
   isRead: boolean;
   createdAt: string;
   dedupeKey: string;
+  action?: AppNotificationAction | null;
 }
 
 export interface DesktopNotificationPayload {
@@ -17,4 +27,5 @@ export interface DesktopNotificationPayload {
   locale: string;
   relativePath?: string;
   dedupeKey?: string;
+  action?: AppNotificationAction;
 }

--- a/src/desktop/shared/taskNotifications.ts
+++ b/src/desktop/shared/taskNotifications.ts
@@ -1,4 +1,5 @@
 import type { DesktopNotificationPayload } from "@/desktop/shared/notifications";
+import type { BackgroundSyncReviewPayload } from "@/lib/boardNotifier";
 
 export type NotificationLocale = "ko" | "en" | "zh";
 
@@ -7,16 +8,28 @@ const NOTIFICATION_MESSAGES = {
     formatStatusChanged: (taskTitle: string, newStatus: string) => `${taskTitle}: ${newStatus}로 변경`,
     formatMissingStatus: (requestedStatus: string) => `${requestedStatus} 상태로 변경하지 못했습니다.`,
     taskNotFound: "연결된 작업을 찾지 못했습니다.",
+    backgroundSyncReviewTitle: "백그라운드 sync 검토 필요",
+    formatMergedPullRequestCount: (count: number) => `merge된 PR ${count}건`,
+    formatRegisteredWorktreeCount: (count: number) => `새 TODO worktree ${count}건`,
+    backgroundSyncReviewPrompt: "알림을 열어 정리 대상을 검토하세요.",
   },
   en: {
     formatStatusChanged: (taskTitle: string, newStatus: string) => `${taskTitle}: changed to ${newStatus}`,
     formatMissingStatus: (requestedStatus: string) => `Failed to change status to ${requestedStatus}.`,
     taskNotFound: "No matching task was found.",
+    backgroundSyncReviewTitle: "Background sync review needed",
+    formatMergedPullRequestCount: (count: number) => `${count} merged PR${count === 1 ? "" : "s"}`,
+    formatRegisteredWorktreeCount: (count: number) => `${count} new TODO worktree${count === 1 ? "" : "s"}`,
+    backgroundSyncReviewPrompt: "Open the notification to review the pending cleanup items.",
   },
   zh: {
     formatStatusChanged: (taskTitle: string, newStatus: string) => `${taskTitle}: 已变更为${newStatus}`,
     formatMissingStatus: (requestedStatus: string) => `未能变更为 ${requestedStatus} 状态。`,
     taskNotFound: "未找到匹配的任务。",
+    backgroundSyncReviewTitle: "需要检查后台同步结果",
+    formatMergedPullRequestCount: (count: number) => `已合并 PR ${count} 个`,
+    formatRegisteredWorktreeCount: (count: number) => `新建 TODO worktree ${count} 个`,
+    backgroundSyncReviewPrompt: "打开通知以检查待整理项目。",
   },
 } as const;
 
@@ -34,6 +47,10 @@ export interface HookStatusTargetMissingNotification {
   taskId: string;
   requestedStatus: string;
   reason: "task-not-found";
+  locale: string;
+}
+
+export interface BackgroundSyncReviewNotification extends BackgroundSyncReviewPayload {
   locale: string;
 }
 
@@ -85,6 +102,51 @@ export function buildHookStatusTargetMissingNotification(payload: HookStatusTarg
       locale: payload.locale,
       relativePath: `/${payload.locale}`,
       dedupeKey: `hook-missing:${payload.taskId}:${payload.requestedStatus}:${payload.reason}`,
+    },
+  };
+}
+
+export function buildBackgroundSyncReviewNotification(payload: BackgroundSyncReviewNotification): PreparedNotification {
+  const messages = NOTIFICATION_MESSAGES[getNotificationLocale(payload.locale)];
+  const title = messages.backgroundSyncReviewTitle;
+  const summaryLines: string[] = [];
+
+  if (payload.mergedPullRequests.length > 0) {
+    summaryLines.push(messages.formatMergedPullRequestCount(payload.mergedPullRequests.length));
+  }
+
+  if (payload.registeredWorktrees.length > 0) {
+    summaryLines.push(messages.formatRegisteredWorktreeCount(payload.registeredWorktrees.length));
+  }
+
+  const body = [summaryLines.join(" / "), messages.backgroundSyncReviewPrompt]
+    .filter(Boolean)
+    .join("\n");
+  const mergedKeys = payload.mergedPullRequests
+    .map((item) => `${item.taskId}:${item.prUrl}:${item.mergedAt}`)
+    .sort()
+    .join("|");
+  const worktreeKeys = payload.registeredWorktrees
+    .map((item) => `${item.taskId}:${item.branchName}:${item.worktreePath}`)
+    .sort()
+    .join("|");
+
+  return {
+    title,
+    body,
+    desktopPayload: {
+      title,
+      body,
+      locale: payload.locale,
+      relativePath: `/${payload.locale}`,
+      dedupeKey: `background-sync-review:${mergedKeys}::${worktreeKeys}`,
+      action: {
+        type: "background-sync-review",
+        payload: {
+          mergedPullRequests: payload.mergedPullRequests,
+          registeredWorktrees: payload.registeredWorktrees,
+        },
+      },
     },
   };
 }

--- a/src/hooks/useTaskNotification.ts
+++ b/src/hooks/useTaskNotification.ts
@@ -3,8 +3,10 @@
 import { useEffect, useCallback, useRef } from "react";
 import type { DesktopNotificationPayload } from "@/desktop/shared/notifications";
 import {
+  buildBackgroundSyncReviewNotification,
   buildHookStatusTargetMissingNotification,
   buildTaskStatusNotification,
+  type BackgroundSyncReviewNotification,
   type HookStatusTargetMissingNotification,
   type TaskStatusNotification,
 } from "@/desktop/shared/taskNotifications";
@@ -17,6 +19,7 @@ interface BrowserNotificationData {
 interface DesktopBridgeNotificationData extends BrowserNotificationData {
   relativePath?: string;
   dedupeKey?: string;
+  action?: DesktopNotificationPayload["action"];
 }
 
 function isDesktopNotificationAvailable() {
@@ -35,6 +38,7 @@ async function showNotificationViaDesktopBridge(title: string, body: string, dat
     locale: data.locale,
     relativePath: data.relativePath,
     dedupeKey: data.dedupeKey,
+    action: data.action,
   };
 
   return (await window.kanvibeDesktop?.showNotification?.(payload)) === true;
@@ -149,5 +153,30 @@ export function useTaskNotification() {
     []
   );
 
-  return { notifyTaskStatusChanged, notifyHookStatusTargetMissing };
+  const notifyBackgroundSyncReview = useCallback(
+    async (payload: BackgroundSyncReviewNotification) => {
+      if (!isPermissionGranted.current) return;
+
+      try {
+        const notification = buildBackgroundSyncReviewNotification(payload);
+        const data = {
+          locale: payload.locale,
+        };
+
+        const isDesktopNotificationShown = await showNotificationViaDesktopBridge(
+          notification.title,
+          notification.body,
+          notification.desktopPayload,
+        );
+        if (!isDesktopNotificationShown) {
+          await showNotificationViaBrowser(notification.title, notification.body, data);
+        }
+      } catch (err) {
+        console.error("[Notification] Failed to show background sync review notification:", err);
+      }
+    },
+    []
+  );
+
+  return { notifyTaskStatusChanged, notifyHookStatusTargetMissing, notifyBackgroundSyncReview };
 }

--- a/src/lib/boardNotifier.ts
+++ b/src/lib/boardNotifier.ts
@@ -37,13 +37,27 @@ export interface TaskPrMergedDetectedBatchPayload {
   mergedPullRequests: TaskPrMergedDetectedPayload[];
 }
 
+export interface BackgroundSyncRegisteredWorktreePayload {
+  taskId: string;
+  projectName: string;
+  branchName: string;
+  worktreePath: string;
+  sshHost: string | null;
+}
+
+export interface BackgroundSyncReviewPayload {
+  mergedPullRequests: TaskPrMergedDetectedPayload[];
+  registeredWorktrees: BackgroundSyncRegisteredWorktreePayload[];
+}
+
 export type BoardEventPayload =
   | BoardUpdatedPayload
   | ({ type: "task-status-changed" } & TaskStatusChangedPayload)
   | ({ type: "hook-status-target-missing" } & HookStatusTargetMissingPayload)
   | ({ type: "task-hook-install-failed" } & TaskHookInstallFailedPayload)
   | ({ type: "task-pr-merged-detected" } & TaskPrMergedDetectedPayload)
-  | ({ type: "task-pr-merged-detected-batch" } & TaskPrMergedDetectedBatchPayload);
+  | ({ type: "task-pr-merged-detected-batch" } & TaskPrMergedDetectedBatchPayload)
+  | ({ type: "background-sync-review-needed" } & BackgroundSyncReviewPayload);
 
 const boardEventEmitter = new EventEmitter();
 
@@ -88,4 +102,9 @@ export function broadcastTaskPrMergedDetected(payload: TaskPrMergedDetectedPaylo
 /** background PR sync 한 사이클에서 감지된 merged PR 목록을 한 번에 전달한다 */
 export function broadcastTaskPrMergedDetectedBatch(payload: TaskPrMergedDetectedBatchPayload) {
   emitBoardEvent({ type: "task-pr-merged-detected-batch", ...payload });
+}
+
+/** background sync가 사용자 검토가 필요한 변경을 발견하면 review payload를 브로드캐스트한다 */
+export function broadcastBackgroundSyncReviewNeeded(payload: BackgroundSyncReviewPayload) {
+  emitBoardEvent({ type: "background-sync-review-needed", ...payload });
 }

--- a/src/types/kanvibeDesktop.d.ts
+++ b/src/types/kanvibeDesktop.d.ts
@@ -7,6 +7,9 @@ interface KanvibeDesktopApi {
   markNotificationRead?: (notificationId: string) => Promise<AppNotification | null>;
   markAllNotificationsRead?: () => Promise<void>;
   onNotificationsChanged?: (listener: () => void) => () => void;
+  activateNotification?: (notificationId: string) => Promise<boolean>;
+  consumePendingNotificationActivation?: () => Promise<AppNotification | null>;
+  onNotificationActivated?: (listener: (notification: AppNotification) => void) => () => void;
   [key: string]: any;
 }
 


### PR DESCRIPTION
## Related
- Base branch: `dev`

## What
- route background sync review through notification activation instead of opening an immediate board modal
- preserve review payloads for merged PR cleanup and newly registered worktrees across desktop delivery and renderer activation
- extend regression coverage around the notification-driven review flow

## How
**Notification activation pipeline**
- add shared notification action metadata for background sync review payloads
- store the action in the desktop notification store and expose activation/consumption bridges through the main and preload layers
- let the renderer consume pending activations and subscribe to notification activation events

**Review dialog behavior**
- open the board review dialog only after a background sync review notification is activated
- keep merged PR cleanup as an explicit checklist action and show newly registered worktrees as a read-only summary
- update localized copy for the new review flow in Korean, English, and Chinese

**Regression coverage**
- add background task sync service coverage for review broadcasts
- add desktop notification, notification center, notification listener, and board tests for the activation flow

## Important changes
### Notification-driven background review

**Background sync review becomes user-initiated**
- **Reason**: background discovery should notify the user without interrupting the current board workflow.
- **Files**: `src/components/Board.tsx`, `src/components/NotificationCenterButton.tsx`, `src/desktop/renderer/actions/notifications.ts`, `electron/main.js`, `electron/preload.js`

**Review payloads survive delivery and activation**
- **Reason**: merged PR cleanup targets and registered worktree summaries need to remain intact from background sync through dialog rendering.
- **Files**: `src/lib/boardNotifier.ts`, `src/desktop/shared/notifications.ts`, `src/desktop/shared/taskNotifications.ts`, `src/desktop/main/notificationStore.ts`, `src/desktop/main/services/desktopNotificationService.ts`, `src/desktop/main/services/projectService.ts`, `src/desktop/main/services/backgroundTaskSyncService.ts`

**Regression coverage follows the new flow**
- **Reason**: the change spans background sync orchestration, notification delivery, and board interaction, so the new behavior needs direct tests at each boundary.
- **Files**: `src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts`, `src/desktop/main/services/__tests__/desktopNotificationService.test.ts`, `src/desktop/main/services/__tests__/projectService.test.ts`, `src/components/__tests__/Board.test.tsx`, `src/components/__tests__/NotificationCenterButton.test.tsx`, `src/desktop/renderer/components/__tests__/NotificationListener.test.tsx`

Co-Authored-By: OpenAI Codex <codex@openai.com>
