### PR TITLE
fix(navigation): fall back to board when back history is empty

### DIFF
--- a/src/desktop/renderer/__tests__/navigation.test.tsx
+++ b/src/desktop/renderer/__tests__/navigation.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useRouter } from "@/desktop/renderer/navigation";
+
+function RouterProbe() {
+  const router = useRouter();
+  const location = useLocation();
+
+  return (
+    <>
+      <div data-testid="pathname">{location.pathname}</div>
+      <button type="button" onClick={() => router.back()}>back</button>
+    </>
+  );
+}
+
+function renderRouterProbe(initialEntries: string[], initialIndex: number, historyState: unknown) {
+  window.history.replaceState(historyState, "", "/");
+
+  render(
+    <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
+      <RouterProbe />
+    </MemoryRouter>,
+  );
+}
+
+describe("useRouter", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("뒤로 갈 히스토리가 있으면 이전 페이지로 이동한다", async () => {
+    renderRouterProbe(["/ko", "/ko/task/task-1"], 1, { idx: 1 });
+
+    fireEvent.click(screen.getByRole("button", { name: "back" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pathname").textContent).toBe("/ko");
+    });
+  });
+
+  it("뒤로 갈 히스토리가 없으면 현재 locale의 칸반 홈으로 이동한다", async () => {
+    renderRouterProbe(["/en/task/previous", "/ko/task/task-1"], 1, { idx: 0 });
+
+    fireEvent.click(screen.getByRole("button", { name: "back" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pathname").textContent).toBe("/ko");
+    });
+  });
+
+  it("히스토리 index를 알 수 없으면 현재 locale의 칸반 홈으로 이동한다", async () => {
+    renderRouterProbe(["/en/task/previous", "/zh/task/task-1"], 1, null);
+
+    fireEvent.click(screen.getByRole("button", { name: "back" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pathname").textContent).toBe("/zh");
+    });
+  });
+});

--- a/src/desktop/renderer/navigation.tsx
+++ b/src/desktop/renderer/navigation.tsx
@@ -24,6 +24,11 @@ function getLocaleFromPathname(pathname: string): SupportedLocale {
   return getSafeLocale(firstSegment);
 }
 
+function canNavigateBack() {
+  const historyIndex = window.history.state?.idx;
+  return typeof historyIndex === "number" && historyIndex > 0;
+}
+
 export function localizeHref(href: string, currentLocale?: string): string {
   if (!href.startsWith("/")) {
     return href;
@@ -68,7 +73,14 @@ export function useRouter() {
 
   return useMemo(
     () => ({
-      back: () => navigate(-1),
+      back: () => {
+        if (canNavigateBack()) {
+          navigate(-1);
+          return;
+        }
+
+        navigate(localizeHref("/", currentLocale), { replace: true });
+      },
       push: (href: string) => navigate(localizeHref(href, currentLocale)),
       replace: (href: string) => navigate(localizeHref(href, currentLocale), { replace: true }),
       refresh: () => triggerDesktopRefresh(getRefreshScope(location.pathname)),


### PR DESCRIPTION
## What changed?
- Add a fallback to shared back navigation so direct-entry pages return to the localized Kanban board when there is no previous history entry.
- Preserve normal `navigate(-1)` behavior when React Router reports an available back history entry.
- Add regression tests for both the fallback path and the existing back-navigation path.

## How was it solved?
**Shared router fallback**
- Read React Router's browser history index from `window.history.state.idx`.
- Navigate back only when the index is greater than zero.
- Replace the current route with the localized board home when no prior history exists.

**Regression coverage**
- Added a focused `useRouter` test harness with `MemoryRouter`.
- Covered history-present, history-empty, and unknown-history-index cases.

## Important details
### Navigation behavior

**Localized board fallback**
- **Why**: A direct task detail, diff, or 404 route can render a back button without a real previous page.
- **Files**: `src/desktop/renderer/navigation.tsx`

**Back navigation tests**
- **Why**: The shared router powers multiple back buttons, so fallback behavior should be fixed at the helper level.
- **Files**: `src/desktop/renderer/__tests__/navigation.test.tsx`

Co-Authored-By: OpenAI Codex <codex@openai.com>
