### PR TITLE
perf(background-sync): parallelize task refresh jobs

### DIFF
--- a/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
+++ b/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   syncRegisteredProjectWorktrees: vi.fn(),
   syncActiveTaskPullRequests: vi.fn(),
+  syncActiveTaskPulls: vi.fn(),
   broadcastBoardUpdate: vi.fn(),
   broadcastBackgroundSyncReviewNeeded: vi.fn(),
 }));
@@ -13,6 +14,7 @@ vi.mock("@/desktop/main/services/projectService", () => ({
 
 vi.mock("@/desktop/main/services/kanbanService", () => ({
   syncActiveTaskPullRequests: mocks.syncActiveTaskPullRequests,
+  syncActiveTaskPulls: mocks.syncActiveTaskPulls,
 }));
 
 vi.mock("@/lib/boardNotifier", () => ({
@@ -36,6 +38,9 @@ describe("backgroundTaskSyncService", () => {
       updatedTaskIds: [],
       mergeEventKeys: [],
       mergedPullRequests: [],
+    });
+    mocks.syncActiveTaskPulls.mockResolvedValue({
+      pulledTasks: [],
     });
   });
 
@@ -91,6 +96,61 @@ describe("backgroundTaskSyncService", () => {
           branchName: "feature/merged-pr",
           prUrl: "https://github.com/kanvibe/kanvibe/pull/211",
           mergedAt: "2026-04-30T02:00:00Z",
+        },
+      ],
+      pulledTasks: [],
+    });
+
+    stop();
+  });
+
+  it("background task sync는 여러 번 시작해도 하나의 loop만 실행한다", async () => {
+    const { startBackgroundTaskSync } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    const stopA = startBackgroundTaskSync();
+    const stopB = startBackgroundTaskSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
+
+    stopA();
+    stopB();
+  });
+
+  it("task pull 결과가 있으면 background sync review event에 포함한다", async () => {
+    mocks.syncActiveTaskPulls.mockResolvedValue({
+      pulledTasks: [
+        {
+          taskId: "task-pull",
+          taskTitle: "Pull target",
+          branchName: "feature/pull",
+          worktreePath: "/workspace/repo__worktrees/feature-pull",
+          sshHost: null,
+          status: "updated",
+          summary: "Fast-forward",
+        },
+      ],
+    });
+
+    const { startBackgroundTaskSync } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    const stop = startBackgroundTaskSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mocks.broadcastBackgroundSyncReviewNeeded).toHaveBeenCalledWith({
+      registeredWorktrees: [],
+      mergedPullRequests: [],
+      pulledTasks: [
+        {
+          taskId: "task-pull",
+          taskTitle: "Pull target",
+          branchName: "feature/pull",
+          worktreePath: "/workspace/repo__worktrees/feature-pull",
+          sshHost: null,
+          status: "updated",
+          summary: "Fast-forward",
         },
       ],
     });

--- a/src/desktop/main/services/__tests__/desktopNotificationService.test.ts
+++ b/src/desktop/main/services/__tests__/desktopNotificationService.test.ts
@@ -193,6 +193,7 @@ describe("desktopNotificationService", () => {
           payload: {
             mergedPullRequests: [],
             registeredWorktrees: [],
+            pulledTasks: [],
           },
         },
       },
@@ -218,8 +219,9 @@ describe("desktopNotificationService", () => {
           branchName: "feature-sync",
           worktreePath: "/workspace/api__worktrees/feature-sync",
           sshHost: null,
-        },
-      ],
+          },
+        ],
+      pulledTasks: [],
     }, "ko", {
       iconPath: "/icon.png",
     })).resolves.toBe(true);
@@ -248,6 +250,7 @@ describe("desktopNotificationService", () => {
               sshHost: null,
             },
           ],
+          pulledTasks: [],
         },
       },
     }));

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   installKanvibeHooks: vi.fn(),
   broadcastBoardUpdate: vi.fn(),
   execGit: vi.fn(),
+  pullCurrentBranch: vi.fn(),
   broadcastTaskHookInstallFailed: vi.fn(),
   broadcastTaskPrMergedDetectedBatch: vi.fn(),
 }));
