### PR TITLE
fix: restore Electron native rebuild detection

### DIFF
--- a/scripts/ensure-native-runtime.cjs
+++ b/scripts/ensure-native-runtime.cjs
@@ -47,10 +47,15 @@ function verifyNodeBetterSqlite3Binding() {
 }
 
 function verifyElectronBetterSqlite3Binding() {
-  execFileSync("pnpm", ["exec", "electron", path.join(__dirname, "verify-electron-better-sqlite3.cjs")], {
-    stdio: "inherit",
-    env: process.env,
-  });
+  try {
+    execFileSync("pnpm", ["exec", "electron", path.join(__dirname, "verify-electron-better-sqlite3.cjs")], {
+      stdio: ["ignore", "inherit", "pipe"],
+      env: process.env,
+    });
+  } catch (error) {
+    const stderr = error?.stderr?.toString?.() || "";
+    throw new Error(stderr || String(error?.message || error));
+  }
 }
 
 function verifyBetterSqlite3Binding() {

--- a/scripts/verify-electron-better-sqlite3.cjs
+++ b/scripts/verify-electron-better-sqlite3.cjs
@@ -1,14 +1,19 @@
 #!/usr/bin/env node
 
-const BetterSqlite3 = require("better-sqlite3");
-
-const database = new BetterSqlite3(":memory:");
-
 try {
-  database.pragma("journal_mode = WAL");
-  database.prepare("SELECT 1").get();
-} finally {
-  database.close();
-}
+  const BetterSqlite3 = require("better-sqlite3");
 
-process.exit(0);
+  const database = new BetterSqlite3(":memory:");
+
+  try {
+    database.pragma("journal_mode = WAL");
+    database.prepare("SELECT 1").get();
+  } finally {
+    database.close();
+  }
+
+  process.exit(0);
+} catch (error) {
+  console.error(String(error?.stack || error?.message || error));
+  process.exit(1);
+}

--- a/src/lib/__tests__/ensureNativeRuntimeScript.test.ts
+++ b/src/lib/__tests__/ensureNativeRuntimeScript.test.ts
@@ -15,4 +15,26 @@ describe("ensure-native-runtime script", () => {
     expect(source).toContain('KANVIBE_NATIVE_REBUILD_ATTEMPTED: "1"');
     expect(source).toContain("process.exit(0);");
   });
+
+  it("captures Electron verification stderr so ABI mismatches trigger rebuilds", () => {
+    const source = readFileSync(
+      path.join(process.cwd(), "scripts", "ensure-native-runtime.cjs"),
+      "utf8",
+    );
+
+    expect(source).toContain("function verifyElectronBetterSqlite3Binding()");
+    expect(source).toContain('stdio: ["ignore", "inherit", "pipe"]');
+    expect(source).toContain("const stderr = error?.stderr?.toString?.() || \"\";");
+  });
+
+  it("exits Electron verification with failure when native loading throws", () => {
+    const source = readFileSync(
+      path.join(process.cwd(), "scripts", "verify-electron-better-sqlite3.cjs"),
+      "utf8",
+    );
+
+    expect(source).toContain("try {");
+    expect(source).toContain('const BetterSqlite3 = require("better-sqlite3");');
+    expect(source).toContain("process.exit(1);");
+  });
 });


### PR DESCRIPTION
## Summary
- Make the Electron better-sqlite3 verifier exit with a failure code when native loading throws.
- Capture Electron verifier stderr so ABI mismatches trigger the automatic Electron rebuild path.
- Add regression coverage for the native runtime guard scripts.

## Validation
- pnpm vitest run src/lib/__tests__/ensureNativeRuntimeScript.test.ts
- pnpm check
- pnpm exec electron scripts/verify-electron-better-sqlite3.cjs
- CSC_IDENTITY_AUTO_DISCOVERY=false pnpm exec electron-builder --dir