### PR TITLE
fix(search): exclude done tasks from quick search

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -684,3 +684,56 @@ describe("kanbanService.createTask", () => {
     });
   });
 });
+
+describe("kanbanService.getSearchableTasks", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("빠른 검색용 task 목록에서 done 상태를 조회하지 않는다", async () => {
+    // Given
+    const updatedAt = new Date("2026-05-02T00:00:00.000Z");
+    mocks.taskRepo.find.mockResolvedValue([
+      {
+        id: "task-active",
+        title: "Active task",
+        branchName: "dev",
+        projectId: "project-kanvibe",
+        project: { name: "kanvibe", sshHost: null },
+        sshHost: null,
+        status: "progress",
+        updatedAt,
+      },
+    ]);
+
+    const { getSearchableTasks } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await getSearchableTasks();
+
+    // Then
+    expect(mocks.taskRepo.find).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        status: expect.objectContaining({
+          _type: "not",
+          _value: "done",
+        }),
+      }),
+      relations: ["project"],
+      order: { updatedAt: "DESC", createdAt: "DESC" },
+    }));
+    expect(result).toEqual([
+      {
+        id: "task-active",
+        title: "Active task",
+        branchName: "dev",
+        projectId: "project-kanvibe",
+        projectName: "kanvibe",
+        sshHost: null,
+        status: "progress",
+        updatedAt: "2026-05-02T00:00:00.000Z",
+      },
+    ]);
+  });
+});

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -312,6 +312,7 @@ export async function getTaskById(taskId: string): Promise<KanbanTask | null> {
 export async function getSearchableTasks(): Promise<SearchableTask[]> {
   const repo = await getTaskRepository();
   const tasks = await repo.find({
+    where: { status: Not(TaskStatus.DONE) },
     relations: ["project"],
     order: { updatedAt: "DESC", createdAt: "DESC" },
   });

--- a/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
@@ -66,6 +66,16 @@ describe("TaskQuickSearchDialog", () => {
         status: "todo",
         updatedAt: "2026-04-30T02:00:00.000Z",
       },
+      {
+        id: "task-dev-kanvibe",
+        title: "Dev branch task",
+        branchName: "dev",
+        projectId: "project-kanvibe",
+        projectName: "kanvibe",
+        sshHost: null,
+        status: "progress",
+        updatedAt: "2026-04-30T03:00:00.000Z",
+      },
     ]);
   });
 
@@ -137,6 +147,25 @@ describe("TaskQuickSearchDialog", () => {
 
     await waitFor(() => {
       expect(mocks.push).toHaveBeenCalledWith("/task/task-alert");
+    });
+  });
+
+  it.each(["dev kanvibe", "kanvibe dev"])("%s 검색어로 project와 branch를 함께 찾는다", async (query) => {
+    render(<TaskQuickSearchDialog shortcut="Ctrl+K" />);
+
+    fireEvent.keyDown(window, {
+      key: "k",
+      ctrlKey: true,
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, {
+      target: { value: query },
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mocks.push).toHaveBeenCalledWith("/task/task-dev-kanvibe");
     });
   });
 


### PR DESCRIPTION
## What changed

- Exclude `done` tasks from the quick search data source in `getSearchableTasks`.
- Add service-level regression coverage for the `done` exclusion query.
- Add quick search UI regression coverage for both `dev kanvibe` and `kanvibe dev` project/branch token orders.

## Why

- Completed tasks should not reappear in quick search when users are trying to navigate active work.
- Project and branch token searches should remain order-independent for common inputs.

## Verification

- `pnpm vitest run src/desktop/main/services/__tests__/kanbanService.test.ts src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx`
- `pnpm check`
- `pnpm exec eslint src/desktop/main/services/kanbanService.ts src/desktop/main/services/__tests__/kanbanService.test.ts src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx`

Note: project-wide `pnpm lint` still fails on pre-existing unrelated lint errors outside this change.

Co-Authored-By: Codex <codex@openai.com>