@@ -73,6 +74,7 @@ vi.mock("@/lib/boardNotifier", () => ({
 
 vi.mock("@/lib/gitOperations", () => ({
   execGit: mocks.execGit,
+  pullCurrentBranch: mocks.pullCurrentBranch,
 }));
 
 describe("kanbanService.createTask", () => {
@@ -681,6 +683,144 @@ describe("kanbanService.createTask", () => {
         prUrl,
         mergedAt: "2026-04-30T02:00:00Z",
       }],
+    });
+  });
+
+  it("active task PR sync는 task별 GitHub CLI 조회를 병렬로 시작한다", async () => {
+    // Given
+    mocks.taskRepo.find.mockResolvedValue([
+      {
+        id: "task-parallel-a",
+        title: "Parallel PR A",
+        projectId: "project-1",
+        branchName: "feature/parallel-a",
+        worktreePath: "/workspace/repo__worktrees/parallel-a",
+        sshHost: null,
+        prUrl: null,
+        status: "review",
+      },
+      {
+        id: "task-parallel-b",
+        title: "Parallel PR B",
+        projectId: "project-1",
+        branchName: "feature/parallel-b",
+        worktreePath: "/workspace/repo__worktrees/parallel-b",
+        sshHost: null,
+        prUrl: null,
+        status: "review",
+      },
+    ]);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+    const callbacks: Array<(error: Error | null, stdout: string, stderr: string) => void> = [];
+    mocks.execFile.mockImplementation((file, args, options, callback) => {
+      callbacks.push(callback);
+      return {} as never;
+    });
+
+    const { syncActiveTaskPullRequests } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const syncPromise = syncActiveTaskPullRequests(new Set());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Then
+    expect(callbacks).toHaveLength(2);
+
+    callbacks.forEach((callback) => {
+      callback(null, JSON.stringify([{
+        url: null,
+        state: null,
+        mergedAt: null,
+        updatedAt: "2026-05-02T01:00:00Z",
+      }]), "");
+    });
+    await syncPromise;
+  });
+
+  it("active task pull sync는 default branch task를 제외하고 task별 pull을 병렬로 실행한다", async () => {
+    // Given
+    mocks.taskRepo.find.mockResolvedValue([
+      {
+        id: "task-main",
+        title: "Main",
+        projectId: "project-1",
+        branchName: "main",
+        worktreePath: "/workspace/repo",
+        sshHost: null,
+        status: "progress",
+      },
+      {
+        id: "task-pull-a",
+        title: "Pull A",
+        projectId: "project-1",
+        branchName: "feature/pull-a",
+        worktreePath: "/workspace/repo__worktrees/pull-a",
+        sshHost: null,
+        status: "progress",
+      },
+      {
+        id: "task-pull-b",
+        title: "Pull B",
+        projectId: "project-1",
+        branchName: "feature/pull-b",
+        worktreePath: "/workspace/repo__worktrees/pull-b",
+        sshHost: null,
+        status: "review",
+      },
+    ]);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+    const resolvers: Array<(value: string) => void> = [];
+    const rejecters: Array<(error: Error) => void> = [];
+    mocks.pullCurrentBranch.mockImplementation(() => new Promise<string>((resolve, reject) => {
+      resolvers.push(resolve);
+      rejecters.push(reject);
+    }));
+
+    const { syncActiveTaskPulls } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const syncPromise = syncActiveTaskPulls();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Then
+    expect(mocks.pullCurrentBranch).toHaveBeenCalledTimes(2);
+    expect(mocks.pullCurrentBranch).toHaveBeenNthCalledWith(1, "/workspace/repo__worktrees/pull-a", null);
+    expect(mocks.pullCurrentBranch).toHaveBeenNthCalledWith(2, "/workspace/repo__worktrees/pull-b", null);
+
+    resolvers[0]("Fast-forward\n src/file.ts | 1 +");
+    rejecters[1](new Error("Not possible to fast-forward"));
+
+    await expect(syncPromise).resolves.toEqual({
+      pulledTasks: [
+        {
+          taskId: "task-pull-a",
+          taskTitle: "Pull A",
+          branchName: "feature/pull-a",
+          worktreePath: "/workspace/repo__worktrees/pull-a",
+          sshHost: null,
+          status: "updated",
+          summary: "Fast-forward",
+        },
+        {
+          taskId: "task-pull-b",
+          taskTitle: "Pull B",
+          branchName: "feature/pull-b",
+          worktreePath: "/workspace/repo__worktrees/pull-b",
+          sshHost: null,
+          status: "failed",
+          summary: "Not possible to fast-forward",
+        },
+      ],
     });
   });
 });

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -1270,6 +1270,73 @@ describe("projectService local hook installation", () => {
       null,
     );
   });
