### PR TITLE
fix(desktop): add packaged diagnostics logging

### DIFF
--- a/electron/diagnostics.js
+++ b/electron/diagnostics.js
@@ -1,0 +1,89 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const process = require("node:process");
+
+function resolveDesktopLogPath(userDataPath) {
+  return path.join(userDataPath, "logs", "kanvibe-desktop.log");
+}
+
+function serializeErrorForLog(error) {
+  if (error instanceof Error) {
+    return error.stack || `${error.name}: ${error.message}`;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function normalizePayload(value, seen = new WeakSet()) {
+  if (value instanceof Error) {
+    return serializeErrorForLog(value);
+  }
+
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizePayload(entry, seen));
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [key, normalizePayload(entry, seen)]),
+  );
+}
+
+function defaultProcessMeta() {
+  return {
+    pid: process.pid,
+    platform: process.platform,
+    arch: process.arch,
+    node: process.versions.node,
+    electron: process.versions.electron || null,
+  };
+}
+
+function createDesktopDiagnostics(options) {
+  const logPath = options.logPath;
+  const getTimestamp = options.getTimestamp || (() => new Date().toISOString());
+  const getProcessMeta = options.getProcessMeta || defaultProcessMeta;
+
+  function log(event, payload = {}) {
+    try {
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      const entry = {
+        ...normalizePayload(payload),
+        process: getProcessMeta(),
+      };
+      fs.appendFileSync(logPath, `[${getTimestamp()}] ${event} ${JSON.stringify(entry)}\n`, "utf8");
+    } catch (error) {
+      console.error("[kanvibe] failed to write desktop diagnostics log:", error);
+    }
+  }
+
+  return {
+    logPath,
+    log,
+  };
+}
+
+module.exports = {
+  createDesktopDiagnostics,
+  resolveDesktopLogPath,
+  serializeErrorForLog,
+};

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
 const fs = require("node:fs");
 const http = require("node:http");
 const Module = require("node:module");
@@ -5,6 +7,7 @@ const path = require("node:path");
 const process = require("node:process");
 const { pathToFileURL } = require("node:url");
 const { app, BrowserWindow, ipcMain, session, shell } = require("electron");
+const { createDesktopDiagnostics, resolveDesktopLogPath, serializeErrorForLog } = require("./diagnostics");
 
 const DEFAULT_LOCALE = "ko";
 const RENDERER_DEV_URL = process.env.KANVIBE_RENDERER_URL || null;
@@ -34,6 +37,102 @@ let hookServer = null;
 let windowOpenHelpers = null;
 let stopBackgroundTaskSync = null;
 let pendingNotificationActivation = null;
