### PR TITLE
fix(board): refresh kanban data with global shortcut

### DIFF
--- a/src/desktop/renderer/components/BoardCommandProvider.tsx
+++ b/src/desktop/renderer/components/BoardCommandProvider.tsx
@@ -12,9 +12,11 @@ import {
 } from "react";
 import { useRouter } from "@/desktop/renderer/navigation";
 import { matchShortcutEvent } from "@/desktop/renderer/utils/keyboardShortcut";
+import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
 
 export const BOARD_NOTIFICATION_SHORTCUT = "Mod+Shift+I";
 export const BOARD_PROJECT_FILTER_SHORTCUT = "Mod+Shift+P";
+export const BOARD_REFRESH_SHORTCUT = "Mod+R";
 export const CREATE_BRANCH_TODO_SHORTCUT = "Mod+N";
 export const PAGE_BACK_SHORTCUT = "Mod+[";
 export const PAGE_FORWARD_SHORTCUT = "Mod+]";
@@ -120,6 +122,12 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
   useEffect(() => {
     function handleGlobalKeyDown(event: KeyboardEvent) {
       if (isTaskQuickSearchOpen || shouldIgnoreGlobalShortcut(event.target)) {
+        return;
+      }
+
+      if (matchShortcutEvent(event, BOARD_REFRESH_SHORTCUT, isMacLike)) {
+        event.preventDefault();
+        triggerDesktopRefresh("all");
         return;
       }
 

--- a/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
+++ b/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
@@ -4,6 +4,14 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BoardCommandProvider, useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
 
+const mocks = vi.hoisted(() => ({
+  triggerDesktopRefresh: vi.fn(),
+}));
+
+vi.mock("@/desktop/renderer/utils/refresh", () => ({
+  triggerDesktopRefresh: (...args: unknown[]) => mocks.triggerDesktopRefresh(...args),
+}));
+
 function BoardCommandHarness({
   onToggleNotificationCenter,
   onOpenProjectFilter,
@@ -63,6 +71,7 @@ function renderWithRouter(children: ReactNode) {
 
 describe("BoardCommandProvider", () => {
   afterEach(() => {
+    vi.clearAllMocks();
     delete window.kanvibeDesktop;
   });
 
@@ -227,5 +236,21 @@ describe("BoardCommandProvider", () => {
 
     expect(onToggleNotificationCenter).toHaveBeenCalledTimes(1);
     expect(screen.getByText("branch-disabled")).toBeTruthy();
+  });
+
+  it("refreshes all kanban data from the global refresh shortcut", () => {
+    renderWithRouter(
+      <BoardCommandProvider>
+        <div />
+      </BoardCommandProvider>,
+    );
+
+    const wasNotPrevented = fireEvent.keyDown(window, {
+      key: "r",
+      ctrlKey: true,
+    });
+
+    expect(wasNotPrevented).toBe(false);
+    expect(mocks.triggerDesktopRefresh).toHaveBeenCalledWith("all");
   });
 });


### PR DESCRIPTION
## What changed?
- Add a global `Mod+R` refresh shortcut to the board command provider.
- Dispatch the shared desktop refresh event with the `all` scope so kanban data reloads without a full window reload.
- Add coverage for the refresh shortcut behavior alongside the existing board command provider shortcuts.

## Why?
- Tasks moved to Done by external board updates could remain stale in the current UI until a refresh path was triggered.
- Handling the standard refresh shortcut through the existing desktop refresh signal keeps board state aligned with persisted kanban data.

## Important details
- The shortcut respects existing global shortcut guards for quick search and editable inputs.
- The branch is rebased on `origin/dev`.

Co-authored-by: OpenAI Codex <codex@openai.com>
