### PR TITLE
fix(notifications): keep sync review dialog on current route

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -45,10 +45,16 @@ function broadcastNotificationsChanged() {
 
 function broadcastNotificationActivated(appNotification) {
   for (const window of BrowserWindow.getAllWindows()) {
-    if (!window.isDestroyed()) {
-      window.webContents.send("kanvibe:notification-activated", appNotification);
-    }
+    sendNotificationActivated(window, appNotification);
   }
+}
+
+function sendNotificationActivated(browserWindow, appNotification) {
+  if (!browserWindow || browserWindow.isDestroyed()) {
+    return;
+  }
+
+  browserWindow.webContents.send("kanvibe:notification-activated", appNotification);
 }
 
 function getBuildMainRoot() {
@@ -325,6 +331,13 @@ async function activateAppNotification(appNotification, options = {}) {
   }
 
   pendingNotificationActivation = activatedNotification;
+  const { shouldKeepCurrentRouteForNotificationActivation } = getWindowOpenHelpers();
+  if (shouldKeepCurrentRouteForNotificationActivation(activatedNotification)) {
+    await focusMainWindow();
+    sendNotificationActivated(mainWindow, activatedNotification);
+    return true;
+  }
+
   const targetPath = getNotificationTargetPath(activatedNotification);
   if (activatedNotification.taskId) {
     await focusTaskNotificationWindow(targetPath);
@@ -408,12 +421,26 @@ function attachWindowHandlers(browserWindow) {
   });
 
   browserWindow.webContents.on("before-input-event", (event, input) => {
+    const isNotificationShortcut =
+      input.type === "keyDown" &&
+      !input.isAutoRepeat &&
+      !input.alt &&
+      input.shift &&
+      (input.control || input.meta) &&
+      input.key.toLowerCase() === "i";
     const isNewWindowShortcut =
       input.type === "keyDown" &&
       !input.isAutoRepeat &&
       !input.alt &&
       (input.control || input.meta) &&
       input.key.toLowerCase() === "n";
+
+    if (isNotificationShortcut) {
+      event.preventDefault();
+
+      browserWindow.webContents.send("kanvibe:notification-shortcut");
+      return;
+    }
 
     if (!isNewWindowShortcut) {
       return;

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -73,6 +73,13 @@ contextBridge.exposeInMainWorld("kanvibeDesktop", {
       ipcRenderer.removeListener("kanvibe:notification-activated", handler);
     };
   },
+  onNotificationShortcut(listener) {
+    const handler = () => listener();
+    ipcRenderer.on("kanvibe:notification-shortcut", handler);
+    return () => {
+      ipcRenderer.removeListener("kanvibe:notification-shortcut", handler);
+    };
+  },
   onCreateTaskShortcut(listener) {
     const handler = () => listener();
     ipcRenderer.on("kanvibe:create-task-shortcut", handler);

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -12,21 +12,14 @@ import ProjectSettings from "./ProjectSettings";
 import TaskContextMenu from "./TaskContextMenu";
 import BranchTaskModal from "./BranchTaskModal";
 import DoneConfirmDialog from "./DoneConfirmDialog";
-import { reorderTasks, deleteTask, getMoreDoneTasks, moveTaskToColumn, updateTaskStatus } from "@/desktop/renderer/actions/kanban";
+import { reorderTasks, deleteTask, getMoreDoneTasks, moveTaskToColumn } from "@/desktop/renderer/actions/kanban";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
 import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
-import type { AppNotification } from "@/desktop/shared/notifications";
 import { useAutoRefresh } from "@/desktop/renderer/hooks/useAutoRefresh";
 import { useProjectFilterParams } from "@/desktop/renderer/hooks/useProjectFilterParams";
-import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { computeProjectColor } from "@/lib/projectColor";
-import type {
-  BackgroundSyncReviewPayload,
-  BackgroundSyncRegisteredWorktreePayload,
-  TaskPrMergedDetectedPayload,
-} from "@/lib/boardNotifier";
 import type { NotificationCenterButtonHandle } from "./NotificationCenterButton";
 import type { ProjectSelectorHandle } from "./ProjectSelector";
 
@@ -98,22 +91,6 @@ function insertAtFilteredIndex(
   }
 
   return arr;
-}
-
-function buildMergedPrEventKey(taskId: string, prUrl: string, mergedAt: string) {
-  return `${taskId}:${prUrl}:${mergedAt}`;
-}
-
-function getMergedPrEventKey(payload: TaskPrMergedDetectedPayload) {
-  return buildMergedPrEventKey(payload.taskId, payload.prUrl, payload.mergedAt);
-}
-
-function getBackgroundSyncReviewPayload(notification: AppNotification | null | undefined): BackgroundSyncReviewPayload | null {
-  if (notification?.action?.type !== "background-sync-review") {
-    return null;
-  }
-
-  return notification.action.payload;
 }
 
 interface DragMovePlan {
@@ -211,8 +188,6 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const t = useTranslations("board");
   const tt = useTranslations("task");
   const tc = useTranslations("common");
-  const tr = useTranslations("common.backgroundSyncReview");
-  const tm = useTranslations("common.prMergeAlert");
   const [tasks, setTasks] = useState<TasksByStatus>(initialTasks);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -233,9 +208,6 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const [currentDefaultSessionType, setCurrentDefaultSessionType] = useState<SessionType>(defaultSessionType);
   const [shouldUseMacTitlebarLayout, setShouldUseMacTitlebarLayout] = useState(false);
   const [, startDragPersistenceTransition] = useTransition();
-  const [isPrMergeActionPending, startPrMergeActionTransition] = useTransition();
-  const [backgroundSyncReview, setBackgroundSyncReview] = useState<BackgroundSyncReviewPayload | null>(null);
-  const [selectedPrMergeEventKeys, setSelectedPrMergeEventKeys] = useState<string[]>([]);
   const notificationCenterRef = useRef<NotificationCenterButtonHandle>(null);
   const projectSelectorRef = useRef<ProjectSelectorHandle>(null);
 
@@ -382,40 +354,6 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
     setShouldUseMacTitlebarLayout(isDesktopApp && isMacDesktop);
   }, []);
 
-  useEffect(() => {
-    let isActive = true;
-
-    const applyNotification = (notification: AppNotification | null | undefined) => {
-      if (!isActive) {
-        return;
-      }
-
-      const payload = getBackgroundSyncReviewPayload(notification);
-      if (!payload) {
-        return;
-      }
-
-      setBackgroundSyncReview(payload);
-    };
-
-    void window.kanvibeDesktop?.consumePendingNotificationActivation?.()
-      .then((notification: AppNotification | null) => {
-        applyNotification(notification);
-      })
-      .catch(() => {
-        /* pending activation consume 실패는 무시 */
-      });
-
-    const dispose = window.kanvibeDesktop?.onNotificationActivated?.((notification: AppNotification) => {
-      applyNotification(notification);
-    });
-
-    return () => {
-      isActive = false;
-      dispose?.();
-    };
-  }, []);
-
   useEffect(() => boardCommands.registerBoardHandlers({
     toggleNotificationCenter() {
       notificationCenterRef.current?.toggle();
@@ -428,15 +366,6 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
       setIsModalOpen(true);
     },
   }), [boardCommands]);
-
-  useEffect(() => {
-    if (!backgroundSyncReview || backgroundSyncReview.mergedPullRequests.length === 0) {
-      setSelectedPrMergeEventKeys([]);
-      return;
-    }
-
-    setSelectedPrMergeEventKeys(backgroundSyncReview.mergedPullRequests.map(getMergedPrEventKey));
-  }, [backgroundSyncReview]);
 
   const handleLoadMoreDone = useCallback(async () => {
     if (isLoadingMore) return;
@@ -520,50 +449,6 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
   const handleDoneCancel = useCallback(() => {
     setPendingDoneResult(null);
   }, []);
-
-  const selectedPrMergeEventKeySet = useMemo(
-    () => new Set(selectedPrMergeEventKeys),
-    [selectedPrMergeEventKeys],
-  );
-
-  const togglePrMergeSelection = useCallback((eventKey: string) => {
-    setSelectedPrMergeEventKeys((current) => (
-      current.includes(eventKey)
-        ? current.filter((key) => key !== eventKey)
-        : [...current, eventKey]
-    ));
-  }, []);
-
-  const handlePrMergeCancel = useCallback(() => {
-    setBackgroundSyncReview(null);
-  }, []);
-
-  useEscapeKey(handlePrMergeCancel, {
-    enabled: Boolean(backgroundSyncReview) && !isPrMergeActionPending,
-  });
-
-  const handlePrMergeConfirm = useCallback(() => {
-    if (!backgroundSyncReview) {
-      return;
-    }
-
-    const selectedEventKeys = new Set(selectedPrMergeEventKeys);
-    const selectedTaskIds = backgroundSyncReview.mergedPullRequests
-      .filter((alert) => selectedEventKeys.has(getMergedPrEventKey(alert)))
-      .map((alert) => alert.taskId);
-
-    setBackgroundSyncReview(null);
-
-    if (selectedTaskIds.length === 0) {
-      return;
-    }
-
-    startPrMergeActionTransition(async () => {
-      for (const taskId of selectedTaskIds) {
-        await updateTaskStatus(taskId, TaskStatus.DONE);
-      }
-    });
-  }, [backgroundSyncReview, selectedPrMergeEventKeys, startPrMergeActionTransition]);
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent, task: KanbanTask) => {
@@ -742,109 +627,6 @@ export default function Board({ initialTasks, initialDoneTotal, initialDoneLimit
         onConfirm={handleDoneConfirm}
         onCancel={handleDoneCancel}
       />
-
-      {backgroundSyncReview && (
-        <div className="fixed inset-0 z-[520] flex items-center justify-center bg-bg-overlay">
-          <div className="w-full max-w-2xl rounded-xl border border-border-default bg-bg-surface p-6 shadow-lg">
-            <h2 className="mb-2 text-lg font-semibold text-text-primary">
-              {tr("title")}
-            </h2>
-            <p className="text-sm text-text-secondary">
-              {tr("message")}
-            </p>
-            <div className="mt-4 max-h-[360px] space-y-5 overflow-y-auto pr-1">
-              <section>
-                <h3 className="text-sm font-semibold text-text-primary">{tr("mergedSection")}</h3>
-                {backgroundSyncReview.mergedPullRequests.length === 0 ? (
-                  <p className="mt-2 text-sm text-text-muted">{tr("emptyMerged")}</p>
-                ) : (
-                  <div className="mt-3 space-y-3">
-                    {backgroundSyncReview.mergedPullRequests.map((alert) => {
-                      const eventKey = getMergedPrEventKey(alert);
-                      return (
-                        <label
-                          key={eventKey}
-                          className="flex cursor-pointer items-start gap-3 rounded-lg border border-border-default bg-bg-page px-4 py-3"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={selectedPrMergeEventKeySet.has(eventKey)}
-                            onChange={() => togglePrMergeSelection(eventKey)}
-                            aria-label={alert.taskTitle}
-                            className="mt-0.5 h-4 w-4 rounded border-border-default text-brand-primary focus:ring-brand-primary"
-                          />
-                          <div className="min-w-0 flex-1">
-                            <p className="text-sm font-semibold text-text-primary">
-                              {alert.taskTitle}
-                            </p>
-                            <p className="mt-1 text-xs text-text-muted">
-                              {alert.branchName}
-                            </p>
-                            <a
-                              href={alert.prUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="mt-3 inline-flex max-w-full items-center gap-1 rounded bg-tag-pr-bg px-2 py-1 text-xs text-tag-pr-text transition-opacity hover:opacity-80"
-                            >
-                              <span className="shrink-0">{tm("prLinkLabel")}</span>
-                              <span className="truncate">{alert.prUrl}</span>
-                            </a>
-                          </div>
-                        </label>
-                      );
-                    })}
-                  </div>
-                )}
-              </section>
-
-              <section>
-                <h3 className="text-sm font-semibold text-text-primary">{tr("registeredSection")}</h3>
-                {backgroundSyncReview.registeredWorktrees.length === 0 ? (
-                  <p className="mt-2 text-sm text-text-muted">{tr("emptyRegistered")}</p>
-                ) : (
-                  <div className="mt-3 space-y-3">
-                    {backgroundSyncReview.registeredWorktrees.map((worktree: BackgroundSyncRegisteredWorktreePayload) => (
-                      <div
-                        key={`${worktree.taskId}:${worktree.worktreePath}`}
-                        className="rounded-lg border border-border-default bg-bg-page px-4 py-3"
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <p className="text-sm font-semibold text-text-primary">
-                            {worktree.projectName}
-                          </p>
-                          <span className="rounded-full bg-bg-surface px-2 py-0.5 text-[11px] text-text-muted">
-                            {tc(worktree.sshHost ? "remote" : "local")}
-                          </span>
-                        </div>
-                        <p className="mt-1 text-xs text-text-muted">{worktree.branchName}</p>
-                        <p className="mt-3 text-xs text-text-secondary">{worktree.worktreePath}</p>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </section>
-            </div>
-            <div className="mt-5 flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={handlePrMergeCancel}
-                disabled={isPrMergeActionPending}
-                className="rounded-md border border-border-default bg-bg-page px-4 py-1.5 text-sm text-text-secondary transition-colors hover:border-brand-primary"
-              >
-                {tc("cancel")}
-              </button>
-              <button
-                type="button"
-                onClick={handlePrMergeConfirm}
-                disabled={isPrMergeActionPending}
-                className="rounded-md bg-brand-primary px-4 py-1.5 text-sm text-text-inverse transition-colors hover:bg-brand-hover disabled:opacity-50"
-              >
-                {tc("confirm")}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -1,9 +1,9 @@
 import { forwardRef, useImperativeHandle } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import Board from "../Board";
-import { reorderTasks, updateTaskStatus } from "@/desktop/renderer/actions/kanban";
+import { reorderTasks } from "@/desktop/renderer/actions/kanban";
 import { SessionType, TaskStatus } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
@@ -429,57 +429,39 @@ describe("Board defaultSessionType sync", () => {
     });
   });
 
-  it("PR merge batch 이벤트를 받으면 하나의 체크리스트 모달을 띄우고 체크된 task만 Done으로 이동한다", async () => {
-    const notificationActivationListeners: Array<(notification: unknown) => void> = [];
+  it("background sync review activation은 전역 dialog host가 처리하므로 Board에서 직접 소비하지 않는다", async () => {
+    const consumePendingNotificationActivation = vi.fn().mockResolvedValue({
+      id: "n-review",
+      title: "Background sync review",
+      body: "Review pending items",
+      taskId: null,
+      relativePath: "/ko",
+      locale: "ko",
+      isRead: false,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      dedupeKey: "background-review-1",
+      action: {
+        type: "background-sync-review",
+        payload: {
+          mergedPullRequests: [
+            {
+              taskId: "task-1",
+              taskTitle: "Test Task",
+              branchName: "feature/pr-sync",
+              prUrl: "https://github.com/kanvibe/kanvibe/pull/210",
+              mergedAt: "2026-04-30T02:00:00Z",
+            },
+          ],
+          registeredWorktrees: [],
+        },
+      },
+    });
+    const onNotificationActivated = vi.fn(() => () => {});
     window.kanvibeDesktop = {
       isDesktop: true,
-      consumePendingNotificationActivation: vi.fn().mockResolvedValue({
-        id: "n-review",
-        title: "Background sync review",
-        body: "Review pending items",
-        taskId: null,
-        relativePath: "/ko",
-        locale: "ko",
-        isRead: false,
-        createdAt: "2026-05-01T00:00:00.000Z",
-        dedupeKey: "background-review-1",
-        action: {
-          type: "background-sync-review",
-          payload: {
-            mergedPullRequests: [
-              {
-                taskId: "task-1",
-                taskTitle: "Test Task",
-                branchName: "feature/pr-sync",
-                prUrl: "https://github.com/kanvibe/kanvibe/pull/210",
-                mergedAt: "2026-04-30T02:00:00Z",
-              },
-              {
-                taskId: "task-2",
-                taskTitle: "Docs Task",
-                branchName: "docs/pr-sync",
-                prUrl: "https://github.com/kanvibe/kanvibe/pull/211",
-                mergedAt: "2026-04-30T02:05:00Z",
-              },
-            ],
-            registeredWorktrees: [
-              {
-                taskId: "task-worktree",
-                projectName: "kanvibe",
-                branchName: "feature-sync",
-                worktreePath: "/repo/kanvibe__worktrees/feature-sync",
-                sshHost: null,
-              },
-            ],
-          },
-        },
-      }),
-      onNotificationActivated: vi.fn((listener) => {
-        notificationActivationListeners.push(listener);
-        return () => {};
-      }),
+      consumePendingNotificationActivation,
+      onNotificationActivated,
     } as never;
-    vi.mocked(updateTaskStatus).mockResolvedValue(null);
 
     render(
       <Board
@@ -497,54 +479,12 @@ describe("Board defaultSessionType sync", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/210")).toBeTruthy();
+      expect(screen.getAllByTestId("column")).toHaveLength(5);
     });
 
-    expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/211")).toBeTruthy();
-    expect(screen.getByText("/repo/kanvibe__worktrees/feature-sync")).toBeTruthy();
-
-    await act(async () => {
-      notificationActivationListeners[0]?.({
-        id: "n-review-2",
-        title: "Background sync review",
-        body: "Review pending items",
-        taskId: null,
-        relativePath: "/ko",
-        locale: "ko",
-        isRead: false,
-        createdAt: "2026-05-01T00:10:00.000Z",
-        dedupeKey: "background-review-2",
-        action: {
-          type: "background-sync-review",
-          payload: {
-            mergedPullRequests: [
-              {
-                taskId: "task-3",
-                taskTitle: "Release Task",
-                branchName: "release/pr-sync",
-                prUrl: "https://github.com/kanvibe/kanvibe/pull/310",
-                mergedAt: "2026-04-30T02:10:00Z",
-              },
-            ],
-            registeredWorktrees: [],
-          },
-        },
-      });
-    });
-
-    expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/310")).toBeTruthy();
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole("checkbox", { name: "Release Task" }));
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "confirm" }));
-    });
-
-    await waitFor(() => {
-      expect(updateTaskStatus).not.toHaveBeenCalled();
-    });
+    expect(consumePendingNotificationActivation).not.toHaveBeenCalled();
+    expect(onNotificationActivated).not.toHaveBeenCalled();
+    expect(screen.queryByText("https://github.com/kanvibe/kanvibe/pull/210")).toBeNull();
   });
 
   it("중앙 board command 요청이 오면 branch TODO 기본값으로 create modal을 연다", async () => {

--- a/src/desktop/main/__tests__/windowOpen.test.ts
+++ b/src/desktop/main/__tests__/windowOpen.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { resolveExistingNavigationTargetWindow, resolveNavigationTargetWindow, resolveWindowOpenAction } from "@/desktop/main/windowOpen";
+import {
+  resolveExistingNavigationTargetWindow,
+  resolveNavigationTargetWindow,
+  resolveWindowOpenAction,
+  shouldKeepCurrentRouteForNotificationActivation,
+} from "@/desktop/main/windowOpen";
 
 describe("resolveWindowOpenAction", () => {
   it("file 기반 내부 URL은 독립적인 내부 창 열기로 판단한다", () => {
@@ -156,5 +161,22 @@ describe("resolveExistingNavigationTargetWindow", () => {
     });
 
     expect(result).toBeNull();
+  });
+});
+
+describe("shouldKeepCurrentRouteForNotificationActivation", () => {
+  it("background sync review 알림은 현재 route를 유지한다", () => {
+    expect(shouldKeepCurrentRouteForNotificationActivation({
+      action: {
+        type: "background-sync-review",
+      },
+    })).toBe(true);
+  });
+
+  it("일반 task 알림은 기존 target route 이동 정책을 유지한다", () => {
+    expect(shouldKeepCurrentRouteForNotificationActivation({
+      taskId: "task-1",
+      action: null,
+    })).toBe(false);
   });
 });

--- a/src/desktop/main/windowOpen.ts
+++ b/src/desktop/main/windowOpen.ts
@@ -29,6 +29,19 @@ interface ResolveNavigationTargetWindowOptions<T> {
   getWindowUrl: (window: T) => string;
 }
 
+interface NotificationActivationLike {
+  taskId?: string | null;
+  action?: {
+    type?: string;
+  } | null;
+}
+
+export function shouldKeepCurrentRouteForNotificationActivation(
+  notification: NotificationActivationLike | null | undefined,
+): boolean {
+  return notification?.action?.type === "background-sync-review";
+}
+
 function normalizeInternalRoute(route: string | null | undefined): string | null {
   if (!route) {
     return null;

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -5,6 +5,7 @@ import { HashRouter, Navigate, Outlet, Route, Routes, useParams } from "react-ro
 import LoginForm from "@/components/LoginForm";
 import { BoardCommandProvider } from "@/desktop/renderer/components/BoardCommandProvider";
 import BoardEventAlert from "@/desktop/renderer/components/BoardEventAlert";
+import BackgroundSyncReviewDialog from "@/desktop/renderer/components/BackgroundSyncReviewDialog";
 import NotificationListener from "@/desktop/renderer/components/NotificationListener";
 import TaskQuickSearchDialog from "@/desktop/renderer/components/TaskQuickSearchDialog";
 import { getSessionState } from "@/desktop/renderer/actions/auth";
@@ -39,6 +40,7 @@ function LocaleShell({ sessionLoading, isAuthenticated }: { sessionLoading: bool
             {isAuthenticated ? <TaskQuickSearchDialog /> : null}
             <NotificationListener />
             <BoardEventAlert />
+            {isAuthenticated ? <BackgroundSyncReviewDialog /> : null}
           </>
         )}
         <Outlet />

--- a/src/desktop/renderer/__tests__/App.test.tsx
+++ b/src/desktop/renderer/__tests__/App.test.tsx
@@ -5,10 +5,15 @@ import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadin
 
 const mocks = vi.hoisted(() => ({
   getSessionState: vi.fn(),
+  updateTaskStatus: vi.fn(),
 }));
 
 vi.mock("@/desktop/renderer/actions/auth", () => ({
   getSessionState: (...args: unknown[]) => mocks.getSessionState(...args),
+}));
+
+vi.mock("@/desktop/renderer/actions/kanban", () => ({
+  updateTaskStatus: (...args: unknown[]) => mocks.updateTaskStatus(...args),
 }));
 
 vi.mock("@/components/LoginForm", () => ({
@@ -91,5 +96,59 @@ describe("App", () => {
     // Then
     expect(screen.queryByText("Loading...")).toBeNull();
     expect(screen.getByText("login form")).toBeTruthy();
+  });
+
+  it("shows a background sync review dialog on the current detail route", async () => {
+    window.location.hash = "#/en/task/task-1";
+    mocks.getSessionState.mockResolvedValue({ isAuthenticated: true });
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      onBoardEvent: vi.fn(() => vi.fn()),
+      consumePendingNotificationActivation: vi.fn().mockResolvedValue({
+        id: "n-review",
+        title: "Background sync review",
+        body: "Review pending items",
+        taskId: null,
+        relativePath: "/en",
+        locale: "en",
+        isRead: false,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        dedupeKey: "background-review-1",
+        action: {
+          type: "background-sync-review",
+          payload: {
+            mergedPullRequests: [
+              {
+                taskId: "task-1",
+                taskTitle: "Detail task",
+                branchName: "feature/current-route",
+                prUrl: "https://github.com/kanvibe/kanvibe/pull/410",
+                mergedAt: "2026-05-01T01:00:00Z",
+              },
+            ],
+            registeredWorktrees: [
+              {
+                taskId: "task-worktree",
+                projectName: "kanvibe",
+                branchName: "feature/new-worktree",
+                worktreePath: "/repo/kanvibe__worktrees/feature-new-worktree",
+                sshHost: null,
+              },
+            ],
+          },
+        },
+      }),
+      onNotificationActivated: vi.fn(() => vi.fn()),
+    } as unknown as NonNullable<typeof window.kanvibeDesktop>;
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("task detail route")).toBeTruthy();
+      expect(screen.getByText("Background Sync Review")).toBeTruthy();
+    });
+    expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/410")).toBeTruthy();
+    expect(screen.getByText("/repo/kanvibe__worktrees/feature-new-worktree")).toBeTruthy();
+    expect(window.location.hash).toBe("#/en/task/task-1");
   });
 });

--- a/src/desktop/renderer/components/BackgroundSyncReviewDialog.tsx
+++ b/src/desktop/renderer/components/BackgroundSyncReviewDialog.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
+import { updateTaskStatus } from "@/desktop/renderer/actions/kanban";
+import type { AppNotification } from "@/desktop/shared/notifications";
+import { TaskStatus } from "@/entities/KanbanTask";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
+import type {
+  BackgroundSyncRegisteredWorktreePayload,
+  BackgroundSyncReviewPayload,
+  TaskPrMergedDetectedPayload,
+} from "@/lib/boardNotifier";
+
+function buildMergedPrEventKey(taskId: string, prUrl: string, mergedAt: string) {
+  return `${taskId}:${prUrl}:${mergedAt}`;
+}
+
+function getMergedPrEventKey(payload: TaskPrMergedDetectedPayload) {
+  return buildMergedPrEventKey(payload.taskId, payload.prUrl, payload.mergedAt);
+}
+
+function getBackgroundSyncReviewPayload(notification: AppNotification | null | undefined): BackgroundSyncReviewPayload | null {
+  if (notification?.action?.type !== "background-sync-review") {
+    return null;
+  }
+
+  return notification.action.payload;
+}
+
+export default function BackgroundSyncReviewDialog() {
+  const tc = useTranslations("common");
+  const tr = useTranslations("common.backgroundSyncReview");
+  const tm = useTranslations("common.prMergeAlert");
+  const [isPrMergeActionPending, startPrMergeActionTransition] = useTransition();
+  const [backgroundSyncReview, setBackgroundSyncReview] = useState<BackgroundSyncReviewPayload | null>(null);
+  const [selectedPrMergeEventKeys, setSelectedPrMergeEventKeys] = useState<string[]>([]);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const applyNotification = (notification: AppNotification | null | undefined) => {
+      if (!isActive) {
+        return;
+      }
+
+      const payload = getBackgroundSyncReviewPayload(notification);
+      if (!payload) {
+        return;
+      }
+
+      setBackgroundSyncReview(payload);
+      setSelectedPrMergeEventKeys(payload.mergedPullRequests.map(getMergedPrEventKey));
+    };
+
+    void window.kanvibeDesktop?.consumePendingNotificationActivation?.()
+      .then((notification: AppNotification | null) => {
+        applyNotification(notification);
+      })
+      .catch(() => {
+        /* pending activation consume 실패는 무시 */
+      });
+
+    const dispose = window.kanvibeDesktop?.onNotificationActivated?.((notification: AppNotification) => {
+      applyNotification(notification);
+    });
+
+    return () => {
+      isActive = false;
+      dispose?.();
+    };
+  }, []);
+
+  const selectedPrMergeEventKeySet = useMemo(
+    () => new Set(selectedPrMergeEventKeys),
+    [selectedPrMergeEventKeys],
+  );
+
+  const togglePrMergeSelection = useCallback((eventKey: string) => {
+    setSelectedPrMergeEventKeys((current) => (
+      current.includes(eventKey)
+        ? current.filter((key) => key !== eventKey)
+        : [...current, eventKey]
+    ));
+  }, []);
+
+  const handlePrMergeCancel = useCallback(() => {
+    setBackgroundSyncReview(null);
+    setSelectedPrMergeEventKeys([]);
+  }, []);
+
+  useEscapeKey(handlePrMergeCancel, {
+    enabled: Boolean(backgroundSyncReview) && !isPrMergeActionPending,
+  });
+
+  const handlePrMergeConfirm = useCallback(() => {
+    if (!backgroundSyncReview) {
+      return;
+    }
+
+    const selectedEventKeys = new Set(selectedPrMergeEventKeys);
+    const selectedTaskIds = backgroundSyncReview.mergedPullRequests
+      .filter((alert) => selectedEventKeys.has(getMergedPrEventKey(alert)))
+      .map((alert) => alert.taskId);
+
+    setBackgroundSyncReview(null);
+    setSelectedPrMergeEventKeys([]);
+
+    if (selectedTaskIds.length === 0) {
+      return;
+    }
+
+    startPrMergeActionTransition(async () => {
+      for (const taskId of selectedTaskIds) {
+        await updateTaskStatus(taskId, TaskStatus.DONE);
+      }
+    });
+  }, [backgroundSyncReview, selectedPrMergeEventKeys, startPrMergeActionTransition]);
+
+  if (!backgroundSyncReview) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[520] flex items-center justify-center bg-bg-overlay">
+      <div className="w-full max-w-2xl rounded-xl border border-border-default bg-bg-surface p-6 shadow-lg">
+        <h2 className="mb-2 text-lg font-semibold text-text-primary">
+          {tr("title")}
+        </h2>
+        <p className="text-sm text-text-secondary">
+          {tr("message")}
+        </p>
+        <div className="mt-4 max-h-[360px] space-y-5 overflow-y-auto pr-1">
+          <section>
+            <h3 className="text-sm font-semibold text-text-primary">{tr("mergedSection")}</h3>
+            {backgroundSyncReview.mergedPullRequests.length === 0 ? (
+              <p className="mt-2 text-sm text-text-muted">{tr("emptyMerged")}</p>
+            ) : (
+              <div className="mt-3 space-y-3">
+                {backgroundSyncReview.mergedPullRequests.map((alert) => {
+                  const eventKey = getMergedPrEventKey(alert);
+                  return (
+                    <label
+                      key={eventKey}
+                      className="flex cursor-pointer items-start gap-3 rounded-lg border border-border-default bg-bg-page px-4 py-3"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedPrMergeEventKeySet.has(eventKey)}
+                        onChange={() => togglePrMergeSelection(eventKey)}
+                        aria-label={alert.taskTitle}
+                        className="mt-0.5 h-4 w-4 rounded border-border-default text-brand-primary focus:ring-brand-primary"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-semibold text-text-primary">
+                          {alert.taskTitle}
+                        </p>
+                        <p className="mt-1 text-xs text-text-muted">
+                          {alert.branchName}
+                        </p>
+                        <a
+                          href={alert.prUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-3 inline-flex max-w-full items-center gap-1 rounded bg-tag-pr-bg px-2 py-1 text-xs text-tag-pr-text transition-opacity hover:opacity-80"
+                        >
+                          <span className="shrink-0">{tm("prLinkLabel")}</span>
+                          <span className="truncate">{alert.prUrl}</span>
+                        </a>
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <h3 className="text-sm font-semibold text-text-primary">{tr("registeredSection")}</h3>
+            {backgroundSyncReview.registeredWorktrees.length === 0 ? (
+              <p className="mt-2 text-sm text-text-muted">{tr("emptyRegistered")}</p>
+            ) : (
+              <div className="mt-3 space-y-3">
+                {backgroundSyncReview.registeredWorktrees.map((worktree: BackgroundSyncRegisteredWorktreePayload) => (
+                  <div
+                    key={`${worktree.taskId}:${worktree.worktreePath}`}
+                    className="rounded-lg border border-border-default bg-bg-page px-4 py-3"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-sm font-semibold text-text-primary">
+                        {worktree.projectName}
+                      </p>
+                      <span className="rounded-full bg-bg-surface px-2 py-0.5 text-[11px] text-text-muted">
+                        {tc(worktree.sshHost ? "remote" : "local")}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-text-muted">{worktree.branchName}</p>
+                    <p className="mt-3 text-xs text-text-secondary">{worktree.worktreePath}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={handlePrMergeCancel}
+            disabled={isPrMergeActionPending}
+            className="rounded-md border border-border-default bg-bg-page px-4 py-1.5 text-sm text-text-secondary transition-colors hover:border-brand-primary"
+          >
+            {tc("cancel")}
+          </button>
+          <button
+            type="button"
+            onClick={handlePrMergeConfirm}
+            disabled={isPrMergeActionPending}
+            className="rounded-md bg-brand-primary px-4 py-1.5 text-sm text-text-inverse transition-colors hover:bg-brand-hover disabled:opacity-50"
+          >
+            {tc("confirm")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/desktop/renderer/components/BoardCommandProvider.tsx
+++ b/src/desktop/renderer/components/BoardCommandProvider.tsx
@@ -189,6 +189,20 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
     };
   }, [isTaskQuickSearchOpen]);
 
+  useEffect(() => {
+    const unsubscribe = window.kanvibeDesktop?.onNotificationShortcut?.(() => {
+      if (isTaskQuickSearchOpen) {
+        return;
+      }
+
+      notificationCenterHandlerRef.current?.();
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [isTaskQuickSearchOpen]);
+
   const value = useMemo<BoardCommandContextValue>(() => ({
     canCreateBranchTodo,
     registerBoardHandlers,

--- a/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
+++ b/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
@@ -238,6 +238,35 @@ describe("BoardCommandProvider", () => {
     expect(screen.getByText("branch-disabled")).toBeTruthy();
   });
 
+  it("forwards the desktop notification shortcut event to a notification-only handler", () => {
+    const onToggleNotificationCenter = vi.fn();
+    let notificationShortcutListener: (() => void) | null = null;
+    const unsubscribe = vi.fn();
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      onNotificationShortcut: vi.fn((listener: () => void) => {
+        notificationShortcutListener = listener;
+        return unsubscribe;
+      }),
+    } as never;
+
+    const { unmount } = renderWithRouter(
+      <BoardCommandProvider>
+        <NotificationOnlyHarness onToggleNotificationCenter={onToggleNotificationCenter} />
+      </BoardCommandProvider>,
+    );
+
+    act(() => {
+      notificationShortcutListener?.();
+    });
+
+    expect(window.kanvibeDesktop.onNotificationShortcut).toHaveBeenCalledTimes(1);
+    expect(onToggleNotificationCenter).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
   it("refreshes all kanban data from the global refresh shortcut", () => {
     renderWithRouter(
       <BoardCommandProvider>

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -32,6 +32,7 @@ declare global {
       activateNotification?: (notificationId: string) => Promise<boolean>;
       consumePendingNotificationActivation?: () => Promise<AppNotification | null>;
       onNotificationActivated?: (listener: (notification: AppNotification) => void) => () => void;
+      onNotificationShortcut?: (listener: () => void) => () => void;
     };
   }
 }

--- a/src/types/kanvibeDesktop.d.ts
+++ b/src/types/kanvibeDesktop.d.ts
@@ -10,8 +10,9 @@ interface KanvibeDesktopApi {
   activateNotification?: (notificationId: string) => Promise<boolean>;
   consumePendingNotificationActivation?: () => Promise<AppNotification | null>;
   onNotificationActivated?: (listener: (notification: AppNotification) => void) => () => void;
+  onNotificationShortcut?: (listener: () => void) => () => void;
   onCreateTaskShortcut?: (listener: () => void) => () => void;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface Window {


### PR DESCRIPTION
## Summary
- Move the background sync review dialog into a global authenticated route host so it can open on the current screen.
- Keep background-sync-review notification activation on the focused route instead of redirecting to the board.
- Forward the notification shortcut through Electron so Cmd/Ctrl+Shift+I works when task detail terminals own keyboard focus.

## Verification
- pnpm exec vitest run src/desktop/renderer/__tests__/App.test.tsx src/components/__tests__/Board.test.tsx src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx src/desktop/main/__tests__/windowOpen.test.ts
- pnpm check
- node --check electron/main.js && node --check electron/preload.js && pnpm build:main
- git diff --check

Co-Authored-By: OpenAI Codex <codex@openai.com>