### PR TITLE
fix(desktop): recover packaged app loading and branding

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: com.kanvibe.desktop
-productName: Kanivibe
+productName: KanVibe
 asar: false
 
 directories:

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -9,6 +9,7 @@ import NotificationListener from "@/desktop/renderer/components/NotificationList
 import TaskQuickSearchDialog from "@/desktop/renderer/components/TaskQuickSearchDialog";
 import { getSessionState } from "@/desktop/renderer/actions/auth";
 import { DEFAULT_LOCALE, getSafeLocale, isSupportedLocale, messagesByLocale } from "@/desktop/renderer/utils/locales";
+import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadingTimeout";
 import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
 import BoardRoute from "@/desktop/renderer/routes/BoardRoute";
 import DiffRoute from "@/desktop/renderer/routes/DiffRoute";
@@ -85,16 +86,36 @@ export default function App() {
 
   useEffect(() => {
     let cancelled = false;
+    let sessionLoadTimeout: number | null = null;
+
+    const clearSessionLoadTimeout = () => {
+      if (sessionLoadTimeout === null) {
+        return;
+      }
+
+      window.clearTimeout(sessionLoadTimeout);
+      sessionLoadTimeout = null;
+    };
 
     const reloadSession = () => {
+      clearSessionLoadTimeout();
+      sessionLoadTimeout = window.setTimeout(() => {
+        sessionLoadTimeout = null;
+        if (!cancelled) {
+          setSessionState((currentState) => currentState ?? { isAuthenticated: false });
+        }
+      }, INITIAL_DESKTOP_LOAD_TIMEOUT_MS);
+
       Promise.resolve()
         .then(() => getSessionState())
         .then((nextState) => {
+          clearSessionLoadTimeout();
           if (!cancelled) {
             setSessionState(nextState);
           }
         })
         .catch((error) => {
+          clearSessionLoadTimeout();
           console.error("Failed to load desktop session state:", error);
           if (!cancelled) {
             setSessionState({ isAuthenticated: false });
@@ -115,6 +136,7 @@ export default function App() {
 
     return () => {
       cancelled = true;
+      clearSessionLoadTimeout();
       window.removeEventListener("kanvibe:session-changed", handleSessionChanged);
       unsubscribeBoardEvents();
     };

--- a/src/desktop/renderer/__tests__/App.test.tsx
+++ b/src/desktop/renderer/__tests__/App.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import App from "@/desktop/renderer/App";
+import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadingTimeout";
 
 const mocks = vi.hoisted(() => ({
   getSessionState: vi.fn(),
@@ -56,6 +57,10 @@ describe("App", () => {
     } as unknown as NonNullable<typeof window.kanvibeDesktop>;
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("session lookup failure does not keep the app on the loading screen", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     mocks.getSessionState.mockRejectedValue(new Error("ipc failed"));
@@ -70,5 +75,21 @@ describe("App", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  it("should not stay on the loading screen when session lookup never settles", async () => {
+    // Given
+    vi.useFakeTimers();
+    mocks.getSessionState.mockReturnValue(new Promise(() => {}));
+
+    // When
+    render(<App />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INITIAL_DESKTOP_LOAD_TIMEOUT_MS);
+    });
+
+    // Then
+    expect(screen.queryByText("Loading...")).toBeNull();
+    expect(screen.getByText("login form")).toBeTruthy();
   });
 });

--- a/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
@@ -81,7 +81,7 @@ describe("TaskQuickSearchDialog", () => {
       expect(screen.getByRole("dialog")).toBeTruthy();
     });
     expect(mocks.getSearchableTasks).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("feat/local-search")).toBeTruthy();
+    expect(await screen.findByText("feat/local-search")).toBeTruthy();
     expect(screen.getByText("feat/api-search")).toBeTruthy();
   });
 
@@ -97,7 +97,7 @@ describe("TaskQuickSearchDialog", () => {
       expect(screen.getByRole("dialog")).toBeTruthy();
     });
 
-    expect(screen.getByText("common.remote")).toBeTruthy();
+    expect(await screen.findByText("common.remote")).toBeTruthy();
     expect(screen.getByText("devbox")).toBeTruthy();
     expect(screen.queryByText("common.local")).toBeNull();
   });

--- a/src/desktop/renderer/routes/BoardRoute.tsx
+++ b/src/desktop/renderer/routes/BoardRoute.tsx
@@ -6,6 +6,7 @@ import { getAllProjects, getAvailableHosts } from "@/desktop/renderer/actions/pr
 import { buildRouteCacheKey, readRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
 import { DEFAULT_TASK_SEARCH_SHORTCUT } from "@/desktop/renderer/utils/keyboardShortcut";
+import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadingTimeout";
 import { SessionType, TaskStatus } from "@/entities/KanbanTask";
 
 interface BoardData {
@@ -54,6 +55,11 @@ export default function BoardRoute() {
 
   useEffect(() => {
     let cancelled = false;
+    const loadingTimeout = window.setTimeout(() => {
+      if (!cancelled) {
+        setData((currentData) => currentData ?? createEmptyBoardData());
+      }
+    }, INITIAL_DESKTOP_LOAD_TIMEOUT_MS);
 
     Promise.all([
       getTasksByStatus(),
@@ -65,6 +71,7 @@ export default function BoardRoute() {
       getDefaultSessionType(),
       getTaskSearchShortcut(),
     ]).then(([tasks, sshHosts, projects, sidebarDefaultCollapsed, doneAlertDismissed, notificationSettings, defaultSessionType, taskSearchShortcut]) => {
+      window.clearTimeout(loadingTimeout);
       if (!cancelled) {
         const nextData = {
           tasks,
@@ -81,6 +88,7 @@ export default function BoardRoute() {
         setData(nextData);
       }
     }).catch((error) => {
+      window.clearTimeout(loadingTimeout);
       console.error("Failed to load board route data:", error);
       if (!cancelled) {
         setData((currentData) => currentData ?? createEmptyBoardData());
@@ -89,6 +97,7 @@ export default function BoardRoute() {
 
     return () => {
       cancelled = true;
+      window.clearTimeout(loadingTimeout);
     };
   }, [refreshSignal]);
 

--- a/src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import BoardRoute from "@/desktop/renderer/routes/BoardRoute";
+import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadingTimeout";
 
 const BOARD_CACHE_KEY = "kanvibe:route-cache:board";
 
@@ -64,6 +65,10 @@ describe("BoardRoute", () => {
     mocks.getNotificationSettings.mockResolvedValue({ isEnabled: true, enabledStatuses: [] });
     mocks.getDefaultSessionType.mockResolvedValue("tmux");
     mocks.getTaskSearchShortcut.mockResolvedValue("Mod+Shift+O");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("캐시가 있으면 stale board를 즉시 렌더링하고 이후 최신 데이터로 갱신한다", async () => {
@@ -139,5 +144,21 @@ describe("BoardRoute", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  it("should not stay on the loading screen when initial data loading never settles", async () => {
+    // Given
+    vi.useFakeTimers();
+    mocks.getTasksByStatus.mockReturnValue(new Promise(() => {}));
+
+    // When
+    render(<BoardRoute />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INITIAL_DESKTOP_LOAD_TIMEOUT_MS);
+    });
+
+    // Then
+    expect(screen.queryByText("Loading...")).toBeNull();
+    expect(screen.getByTestId("board-titles").textContent).toBe("");
   });
 });

--- a/src/desktop/renderer/utils/loadingTimeout.ts
+++ b/src/desktop/renderer/utils/loadingTimeout.ts
@@ -1,0 +1,1 @@
+export const INITIAL_DESKTOP_LOAD_TIMEOUT_MS = 5000;

--- a/src/lib/__tests__/packageScripts.test.ts
+++ b/src/lib/__tests__/packageScripts.test.ts
@@ -3,11 +3,25 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("package scripts", () => {
+  it("should configure the packaged app product name as KanVibe", () => {
+    // Given
+    const electronBuilderConfig = readFileSync(
+      path.join(process.cwd(), "electron-builder.yml"),
+      "utf8",
+    );
+
+    // When / Then
+    expect(electronBuilderConfig).toContain("productName: KanVibe");
+    expect(electronBuilderConfig).not.toContain("productName: Kanivibe");
+  });
+
   it("rebuilds native dependencies for Electron after preparing the Node seed database", () => {
+    // Given
     const packageJson = JSON.parse(
       readFileSync(path.join(process.cwd(), "package.json"), "utf8"),
     ) as { scripts: Record<string, string> };
 
+    // When / Then
     expect(packageJson.scripts["rebuild:native:electron"]).toBe(
       "electron-rebuild -f --build-from-source -w better-sqlite3",
     );


### PR DESCRIPTION
## Related Materials
- No external ticket linked.

## What is this PR?
- Fixes the packaged desktop app branding and prevents initial desktop IPC calls from leaving the UI stuck on `Loading...`.

## How did I solve it?
**Desktop packaging branding**
- Corrected the Electron Builder product name from `Kanivibe` to `KanVibe` while keeping the existing lowercase `kanvibe.dmg` artifact name.
- Added a package config regression test to prevent the typo from returning.

**Initial loading recovery**
- Added a shared initial desktop load timeout constant.
- Added guarded fallback behavior for session bootstrap and board data bootstrap so unresolved IPC calls render the login/empty board fallback instead of staying on the loading screen indefinitely.
- Preserved late successful responses so real data still replaces fallback state when IPC eventually completes.

**Test stability**
- Added regression tests for unresolved initial loading promises.
- Tightened quick search tests to wait for loaded results instead of only the dialog container.

## Important changes
### Packaged app name

**Correct Electron product name**
- **Reason**: DMG/app display name used the misspelled `Kanivibe` value from Electron Builder config.
- **Modified file**: `electron-builder.yml`

### Loading fallback

**Recover from unresolved initial IPC**
- **Reason**: A pending desktop IPC call could leave either the session shell or board route on `Loading...` forever.
- **Modified files**: `src/desktop/renderer/App.tsx`, `src/desktop/renderer/routes/BoardRoute.tsx`, `src/desktop/renderer/utils/loadingTimeout.ts`

**Cover loading and packaging regressions**
- **Reason**: The product name and unresolved loading states need automated coverage.
- **Modified files**: `src/lib/__tests__/packageScripts.test.ts`, `src/desktop/renderer/__tests__/App.test.tsx`, `src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx`, `src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx`

## Verification
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `pnpm dist:dir`
- Packaged Electron runtime smoke check for `better-sqlite3`, `node-pty`, and bundled seed DB tables

Co-Authored-By: OpenAI Codex <codex@openai.com>
