### PR TITLE
fix(shortcuts): enable notification shortcut on task detail

### DIFF
--- a/src/desktop/renderer/components/BoardCommandProvider.tsx
+++ b/src/desktop/renderer/components/BoardCommandProvider.tsx
@@ -30,6 +30,7 @@ interface BoardCommandHandlers {
 interface BoardCommandContextValue {
   canCreateBranchTodo: boolean;
   registerBoardHandlers: (handlers: BoardCommandHandlers) => () => void;
+  registerNotificationCenterHandler: (handler: () => void) => () => void;
   requestCreateBranchTodo: (defaults: BranchTodoDefaults) => void;
   setTaskQuickSearchOpen: (isOpen: boolean) => void;
 }
@@ -38,6 +39,7 @@ const noopDisposer = () => {};
 const defaultBoardCommandContextValue: BoardCommandContextValue = {
   canCreateBranchTodo: false,
   registerBoardHandlers: () => noopDisposer,
+  registerNotificationCenterHandler: () => noopDisposer,
   requestCreateBranchTodo: () => {},
   setTaskQuickSearchOpen: () => {},
 };
@@ -71,18 +73,34 @@ function shouldIgnoreGlobalShortcut(eventTarget: EventTarget | null) {
 
 export function BoardCommandProvider({ children }: PropsWithChildren) {
   const handlersRef = useRef<BoardCommandHandlers | null>(null);
+  const notificationCenterHandlerRef = useRef<(() => void) | null>(null);
   const [canCreateBranchTodo, setCanCreateBranchTodo] = useState(false);
   const [isTaskQuickSearchOpen, setIsTaskQuickSearchOpen] = useState(false);
   const isMacLike = isMacLikePlatform();
 
   const registerBoardHandlers = useCallback((handlers: BoardCommandHandlers) => {
     handlersRef.current = handlers;
+    notificationCenterHandlerRef.current = handlers.toggleNotificationCenter;
     setCanCreateBranchTodo(true);
 
     return () => {
       if (handlersRef.current === handlers) {
         handlersRef.current = null;
         setCanCreateBranchTodo(false);
+      }
+
+      if (notificationCenterHandlerRef.current === handlers.toggleNotificationCenter) {
+        notificationCenterHandlerRef.current = null;
+      }
+    };
+  }, []);
+
+  const registerNotificationCenterHandler = useCallback((handler: () => void) => {
+    notificationCenterHandlerRef.current = handler;
+
+    return () => {
+      if (notificationCenterHandlerRef.current === handler) {
+        notificationCenterHandlerRef.current = null;
       }
     };
   }, []);
@@ -97,17 +115,25 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     function handleGlobalKeyDown(event: KeyboardEvent) {
-      if (!handlersRef.current || isTaskQuickSearchOpen || shouldIgnoreGlobalShortcut(event.target)) {
+      if (isTaskQuickSearchOpen || shouldIgnoreGlobalShortcut(event.target)) {
         return;
       }
 
       if (matchShortcutEvent(event, BOARD_NOTIFICATION_SHORTCUT, isMacLike)) {
+        if (!notificationCenterHandlerRef.current) {
+          return;
+        }
+
         event.preventDefault();
-        handlersRef.current.toggleNotificationCenter();
+        notificationCenterHandlerRef.current();
         return;
       }
 
       if (matchShortcutEvent(event, BOARD_PROJECT_FILTER_SHORTCUT, isMacLike)) {
+        if (!handlersRef.current) {
+          return;
+        }
+
         event.preventDefault();
         handlersRef.current.openProjectFilter();
       }
@@ -122,9 +148,10 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
   const value = useMemo<BoardCommandContextValue>(() => ({
     canCreateBranchTodo,
     registerBoardHandlers,
+    registerNotificationCenterHandler,
     requestCreateBranchTodo,
     setTaskQuickSearchOpen,
-  }), [canCreateBranchTodo, registerBoardHandlers, requestCreateBranchTodo]);
+  }), [canCreateBranchTodo, registerBoardHandlers, registerNotificationCenterHandler, requestCreateBranchTodo, setTaskQuickSearchOpen]);
 
   return (
     <BoardCommandContext.Provider value={value}>

--- a/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
+++ b/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
@@ -42,6 +42,16 @@ function BoardCommandHarness({
   );
 }
 
+function NotificationOnlyHarness({ onToggleNotificationCenter }: { onToggleNotificationCenter: () => void }) {
+  const boardCommands = useBoardCommands();
+
+  useEffect(() => boardCommands.registerNotificationCenterHandler(onToggleNotificationCenter), [boardCommands, onToggleNotificationCenter]);
+
+  return (
+    <span>{boardCommands.canCreateBranchTodo ? "branch-enabled" : "branch-disabled"}</span>
+  );
+}
+
 describe("BoardCommandProvider", () => {
   it("dispatches board shortcuts to registered handlers", () => {
     const onToggleNotificationCenter = vi.fn();
@@ -126,5 +136,24 @@ describe("BoardCommandProvider", () => {
       projectId: "project-1",
       baseBranch: "feat/from-search",
     });
+  });
+
+  it("dispatches the notification shortcut to a notification-only handler", () => {
+    const onToggleNotificationCenter = vi.fn();
+
+    render(
+      <BoardCommandProvider>
+        <NotificationOnlyHarness onToggleNotificationCenter={onToggleNotificationCenter} />
+      </BoardCommandProvider>,
+    );
+
+    fireEvent.keyDown(window, {
+      key: "i",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(onToggleNotificationCenter).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("branch-disabled")).toBeTruthy();
   });
 });

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useParams } from "react-router-dom";
 import AiSessionsCard from "@/components/AiSessionsCard";
@@ -7,7 +7,7 @@ import ConnectTerminalForm from "@/components/ConnectTerminalForm";
 import DeleteTaskButton from "@/components/DeleteTaskButton";
 import DoneStatusButton from "@/components/DoneStatusButton";
 import HooksStatusCard from "@/components/HooksStatusCard";
-import NotificationCenterButton from "@/components/NotificationCenterButton";
+import NotificationCenterButton, { type NotificationCenterButtonHandle } from "@/components/NotificationCenterButton";
 import TaskDetailInfoCard from "@/components/TaskDetailInfoCard";
 import TaskDetailTitleCard from "@/components/TaskDetailTitleCard";
 import { Link, useRouter } from "@/desktop/renderer/navigation";
@@ -21,6 +21,7 @@ import {
   getTaskHooksStatus,
   getTaskOpenCodeHooksStatus,
 } from "@/desktop/renderer/actions/project";
+import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
 import TerminalLoader from "@/desktop/renderer/components/TerminalLoader";
 import { fetchPrUrlWithPrompt } from "@/desktop/renderer/utils/fetchPrUrlWithPrompt";
 import { buildRouteCacheKey, readRouteCache, removeRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
@@ -82,6 +83,7 @@ function getTaskDetailRouteCacheKey(taskId: string) {
 export default function TaskDetailRoute() {
   const { id = "" } = useParams();
   const router = useRouter();
+  const boardCommands = useBoardCommands();
   const t = useTranslations("taskDetail");
   const tc = useTranslations("common");
   const refreshSignal = useRefreshSignal(["all", "task-detail"]);
@@ -91,6 +93,11 @@ export default function TaskDetailRoute() {
   );
   const [state, setState] = useState<TaskDetailState | null | undefined>(cachedState ?? undefined);
   const [needsMacDesktopHeaderOffset, setNeedsMacDesktopHeaderOffset] = useState(false);
+  const notificationCenterRef = useRef<NotificationCenterButtonHandle>(null);
+
+  useEffect(() => boardCommands.registerNotificationCenterHandler(() => {
+    notificationCenterRef.current?.toggle();
+  }), [boardCommands]);
 
   useEffect(() => {
     const isDesktopApp = window.kanvibeDesktop?.isDesktop === true;
@@ -286,7 +293,7 @@ export default function TaskDetailRoute() {
               </svg>
               {t("backToBoard")}
             </Link>
-            {!hasTerminal ? <NotificationCenterButton buttonClassName="hover:bg-bg-page" /> : null}
+            {!hasTerminal ? <NotificationCenterButton ref={notificationCenterRef} buttonClassName="hover:bg-bg-page" /> : null}
           </div>
 
           <TaskDetailTitleCard task={state.task} taskId={state.task.id} />
@@ -347,7 +354,7 @@ export default function TaskDetailRoute() {
               <span className="w-3 h-3 rounded-full bg-traffic-maximize" />
               <span className="ml-3 text-xs text-terminal-text font-mono truncate">{state.task.sessionName ?? t("terminal")}</span>
               <div className="ml-auto">
-                <NotificationCenterButton buttonClassName="text-terminal-text hover:text-white hover:bg-white/10" panelClassName="mt-3" />
+                <NotificationCenterButton ref={notificationCenterRef} buttonClassName="text-terminal-text hover:text-white hover:bg-white/10" panelClassName="mt-3" />
               </div>
             </div>
             <div className="flex-1 min-h-0 bg-terminal-bg">

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BoardCommandProvider } from "@/desktop/renderer/components/BoardCommandProvider";
 import TaskDetailRoute from "@/desktop/renderer/routes/TaskDetailRoute";
 
 const TASK_DETAIL_CACHE_KEY = "kanvibe:route-cache:task-detail:task-1";
@@ -19,8 +20,13 @@ const mocks = vi.hoisted(() => ({
   getSidebarDefaultCollapsed: vi.fn(),
   getSidebarHintDismissed: vi.fn(),
   getDoneAlertDismissed: vi.fn(),
+  listNotifications: vi.fn(),
+  markNotificationRead: vi.fn(),
+  markAllNotificationsRead: vi.fn(),
+  activateNotification: vi.fn(),
   fetchPrUrlWithPrompt: vi.fn(),
   useRefreshSignal: vi.fn(() => 0),
+  redirect: vi.fn(),
   push: vi.fn(),
   back: vi.fn(),
 }));
@@ -45,6 +51,7 @@ vi.mock("react-router-dom", () => ({
 
 vi.mock("@/desktop/renderer/navigation", () => ({
   Link: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  redirect: (...args: unknown[]) => mocks.redirect(...args),
   useRouter: () => ({ push: mocks.push, back: mocks.back }),
 }));
 
@@ -77,6 +84,13 @@ vi.mock("@/desktop/renderer/actions/appSettings", () => ({
   getDoneAlertDismissed: (...args: unknown[]) => mocks.getDoneAlertDismissed(...args),
 }));
 
+vi.mock("@/desktop/renderer/actions/notifications", () => ({
+  listNotifications: (...args: unknown[]) => mocks.listNotifications(...args),
+  markNotificationRead: (...args: unknown[]) => mocks.markNotificationRead(...args),
+  markAllNotificationsRead: (...args: unknown[]) => mocks.markAllNotificationsRead(...args),
+  activateNotification: (...args: unknown[]) => mocks.activateNotification(...args),
+}));
+
 vi.mock("@/desktop/renderer/utils/fetchPrUrlWithPrompt", () => ({
   fetchPrUrlWithPrompt: (...args: unknown[]) => mocks.fetchPrUrlWithPrompt(...args),
 }));
@@ -103,10 +117,6 @@ vi.mock("@/components/DoneStatusButton", () => ({
 
 vi.mock("@/components/HooksStatusCard", () => ({
   default: () => <div data-testid="hooks-status-card" />,
-}));
-
-vi.mock("@/components/NotificationCenterButton", () => ({
-  default: () => <div data-testid="notification-center" />,
 }));
 
 vi.mock("@/components/TaskDetailInfoCard", () => ({
@@ -145,6 +155,10 @@ describe("TaskDetailRoute", () => {
     mocks.getSidebarDefaultCollapsed.mockResolvedValue(false);
     mocks.getSidebarHintDismissed.mockResolvedValue(false);
     mocks.getDoneAlertDismissed.mockResolvedValue(false);
+    mocks.listNotifications.mockResolvedValue([]);
+    mocks.markNotificationRead.mockResolvedValue(undefined);
+    mocks.markAllNotificationsRead.mockResolvedValue(undefined);
+    mocks.activateNotification.mockResolvedValue(true);
     mocks.updateTaskStatus.mockResolvedValue(null);
     mocks.deleteTask.mockResolvedValue(true);
     mocks.fetchPrUrlWithPrompt.mockResolvedValue(null);
@@ -230,6 +244,43 @@ describe("TaskDetailRoute", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("task-title").textContent).toBe("fresh task title");
+    });
+  });
+
+  it("알림 단축키로 상세 화면의 알림 센터를 토글한다", async () => {
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(
+      <BoardCommandProvider>
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    await screen.findByRole("button", { name: "notifications" });
+
+    fireEvent.keyDown(window, {
+      key: "i",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("noNotifications")).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## What changed?
- Enable the global notification-center shortcut on task detail pages.
- Split notification shortcut registration from board-only command handlers so task detail can register only the notification toggle.
- Add regression coverage for provider-level notification-only registration and the task detail route shortcut behavior.

## How was it solved?
**Global shortcut provider**
- Add `registerNotificationCenterHandler` to `BoardCommandProvider`.
- Keep board-specific commands behind `registerBoardHandlers`, so task detail does not accidentally enable board-only actions.

**Task detail route**
- Register the current `NotificationCenterButton` ref with the global provider.
- Reuse the existing `NotificationCenterButtonHandle.toggle()` behavior for both terminal and non-terminal task detail layouts.

## Important files
- `src/desktop/renderer/components/BoardCommandProvider.tsx`
- `src/desktop/renderer/routes/TaskDetailRoute.tsx`
- `src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx`
- `src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx`

Co-authored-by: OpenAI Codex <codex@openai.com>
