### PR TITLE
Fix task alert window targeting

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -280,6 +280,33 @@ async function focusMainWindow(relativePath) {
   }
 }
 
+async function focusTaskNotificationWindow(relativePath) {
+  const targetUrl = getRendererNavigationUrl(relativePath);
+  const { resolveExistingNavigationTargetWindow } = getWindowOpenHelpers();
+  const existingWindow = resolveExistingNavigationTargetWindow({
+    targetUrl,
+    rendererDevUrl: RENDERER_DEV_URL,
+    openWindows: getAvailableWindows(),
+    getWindowUrl: (window) => window.webContents.getURL(),
+  });
+
+  if (existingWindow) {
+    mainWindow = existingWindow;
+  } else {
+    mainWindow = await createAppWindow(relativePath);
+  }
+
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
+
+  focusWindow(mainWindow);
+
+  if (mainWindow.webContents.getURL() !== targetUrl) {
+    await mainWindow.loadURL(targetUrl);
+  }
+}
+
 function getNotificationStore() {
   return require(getRuntimeModulePath(path.join("src", "desktop", "main", "notificationStore.ts")));
 }
@@ -298,7 +325,12 @@ async function activateAppNotification(appNotification, options = {}) {
   }
 
   pendingNotificationActivation = activatedNotification;
-  await focusMainWindow(getNotificationTargetPath(activatedNotification));
+  const targetPath = getNotificationTargetPath(activatedNotification);
+  if (activatedNotification.taskId) {
+    await focusTaskNotificationWindow(targetPath);
+  } else {
+    await focusMainWindow(targetPath);
+  }
   broadcastNotificationActivated(activatedNotification);
   return true;
 }

--- a/src/desktop/main/__tests__/windowOpen.test.ts
+++ b/src/desktop/main/__tests__/windowOpen.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { resolveNavigationTargetWindow, resolveWindowOpenAction } from "@/desktop/main/windowOpen";
+import { resolveExistingNavigationTargetWindow, resolveNavigationTargetWindow, resolveWindowOpenAction } from "@/desktop/main/windowOpen";
 
 describe("resolveWindowOpenAction", () => {
   it("file 기반 내부 URL은 독립적인 내부 창 열기로 판단한다", () => {
@@ -114,5 +114,47 @@ describe("resolveNavigationTargetWindow", () => {
     });
 
     expect(result).toBe(preferredWindow);
+  });
+});
+
+describe("resolveExistingNavigationTargetWindow", () => {
+  it("이동 대상과 같은 상세 route 창이 이미 열려 있으면 그 창을 선택한다", () => {
+    const currentWindow = {
+      id: "window-1",
+      url: "http://localhost:3000/#/ko",
+    };
+    const detailWindow = {
+      id: "window-2",
+      url: "http://localhost:3000/#/ko/task/task-1",
+    };
+
+    const result = resolveExistingNavigationTargetWindow({
+      targetUrl: "http://localhost:3000/#/ko/task/task-1",
+      rendererDevUrl: "http://localhost:3000",
+      openWindows: [currentWindow, detailWindow],
+      getWindowUrl: (windowRecord) => windowRecord.url,
+    });
+
+    expect(result).toBe(detailWindow);
+  });
+
+  it("이동 대상과 같은 상세 route 창이 없으면 현재 창 대신 null을 반환한다", () => {
+    const currentWindow = {
+      id: "window-1",
+      url: "http://localhost:3000/#/ko",
+    };
+    const anotherDetailWindow = {
+      id: "window-2",
+      url: "http://localhost:3000/#/ko/task/task-2",
+    };
+
+    const result = resolveExistingNavigationTargetWindow({
+      targetUrl: "http://localhost:3000/#/ko/task/task-1",
+      rendererDevUrl: "http://localhost:3000",
+      openWindows: [currentWindow, anotherDetailWindow],
+      getWindowUrl: (windowRecord) => windowRecord.url,
+    });
+
+    expect(result).toBeNull();
   });
 });

--- a/src/desktop/main/windowOpen.ts
+++ b/src/desktop/main/windowOpen.ts
@@ -142,6 +142,22 @@ export function resolveNavigationTargetWindow<T>({
   return existingWindow ?? preferredWindow;
 }
 
+export function resolveExistingNavigationTargetWindow<T>({
+  targetUrl,
+  rendererDevUrl,
+  openWindows,
+  getWindowUrl,
+}: ResolveNavigationTargetWindowOptions<T>): T | null {
+  const { existingWindow } = findExistingInternalWindow({
+    targetUrl,
+    rendererDevUrl,
+    openWindows,
+    getWindowUrl,
+  });
+
+  return existingWindow;
+}
+
 export function resolveWindowOpenAction<T>({
   targetUrl,
   rendererDevUrl,


### PR DESCRIPTION
## What
- Focus an existing matching task detail window when a task notification is activated.
- Open a new app window for task notification targets when no matching task detail window exists.
- Preserve the existing main-window navigation path for non-task notifications.

## How
- Add `resolveExistingNavigationTargetWindow` to reuse internal route matching without falling back to the preferred window.
- Route task notification activation through a dedicated Electron main-process window target flow.
- Add regression coverage for both existing and missing task detail window cases.

Co-Authored-By: Codex <codex@openai.com>