### PR TITLE
fix(sync): throttle remote SSH worktree scans

### DIFF
--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -1271,7 +1271,7 @@ describe("projectService local hook installation", () => {
     );
   });
 
-  it("등록된 프로젝트 background sync는 프로젝트별 worktree 조회를 병렬로 시작한다", async () => {
+  it("등록된 프로젝트 background sync는 프로젝트별 worktree 조회를 직렬로 실행한다", async () => {
     // Given
     mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
     mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
@@ -1331,11 +1331,12 @@ describe("projectService local hook installation", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     // Then
-    const targetRepoPaths = seenRepoPaths.filter((repoPath) => repoPath.startsWith("/workspace/api-"));
-    expect(targetRepoPaths.slice(0, 2)).toEqual(["/workspace/api-a", "/workspace/api-b"]);
+    expect(Array.from(firstCalls).filter((repoPath) => repoPath.startsWith("/workspace/api-"))).toEqual(["/workspace/api-a"]);
 
     releaseGate?.();
     await syncPromise;
+
+    expect(Array.from(firstCalls).filter((repoPath) => repoPath.startsWith("/workspace/api-"))).toEqual(["/workspace/api-a", "/workspace/api-b"]);
   });
 });
 

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -656,9 +656,10 @@ export async function syncRegisteredProjectWorktrees(
     changed: false,
   };
 
-  const projectResults = await Promise.all(
-    projects.map((project) => syncProjectWorktrees(project, taskRepo)),
-  );
+  const projectResults: RegisteredProjectWorktreeSyncResult[] = [];
+  for (const project of projects) {
+    projectResults.push(await syncProjectWorktrees(project, taskRepo));
+  }
 
   for (const projectResult of projectResults) {
     mergeRegisteredProjectWorktreeSyncResult(

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -123,6 +123,89 @@ describe("gitOperations.resolvePathForShell", () => {
     );
   });
 
+  it("SSH transport 실패 직후 같은 host의 후속 명령은 새 ssh 프로세스를 만들지 않는다", async () => {
+    // Given
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.execFile.mockImplementation((_file: string, _args: string[], _options: unknown, callback: (error: Error & { stderr?: string }) => void) => {
+      const error = new Error("Command failed") as Error & { stderr?: string };
+      error.stderr = [
+        "mux_client_request_session: session request failed: Session open refused by peer",
+        "Connection closed by 100.73.171.123 port 22",
+      ].join("\n");
+      callback(error);
+    });
+
+    vi.doMock("@/lib/sshConfig", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/sshConfig")>();
+      return {
+        ...actual,
+        parseSSHConfig: vi.fn(async () => [{
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        }]),
+      };
+    });
+
+    const { execGit } = await import("@/lib/gitOperations");
+
+    try {
+      // When
+      await expect(execGit("git -C /repo worktree list --porcelain", "remote-host")).rejects.toThrow();
+      await expect(execGit("git -C /repo status --short", "remote-host")).rejects.toThrow();
+
+      // Then
+      expect(mocks.execFile).toHaveBeenCalledTimes(1);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("같은 SSH host의 원격 명령은 한 번에 하나씩 실행한다", async () => {
+    // Given
+    const startedCommands: string[] = [];
+    const pendingCallbacks: Array<(error: null, result: { stdout: string }) => void> = [];
+    mocks.execFile.mockImplementation((_file: string, args: string[], _options: unknown, callback: (error: null, result: { stdout: string }) => void) => {
+      startedCommands.push(args.at(-1) ?? "");
+      pendingCallbacks.push(callback);
+    });
+
+    vi.doMock("@/lib/sshConfig", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/sshConfig")>();
+      return {
+        ...actual,
+        parseSSHConfig: vi.fn(async () => [{
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        }]),
+      };
+    });
+
+    const { execGit } = await import("@/lib/gitOperations");
+
+    // When
+    const first = execGit("first", "remote-host");
+    const second = execGit("second", "remote-host");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Then
+    expect(startedCommands).toEqual(["sh -lc 'first'"]);
+
+    pendingCallbacks.shift()?.(null, { stdout: "one\n" });
+    await expect(first).resolves.toBe("one");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(startedCommands).toEqual(["sh -lc 'first'", "sh -lc 'second'"]);
+
+    pendingCallbacks.shift()?.(null, { stdout: "two\n" });
+    await expect(second).resolves.toBe("two");
+  });
+
   it("조용한 probe 명령 실패는 콘솔 에러를 남기지 않는다", async () => {
     // Given
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -26,8 +26,13 @@ const SSH_TRANSPORT_ERROR_PATTERNS = [
   /permission denied \(publickey/i,
   /too many authentication failures/i,
   /bad owner or permissions/i,
+  /session open refused by peer/i,
   /ssh: connect to host/i,
 ];
+
+const REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS = 60_000;
+const remoteSSHHostQueues = new Map<string, Promise<void>>();
+const remoteSSHTransportFailures = new Map<string, { until: number; error: Error }>();
 
 function collectErrorOutput(error: unknown): string {
   const outputs: string[] = [];
@@ -88,39 +93,96 @@ async function execLocal(command: string): Promise<string> {
 
 /** SSH를 통해 원격에서 명령을 실행하고 stdout을 반환한다 */
 async function execRemote(sshHost: string, command: string): Promise<string> {
-  const configs = await parseSSHConfig();
-  const hostConfig = configs.find((c) => c.host === sshHost);
+  return runQueuedRemoteCommand(sshHost, async () => {
+    throwIfSSHTransportCooldownActive(sshHost);
 
-  if (!hostConfig) {
-    throw new Error(`SSH 호스트를 찾을 수 없습니다: ${sshHost}`);
-  }
+    const configs = await parseSSHConfig();
+    const hostConfig = configs.find((c) => c.host === sshHost);
 
-  const sshArgs = [
-    ...await buildExecSSHArgs(hostConfig),
-    buildRemoteShellCommand(command),
-  ];
-
-  try {
-    const { stdout } = await execFileAsync("ssh", sshArgs, {
-      maxBuffer: 10 * 1024 * 1024,
-    });
-    return stdout.trim();
-  } catch (error) {
-    const stderr = error && typeof error === "object" && "stderr" in error
-      ? String((error as { stderr?: string }).stderr || "")
-      : "";
-
-    if (shouldLogRemoteCommandFailure(command, stderr)) {
-      console.error("[remote-ssh] command failed", {
-        sshHost,
-        command,
-        sshArgs,
-        error: error instanceof Error ? error.message : String(error),
-      });
+    if (!hostConfig) {
+      throw new Error(`SSH 호스트를 찾을 수 없습니다: ${sshHost}`);
     }
 
-    throw normalizeSSHExecError(error, sshHost);
+    const sshArgs = [
+      ...await buildExecSSHArgs(hostConfig),
+      buildRemoteShellCommand(command),
+    ];
+
+    try {
+      const { stdout } = await execFileAsync("ssh", sshArgs, {
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      return stdout.trim();
+    } catch (error) {
+      const stderr = error && typeof error === "object" && "stderr" in error
+        ? String((error as { stderr?: string }).stderr || "")
+        : "";
+
+      if (shouldLogRemoteCommandFailure(command, stderr)) {
+        console.error("[remote-ssh] command failed", {
+          sshHost,
+          command,
+          sshArgs,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      const normalizedError = normalizeSSHExecError(error, sshHost);
+      rememberSSHTransportFailure(sshHost, normalizedError);
+      throw normalizedError;
+    }
+  });
+}
+
+async function runQueuedRemoteCommand<T>(
+  sshHost: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = remoteSSHHostQueues.get(sshHost) ?? Promise.resolve();
+  let releaseCurrent: () => void = () => {};
+  const current = new Promise<void>((resolve) => {
+    releaseCurrent = resolve;
+  });
+  const queued = previous.catch(() => undefined).then(() => current);
+  remoteSSHHostQueues.set(sshHost, queued);
+
+  await previous.catch(() => undefined);
+
+  try {
+    return await operation();
+  } finally {
+    releaseCurrent();
+    if (remoteSSHHostQueues.get(sshHost) === queued) {
+      remoteSSHHostQueues.delete(sshHost);
+    }
   }
+}
+
+function throwIfSSHTransportCooldownActive(sshHost: string): void {
+  const failure = remoteSSHTransportFailures.get(sshHost);
+  if (!failure) {
+    return;
+  }
+
+  if (Date.now() >= failure.until) {
+    remoteSSHTransportFailures.delete(sshHost);
+    return;
+  }
+
+  throw new Error(
+    `${sshHost} 원격 명령 실패: 최근 SSH transport 실패로 원격 명령을 잠시 건너뜁니다. 마지막 오류: ${failure.error.message}`,
+  );
+}
+
+function rememberSSHTransportFailure(sshHost: string, error: Error): void {
+  if (!isSSHTransportError(error)) {
+    return;
+  }
+
+  remoteSSHTransportFailures.set(sshHost, {
+    until: Date.now() + REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS,
+    error,
+  });
 }
 
 async function buildExecSSHArgs(


### PR DESCRIPTION
## What changed
- Limit remote SSH execution to one command at a time per host.
- Add a 60-second cooldown after SSH transport failures so repeated background scans do not keep spawning new ssh processes.
- Run registered project worktree sync sequentially across projects to reduce background scan pressure.
- Add regression coverage for host-level SSH queuing, transport-failure cooldown, and serialized worktree sync.

## Why
Background worktree scanning could fan out multiple remote `git worktree list --porcelain` calls. When a remote host refused SSH sessions, those retries repeatedly created ssh processes and could drive CPU usage high.

## Key files
- `src/lib/gitOperations.ts`
- `src/desktop/main/services/projectService.ts`
- `src/lib/__tests__/gitOperations.test.ts`
- `src/desktop/main/services/__tests__/projectService.test.ts`

Co-Authored-By: Codex <codex@openai.com>
