### PR TITLE
build(desktop): limit Electron native rebuilds to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This builds the renderer bundle, compiles the desktop main process into `build/m
 If macOS shows a `better-sqlite3` `NODE_MODULE_VERSION` mismatch, KanVibe now verifies the binding before startup and attempts an automatic rebuild when possible.
 
 - browser/server runtime: `pnpm rebuild better-sqlite3`
-- desktop runtime: `pnpm exec electron-rebuild -f --build-from-source -w better-sqlite3`
+- desktop runtime: `pnpm exec electron-rebuild -f --build-from-source --only better-sqlite3`
 
 For local desktop runs, `pnpm start` and `pnpm dev` already perform this compatibility check before Electron launches.
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -99,7 +99,7 @@ pnpm dist
 macOS에서 `better-sqlite3` `NODE_MODULE_VERSION` 불일치가 발생하면, KanVibe는 시작 전에 바인딩을 검증하고 가능하면 자동 재빌드를 시도합니다.
 
 - 브라우저/서버 런타임: `pnpm rebuild better-sqlite3`
-- 데스크톱 런타임: `pnpm exec electron-rebuild -f --build-from-source -w better-sqlite3`
+- 데스크톱 런타임: `pnpm exec electron-rebuild -f --build-from-source --only better-sqlite3`
 
 로컬 데스크톱 실행에서는 `pnpm start`, `pnpm dev`가 Electron 실행 전에 이 호환성 검사를 이미 수행합니다.
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -99,7 +99,7 @@ pnpm dist
 如果 macOS 上出现 `better-sqlite3` 的 `NODE_MODULE_VERSION` 不匹配，KanVibe 现在会在启动前先验证绑定，并在可能时自动尝试重建。
 
 - 浏览器/服务器运行时：`pnpm rebuild better-sqlite3`
-- 桌面运行时：`pnpm exec electron-rebuild -f --build-from-source -w better-sqlite3`
+- 桌面运行时：`pnpm exec electron-rebuild -f --build-from-source --only better-sqlite3`
 
 对于本地桌面运行，`pnpm start` 和 `pnpm dev` 会在 Electron 启动前先执行这项兼容性检查。
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,7 @@
 appId: com.kanvibe.desktop
 productName: Kanivibe
 asar: false
+npmRebuild: false
 
 directories:
   output: dist

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "node scripts/run-desktop-start.cjs",
     "desktop:dev": "node scripts/run-desktop-dev.cjs",
     "db:prepare": "tsx scripts/build-seed-db.ts",
-    "rebuild:native:electron": "electron-rebuild -f --build-from-source -w better-sqlite3",
+    "rebuild:native:electron": "electron-rebuild -f --build-from-source --only better-sqlite3",
     "dist": "pnpm db:prepare && pnpm build && pnpm rebuild:native:electron && electron-builder --mac dmg zip",
     "dist:dir": "pnpm db:prepare && pnpm build && pnpm rebuild:native:electron && electron-builder --dir",
     "lint": "eslint",

--- a/scripts/ensure-native-runtime.cjs
+++ b/scripts/ensure-native-runtime.cjs
@@ -95,7 +95,7 @@ function rebuildNativeDependency() {
     }
 
     console.warn("[kanvibe] Detected Electron native ABI mismatch. Rebuilding better-sqlite3 for Electron from source...");
-    execFileSync("pnpm", ["exec", "electron-rebuild", "-f", "--build-from-source", "-w", "better-sqlite3"], {
+    execFileSync("pnpm", ["exec", "electron-rebuild", "-f", "--build-from-source", "--only", "better-sqlite3"], {
       stdio: "inherit",
       env,
     });
@@ -119,7 +119,7 @@ function printRebuildFailureGuidance(error) {
       return;
     }
 
-    console.error("[kanvibe] Try running `pnpm exec electron-rebuild -f --build-from-source -w better-sqlite3` and launch the desktop app again.");
+    console.error("[kanvibe] Try running `pnpm exec electron-rebuild -f --build-from-source --only better-sqlite3` and launch the desktop app again.");
     return;
   }
 

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -42,7 +42,7 @@ function hasElectronBuilderInstalled() {
 
 function rebuildElectronNativeDependencies() {
   console.warn("[kanvibe] Postinstall: rebuilding native dependencies for the Electron runtime...");
-  execFileSync("pnpm", ["exec", "electron-rebuild", "-f", "--build-from-source", "-w", "better-sqlite3"], {
+  execFileSync("pnpm", ["exec", "electron-rebuild", "-f", "--build-from-source", "--only", "better-sqlite3"], {
     stdio: "inherit",
     env: process.env,
   });
@@ -53,7 +53,7 @@ function main() {
 
   if (getNodeMajor() !== REQUIRED_NODE_MAJOR) {
     console.warn(
-      `[kanvibe] Postinstall: skipping Electron native rebuild because Node ${process.versions.node} is active. Use Node ${REQUIRED_NODE_MAJOR}.x and run \`pnpm exec electron-rebuild -f --build-from-source -w better-sqlite3\` if needed.`,
+      `[kanvibe] Postinstall: skipping Electron native rebuild because Node ${process.versions.node} is active. Use Node ${REQUIRED_NODE_MAJOR}.x and run \`pnpm exec electron-rebuild -f --build-from-source --only better-sqlite3\` if needed.`,
     );
     return;
   }

