### PR TITLE
Skip completed and missing remote branch pulls

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   broadcastBoardUpdate: vi.fn(),
   execGit: vi.fn(),
   pullCurrentBranch: vi.fn(),
+  remoteBranchExists: vi.fn(),
   broadcastTaskHookInstallFailed: vi.fn(),
   broadcastTaskPrMergedDetectedBatch: vi.fn(),
 }));
@@ -75,6 +76,7 @@ vi.mock("@/lib/boardNotifier", () => ({
 vi.mock("@/lib/gitOperations", () => ({
   execGit: mocks.execGit,
   pullCurrentBranch: mocks.pullCurrentBranch,
+  remoteBranchExists: mocks.remoteBranchExists,
 }));
 
 describe("kanbanService.createTask", () => {
@@ -83,6 +85,7 @@ describe("kanbanService.createTask", () => {
     vi.clearAllMocks();
     mocks.taskRepo.create.mockImplementation((value) => value);
     mocks.installKanvibeHooks.mockResolvedValue(undefined);
+    mocks.remoteBranchExists.mockResolvedValue(true);
     mocks.taskRepo.createQueryBuilder.mockReturnValue({
       select: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
@@ -876,6 +879,124 @@ describe("kanbanService.createTask", () => {
         },
       ],
     });
+  });
+
+  it("active task pull sync는 done task를 pull하지 않는다", async () => {
+    // Given
+    mocks.taskRepo.find.mockResolvedValue([
+      {
+        id: "task-done",
+        title: "Done task",
+        projectId: "project-1",
+        branchName: "feature/done",
+        worktreePath: "/workspace/repo__worktrees/done",
+        sshHost: null,
+        status: "done",
+      },
+      {
+        id: "task-progress",
+        title: "Progress task",
+        projectId: "project-1",
+        branchName: "feature/progress",
+        worktreePath: "/workspace/repo__worktrees/progress",
+        sshHost: null,
+        status: "progress",
+      },
+    ]);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+    mocks.pullCurrentBranch.mockResolvedValue("Already up to date.");
+
+    const { syncActiveTaskPulls } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await syncActiveTaskPulls();
+
+    // Then
+    expect(mocks.taskRepo.find).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        status: expect.objectContaining({
+          _type: "in",
+          _value: ["todo", "progress", "pending", "review"],
+        }),
+      }),
+    }));
+    expect(mocks.pullCurrentBranch).toHaveBeenCalledTimes(1);
+    expect(mocks.pullCurrentBranch).toHaveBeenCalledWith("/workspace/repo__worktrees/progress", null);
+    expect(result).toEqual({ pulledTasks: [] });
+  });
+
+  it("active task pull sync는 remote branch가 없으면 pull하지 않는다", async () => {
+    // Given
+    mocks.taskRepo.find.mockResolvedValue([
+      {
+        id: "task-missing-remote",
+        title: "Missing remote branch",
+        projectId: "project-1",
+        branchName: "feature/missing-remote",
+        worktreePath: "/workspace/repo__worktrees/missing-remote",
+        sshHost: null,
+        status: "review",
+      },
+    ]);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+    mocks.remoteBranchExists.mockResolvedValue(false);
+
+    const { syncActiveTaskPulls } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await syncActiveTaskPulls();
+
+    // Then
+    expect(mocks.remoteBranchExists).toHaveBeenCalledWith(
+      "/workspace/repo__worktrees/missing-remote",
+      "feature/missing-remote",
+      null,
+    );
+    expect(mocks.pullCurrentBranch).not.toHaveBeenCalled();
+    expect(result).toEqual({ pulledTasks: [] });
+  });
+
+  it("active task pull sync는 remote branch 없음 pull 오류를 실패로 반환하지 않는다", async () => {
+    // Given
+    mocks.taskRepo.find.mockResolvedValue([
+      {
+        id: "task-stale-upstream",
+        title: "Stale upstream",
+        projectId: "project-1",
+        branchName: "feature/stale-upstream",
+        worktreePath: "/workspace/repo__worktrees/stale-upstream",
+        sshHost: "remote-host",
+        status: "review",
+      },
+    ]);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: "remote-host",
+    });
+    mocks.remoteBranchExists.mockResolvedValue(true);
+    mocks.pullCurrentBranch.mockRejectedValue(new Error(
+      "remote-host 원격 명령 실패: Your configuration specifies to merge with the ref 'refs/heads/feature/stale-upstream' from the remote, but no such ref was fetched.",
+    ));
+
+    const { syncActiveTaskPulls } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await syncActiveTaskPulls();
+
+    // Then
+    expect(result).toEqual({ pulledTasks: [] });
   });
 
   it("active task pull sync는 같은 task pull 실패를 성공 전까지 한 번만 반환한다", async () => {

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -1,5 +1,5 @@
 import { execFile } from "child_process";
-import { Not, Like } from "typeorm";
+import { In, Not, Like } from "typeorm";
 import { getTaskRepository } from "@/lib/database";
 import { KanbanTask, TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
@@ -13,7 +13,7 @@ import {
   type TaskPrMergedDetectedPayload,
 } from "@/lib/boardNotifier";
 import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
-import { execGit, pullCurrentBranch } from "@/lib/gitOperations";
+import { execGit, pullCurrentBranch, remoteBranchExists } from "@/lib/gitOperations";
 
 export type TasksByStatus = Record<TaskStatus, KanbanTask[]>;
 
@@ -40,6 +40,12 @@ export interface SearchableTask {
 }
 
 const DONE_PAGE_SIZE = 20;
+const ACTIVE_PULL_TASK_STATUSES = [
+  TaskStatus.TODO,
+  TaskStatus.PROGRESS,
+  TaskStatus.PENDING,
+  TaskStatus.REVIEW,
+];
 const notifiedPullFailureKeys = new Set<string>();
 
 interface GitHubPullRequestInfo {
@@ -308,6 +314,13 @@ function isPullNoop(output: string): boolean {
 
 function buildPullFailureKey(taskId: string, branchName: string, worktreePath: string, sshHost: string | null): string {
   return [taskId, branchName, worktreePath, sshHost ?? ""].join("::");
+}
+
+function isMissingRemoteBranchPullError(error: unknown): boolean {
+  const message = getErrorMessage(error);
+  return /no such ref was fetched/i.test(message)
+    || /could(?: not|n't) find remote ref/i.test(message)
+    || /requested upstream branch .* does not exist/i.test(message);
 }
 
 /** 모든 작업을 상태별로 그룹핑하여 반환한다. Done 컬럼은 첫 페이지만 로드한다 */
@@ -896,11 +909,15 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
   const repo = await getTaskRepository();
   const projectRepo = await getProjectRepository();
   const tasks = await repo.find({
-    where: { status: Not(TaskStatus.DONE) },
+    where: { status: In(ACTIVE_PULL_TASK_STATUSES) },
     order: { updatedAt: "ASC" },
   });
 
   const pulledTasks = await Promise.all(tasks.map(async (task): Promise<TaskPullSyncPayload | null> => {
+    if (task.status === TaskStatus.DONE) {
+      return null;
+    }
+
     if (!task.branchName || !task.worktreePath) {
       return null;
     }
@@ -917,6 +934,12 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
     const pullFailureKey = buildPullFailureKey(task.id, task.branchName, task.worktreePath, sshHost);
 
     try {
+      const hasRemoteBranch = await remoteBranchExists(task.worktreePath, task.branchName, sshHost);
+      if (!hasRemoteBranch) {
+        notifiedPullFailureKeys.delete(pullFailureKey);
+        return null;
+      }
+
       const output = await pullCurrentBranch(task.worktreePath, sshHost);
       notifiedPullFailureKeys.delete(pullFailureKey);
       if (isPullNoop(output)) {
@@ -933,6 +956,11 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
         summary: summarizePullOutput(output),
       };
     } catch (error) {
+      if (isMissingRemoteBranchPullError(error)) {
+        notifiedPullFailureKeys.delete(pullFailureKey);
+        return null;
+      }
+
       if (notifiedPullFailureKeys.has(pullFailureKey)) {
         return null;
       }

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -203,6 +203,46 @@ describe("gitOperations.resolvePathForShell", () => {
     expect(isSSHTransportError(commandError)).toBe(false);
   });
 
+  it("remoteBranchExists는 origin branch가 있으면 true를 반환한다", async () => {
+    // Given
+    mocks.exec.mockImplementation((
+      command: string,
+      callback: (error: null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      expect(command).toContain("refs/heads/feature/exists");
+      callback(null, { stdout: "exists", stderr: "" });
+      return {} as never;
+    });
+
+    const { remoteBranchExists } = await import("@/lib/gitOperations");
+
+    // When
+    const result = await remoteBranchExists("/workspace/repo", "feature/exists");
+
+    // Then
+    expect(result).toBe(true);
+  });
+
+  it("remoteBranchExists는 origin branch가 없으면 false를 반환한다", async () => {
+    // Given
+    mocks.exec.mockImplementation((
+      command: string,
+      callback: (error: null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      expect(command).toContain("refs/heads/feature/missing");
+      callback(null, { stdout: "missing", stderr: "" });
+      return {} as never;
+    });
+
+    const { remoteBranchExists } = await import("@/lib/gitOperations");
+
+    // When
+    const result = await remoteBranchExists("/workspace/repo", "feature/missing");
+
+    // Then
+    expect(result).toBe(false);
+  });
+
   it("scanGitRepos는 일반 저장소와 worktree 저장소를 모두 찾는다", async () => {
     // Given
     mocks.exec.mockImplementation((

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -205,6 +205,24 @@ export async function pullCurrentBranch(
   return execGit(`git -C "${repoPath}" pull --ff-only`, sshHost);
 }
 
+/** origin에 현재 task 브랜치가 존재하는지 확인한다 */
+export async function remoteBranchExists(
+  repoPath: string,
+  branchName: string,
+  sshHost?: string | null,
+): Promise<boolean> {
+  const resolvedRepoPath = resolvePathForShell(repoPath, sshHost);
+  const remoteRef = quoteForPosixShell(`refs/heads/${branchName}`);
+  const command = [
+    `git -C ${resolvedRepoPath} ls-remote --exit-code --heads origin ${remoteRef} >/dev/null`,
+    `status=$?`,
+    `if [ "$status" -eq 0 ]; then printf exists; elif [ "$status" -eq 2 ]; then printf missing; else exit "$status"; fi`,
+  ].join("; ");
+
+  const output = await execGit(command, sshHost);
+  return output.trim() === "exists";
+}
+
 /**
  * git 저장소의 브랜치 목록을 반환한다.
  * remote origin을 먼저 fetch하여 최신 상태를 반영하며,


### PR DESCRIPTION
## What changed?
- Limit background pull sync to active task statuses and defensively skip completed tasks.
- Check whether `origin/<branch>` exists before running `git pull`.
- Treat missing remote branch pull errors as non-reportable so stale upstream branches do not appear as background sync failures.
- Add regression coverage for completed tasks, missing remote branches, and the new `remoteBranchExists` helper.

## Why?
Background pull sync should not surface noisy failures for tasks that are already done or for worktrees whose remote branch has been removed.

Co-authored-by: OpenAI Codex <codex@openai.com>