### PR TITLE
Fix Electron native binding recovery

### DIFF
--- a/scripts/ensure-native-runtime.cjs
+++ b/scripts/ensure-native-runtime.cjs
@@ -16,10 +16,11 @@ function getNodeMajor() {
   return Number.parseInt(process.versions.node.split(".")[0] || "0", 10);
 }
 
-function isNativeModuleMismatch(error) {
+function isRecoverableNativeModuleLoadError(error) {
   const message = String(error?.stack || error?.message || error || "");
   return (
     message.includes("NODE_MODULE_VERSION") ||
+    message.includes("Could not locate the bindings file") ||
     message.includes("did not self-register") ||
     message.includes("ERR_DLOPEN_FAILED") ||
     message.includes("compiled against a different Node.js version")
@@ -140,7 +141,7 @@ function main() {
   try {
     verifyBetterSqlite3Binding();
   } catch (error) {
-    if (!isNativeModuleMismatch(error)) {
+    if (!isRecoverableNativeModuleLoadError(error)) {
       throw error;
     }
 

--- a/src/lib/__tests__/ensureNativeRuntimeScript.test.ts
+++ b/src/lib/__tests__/ensureNativeRuntimeScript.test.ts
@@ -27,6 +27,16 @@ describe("ensure-native-runtime script", () => {
     expect(source).toContain("const stderr = error?.stderr?.toString?.() || \"\";");
   });
 
+  it("treats missing native binding files as recoverable rebuild failures", () => {
+    const source = readFileSync(
+      path.join(process.cwd(), "scripts", "ensure-native-runtime.cjs"),
+      "utf8",
+    );
+
+    expect(source).toContain("function isRecoverableNativeModuleLoadError(error)");
+    expect(source).toContain("Could not locate the bindings file");
+  });
+
   it("exits Electron verification with failure when native loading throws", () => {
     const source = readFileSync(
       path.join(process.cwd(), "scripts", "verify-electron-better-sqlite3.cjs"),


### PR DESCRIPTION
## What changed?
- Expand native runtime recovery so missing `better-sqlite3` binding files trigger the existing Electron rebuild flow.

## How was it solved?
**Recover missing native bindings**
- Rename the native load classifier to reflect recoverable load errors beyond ABI mismatches.
- Treat `Could not locate the bindings file` as a rebuildable native module load failure.

**Lock the behavior with coverage**
- Add a script-level test assertion for the missing binding recovery case.

## Important Changes
### Electron native runtime recovery

**Missing binding files now rebuild automatically**
- **Why**: Electron startup could fail when the `better-sqlite3` binary was absent even though the existing rebuild path could recover it.
- **Files**: `scripts/ensure-native-runtime.cjs`

**Recovery behavior is covered by tests**
- **Why**: The previous coverage focused on ABI mismatch handling and did not pin the missing binding case.
- **Files**: `src/lib/__tests__/ensureNativeRuntimeScript.test.ts`
