### PR TITLE
fix(session): clean up remote sessions on task delete

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
     createQueryBuilder: vi.fn(),
     find: vi.fn(),
     findOneBy: vi.fn(),
+    remove: vi.fn(),
     save: vi.fn(),
   },
   projectRepo: {
@@ -295,7 +296,7 @@ describe("kanbanService.createTask", () => {
     expect(consoleWarnSpy).toHaveBeenCalled();
   });
 
-  it("연결된 프로젝트를 찾을 수 없는 원격 stale task는 정리를 시도하지 않는다", async () => {
+  it("연결된 프로젝트를 찾을 수 없는 원격 stale task는 세션만 정리한다", async () => {
     // Given
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     mocks.projectRepo.findOneBy.mockResolvedValue(null);
@@ -314,12 +315,16 @@ describe("kanbanService.createTask", () => {
     } as never);
 
     // Then
-    expect(mocks.removeSessionOnly).not.toHaveBeenCalled();
+    expect(mocks.removeSessionOnly).toHaveBeenCalledWith(
+      "tmux",
+      "prompt-main",
+      "roky-home",
+    );
     expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
-  it("프로젝트가 삭제되어 orphan 상태가 된 원격 stale task도 정리를 시도하지 않는다", async () => {
+  it("프로젝트가 삭제되어 orphan 상태가 된 원격 stale task도 세션만 정리한다", async () => {
     // Given
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -338,9 +343,45 @@ describe("kanbanService.createTask", () => {
 
     // Then
     expect(mocks.projectRepo.findOneBy).not.toHaveBeenCalled();
-    expect(mocks.removeSessionOnly).not.toHaveBeenCalled();
+    expect(mocks.removeSessionOnly).toHaveBeenCalledWith(
+      "tmux",
+      "techtaurant-be-dev",
+      "roky-home",
+    );
     expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("원격 task 삭제는 프로젝트를 찾지 못해도 연결된 tmux 세션을 정리한다", async () => {
+    // Given
+    const task = {
+      id: "task-remote",
+      projectId: "missing-project",
+      branchName: "main",
+      worktreePath: "/home/rookedsysc/Downloads/prompt",
+      sshHost: "roky-home",
+      sessionType: "tmux" as never,
+      sessionName: "prompt-main",
+    };
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.projectRepo.findOneBy.mockResolvedValue(null);
+    mocks.taskRepo.remove.mockResolvedValue(task);
+
+    const { deleteTask } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await deleteTask("task-remote");
+
+    // Then
+    expect(result).toBe(true);
+    expect(mocks.removeSessionOnly).toHaveBeenCalledWith(
+      "tmux",
+      "prompt-main",
+      "roky-home",
+    );
+    expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
+    expect(mocks.taskRepo.remove).toHaveBeenCalledWith(task);
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
   });
 
   it("PR URL 조회는 셸 없이 gh CLI를 직접 실행한다", async () => {

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -505,16 +505,6 @@ export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
 
   const sshHost = task.sshHost || project?.sshHost || null;
 
-  // 프로젝트 없이 브랜치/worktree만 남은 태스크는 stale 상태이므로 정리를 시도하면 잘못된 원격 세션에 접근할 수 있다.
-  if (!project && task.branchName && task.worktreePath) {
-    return;
-  }
-
-  const isProjectRoot = project && task.worktreePath === project.repoPath;
-  const expectedWorktreePath = project?.repoPath && task.branchName
-    ? buildManagedWorktreePath(project.repoPath, task.branchName)
-    : null;
-
   /** 브랜치별 독립 세션 정리 */
   if (task.sessionType && task.sessionName) {
     try {
@@ -527,6 +517,16 @@ export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
       console.error("세션 정리 실패:", error);
     }
   }
+
+  // 프로젝트 없이 브랜치/worktree만 남은 태스크는 stale 상태이므로 worktree/브랜치 정리는 건너뛴다.
+  if (!project && task.branchName && task.worktreePath) {
+    return;
+  }
+
+  const isProjectRoot = project && task.worktreePath === project.repoPath;
+  const expectedWorktreePath = project?.repoPath && task.branchName
+    ? buildManagedWorktreePath(project.repoPath, task.branchName)
+    : null;
 
   /** worktree + 브랜치 정리 (프로젝트 루트 브랜치 제외) */
   if (task.branchName && !isProjectRoot) {

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -211,7 +211,7 @@ describe("removeSessionOnly", () => {
     );
   });
 
-  it("should kill zellij session with fallback to delete", async () => {
+  it("should kill zellij session and delete resurrectable session data", async () => {
     // Given
     mockExecGit.mockResolvedValue("");
     const { removeSessionOnly } = await import("@/lib/worktree");
@@ -221,8 +221,23 @@ describe("removeSessionOnly", () => {
 
     // Then
     expect(mockExecGit).toHaveBeenCalledWith(
-      'zellij kill-session "feat-branch" 2>/dev/null || zellij delete-session "feat-branch" 2>/dev/null',
+      'zellij kill-session "feat-branch" 2>/dev/null || true; zellij delete-session "feat-branch" 2>/dev/null || true',
       undefined,
+    );
+  });
+
+  it("should pass sshHost when cleaning remote zellij session", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("");
+    const { removeSessionOnly } = await import("@/lib/worktree");
+
+    // When
+    await removeSessionOnly(SessionType.ZELLIJ, "feat-branch", "remote-host");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledWith(
+      'zellij kill-session "feat-branch" 2>/dev/null || true; zellij delete-session "feat-branch" 2>/dev/null || true',
+      "remote-host",
     );
   });
 

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -419,7 +419,7 @@ export async function removeSessionOnly(
       );
     } else {
       await execGit(
-        `zellij kill-session "${sessionName}" 2>/dev/null || zellij delete-session "${sessionName}" 2>/dev/null`,
+        `zellij kill-session "${sessionName}" 2>/dev/null || true; zellij delete-session "${sessionName}" 2>/dev/null || true`,
         sshHost,
       );
     }


### PR DESCRIPTION
## Summary
- Clean up task-linked tmux/zellij sessions before skipping unsafe stale worktree cleanup.
- Ensure zellij cleanup deletes resurrectable session data after killing a running session.
- Add regression coverage for remote stale task deletion and remote zellij cleanup.

## Verification
- pnpm exec vitest run src/desktop/main/services/__tests__/kanbanService.test.ts src/lib/__tests__/worktree.test.ts
- pnpm check

Co-Authored-By: OpenAI Codex <codex@openai.com>