+
+  it("등록된 프로젝트 background sync는 프로젝트별 worktree 조회를 병렬로 시작한다", async () => {
+    // Given
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.isSessionAlive.mockResolvedValue(false);
+
+    const seenRepoPaths: string[] = [];
+    const firstCalls = new Set<string>();
+    let releaseGate: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    mocks.listWorktrees.mockImplementation(async (repoPath: string) => {
+      seenRepoPaths.push(repoPath);
+      if (!firstCalls.has(repoPath)) {
+        firstCalls.add(repoPath);
+        await gate;
+      }
+      return [];
+    });
+
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => ({
+        id: `task-${criteria.projectId}`,
+        branchName: criteria.branchName,
+        projectId: criteria.projectId,
+        baseBranch: criteria.branchName,
+        worktreePath: null,
+        sshHost: null,
+      })),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => value),
+    });
+
+    const projects = [
+      {
+        id: "project-a",
+        name: "api-a",
+        repoPath: "/workspace/api-a",
+        defaultBranch: "main",
+        sshHost: null,
+      },
+      {
+        id: "project-b",
+        name: "api-b",
+        repoPath: "/workspace/api-b",
+        defaultBranch: "main",
+        sshHost: null,
+      },
+    ];
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const syncPromise = syncRegisteredProjectWorktrees(projects as never);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Then
+    const targetRepoPaths = seenRepoPaths.filter((repoPath) => repoPath.startsWith("/workspace/api-"));
+    expect(targetRepoPaths.slice(0, 2)).toEqual(["/workspace/api-a", "/workspace/api-b"]);
+
+    releaseGate?.();
+    await syncPromise;
+  });
 });
 
 describe("projectService remote hook and AI session support", () => {

--- a/src/desktop/main/services/backgroundTaskSyncService.ts
+++ b/src/desktop/main/services/backgroundTaskSyncService.ts
@@ -1,11 +1,17 @@
 import { syncRegisteredProjectWorktrees } from "@/desktop/main/services/projectService";
-import { syncActiveTaskPullRequests } from "@/desktop/main/services/kanbanService";
+import { syncActiveTaskPullRequests, syncActiveTaskPulls } from "@/desktop/main/services/kanbanService";
 import { broadcastBackgroundSyncReviewNeeded, broadcastBoardUpdate } from "@/lib/boardNotifier";
 
 const INITIAL_SYNC_DELAY_MS = 20_000;
 const SYNC_INTERVAL_MS = 90_000;
 
+let activeBackgroundTaskSyncStop: (() => void) | null = null;
+
 export function startBackgroundTaskSync() {
+  if (activeBackgroundTaskSyncStop) {
+    return activeBackgroundTaskSyncStop;
+  }
+
   let disposed = false;
   let running = false;
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
@@ -30,17 +36,30 @@ export function startBackgroundTaskSync() {
     running = true;
 
     try {
-      const worktreeSyncResult = await syncRegisteredProjectWorktrees();
-      const prSyncResult = await syncActiveTaskPullRequests(emittedMergeEventKeys);
+      const [
+        worktreeSyncResult,
+        prSyncResult,
+        pullSyncResult,
+      ] = await Promise.all([
+        syncRegisteredProjectWorktrees(),
+        syncActiveTaskPullRequests(emittedMergeEventKeys),
+        syncActiveTaskPulls(),
+      ]);
 
-      if (worktreeSyncResult.registeredWorktrees.length > 0 || prSyncResult.mergedPullRequests.length > 0) {
+      if (
+        worktreeSyncResult.registeredWorktrees.length > 0
+        || prSyncResult.mergedPullRequests.length > 0
+        || pullSyncResult.pulledTasks.length > 0
+      ) {
         broadcastBackgroundSyncReviewNeeded({
           registeredWorktrees: worktreeSyncResult.registeredWorktrees,
           mergedPullRequests: prSyncResult.mergedPullRequests,
+          pulledTasks: pullSyncResult.pulledTasks,
         });
       }
 
-      if (worktreeSyncResult.changed || prSyncResult.updatedTaskIds.length > 0) {
+      const hasUpdatedPulledTasks = pullSyncResult.pulledTasks.some((task) => task.status === "updated");
+      if (worktreeSyncResult.changed || prSyncResult.updatedTaskIds.length > 0 || hasUpdatedPulledTasks) {
         broadcastBoardUpdate();
       }
     } catch (error) {
@@ -53,11 +72,17 @@ export function startBackgroundTaskSync() {
 
   scheduleNext(INITIAL_SYNC_DELAY_MS);
 
-  return () => {
+  function stopBackgroundTaskSync() {
     disposed = true;
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
       timeoutHandle = null;
     }
-  };
+    if (activeBackgroundTaskSyncStop === stopBackgroundTaskSync) {
+      activeBackgroundTaskSyncStop = null;
+    }
+  }
+
+  activeBackgroundTaskSyncStop = stopBackgroundTaskSync;
+  return activeBackgroundTaskSyncStop;
 }

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -7,7 +7,7 @@ import { createWorktreeWithSession, removeWorktreeAndBranch, createSessionWithou
 import { getProjectRepository } from "@/lib/database";
 import { broadcastBoardUpdate, broadcastTaskHookInstallFailed, broadcastTaskPrMergedDetectedBatch, type TaskPrMergedDetectedPayload } from "@/lib/boardNotifier";
 import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
-import { execGit } from "@/lib/gitOperations";
+import { execGit, pullCurrentBranch } from "@/lib/gitOperations";
 
 export type TasksByStatus = Record<TaskStatus, KanbanTask[]>;
 
@@ -46,6 +46,20 @@ export interface ActiveTaskPullRequestSyncResult {
   updatedTaskIds: string[];
   mergeEventKeys: string[];
   mergedPullRequests: TaskPrMergedDetectedPayload[];
+}
+
+export interface TaskPullSyncPayload {
+  taskId: string;
+  taskTitle: string;
+  branchName: string;
+  worktreePath: string;
+  sshHost: string | null;
+  status: "updated" | "failed";
+  summary: string;
+}
+
+export interface ActiveTaskPullSyncResult {
+  pulledTasks: TaskPullSyncPayload[];
 }
 
 /** TypeORM 엔티티를 직렬화 가능한 plain object로 변환한다 */
@@ -252,6 +266,20 @@ function buildMergedPullRequestEventKey(
   mergedAt: string,
 ): string {
   return `${taskId}:${prUrl}:${mergedAt}`;
+}
+
+function summarizePullOutput(output: string): string {
+  const line = output
+    .split(/\r?\n/)
+    .map((item) => item.trim())
+    .find(Boolean);
+
+  return line ?? "Pull completed";
+}
+
+function isPullNoop(output: string): boolean {
+  return /already up[- ]to[- ]date/i.test(output)
+    || /current branch .* is up to date/i.test(output);
 }
 
 /** 모든 작업을 상태별로 그룹핑하여 반환한다. Done 컬럼은 첫 페이지만 로드한다 */
@@ -751,9 +779,9 @@ export async function syncActiveTaskPullRequests(
     mergedPullRequests: [],
   };
 
-  for (const task of tasks) {
+  const taskResults = await Promise.all(tasks.map(async (task) => {
     if (!task.branchName) {
-      continue;
+      return null;
     }
 
     try {
@@ -762,31 +790,35 @@ export async function syncActiveTaskPullRequests(
         : null;
 
       if (isDefaultBranchTask(task, project)) {
-        continue;
+        return null;
       }
 
       const { cwd, sshHost } = await resolveTaskGitContext(task, project);
       const prInfo = await getPrInfoFromGitHubCli(task.branchName, cwd, sshHost);
 
       if (!prInfo?.url) {
-        continue;
+        return null;
       }
+
+      const updatedTaskIds: string[] = [];
+      const mergeEventKeys: string[] = [];
+      const mergedPullRequests: TaskPrMergedDetectedPayload[] = [];
 
       if (task.prUrl !== prInfo.url) {
         task.prUrl = prInfo.url;
         await repo.save(task);
-        result.updatedTaskIds.push(task.id);
+        updatedTaskIds.push(task.id);
       }
 
       if (prInfo.state === "MERGED" && prInfo.mergedAt) {
         const mergeEventKey = buildMergedPullRequestEventKey(task.id, prInfo.url, prInfo.mergedAt);
         if (emittedMergeEventKeys.has(mergeEventKey)) {
-          continue;
+          return { updatedTaskIds, mergeEventKeys, mergedPullRequests };
         }
 
         emittedMergeEventKeys.add(mergeEventKey);
-        result.mergeEventKeys.push(mergeEventKey);
-        result.mergedPullRequests.push({
+        mergeEventKeys.push(mergeEventKey);
+        mergedPullRequests.push({
           taskId: task.id,
           taskTitle: task.title,
           branchName: task.branchName,
@@ -794,13 +826,26 @@ export async function syncActiveTaskPullRequests(
           mergedAt: prInfo.mergedAt,
         });
       }
+
+      return { updatedTaskIds, mergeEventKeys, mergedPullRequests };
     } catch (error) {
       console.error("PR 상태 동기화 실패:", {
         taskId: task.id,
         branchName: task.branchName,
         error: getErrorMessage(error),
       });
+      return null;
     }
+  }));
+
+  for (const taskResult of taskResults) {
+    if (!taskResult) {
+      continue;
+    }
+
+    result.updatedTaskIds.push(...taskResult.updatedTaskIds);
+    result.mergeEventKeys.push(...taskResult.mergeEventKeys);
+    result.mergedPullRequests.push(...taskResult.mergedPullRequests);
   }
 
   if (result.mergedPullRequests.length > 0) {
@@ -810,4 +855,60 @@ export async function syncActiveTaskPullRequests(
   }
 
   return result;
+}
+
+export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
+  const repo = await getTaskRepository();
+  const projectRepo = await getProjectRepository();
+  const tasks = await repo.find({
+    where: { status: Not(TaskStatus.DONE) },
+    order: { updatedAt: "ASC" },
+  });
+
+  const pulledTasks = await Promise.all(tasks.map(async (task): Promise<TaskPullSyncPayload | null> => {
+    if (!task.branchName || !task.worktreePath) {
+      return null;
+    }
+
+    const project = task.projectId
+      ? await projectRepo.findOneBy({ id: task.projectId })
+      : null;
+
+    if (isDefaultBranchTask(task, project)) {
+      return null;
+    }
+
+    const sshHost = task.sshHost || project?.sshHost || null;
+
+    try {
+      const output = await pullCurrentBranch(task.worktreePath, sshHost);
+      if (isPullNoop(output)) {
+        return null;
+      }
+
+      return {
+        taskId: task.id,
+        taskTitle: task.title,
+        branchName: task.branchName,
+        worktreePath: task.worktreePath,
+        sshHost,
+        status: "updated",
+        summary: summarizePullOutput(output),
+      };
+    } catch (error) {
+      return {
+        taskId: task.id,
+        taskTitle: task.title,
+        branchName: task.branchName,
+        worktreePath: task.worktreePath,
+        sshHost,
+        status: "failed",
+        summary: getErrorMessage(error),
+      };
+    }
+  }));
+
+  return {
+    pulledTasks: pulledTasks.filter((task): task is TaskPullSyncPayload => task !== null),
+  };
 }

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -656,10 +656,14 @@ export async function syncRegisteredProjectWorktrees(
     changed: false,
   };
 
-  for (const project of projects) {
+  const projectResults = await Promise.all(
+    projects.map((project) => syncProjectWorktrees(project, taskRepo)),
+  );
+
+  for (const projectResult of projectResults) {
     mergeRegisteredProjectWorktreeSyncResult(
       mergedResult,
-      await syncProjectWorktrees(project, taskRepo),
+      projectResult,
     );
   }
 

--- a/src/desktop/shared/__tests__/taskNotifications.test.ts
+++ b/src/desktop/shared/__tests__/taskNotifications.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildBackgroundSyncReviewNotification,
   buildHookStatusTargetMissingNotification,
   buildTaskStatusNotification,
   getNotificationLocale,
@@ -65,6 +66,52 @@ describe("taskNotifications", () => {
       locale: "zh-CN",
       relativePath: "/zh-CN",
       dedupeKey: "hook-missing:task-404:pending:task-not-found",
+    });
+  });
+
+  it("background sync review 알림은 pull 결과를 요약하고 action payload에 포함한다", () => {
+    // Given
+    const payload = {
+      locale: "ko",
+      mergedPullRequests: [],
+      registeredWorktrees: [],
+      pulledTasks: [
+        {
+          taskId: "task-pull-a",
+          taskTitle: "Pull A",
+          branchName: "feature/pull-a",
+          worktreePath: "/workspace/repo__worktrees/pull-a",
+          sshHost: null,
+          status: "updated" as const,
+          summary: "Fast-forward",
+        },
+        {
+          taskId: "task-pull-b",
+          taskTitle: "Pull B",
+          branchName: "feature/pull-b",
+          worktreePath: "/workspace/repo__worktrees/pull-b",
+          sshHost: "remote-host",
+          status: "failed" as const,
+          summary: "Not possible to fast-forward",
+        },
+      ],
+    };
+
+    // When
+    const notification = buildBackgroundSyncReviewNotification(payload);
+
+    // Then
+    expect(notification.body).toBe("pull 완료 1건 / pull 실패 1건\n알림을 열어 정리 대상을 검토하세요.");
+    expect(notification.desktopPayload.dedupeKey).toBe(
+      "background-sync-review:::::task-pull-a:feature/pull-a:updated|task-pull-b:feature/pull-b:failed",
+    );
+    expect(notification.desktopPayload.action).toEqual({
+      type: "background-sync-review",
+      payload: {
+        mergedPullRequests: [],
+        registeredWorktrees: [],
+        pulledTasks: payload.pulledTasks,
+      },
     });
   });
 });

--- a/src/desktop/shared/taskNotifications.ts
+++ b/src/desktop/shared/taskNotifications.ts
@@ -11,6 +11,8 @@ const NOTIFICATION_MESSAGES = {
     backgroundSyncReviewTitle: "백그라운드 sync 검토 필요",
     formatMergedPullRequestCount: (count: number) => `merge된 PR ${count}건`,
     formatRegisteredWorktreeCount: (count: number) => `새 TODO worktree ${count}건`,
+    formatUpdatedPullCount: (count: number) => `pull 완료 ${count}건`,
+    formatFailedPullCount: (count: number) => `pull 실패 ${count}건`,
     backgroundSyncReviewPrompt: "알림을 열어 정리 대상을 검토하세요.",
   },
   en: {
@@ -20,6 +22,8 @@ const NOTIFICATION_MESSAGES = {
     backgroundSyncReviewTitle: "Background sync review needed",
     formatMergedPullRequestCount: (count: number) => `${count} merged PR${count === 1 ? "" : "s"}`,
     formatRegisteredWorktreeCount: (count: number) => `${count} new TODO worktree${count === 1 ? "" : "s"}`,
+    formatUpdatedPullCount: (count: number) => `${count} pull update${count === 1 ? "" : "s"}`,
+    formatFailedPullCount: (count: number) => `${count} failed pull${count === 1 ? "" : "s"}`,
     backgroundSyncReviewPrompt: "Open the notification to review the pending cleanup items.",
   },
   zh: {
@@ -29,6 +33,8 @@ const NOTIFICATION_MESSAGES = {
     backgroundSyncReviewTitle: "需要检查后台同步结果",
     formatMergedPullRequestCount: (count: number) => `已合并 PR ${count} 个`,
     formatRegisteredWorktreeCount: (count: number) => `新建 TODO worktree ${count} 个`,
+    formatUpdatedPullCount: (count: number) => `pull 完成 ${count} 个`,
+    formatFailedPullCount: (count: number) => `pull 失败 ${count} 个`,
     backgroundSyncReviewPrompt: "打开通知以检查待整理项目。",
   },
 } as const;
@@ -110,6 +116,7 @@ export function buildBackgroundSyncReviewNotification(payload: BackgroundSyncRev
   const messages = NOTIFICATION_MESSAGES[getNotificationLocale(payload.locale)];
   const title = messages.backgroundSyncReviewTitle;
   const summaryLines: string[] = [];
+  const pulledTasks = payload.pulledTasks ?? [];
 
   if (payload.mergedPullRequests.length > 0) {
     summaryLines.push(messages.formatMergedPullRequestCount(payload.mergedPullRequests.length));
@@ -117,6 +124,15 @@ export function buildBackgroundSyncReviewNotification(payload: BackgroundSyncRev
 
   if (payload.registeredWorktrees.length > 0) {
     summaryLines.push(messages.formatRegisteredWorktreeCount(payload.registeredWorktrees.length));
+  }
+
+  const updatedPullCount = pulledTasks.filter((item) => item.status === "updated").length;
+  const failedPullCount = pulledTasks.filter((item) => item.status === "failed").length;
+  if (updatedPullCount > 0) {
+    summaryLines.push(messages.formatUpdatedPullCount(updatedPullCount));
+  }
+  if (failedPullCount > 0) {
+    summaryLines.push(messages.formatFailedPullCount(failedPullCount));
   }
 
   const body = [summaryLines.join(" / "), messages.backgroundSyncReviewPrompt]
@@ -130,6 +146,10 @@ export function buildBackgroundSyncReviewNotification(payload: BackgroundSyncRev
     .map((item) => `${item.taskId}:${item.branchName}:${item.worktreePath}`)
     .sort()
     .join("|");
+  const pullKeys = pulledTasks
+    .map((item) => `${item.taskId}:${item.branchName}:${item.status}`)
+    .sort()
+    .join("|");
 
   return {
     title,
@@ -139,12 +159,13 @@ export function buildBackgroundSyncReviewNotification(payload: BackgroundSyncRev
       body,
       locale: payload.locale,
       relativePath: `/${payload.locale}`,
-      dedupeKey: `background-sync-review:${mergedKeys}::${worktreeKeys}`,
+      dedupeKey: `background-sync-review:${mergedKeys}::${worktreeKeys}::${pullKeys}`,
       action: {
         type: "background-sync-review",
         payload: {
           mergedPullRequests: payload.mergedPullRequests,
           registeredWorktrees: payload.registeredWorktrees,
+          pulledTasks,
         },
       },
     },

--- a/src/lib/boardNotifier.ts
+++ b/src/lib/boardNotifier.ts
@@ -45,9 +45,20 @@ export interface BackgroundSyncRegisteredWorktreePayload {
   sshHost: string | null;
 }
 
+export interface BackgroundSyncPulledTaskPayload {
+  taskId: string;
+  taskTitle: string;
+  branchName: string;
+  worktreePath: string;
+  sshHost: string | null;
+  status: "updated" | "failed";
+  summary: string;
+}
+
 export interface BackgroundSyncReviewPayload {
   mergedPullRequests: TaskPrMergedDetectedPayload[];
   registeredWorktrees: BackgroundSyncRegisteredWorktreePayload[];
+  pulledTasks?: BackgroundSyncPulledTaskPayload[];
 }
 
 export type BoardEventPayload =

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -1,6 +1,6 @@
 import { exec, execFile } from "child_process";
 import { promisify } from "util";
-import { mkdir, readFile } from "fs/promises";
+import { mkdir } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
 import { buildSSHArgs, parseSSHConfig, type SSHHostConfig } from "@/lib/sshConfig";
@@ -195,6 +195,14 @@ export async function fetchOrigin(
   } catch {
     /* 네트워크 실패 시에도 로컬 브랜치 목록은 정상 제공해야 하므로 무시한다 */
   }
+}
+
+/** 현재 checkout된 브랜치를 fast-forward 가능한 경우에만 pull한다 */
+export async function pullCurrentBranch(
+  repoPath: string,
+  sshHost?: string | null
+): Promise<string> {
+  return execGit(`git -C "${repoPath}" pull --ff-only`, sshHost);
 }
 
 /**


### PR DESCRIPTION
## What
- Parallelize background worktree registration, PR status checks, and task pull refresh jobs.
- Keep the Electron main-process background scheduler singleton-bound so route changes or multiple windows do not duplicate the loop.
- Add fast-forward-only pull refresh for active non-default task worktrees and surface pull results in background review notifications.

## How
- Run background sync sub-jobs with `Promise.all` and aggregate review payloads before broadcasting board updates.
- Convert active task PR checks and registered project worktree scans from sequential loops to per-item parallel work.
- Add `git pull --ff-only` support through the shared git helper and report updated or failed pull results without touching default branch tasks.
- Extend background sync review notification payloads, dedupe keys, and shared notification tests for pull summaries.

## Important Changes
- Background sync is now guarded by a module-level singleton disposer in `backgroundTaskSyncService`.
- Pull refresh skips DONE tasks, branchless tasks, default branch tasks, and tasks without a worktree path.
- Pull failures are captured per task and included in the review notification instead of failing the full sync cycle.

Co-Authored-By: Codex <codex@openai.com>