--- a/src/lib/__tests__/electronBuilderConfig.test.ts
+++ b/src/lib/__tests__/electronBuilderConfig.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("electron-builder config", () => {
+  it("does not run an unscoped native rebuild during packaging", () => {
+    const source = readFileSync(path.join(process.cwd(), "electron-builder.yml"), "utf8");
+
+    expect(source).toContain("npmRebuild: false");
+  });
+});

--- a/src/lib/__tests__/ensureNativeRuntimeScript.test.ts
+++ b/src/lib/__tests__/ensureNativeRuntimeScript.test.ts
@@ -15,4 +15,16 @@ describe("ensure-native-runtime script", () => {
     expect(source).toContain('KANVIBE_NATIVE_REBUILD_ATTEMPTED: "1"');
     expect(source).toContain("process.exit(0);");
   });
+
+  it("limits Electron native rebuilds to better-sqlite3", () => {
+    const source = readFileSync(
+      path.join(process.cwd(), "scripts", "ensure-native-runtime.cjs"),
+      "utf8",
+    );
+
+    expect(source).toContain('"--only", "better-sqlite3"');
+    expect(source).toContain("--only better-sqlite3");
+    expect(source).not.toContain('"-w", "better-sqlite3"');
+    expect(source).not.toContain("-w better-sqlite3");
+  });
 });

--- a/src/lib/__tests__/packageScripts.test.ts
+++ b/src/lib/__tests__/packageScripts.test.ts
@@ -9,7 +9,7 @@ describe("package scripts", () => {
     ) as { scripts: Record<string, string> };
 
     expect(packageJson.scripts["rebuild:native:electron"]).toBe(
-      "electron-rebuild -f --build-from-source -w better-sqlite3",
+      "electron-rebuild -f --build-from-source --only better-sqlite3",
     );
     expect(packageJson.scripts.dist).toContain(
       "pnpm db:prepare && pnpm build && pnpm rebuild:native:electron && electron-builder",

--- a/src/lib/__tests__/postinstallScript.test.ts
+++ b/src/lib/__tests__/postinstallScript.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("postinstall script", () => {
+  it("limits Electron native rebuilds to better-sqlite3", () => {
+    const source = readFileSync(
+      path.join(process.cwd(), "scripts", "postinstall.cjs"),
+      "utf8",
+    );
+
+    expect(source).toContain('"--only", "better-sqlite3"');
+    expect(source).toContain("--only better-sqlite3");
+    expect(source).not.toContain('"-w", "better-sqlite3"');
+    expect(source).not.toContain("-w better-sqlite3");
+  });
+});


### PR DESCRIPTION
## What changed?
- Fix the Electron packaging rebuild flow so it rebuilds only `better-sqlite3` instead of attempting optional tooling modules such as `@parcel/watcher`.

## How was it fixed?
**Scope Electron native rebuilds**
- Replace `electron-rebuild -w better-sqlite3` with `electron-rebuild --only better-sqlite3` in package scripts and runtime recovery scripts.
- Update rebuild guidance in English, Korean, and Chinese docs.

**Avoid duplicate unscoped packaging rebuilds**
- Set `npmRebuild: false` in `electron-builder.yml` because the dist flow already runs the scoped rebuild explicitly before packaging.

**Add regression coverage**
- Add tests that assert Electron rebuild commands stay scoped to `better-sqlite3`.
- Add a config test that prevents `electron-builder` from re-enabling an unscoped dependency rebuild.

## Important details
### Native dependency rebuild scope

**Why this changed**
- `--which-module` still allows rebuild candidates from dependency type scanning, which can pull in optional modules like `@parcel/watcher`.
- `--only` ignores every module except the specified target, matching the desktop runtime need.

**Files changed**
- `package.json`
- `scripts/ensure-native-runtime.cjs`
- `scripts/postinstall.cjs`
- `electron-builder.yml`

### Documentation and regression tests

**Why this changed**
- Manual recovery instructions and automated safeguards need to match the new scoped rebuild behavior.

**Files changed**
- `README.md`
- `docs/README.ko.md`
- `docs/README.zh.md`
- `src/lib/__tests__/ensureNativeRuntimeScript.test.ts`
- `src/lib/__tests__/packageScripts.test.ts`
- `src/lib/__tests__/electronBuilderConfig.test.ts`
- `src/lib/__tests__/postinstallScript.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>
