### PR TITLE
fix(task): preserve base branch selection during refresh

### DIFF
--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useTransition } from "react";
+import { useState, useEffect, useTransition, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "@/desktop/renderer/navigation";
 import { createTask } from "@/desktop/renderer/actions/kanban";
@@ -23,57 +23,99 @@ interface CreateTaskModalProps {
   defaultSessionType?: string;
 }
 
+type CreateTaskModalContentProps = Pick<
+  CreateTaskModalProps,
+  "onClose" | "projects" | "defaultProjectId" | "defaultBaseBranch" | "defaultSessionType"
+>;
+
+function findProjectDefaultBranch(projects: Project[], projectId: string) {
+  return projects.find((p) => p.id === projectId)?.defaultBranch ?? "";
+}
+
+function resolveInitialBaseBranch(
+  projects: Project[],
+  projectId: string,
+  defaultBaseBranch?: string,
+) {
+  if (!projectId) return "";
+  return defaultBaseBranch || findProjectDefaultBranch(projects, projectId);
+}
+
 export default function CreateTaskModal({
   isOpen,
   onClose,
-  sshHosts,
   projects,
   defaultProjectId,
   defaultBaseBranch,
   defaultSessionType,
 }: CreateTaskModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <CreateTaskModalContent
+      onClose={onClose}
+      projects={projects}
+      defaultProjectId={defaultProjectId}
+      defaultBaseBranch={defaultBaseBranch}
+      defaultSessionType={defaultSessionType}
+    />
+  );
+}
+
+function CreateTaskModalContent({
+  onClose,
+  projects,
+  defaultProjectId,
+  defaultBaseBranch,
+  defaultSessionType,
+}: CreateTaskModalContentProps) {
   const t = useTranslations("task");
   const tc = useTranslations("common");
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const [selectedProjectId, setSelectedProjectId] = useState(defaultProjectId || "");
+  const initialProjectId = defaultProjectId || "";
+  const [selectedProjectId, setSelectedProjectId] = useState(initialProjectId);
   const [branches, setBranches] = useState<string[]>([]);
-  const [baseBranch, setBaseBranch] = useState("");
+  const [baseBranch, setBaseBranch] = useState(() =>
+    resolveInitialBaseBranch(projects, initialProjectId, defaultBaseBranch)
+  );
   const [priority, setPriority] = useState<TaskPriority | null>(null);
   const [error, setError] = useState<string | null>(null);
-
-  /** 모달이 열릴 때 필터에서 선택된 프로젝트를 자동 설정한다 */
-  useEffect(() => {
-    if (isOpen && defaultProjectId) {
-      setSelectedProjectId(defaultProjectId);
-    }
-  }, [isOpen, defaultProjectId]);
 
   /** worktree가 아닌 프로젝트만 필터링한다 */
   const availableProjects = projects.filter((p) => !p.isWorktree);
 
-  useEffect(() => {
-    if (!selectedProjectId) {
+  const handleProjectSelect = useCallback(
+    (projectId: string) => {
+      setSelectedProjectId(projectId);
+      setBaseBranch(projectId ? findProjectDefaultBranch(projects, projectId) : "");
       setBranches([]);
-      setBaseBranch("");
-      return;
-    }
+    },
+    [projects],
+  );
 
-    const selectedProject = projects.find((p) => p.id === selectedProjectId);
-    if (selectedProject) {
-      setBaseBranch(defaultBaseBranch || selectedProject.defaultBranch);
-    }
+  useEffect(() => {
+    if (!selectedProjectId) return;
 
+    let isCancelled = false;
     getProjectBranches(selectedProjectId).then((result) => {
+      if (isCancelled) return;
+
       setBranches(result);
       /** defaultBaseBranch가 브랜치 목록에 없으면 옵션에 추가한다 */
       if (defaultBaseBranch && !result.includes(defaultBaseBranch)) {
         setBranches((prev) => [defaultBaseBranch, ...prev]);
       }
     });
-  }, [selectedProjectId, projects, defaultBaseBranch]);
 
-  if (!isOpen) return null;
+    return () => {
+      isCancelled = true;
+    };
+  }, [selectedProjectId, defaultBaseBranch]);
+
+  const branchOptions = baseBranch && !branches.includes(baseBranch)
+    ? [baseBranch, ...branches]
+    : branches;
 
   function handleSubmit(formData: FormData) {
     const branchName = formData.get("branchName") as string;
@@ -125,7 +167,7 @@ export default function CreateTaskModal({
             <ProjectSelector
               projects={availableProjects}
               selectedProjectId={selectedProjectId}
-              onSelect={setSelectedProjectId}
+              onSelect={handleProjectSelect}
               placeholder={t("projectSelect")}
               searchPlaceholder={t("projectSearch")}
             />
@@ -137,7 +179,7 @@ export default function CreateTaskModal({
                 {t("baseBranch")}
               </label>
               <BranchSearchInput
-                branches={branches.length > 0 ? branches : baseBranch ? [baseBranch] : []}
+                branches={branchOptions}
                 value={baseBranch}
                 onChange={setBaseBranch}
               />

--- a/src/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/components/__tests__/CreateTaskModal.test.tsx
@@ -41,7 +41,14 @@ vi.mock("../PrioritySelector", () => ({
 }));
 
 vi.mock("../BranchSearchInput", () => ({
-  default: ({ value }: { value: string }) => <div data-testid="branch-search-input">{value}</div>,
+  default: ({ value, onChange }: { value: string; onChange: (branch: string) => void }) => (
+    <div>
+      <div data-testid="branch-search-input">{value}</div>
+      <button type="button" onClick={() => onChange("develop")}>
+        select develop
+      </button>
+    </div>
+  ),
 }));
 
 function createProject(overrides?: Partial<Project>): Project {
@@ -162,5 +169,42 @@ describe("CreateTaskModal", () => {
     });
     expect(onClose).toHaveBeenCalled();
     expect(mockPush).toHaveBeenCalledWith("/task/task-2");
+  });
+
+  it("프로젝트 목록이 새로고침되어도 사용자가 선택한 베이스 브랜치를 유지한다", async () => {
+    // Given
+    const project = createProject();
+    const { rerender } = render(
+      <CreateTaskModal
+        isOpen
+        onClose={vi.fn()}
+        sshHosts={["remote-box"]}
+        projects={[project]}
+        defaultProjectId="project-remote"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("branch-search-input").textContent).toBe("main");
+    });
+
+    // When
+    fireEvent.click(screen.getByRole("button", { name: "select develop" }));
+    expect(screen.getByTestId("branch-search-input").textContent).toBe("develop");
+
+    rerender(
+      <CreateTaskModal
+        isOpen
+        onClose={vi.fn()}
+        sshHosts={["remote-box"]}
+        projects={[createProject({ createdAt: new Date("2026-05-01T00:00:00.000Z") })]}
+        defaultProjectId="project-remote"
+      />,
+    );
+
+    // Then
+    await waitFor(() => {
+      expect(screen.getByTestId("branch-search-input").textContent).toBe("develop");
+    });
   });
 });


### PR DESCRIPTION
## What changed?
- Fixed the create task modal so the selected base branch remains isolated from background project refreshes.
- Added a regression test that preserves the user-selected base branch when the project list rerenders.

## How it works
**Create task modal state isolation**
- Scope form state to a modal session component that mounts only while the modal is open.
- Resolve the initial base branch only when the modal opens or the user explicitly changes projects.
- Keep the current base branch in the option list even when the loaded branch list changes.

Co-Authored-By: OpenAI Codex <codex@openai.com>