### PR TITLE
Fix task creation dialog keyboard navigation

### DIFF
--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -155,6 +155,27 @@ function CreateTaskModalContent({
     });
   }
 
+  function handleFormKeyDown(event: React.KeyboardEvent<HTMLFormElement>) {
+    if (
+      event.key !== "Enter" ||
+      event.defaultPrevented ||
+      event.nativeEvent.isComposing ||
+      event.shiftKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey
+    ) {
+      return;
+    }
+
+    if (event.target instanceof HTMLButtonElement) {
+      return;
+    }
+
+    event.preventDefault();
+    event.currentTarget.requestSubmit();
+  }
+
   return (
     <div className="fixed inset-0 z-[400] flex items-center justify-center bg-bg-overlay">
       <div className="w-full max-w-md bg-bg-surface rounded-xl border border-border-default shadow-lg p-6">
@@ -162,7 +183,7 @@ function CreateTaskModalContent({
           {t("createTitle")}
         </h2>
 
-        <form action={handleSubmit} className="space-y-4">
+        <form action={handleSubmit} className="space-y-4" onKeyDown={handleFormKeyDown}>
           <div>
             <label className="block text-sm text-text-secondary mb-1">
               {t("project")} *

--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useState, useEffect, useRef, useCallback, useImperativeHand
 import type { Project } from "@/entities/Project";
 
 const MAX_VISIBLE_CHIPS = 2;
+const EMPTY_SELECTED_PROJECT_IDS: string[] = [];
 
 type BaseProps = {
   projects: Project[];
@@ -57,7 +58,7 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
 
   const selectedProjectIds = isMultiple
     ? (props as MultiSelectProps).selectedProjectIds
-    : [];
+    : EMPTY_SELECTED_PROJECT_IDS;
   const onSelectionChange = isMultiple
     ? (props as MultiSelectProps).onSelectionChange
     : undefined;
@@ -142,25 +143,6 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
     }
   }, [isOpen]);
 
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const maxIndex = isMultiple ? orderedProjects.length - 1 : singleTotalItems - 1;
-    setHighlightedIndex((current) => {
-      if (maxIndex < 0) {
-        return -1;
-      }
-
-      if (current < 0 || current > maxIndex) {
-        return 0;
-      }
-
-      return current;
-    });
-  }, [isOpen, isMultiple, orderedProjects.length, singleTotalItems]);
-
   useImperativeHandle(ref, () => ({
     close: closeDropdown,
     focus() {
@@ -226,11 +208,16 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
     []
   );
 
+  const maxHighlightedIndex = isMultiple ? orderedProjects.length - 1 : singleTotalItems - 1;
+  const normalizedHighlightedIndex = isOpen && maxHighlightedIndex >= 0
+    ? Math.min(Math.max(highlightedIndex, 0), maxHighlightedIndex)
+    : -1;
+
   // ===== 멀티 선택 모드 =====
   if (isMultiple) {
     const handleMultiKeyDown = (e: React.KeyboardEvent) => {
       if (!isOpen) {
-        if (e.key === "ArrowDown" || e.key === "Enter") {
+        if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           openDropdown();
         }
@@ -253,10 +240,10 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
         case "Enter":
           e.preventDefault();
           if (
-            highlightedIndex >= 0 &&
-            highlightedIndex < orderedProjects.length
+            normalizedHighlightedIndex >= 0 &&
+            normalizedHighlightedIndex < orderedProjects.length
           ) {
-            handleToggle(orderedProjects[highlightedIndex].id);
+            handleToggle(orderedProjects[normalizedHighlightedIndex].id);
           }
           break;
         case "Escape":
@@ -274,10 +261,14 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
       >
         {/* 트리거: 선택된 프로젝트 칩 또는 placeholder. 칩은 최대 2개까지 표시하고 나머지는 "+N" 배지로 축약한다 */}
         <div
+          role="button"
+          tabIndex={0}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen}
           onClick={() => (isOpen ? closeDropdown() : openDropdown())}
           className={`w-full px-2 bg-bg-page border rounded-md text-text-primary cursor-pointer flex items-center gap-1 overflow-hidden ${
             compact ? "py-1 min-h-[34px]" : "py-1.5 min-h-[38px]"
-          } ${isOpen ? "border-brand-primary" : "border-border-default"}`}
+          } ${isOpen ? "border-brand-primary" : "border-border-default"} focus:outline-none focus:border-brand-primary`}
         >
           {selectedProjects.length === 0 ? (
             <span className="text-text-muted text-sm px-1">{placeholder}</span>
@@ -353,7 +344,7 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
                       }}
                       onMouseEnter={() => setHighlightedIndex(index)}
                       className={`flex items-center gap-2 px-3 py-2 text-sm cursor-pointer transition-colors ${
-                        index === highlightedIndex
+                        index === normalizedHighlightedIndex
                           ? "bg-brand-primary/10 text-text-primary"
                           : "text-text-primary hover:bg-bg-page"
                       }`}
@@ -404,7 +395,7 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
   // ===== 단일 선택 모드 =====
   const handleSingleKeyDown = (e: React.KeyboardEvent) => {
     if (!isOpen) {
-      if (e.key === "ArrowDown" || e.key === "Enter") {
+      if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
         e.preventDefault();
         openDropdown();
       }
@@ -426,13 +417,13 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
         break;
       case "Enter":
         e.preventDefault();
-        if (highlightedIndex >= 0 && highlightedIndex < singleTotalItems) {
-          if (showAllOption && highlightedIndex === 0) {
+        if (normalizedHighlightedIndex >= 0 && normalizedHighlightedIndex < singleTotalItems) {
+          if (showAllOption && normalizedHighlightedIndex === 0) {
             handleSelectAll();
           } else {
             const projectIndex = showAllOption
-              ? highlightedIndex - 1
-              : highlightedIndex;
+              ? normalizedHighlightedIndex - 1
+              : normalizedHighlightedIndex;
             if (
               projectIndex >= 0 &&
               projectIndex < filteredProjects.length
@@ -457,10 +448,14 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
     >
       {/* 트리거: 선택된 프로젝트명 또는 placeholder */}
       <div
+        role="button"
+        tabIndex={0}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
         onClick={() => (isOpen ? closeDropdown() : openDropdown())}
         className={`w-full px-2 bg-bg-page border rounded-md text-text-primary cursor-pointer flex items-center gap-1 ${
           compact ? "py-1 min-h-[34px]" : "py-1.5 min-h-[38px]"
-        } ${isOpen ? "border-brand-primary" : "border-border-default"}`}
+        } ${isOpen ? "border-brand-primary" : "border-border-default"} focus:outline-none focus:border-brand-primary`}
       >
         {singleDisplayText ? (
           <span className="text-sm px-1 truncate">{singleDisplayText}</span>
@@ -507,7 +502,7 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
                 }}
                 onMouseEnter={() => setHighlightedIndex(0)}
                 className={`px-3 py-2 text-sm cursor-pointer transition-colors ${
-                  highlightedIndex === 0
+                  normalizedHighlightedIndex === 0
                     ? "bg-brand-primary/10 text-text-primary"
                     : "text-text-primary hover:bg-bg-page"
                 } ${!selectedProjectId ? "font-medium" : ""}`}
@@ -531,7 +526,7 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
                     }}
                     onMouseEnter={() => setHighlightedIndex(itemIndex)}
                     className={`px-3 py-2 text-sm cursor-pointer transition-colors ${
-                      itemIndex === highlightedIndex
+                      itemIndex === normalizedHighlightedIndex
                         ? "bg-brand-primary/10 text-text-primary"
                         : "text-text-primary hover:bg-bg-page"
                     } ${project.id === selectedProjectId ? "font-medium" : ""}`}

--- a/src/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/components/__tests__/CreateTaskModal.test.tsx
@@ -196,6 +196,48 @@ describe("CreateTaskModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("입력창에서 Enter를 누르면 작업을 생성한다", async () => {
+    // Given
+    const onClose = vi.fn();
+    mockEnsureSessionDependencyWithPrompt.mockResolvedValue(true);
+    mockCreateTask.mockResolvedValue({ id: "task-enter" });
+
+    render(
+      <CreateTaskModal
+        isOpen
+        onClose={onClose}
+        sshHosts={["remote-box"]}
+        projects={[createProject()]}
+        defaultProjectId="project-remote"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetProjectBranches).toHaveBeenCalledWith("project-remote");
+    });
+
+    // When
+    const branchNameInput = screen.getByPlaceholderText("branchPlaceholder");
+    fireEvent.change(branchNameInput, { target: { value: "fix/enter-submit" } });
+    fireEvent.keyDown(branchNameInput, { key: "Enter" });
+
+    // Then
+    await waitFor(() => {
+      expect(mockCreateTask).toHaveBeenCalledWith({
+        title: "fix/enter-submit",
+        description: undefined,
+        branchName: "fix/enter-submit",
+        baseBranch: "main",
+        sessionType: "tmux",
+        sshHost: undefined,
+        projectId: "project-remote",
+        priority: undefined,
+      });
+    });
+    expect(onClose).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/task/task-enter");
+  });
+
   it("프로젝트 목록이 새로고침되어도 사용자가 선택한 베이스 브랜치를 유지한다", async () => {
     // Given
     const project = createProject();

--- a/src/components/__tests__/ProjectSelector.test.tsx
+++ b/src/components/__tests__/ProjectSelector.test.tsx
@@ -1,6 +1,7 @@
 import { createRef } from "react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { act, render, screen, cleanup, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { Project } from "@/entities/Project";
 
 vi.mock("next-intl", () => ({
@@ -155,5 +156,29 @@ describe("ProjectSelector chip truncation", () => {
     fireEvent.keyDown(searchInput, { key: "Enter" });
 
     expect(onSelectionChange).toHaveBeenCalledWith([]);
+  });
+
+  it("should include the single-select trigger in the tab order", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <>
+        <button type="button">Before</button>
+        <ProjectSelector
+          projects={projects}
+          selectedProjectId=""
+          onSelect={vi.fn()}
+          placeholder="Select project"
+          searchPlaceholder="Search project..."
+        />
+        <button type="button">After</button>
+      </>,
+    );
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: "Before" })).toBe(document.activeElement);
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: "Select project" })).toBe(document.activeElement);
   });
 });


### PR DESCRIPTION
## What changed
- Make the task creation project selector trigger reachable through Tab navigation by exposing focusable button semantics.
- Submit task creation with Enter from form fields while preserving dropdown Enter handling for option selection.
- Add regression coverage for Enter submit and project selector tab order.

## Review notes
- Escape cancellation continues to use the existing modal escape-key handler.
- The PR targets the detected base branch, `dev`.

Co-Authored-By: OpenAI Codex <codex@openai.com>