### PR TITLE
fix(sync): suppress repeated pull failure notifications

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -823,6 +823,60 @@ describe("kanbanService.createTask", () => {
       ],
     });
   });
+
+  it("active task pull sync는 같은 task pull 실패를 성공 전까지 한 번만 반환한다", async () => {
+    // Given
+    mocks.taskRepo.find.mockResolvedValue([
+      {
+        id: "task-pull-b",
+        title: "Pull B",
+        projectId: "project-1",
+        branchName: "feature/pull-b",
+        worktreePath: "/workspace/repo__worktrees/pull-b",
+        sshHost: null,
+        status: "review",
+      },
+    ]);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+    mocks.pullCurrentBranch
+      .mockRejectedValueOnce(new Error("Not possible to fast-forward"))
+      .mockRejectedValueOnce(new Error("Not possible to fast-forward"))
+      .mockResolvedValueOnce("Already up to date.")
+      .mockRejectedValueOnce(new Error("Not possible to fast-forward"));
+
+    const { syncActiveTaskPulls } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const firstFailure = await syncActiveTaskPulls();
+    const repeatedFailure = await syncActiveTaskPulls();
+    const recovery = await syncActiveTaskPulls();
+    const failureAfterRecovery = await syncActiveTaskPulls();
+
+    // Then
+    expect(firstFailure.pulledTasks).toEqual([
+      expect.objectContaining({
+        taskId: "task-pull-b",
+        branchName: "feature/pull-b",
+        status: "failed",
+        summary: "Not possible to fast-forward",
+      }),
+    ]);
+    expect(repeatedFailure.pulledTasks).toEqual([]);
+    expect(recovery.pulledTasks).toEqual([]);
+    expect(failureAfterRecovery.pulledTasks).toEqual([
+      expect.objectContaining({
+        taskId: "task-pull-b",
+        branchName: "feature/pull-b",
+        status: "failed",
+        summary: "Not possible to fast-forward",
+      }),
+    ]);
+  });
 });
 
 describe("kanbanService.getSearchableTasks", () => {

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -34,6 +34,7 @@ export interface SearchableTask {
 }
 
 const DONE_PAGE_SIZE = 20;
+const notifiedPullFailureKeys = new Set<string>();
 
 interface GitHubPullRequestInfo {
   url: string | null;
@@ -280,6 +281,10 @@ function summarizePullOutput(output: string): string {
 function isPullNoop(output: string): boolean {
   return /already up[- ]to[- ]date/i.test(output)
     || /current branch .* is up to date/i.test(output);
+}
+
+function buildPullFailureKey(taskId: string, branchName: string, worktreePath: string, sshHost: string | null): string {
+  return [taskId, branchName, worktreePath, sshHost ?? ""].join("::");
 }
 
 /** 모든 작업을 상태별로 그룹핑하여 반환한다. Done 컬럼은 첫 페이지만 로드한다 */
@@ -880,9 +885,11 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
     }
 
     const sshHost = task.sshHost || project?.sshHost || null;
+    const pullFailureKey = buildPullFailureKey(task.id, task.branchName, task.worktreePath, sshHost);
 
     try {
       const output = await pullCurrentBranch(task.worktreePath, sshHost);
+      notifiedPullFailureKeys.delete(pullFailureKey);
       if (isPullNoop(output)) {
         return null;
       }
@@ -897,6 +904,11 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
         summary: summarizePullOutput(output),
       };
     } catch (error) {
+      if (notifiedPullFailureKeys.has(pullFailureKey)) {
+        return null;
+      }
+
+      notifiedPullFailureKeys.add(pullFailureKey);
       return {
         taskId: task.id,
         taskTitle: task.title,


### PR DESCRIPTION
## What changed?
- Prevent repeated background sync review notifications for the same task pull failure until that pull target recovers.

## How was it solved?
**Track notified pull failures**
- Store a pull failure marker per task, branch, worktree path, and SSH host.
- Skip returning repeated failed pull results while the marker is active, which keeps duplicate review alerts from being created.

**Reset after recovery**
- Clear the failure marker after any successful pull, including no-op success output such as `Already up to date`.
- Allow a new failure notification after that recovery point.

**Regression coverage**
- Add coverage for first failure notification, repeated failure suppression, recovery reset, and failure notification after recovery.

Co-Authored-By: OpenAI Codex <codex@openai.com>
