### PR TITLE
modify(background-sync): throttle background task refresh schedule

### DIFF
--- a/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
+++ b/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
@@ -119,6 +119,77 @@ describe("backgroundTaskSyncService", () => {
     stopB();
   });
 
+  it("실행 중인 background task sync cycle이 있으면 추가 cycle을 실행하지 않는다", async () => {
+    let resolveWorktreeSync: (result: {
+      worktreeTasks: string[];
+      registeredWorktrees: never[];
+      hooksSetup: never[];
+      errors: never[];
+      changed: boolean;
+    }) => void = () => {};
+    mocks.syncRegisteredProjectWorktrees.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveWorktreeSync = resolve;
+      }),
+    );
+
+    const { startBackgroundTaskSync } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    const stop = startBackgroundTaskSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
+
+    resolveWorktreeSync({
+      worktreeTasks: [],
+      registeredWorktrees: [],
+      hooksSetup: [],
+      errors: [],
+      changed: false,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(2);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(2);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(2);
+
+    stop();
+  });
+
+  it("background task sync 갱신 주기는 최초 실행 후 10분이다", async () => {
+    const { startBackgroundTaskSync } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    const stop = startBackgroundTaskSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000 - 1);
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(2);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(2);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(2);
+
+    stop();
+  });
+
   it("task pull 결과가 있으면 background sync review event에 포함한다", async () => {
     mocks.syncActiveTaskPulls.mockResolvedValue({
       pulledTasks: [

--- a/src/desktop/main/services/backgroundTaskSyncService.ts
+++ b/src/desktop/main/services/backgroundTaskSyncService.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/boardNotifier";
 
 const INITIAL_SYNC_DELAY_MS = 20_000;
-const SYNC_INTERVAL_MS = 90_000;
+const SYNC_INTERVAL_MS = 10 * 60_000;
 
 let activeBackgroundTaskSyncStop: (() => void) | null = null;
 
@@ -32,8 +32,11 @@ export function startBackgroundTaskSync() {
   }
 
   async function runSyncCycle() {
-    if (disposed || running) {
-      scheduleNext(SYNC_INTERVAL_MS);
+    if (disposed) {
+      return;
+    }
+
+    if (running) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Change the recurring background task sync interval from 90 seconds to 10 minutes.
- Prevent an additional background sync cycle from starting or being scheduled while a cycle is already running.
- Add regression coverage for the 10-minute schedule and in-flight sync guard behavior.

## Key Changes
### Background sync scheduling
- Update `SYNC_INTERVAL_MS` to express a 10-minute interval directly.
- Split the disposed and running guards so an in-flight sync returns without creating another timer.

### Regression tests
- Verify the next sync does not run before 10 minutes elapse after the initial cycle.
- Verify an in-flight sync cycle suppresses additional cycles until it finishes.

## Validation
- `pnpm exec vitest run src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts`
- `pnpm check`
- `pnpm exec eslint src/desktop/main/services/backgroundTaskSyncService.ts src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>