+let diagnostics = null;
+const pendingDiagnosticEvents = [];
+
+function logDiagnostic(event, payload = {}) {
+  if (!diagnostics) {
+    pendingDiagnosticEvents.push({ event, payload });
+    return;
+  }
+
+  diagnostics.log(event, payload);
+}
+
+function initializeDiagnostics() {
+  diagnostics = createDesktopDiagnostics({
+    logPath: resolveDesktopLogPath(app.getPath("userData")),
+  });
+
+  console.log(`[kanvibe] Desktop diagnostics log: ${diagnostics.logPath}`);
+
+  for (const entry of pendingDiagnosticEvents.splice(0)) {
+    diagnostics.log(entry.event, entry.payload);
+  }
+}
+
+function registerProcessDiagnostics() {
+  process.on("uncaughtException", (error) => {
+    logDiagnostic("main:uncaught-exception", { error: serializeErrorForLog(error) });
+    console.error("[kanvibe] uncaught exception:", error);
+    process.exit(1);
+  });
+
+  process.on("unhandledRejection", (reason) => {
+    logDiagnostic("main:unhandled-rejection", { reason: serializeErrorForLog(reason) });
+    console.error("[kanvibe] unhandled rejection:", reason);
+  });
+
+  app.on("child-process-gone", (_event, details) => {
+    logDiagnostic("main:child-process-gone", details);
+  });
+}
+
+function normalizeConsoleMessage(args) {
+  const [first, second, third, fourth] = args;
+  if (first && typeof first === "object" && "message" in first) {
+    return first;
+  }
+
+  return {
+    level: first,
+    message: second,
+    line: third,
+    sourceId: fourth,
+  };
+}
+
+function attachRendererDiagnostics(browserWindow) {
+  const { webContents } = browserWindow;
+
+  webContents.on("did-start-loading", () => {
+    logDiagnostic("renderer:did-start-loading", { url: webContents.getURL() });
+  });
+
+  webContents.on("did-finish-load", () => {
+    logDiagnostic("renderer:did-finish-load", { url: webContents.getURL() });
+  });
+
+  webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    logDiagnostic("renderer:did-fail-load", {
+      errorCode,
+      errorDescription,
+      validatedURL,
+      isMainFrame,
+      currentUrl: webContents.getURL(),
+    });
+  });
+
+  webContents.on("render-process-gone", (_event, details) => {
+    logDiagnostic("renderer:render-process-gone", {
+      url: webContents.getURL(),
+      details,
+    });
+  });
+
+  webContents.on("console-message", (_event, ...args) => {
+    logDiagnostic("renderer:console-message", normalizeConsoleMessage(args));
+  });
+
+  webContents.on("preload-error", (_event, preloadPath, error) => {
+    logDiagnostic("renderer:preload-error", {
+      preloadPath,
+      error: serializeErrorForLog(error),
+    });
+  });
+}
+
+registerProcessDiagnostics();
 
 function broadcastNotificationsChanged() {
   for (const window of BrowserWindow.getAllWindows()) {
@@ -233,6 +332,7 @@ function focusWindow(window) {
 function registerAppWindow(browserWindow) {
   mainWindow = browserWindow;
   attachWindowHandlers(browserWindow);
+  attachRendererDiagnostics(browserWindow);
 
   browserWindow.on("focus", () => {
     if (!browserWindow.isDestroyed()) {
@@ -488,18 +588,31 @@ function registerDesktopHandlers() {
     closeWindowTerminals,
   } = require(getRuntimeModulePath(path.join("src", "desktop", "main", "terminalBridge.ts")));
 
+  ipcMain.on("kanvibe:renderer-log", (_event, payload) => {
+    logDiagnostic("renderer:bridge", payload);
+  });
+
   ipcMain.handle("kanvibe:invoke", async (_event, namespace, method, args) => {
-    const service = desktopServices[namespace];
-    if (!service) {
-      throw new Error(`Unknown desktop service namespace: ${namespace}`);
-    }
+    try {
+      const service = desktopServices[namespace];
+      if (!service) {
+        throw new Error(`Unknown desktop service namespace: ${namespace}`);
+      }
 
-    const targetMethod = service[method];
-    if (typeof targetMethod !== "function") {
-      throw new Error(`Unknown desktop service method: ${namespace}.${method}`);
-    }
+      const targetMethod = service[method];
+      if (typeof targetMethod !== "function") {
+        throw new Error(`Unknown desktop service method: ${namespace}.${method}`);
+      }
 
-    return targetMethod(...(Array.isArray(args) ? args : []));
+      return await targetMethod(...(Array.isArray(args) ? args : []));
+    } catch (error) {
+      diagnostics.log("ipc:invoke-failed", {
+        namespace,
+        method,
+        error: serializeErrorForLog(error),
+      });
+      throw error;
+    }
   });
 
   ipcMain.handle("kanvibe:terminal-open", async (event, taskId, cols, rows) => {
@@ -556,6 +669,13 @@ function startHookServer() {
 }
 
 async function loadRenderer(window, targetUrl = getRendererNavigationUrl()) {
+  logDiagnostic("renderer:load-start", {
+    targetUrl,
+    rendererDevUrl: RENDERER_DEV_URL,
+    isPackaged: app.isPackaged,
+    appPath: app.getAppPath(),
+  });
+
   if (RENDERER_DEV_URL) {
     await waitForServer(RENDERER_DEV_URL);
   } else {
@@ -565,7 +685,16 @@ async function loadRenderer(window, targetUrl = getRendererNavigationUrl()) {
     }
   }
 
-  await window.loadURL(targetUrl);
+  try {
+    await window.loadURL(targetUrl);
+    logDiagnostic("renderer:load-complete", { targetUrl });
+  } catch (error) {
+    logDiagnostic("renderer:load-failed", {
+      targetUrl,
+      error: serializeErrorForLog(error),
+    });
+    throw error;
+  }
 }
 
 async function createAppWindow(target = getRendererNavigationUrl()) {
@@ -582,7 +711,18 @@ async function createMainWindow(target) {
 }
 
 app.whenReady().then(async () => {
+  initializeDiagnostics();
   ensureRuntimeEnvironment();
+  diagnostics.log("main:startup", {
+    appPath: app.getAppPath(),
+    userDataPath: app.getPath("userData"),
+    resourcesPath: process.resourcesPath,
+    cwd: process.cwd(),
+    isPackaged: app.isPackaged,
+    rendererDevUrl: RENDERER_DEV_URL,
+    seedDbPath: process.env.KANVIBE_SEED_DB_PATH,
+  });
+
   registerRuntimeAliases();
   session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
     callback(permission === "notifications");

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,7 +1,52 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
 const { contextBridge, ipcRenderer } = require("electron");
+
+function serializeRendererError(error) {
+  if (error instanceof Error) {
+    return error.stack || `${error.name}: ${error.message}`;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function sendRendererLog(event, payload = {}) {
+  try {
+    ipcRenderer.send("kanvibe:renderer-log", { event, payload });
+  } catch {
+    // Logging must never break the renderer bridge.
+  }
+}
+
+window.addEventListener("error", (event) => {
+  sendRendererLog("preload:window-error", {
+    message: event.message,
+    filename: event.filename,
+    lineno: event.lineno,
+    colno: event.colno,
+    error: serializeRendererError(event.error),
+  });
+});
+
+window.addEventListener("unhandledrejection", (event) => {
+  sendRendererLog("preload:unhandled-rejection", {
+    reason: serializeRendererError(event.reason),
+  });
+});
 
 contextBridge.exposeInMainWorld("kanvibeDesktop", {
   isDesktop: true,
+  logRendererError(event, payload) {
+    sendRendererLog(event, payload);
+  },
   invoke(namespace, method, args) {
     return ipcRenderer.invoke("kanvibe:invoke", namespace, method, args);
   },

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -15,6 +15,7 @@ declare global {
     ) => boolean;
     kanvibeDesktop: {
       isDesktop: boolean;
+      logRendererError?: (event: string, payload?: Record<string, unknown>) => void;
       invoke: (namespace: DesktopServiceNamespace, method: string, args: unknown[]) => Promise<unknown>;
       onBoardEvent: (listener: (event: BoardEventPayload) => void) => () => void;
       openTerminal: (taskId: string, cols: number, rows: number) => Promise<{ ok: boolean; error?: string }>;

--- a/src/desktop/renderer/main.tsx
+++ b/src/desktop/renderer/main.tsx
@@ -3,6 +3,47 @@ import { createRoot } from "react-dom/client";
 import App from "@/desktop/renderer/App";
 import "@/styles/globals.css";
 
+function serializeRendererError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack || `${error.name}: ${error.message}`;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function installRendererDiagnostics() {
+  window.kanvibeDesktop?.logRendererError?.("renderer:bootstrap", {
+    href: window.location.href,
+    userAgent: window.navigator.userAgent,
+  });
+
+  window.addEventListener("error", (event) => {
+    window.kanvibeDesktop?.logRendererError?.("renderer:window-error", {
+      message: event.message,
+      filename: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+      error: serializeRendererError(event.error),
+    });
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    window.kanvibeDesktop?.logRendererError?.("renderer:unhandled-rejection", {
+      reason: serializeRendererError(event.reason),
+    });
+  });
+}
+
+installRendererDiagnostics();
+
 const container = document.getElementById("root");
 
 if (!container) {

--- a/src/lib/__tests__/desktopDiagnostics.test.ts
+++ b/src/lib/__tests__/desktopDiagnostics.test.ts
@@ -1,0 +1,100 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const tempDirs: string[] = [];
+
+interface DesktopDiagnosticsModule {
+  createDesktopDiagnostics: (options: {
+    logPath: string;
+    getTimestamp?: () => string;
+    getProcessMeta?: () => Record<string, unknown>;
+  }) => {
+    logPath: string;
+    log: (event: string, payload?: Record<string, unknown>) => void;
+  };
+  resolveDesktopLogPath: (userDataPath: string) => string;
+  serializeErrorForLog: (error: unknown) => string;
+}
+
+function readSource(relativePath: string): string {
+  return readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+function loadDiagnosticsModule(): DesktopDiagnosticsModule {
+  return require(path.join(process.cwd(), "electron", "diagnostics.js")) as DesktopDiagnosticsModule;
+}
+
+function createTempDir(): string {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "kanvibe-diagnostics-test-"));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("desktop diagnostics", () => {
+  it("writes structured diagnostic events to the packaged app log path", () => {
+    const diagnosticsModule = loadDiagnosticsModule();
+    const userDataPath = createTempDir();
+    const logPath = diagnosticsModule.resolveDesktopLogPath(userDataPath);
+    const diagnostics = diagnosticsModule.createDesktopDiagnostics({
+      logPath,
+      getTimestamp: () => "2026-05-02T07:30:00.000Z",
+      getProcessMeta: () => ({ pid: 1234, platform: "darwin", arch: "arm64" }),
+    });
+
+    diagnostics.log("renderer:load-start", { url: "file:///KanVibe/index.html#/ko/login" });
+
+    const log = readFileSync(logPath, "utf8");
+    expect(diagnostics.logPath).toBe(path.join(userDataPath, "logs", "kanvibe-desktop.log"));
+    expect(log).toContain("[2026-05-02T07:30:00.000Z] renderer:load-start");
+    expect(log).toContain('"url":"file:///KanVibe/index.html#/ko/login"');
+    expect(log).toContain('"pid":1234');
+    expect(log).toContain('"platform":"darwin"');
+  });
+
+  it("serializes thrown values into readable log payloads", () => {
+    const diagnosticsModule = loadDiagnosticsModule();
+
+    expect(diagnosticsModule.serializeErrorForLog(new Error("native module failed"))).toContain("native module failed");
+    expect(diagnosticsModule.serializeErrorForLog("string failure")).toBe("string failure");
+  });
+
+  it("wires main process diagnostics around startup, renderer loading, and IPC failures", () => {
+    const source = readSource("electron/main.js");
+
+    expect(source).toContain("createDesktopDiagnostics");
+    expect(source).toContain('diagnostics.log("main:startup"');
+    expect(source).toContain('process.on("uncaughtException"');
+    expect(source).toContain('process.on("unhandledRejection"');
+    expect(source).toContain('ipcMain.on("kanvibe:renderer-log"');
+    expect(source).toContain('diagnostics.log("ipc:invoke-failed"');
+    expect(source).toContain('webContents.on("did-fail-load"');
+    expect(source).toContain('webContents.on("render-process-gone"');
+    expect(source).toContain('webContents.on("console-message"');
+    expect(source).toContain('webContents.on("preload-error"');
+  });
+
+  it("wires preload and renderer diagnostics before React bootstraps", () => {
+    const preloadSource = readSource("electron/preload.js");
+    const rendererSource = readSource("src/desktop/renderer/main.tsx");
+    const globalTypes = readSource("src/desktop/renderer/global.d.ts");
+
+    expect(preloadSource).toContain('ipcRenderer.send("kanvibe:renderer-log"');
+    expect(preloadSource).toContain("logRendererError");
+    expect(preloadSource).toContain('window.addEventListener("error"');
+    expect(preloadSource).toContain('window.addEventListener("unhandledrejection"');
+    expect(rendererSource).toContain("installRendererDiagnostics");
+    expect(rendererSource).toContain("window.kanvibeDesktop?.logRendererError");
+    expect(rendererSource.indexOf("installRendererDiagnostics();")).toBeLessThan(rendererSource.indexOf("createRoot(container)"));
+    expect(globalTypes).toContain("logRendererError?:");
+  });
+});


### PR DESCRIPTION
## Related Materials
- Issue: N/A

## What does this PR do?
- Add packaged Electron diagnostics so DMG startup hangs can be traced from a persistent desktop log file.

## How was it solved?
**Packaged diagnostics logger**
- Add an append-only desktop diagnostics logger under `electron/diagnostics.js`.
- Write logs to the Electron `userData` logs directory so packaged apps can record failures outside the install path.

**Main process and IPC instrumentation**
- Capture startup metadata, renderer load events, renderer process failures, preload errors, console messages, uncaught exceptions, and unhandled rejections.
- Record `kanvibe:invoke` failures with namespace, method, and serialized error details before rethrowing.

**Renderer bridge instrumentation**
- Add a preload bridge for renderer diagnostics.
- Install renderer error and unhandled rejection listeners before React bootstraps.

## Important Changes
### Desktop runtime diagnostics

**Persistent log file**
- **Reason**: Packaged DMG failures had no useful runtime logs when the app stayed on the loading screen.
- **Files**: `electron/diagnostics.js`, `electron/main.js`

**Renderer and preload failure tracing**
- **Reason**: Loading hangs can happen before React fallback handling, so errors need to be captured at the Electron boundary.
- **Files**: `electron/main.js`, `electron/preload.js`, `src/desktop/renderer/main.tsx`, `src/desktop/renderer/global.d.ts`

**Regression coverage**
- **Reason**: Keep diagnostics wiring from being removed silently.
- **Files**: `src/lib/__tests__/desktopDiagnostics.test.ts`

Co-authored-by: OpenAI Codex <codex@openai.com>
