### PR TITLE
fix(desktop): keep packaged app responsive on initial load and instrument IPC

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -38,6 +38,7 @@ let windowOpenHelpers = null;
 let stopBackgroundTaskSync = null;
 let pendingNotificationActivation = null;
 let diagnostics = null;
+let nextIpcRequestId = 1;
 const pendingDiagnosticEvents = [];
 
 function logDiagnostic(event, payload = {}) {
@@ -90,6 +91,14 @@ function normalizeConsoleMessage(args) {
     line: third,
     sourceId: fourth,
   };
+}
+
+function getIpcSenderUrl(event) {
+  try {
+    return event.sender.getURL();
+  } catch {
+    return null;
+  }
 }
 
 function attachRendererDiagnostics(browserWindow) {
@@ -601,7 +610,18 @@ function registerDesktopHandlers() {
     logDiagnostic("renderer:bridge", payload);
   });
 
-  ipcMain.handle("kanvibe:invoke", async (_event, namespace, method, args) => {
+  ipcMain.handle("kanvibe:invoke", async (event, namespace, method, args) => {
+    const requestId = nextIpcRequestId;
+    nextIpcRequestId += 1;
+    const startedAt = Date.now();
+
+    logDiagnostic("ipc:invoke-start", {
+      requestId,
+      namespace,
+      method,
+      senderUrl: getIpcSenderUrl(event),
+    });
+
     try {
       const service = desktopServices[namespace];
       if (!service) {
@@ -613,11 +633,20 @@ function registerDesktopHandlers() {
         throw new Error(`Unknown desktop service method: ${namespace}.${method}`);
       }
 
-      return await targetMethod(...(Array.isArray(args) ? args : []));
-    } catch (error) {
-      diagnostics.log("ipc:invoke-failed", {
+      const result = await targetMethod(...(Array.isArray(args) ? args : []));
+      logDiagnostic("ipc:invoke-succeeded", {
+        requestId,
         namespace,
         method,
+        durationMs: Date.now() - startedAt,
+      });
+      return result;
+    } catch (error) {
+      logDiagnostic("ipc:invoke-failed", {
+        requestId,
+        namespace,
+        method,
+        durationMs: Date.now() - startedAt,
         error: serializeErrorForLog(error),
       });
       throw error;

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -10,7 +10,7 @@ import NotificationListener from "@/desktop/renderer/components/NotificationList
 import TaskQuickSearchDialog from "@/desktop/renderer/components/TaskQuickSearchDialog";
 import { getSessionState } from "@/desktop/renderer/actions/auth";
 import { DEFAULT_LOCALE, getSafeLocale, isSupportedLocale, messagesByLocale } from "@/desktop/renderer/utils/locales";
-import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadingTimeout";
+import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
 import BoardRoute from "@/desktop/renderer/routes/BoardRoute";
 import DiffRoute from "@/desktop/renderer/routes/DiffRoute";
@@ -104,6 +104,7 @@ export default function App() {
       sessionLoadTimeout = window.setTimeout(() => {
         sessionLoadTimeout = null;
         if (!cancelled) {
+          logDesktopInitialLoadTimeout("session", { href: window.location.href });
           setSessionState((currentState) => currentState ?? { isAuthenticated: false });
         }
       }, INITIAL_DESKTOP_LOAD_TIMEOUT_MS);

--- a/src/desktop/renderer/routes/BoardRoute.tsx
+++ b/src/desktop/renderer/routes/BoardRoute.tsx
@@ -6,7 +6,7 @@ import { getAllProjects, getAvailableHosts } from "@/desktop/renderer/actions/pr
 import { buildRouteCacheKey, readRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
 import { DEFAULT_TASK_SEARCH_SHORTCUT } from "@/desktop/renderer/utils/keyboardShortcut";
-import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadingTimeout";
+import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { SessionType, TaskStatus } from "@/entities/KanbanTask";
 
 interface BoardData {
@@ -57,6 +57,7 @@ export default function BoardRoute() {
     let cancelled = false;
     const loadingTimeout = window.setTimeout(() => {
       if (!cancelled) {
+        logDesktopInitialLoadTimeout("board");
         setData((currentData) => currentData ?? createEmptyBoardData());
       }
     }, INITIAL_DESKTOP_LOAD_TIMEOUT_MS);

--- a/src/desktop/renderer/routes/DiffRoute.tsx
+++ b/src/desktop/renderer/routes/DiffRoute.tsx
@@ -5,30 +5,69 @@ import { Link, useRouter } from "@/desktop/renderer/navigation";
 import { getGitDiffFiles } from "@/desktop/renderer/actions/diff";
 import { getTaskById } from "@/desktop/renderer/actions/kanban";
 import DiffPageClient from "@/desktop/renderer/components/DiffPageClient";
+import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
+
+interface DiffRouteState {
+  task: Awaited<ReturnType<typeof getTaskById>>;
+  files: Awaited<ReturnType<typeof getGitDiffFiles>>;
+}
+
+function createEmptyDiffState(): DiffRouteState {
+  return {
+    task: null,
+    files: [],
+  };
+}
 
 export default function DiffRoute() {
   const { id = "" } = useParams();
   const t = useTranslations("diffView");
   const router = useRouter();
   const refreshSignal = useRefreshSignal(["all", "diff"]);
-  const [state, setState] = useState<{ task: Awaited<ReturnType<typeof getTaskById>>; files: Awaited<ReturnType<typeof getGitDiffFiles>> } | null>(null);
+  const [state, setState] = useState<DiffRouteState | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    let loadingTimeout: number | null = window.setTimeout(() => {
+      loadingTimeout = null;
+      if (!cancelled) {
+        logDesktopInitialLoadTimeout("diff", { taskId: id });
+        setState((current) => current ?? createEmptyDiffState());
+      }
+    }, INITIAL_DESKTOP_LOAD_TIMEOUT_MS);
+
+    const clearLoadingTimeout = () => {
+      if (loadingTimeout === null) {
+        return;
+      }
+
+      window.clearTimeout(loadingTimeout);
+      loadingTimeout = null;
+    };
 
     void (async () => {
-      const task = await getTaskById(id);
-      const files = task?.branchName && task.worktreePath ? await getGitDiffFiles(id) : [];
+      try {
+        const task = await getTaskById(id);
+        const files = task?.branchName && task.worktreePath ? await getGitDiffFiles(id) : [];
 
-      if (!cancelled) {
-        setState({ task, files });
-        document.title = task?.branchName ? `Diff - ${task.branchName}` : "";
+        clearLoadingTimeout();
+        if (!cancelled) {
+          setState({ task, files });
+          document.title = task?.branchName ? `Diff - ${task.branchName}` : "";
+        }
+      } catch (error) {
+        clearLoadingTimeout();
+        console.error("Failed to load diff route data:", error);
+        if (!cancelled) {
+          setState((current) => current ?? createEmptyDiffState());
+        }
       }
     })();
 
     return () => {
       cancelled = true;
+      clearLoadingTimeout();
     };
   }, [id, refreshSignal]);
 

--- a/src/desktop/renderer/routes/PaneLayoutRoute.tsx
+++ b/src/desktop/renderer/routes/PaneLayoutRoute.tsx
@@ -5,12 +5,21 @@ import { Link } from "@/desktop/renderer/navigation";
 import { getAllProjects } from "@/desktop/renderer/actions/project";
 import { getGlobalPaneLayout, getProjectPaneLayout } from "@/desktop/renderer/actions/paneLayout";
 import type { PaneLayoutConfig } from "@/entities/PaneLayoutConfig";
+import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
 
 interface PaneLayoutState {
   globalConfig: PaneLayoutConfig | null;
   projects: Awaited<ReturnType<typeof getAllProjects>>;
   projectConfigs: Map<string, PaneLayoutConfig | null>;
+}
+
+function createEmptyPaneLayoutState(): PaneLayoutState {
+  return {
+    globalConfig: null,
+    projects: [],
+    projectConfigs: new Map(),
+  };
 }
 
 export default function PaneLayoutRoute() {
@@ -24,26 +33,52 @@ export default function PaneLayoutRoute() {
 
   useEffect(() => {
     let cancelled = false;
+    let loadingTimeout: number | null = window.setTimeout(() => {
+      loadingTimeout = null;
+      if (!cancelled) {
+        logDesktopInitialLoadTimeout("pane-layout");
+        setState((current) => current ?? createEmptyPaneLayoutState());
+      }
+    }, INITIAL_DESKTOP_LOAD_TIMEOUT_MS);
+
+    const clearLoadingTimeout = () => {
+      if (loadingTimeout === null) {
+        return;
+      }
+
+      window.clearTimeout(loadingTimeout);
+      loadingTimeout = null;
+    };
 
     (async () => {
-      const [globalConfig, projects] = await Promise.all([getGlobalPaneLayout(), getAllProjects()]);
-      const projectConfigs = new Map<string, PaneLayoutConfig | null>();
+      try {
+        const [globalConfig, projects] = await Promise.all([getGlobalPaneLayout(), getAllProjects()]);
+        const projectConfigs = new Map<string, PaneLayoutConfig | null>();
 
-      await Promise.all(projects.map(async (project) => {
-        try {
-          projectConfigs.set(project.id, await getProjectPaneLayout(project.id));
-        } catch {
-          projectConfigs.set(project.id, null);
+        await Promise.all(projects.map(async (project) => {
+          try {
+            projectConfigs.set(project.id, await getProjectPaneLayout(project.id));
+          } catch {
+            projectConfigs.set(project.id, null);
+          }
+        }));
+
+        clearLoadingTimeout();
+        if (!cancelled) {
+          setState({ globalConfig, projects, projectConfigs });
         }
-      }));
-
-      if (!cancelled) {
-        setState({ globalConfig, projects, projectConfigs });
+      } catch (error) {
+        clearLoadingTimeout();
+        console.error("Failed to load pane layout route data:", error);
+        if (!cancelled) {
+          setState((current) => current ?? createEmptyPaneLayoutState());
+        }
       }
     })();
 
     return () => {
       cancelled = true;
+      clearLoadingTimeout();
     };
   }, [refreshSignal]);
 

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -26,6 +26,7 @@ import {
 import { useBoardCommands, type BranchTodoDefaults } from "@/desktop/renderer/components/BoardCommandProvider";
 import TerminalLoader from "@/desktop/renderer/components/TerminalLoader";
 import { fetchPrUrlWithPrompt } from "@/desktop/renderer/utils/fetchPrUrlWithPrompt";
+import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { buildRouteCacheKey, readRouteCache, removeRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
 import { SessionType, TaskStatus } from "@/entities/KanbanTask";
@@ -159,73 +160,34 @@ export default function TaskDetailRoute() {
 
   useEffect(() => {
     let cancelled = false;
+    let loadingTimeout: number | null = window.setTimeout(() => {
+      loadingTimeout = null;
+      if (!cancelled) {
+        logDesktopInitialLoadTimeout("task-detail", { taskId: id });
+        setState((current) => current === undefined ? null : current);
+      }
+    }, INITIAL_DESKTOP_LOAD_TIMEOUT_MS);
+
+    const clearLoadingTimeout = () => {
+      if (loadingTimeout === null) {
+        return;
+      }
+
+      window.clearTimeout(loadingTimeout);
+      loadingTimeout = null;
+    };
 
     (async () => {
-      const task = await getTaskById(id);
-      if (!task) {
-        if (!cancelled) {
-          setState(null);
+      try {
+        const task = await getTaskById(id);
+        clearLoadingTimeout();
+
+        if (!task) {
+          if (!cancelled) {
+            setState(null);
+          }
+          return;
         }
-        return;
-      }
-
-      if (cancelled) {
-        return;
-      }
-
-      setState((current) => current && current.task.id === task.id
-        ? {
-            ...current,
-            task: {
-              ...current.task,
-              ...task,
-            },
-          }
-        : {
-            task,
-            ...DEFAULT_DETAIL_STATE,
-          });
-
-      if (task.branchName && !task.prUrl) {
-        void (async () => {
-          try {
-            const prUrl = await fetchPrUrlWithPrompt(task, tc);
-            if (!prUrl || cancelled) {
-              return;
-            }
-
-            setState((current) => current && current.task.id === task.id
-              ? {
-                  ...current,
-                  task: {
-                    ...current.task,
-                    prUrl,
-                  },
-                }
-              : current);
-          } catch (error) {
-            console.error("PR URL 자동 조회 실패:", error);
-          }
-        })();
-      }
-
-      void (async () => {
-        const baseBranchName = task.baseBranch ?? "main";
-        const foundTaskId = task.projectId ? await getTaskIdByProjectAndBranch(task.projectId, baseBranchName) : null;
-        const baseBranchTaskId = foundTaskId !== task.id ? foundTaskId : null;
-        const diffFiles = task.branchName && task.worktreePath ? await getGitDiffFiles(id) : [];
-        const [claudeHooksStatus, geminiHooksStatus, codexHooksStatus, openCodeHooksStatus, aiSessions, projects, defaultSessionType, sidebarDefaultCollapsed, sidebarHintDismissed, doneAlertDismissed] = await Promise.all([
-          task.projectId ? getTaskHooksStatus(id) : Promise.resolve(null),
-          task.projectId ? getTaskGeminiHooksStatus(id) : Promise.resolve(null),
-          task.projectId ? getTaskCodexHooksStatus(id) : Promise.resolve(null),
-          task.projectId ? getTaskOpenCodeHooksStatus(id) : Promise.resolve(null),
-          task.projectId ? getTaskAiSessions(id) : Promise.resolve(EMPTY_AI_SESSIONS),
-          getAllProjects(),
-          getDefaultSessionType(),
-          getSidebarDefaultCollapsed(),
-          getSidebarHintDismissed(),
-          getDoneAlertDismissed(),
-        ]);
 
         if (cancelled) {
           return;
@@ -234,25 +196,95 @@ export default function TaskDetailRoute() {
         setState((current) => current && current.task.id === task.id
           ? {
               ...current,
-              baseBranchTaskId,
-              diffFiles,
-              claudeHooksStatus,
-              geminiHooksStatus,
-              codexHooksStatus,
-              openCodeHooksStatus,
-              aiSessions,
-              projects,
-              defaultSessionType,
-              sidebarDefaultCollapsed,
-              sidebarHintDismissed,
-              doneAlertDismissed,
+              task: {
+                ...current.task,
+                ...task,
+              },
             }
-          : current);
-      })();
+          : {
+              task,
+              ...DEFAULT_DETAIL_STATE,
+            });
+
+        if (task.branchName && !task.prUrl) {
+          void (async () => {
+            try {
+              const prUrl = await fetchPrUrlWithPrompt(task, tc);
+              if (!prUrl || cancelled) {
+                return;
+              }
+
+              setState((current) => current && current.task.id === task.id
+                ? {
+                    ...current,
+                    task: {
+                      ...current.task,
+                      prUrl,
+                    },
+                  }
+                : current);
+            } catch (error) {
+              console.error("PR URL 자동 조회 실패:", error);
+            }
+          })();
+        }
+
+        void (async () => {
+          try {
+            const baseBranchName = task.baseBranch ?? "main";
+            const foundTaskId = task.projectId ? await getTaskIdByProjectAndBranch(task.projectId, baseBranchName) : null;
+            const baseBranchTaskId = foundTaskId !== task.id ? foundTaskId : null;
+            const diffFiles = task.branchName && task.worktreePath ? await getGitDiffFiles(id) : [];
+            const [claudeHooksStatus, geminiHooksStatus, codexHooksStatus, openCodeHooksStatus, aiSessions, projects, defaultSessionType, sidebarDefaultCollapsed, sidebarHintDismissed, doneAlertDismissed] = await Promise.all([
+              task.projectId ? getTaskHooksStatus(id) : Promise.resolve(null),
+              task.projectId ? getTaskGeminiHooksStatus(id) : Promise.resolve(null),
+              task.projectId ? getTaskCodexHooksStatus(id) : Promise.resolve(null),
+              task.projectId ? getTaskOpenCodeHooksStatus(id) : Promise.resolve(null),
+              task.projectId ? getTaskAiSessions(id) : Promise.resolve(EMPTY_AI_SESSIONS),
+              getAllProjects(),
+              getDefaultSessionType(),
+              getSidebarDefaultCollapsed(),
+              getSidebarHintDismissed(),
+              getDoneAlertDismissed(),
+            ]);
+
+            if (cancelled) {
+              return;
+            }
+
+            setState((current) => current && current.task.id === task.id
+              ? {
+                  ...current,
+                  baseBranchTaskId,
+                  diffFiles,
+                  claudeHooksStatus,
+                  geminiHooksStatus,
+                  codexHooksStatus,
+                  openCodeHooksStatus,
+                  aiSessions,
+                  projects,
+                  defaultSessionType,
+                  sidebarDefaultCollapsed,
+                  sidebarHintDismissed,
+                  doneAlertDismissed,
+                }
+              : current);
+          } catch (error) {
+            console.error("Failed to load task detail supplemental data:", error);
+          }
+        })();
+      } catch (error) {
+        clearLoadingTimeout();
+        console.error("Failed to load task detail:", error);
+        if (!cancelled) {
+          setState((current) => current === undefined ? null : current);
+        }
+      }
     })();
 
     return () => {
       cancelled = true;
+      clearLoadingTimeout();
     };
   }, [id, refreshSignal]);
 

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BoardCommandProvider } from "@/desktop/renderer/components/BoardCommandProvider";
 import TaskDetailRoute from "@/desktop/renderer/routes/TaskDetailRoute";
+import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadingTimeout";
 
 const TASK_DETAIL_CACHE_KEY = "kanvibe:route-cache:task-detail:task-1";
 
@@ -201,6 +202,10 @@ describe("TaskDetailRoute", () => {
     mocks.fetchPrUrlWithPrompt.mockResolvedValue(null);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("캐시가 있으면 stale task detail을 즉시 렌더링하고 이후 최신 데이터로 갱신한다", async () => {
     // Given
     sessionStorage.setItem(TASK_DETAIL_CACHE_KEY, JSON.stringify({
@@ -282,6 +287,19 @@ describe("TaskDetailRoute", () => {
     await waitFor(() => {
       expect(screen.getByTestId("task-title").textContent).toBe("fresh task title");
     });
+  });
+
+  it("초기 task 조회가 끝나지 않아도 Loading 화면에 고착되지 않는다", async () => {
+    vi.useFakeTimers();
+    mocks.getTaskById.mockReturnValue(new Promise(() => {}));
+
+    render(<TaskDetailRoute />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INITIAL_DESKTOP_LOAD_TIMEOUT_MS);
+    });
+
+    expect(screen.queryByText("Loading...")).toBeNull();
+    expect(screen.getByText("taskNotFound")).toBeTruthy();
   });
 
   it("알림 단축키로 상세 화면의 알림 센터를 토글한다", async () => {

--- a/src/desktop/renderer/utils/loadingTimeout.ts
+++ b/src/desktop/renderer/utils/loadingTimeout.ts
@@ -1,1 +1,12 @@
 export const INITIAL_DESKTOP_LOAD_TIMEOUT_MS = 5000;
+
+export function logDesktopInitialLoadTimeout(
+  routeName: string,
+  details: Record<string, unknown> = {},
+) {
+  window.kanvibeDesktop?.logRendererError?.("renderer:initial-load-timeout", {
+    routeName,
+    timeoutMs: INITIAL_DESKTOP_LOAD_TIMEOUT_MS,
+    ...details,
+  });
+}

--- a/src/lib/__tests__/desktopDiagnostics.test.ts
+++ b/src/lib/__tests__/desktopDiagnostics.test.ts
@@ -76,7 +76,9 @@ describe("desktop diagnostics", () => {
     expect(source).toContain('process.on("uncaughtException"');
     expect(source).toContain('process.on("unhandledRejection"');
     expect(source).toContain('ipcMain.on("kanvibe:renderer-log"');
-    expect(source).toContain('diagnostics.log("ipc:invoke-failed"');
+    expect(source).toContain('logDiagnostic("ipc:invoke-start"');
+    expect(source).toContain('logDiagnostic("ipc:invoke-succeeded"');
+    expect(source).toContain('logDiagnostic("ipc:invoke-failed"');
     expect(source).toContain('webContents.on("did-fail-load"');
     expect(source).toContain('webContents.on("render-process-gone"');
     expect(source).toContain('webContents.on("console-message"');


### PR DESCRIPTION
## Summary
- Prevents DiffRoute, PaneLayoutRoute, and TaskDetailRoute from sticking on \"Loading...\" forever in the packaged DMG by adding the existing INITIAL_DESKTOP_LOAD_TIMEOUT_MS fallback, try/catch, and a shared logDesktopInitialLoadTimeout call so stalls are visible in renderer logs.
- Wires App and BoardRoute into the same structured stall log so every initial-load timeout has a consistent diagnostic event.
- Instruments kanvibe:invoke with a monotonic request ID, sender URL, and duration, emitting ipc:invoke-start / ipc:invoke-succeeded / ipc:invoke-failed through logDiagnostic so packaged-build hangs can be correlated end-to-end.

## Test plan
- [ ] \`pnpm test\` (or the project's vitest runner) — TaskDetailRoute now has a regression test asserting the loading state is replaced with the not-found state after the timeout fires.
- [ ] Manual smoke on the packaged DMG: open Diff, Pane Layout, and Task Detail with a slow / non-responsive desktop service and confirm each route swaps to its empty state instead of staying on Loading.
- [ ] Inspect renderer logs to confirm renderer:initial-load-timeout and ipc:invoke-* events are emitted with requestId / durationMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)