### PR TITLE
fix(ui): improve keyboard access for task and notification dialogs

### DIFF
--- a/src/components/BranchSearchInput.tsx
+++ b/src/components/BranchSearchInput.tsx
@@ -10,6 +10,7 @@ interface BranchSearchInputProps {
   value: string;
   onChange: (branch: string) => void;
   placeholder?: string;
+  autoFocus?: boolean;
 }
 
 /** 브랜치 목록에서 fuzzy 검색으로 선택할 수 있는 입력 컴포넌트 */
@@ -18,6 +19,7 @@ export default function BranchSearchInput({
   value,
   onChange,
   placeholder,
+  autoFocus = false,
 }: BranchSearchInputProps) {
   const t = useTranslations("task");
   const [inputValue, setInputValue] = useState(value);
@@ -33,6 +35,14 @@ export default function BranchSearchInput({
   useEffect(() => {
     setInputValue(value);
   }, [value]);
+
+  useEffect(() => {
+    if (!autoFocus) {
+      return;
+    }
+
+    inputRef.current?.focus();
+  }, [autoFocus]);
 
   /** 검색어 변경 시 fuzzy 필터링을 수행한다 */
   useEffect(() => {

--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useTransition, useCallback } from "react";
+import { useState, useEffect, useTransition, useCallback, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "@/desktop/renderer/navigation";
 import { createTask } from "@/desktop/renderer/actions/kanban";
@@ -29,6 +29,14 @@ type CreateTaskModalContentProps = Pick<
   "onClose" | "projects" | "defaultProjectId" | "defaultBaseBranch" | "defaultSessionType"
 >;
 
+const FOCUSABLE_SELECTOR = [
+  "button:not([disabled])",
+  "input:not([disabled]):not([type='hidden'])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
 function findProjectDefaultBranch(projects: Project[], projectId: string) {
   return projects.find((p) => p.id === projectId)?.defaultBranch ?? "";
 }
@@ -40,6 +48,15 @@ function resolveInitialBaseBranch(
 ) {
   if (!projectId) return "";
   return defaultBaseBranch || findProjectDefaultBranch(projects, projectId);
+}
+
+function getFocusableElements(container: HTMLElement | null) {
+  if (!container) {
+    return [];
+  }
+
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => element.tabIndex >= 0 && !element.hasAttribute("disabled"));
 }
 
 export default function CreateTaskModal({
@@ -73,6 +90,7 @@ function CreateTaskModalContent({
   const t = useTranslations("task");
   const tc = useTranslations("common");
   const router = useRouter();
+  const dialogRef = useRef<HTMLDivElement>(null);
   const [isPending, startTransition] = useTransition();
   const initialProjectId = defaultProjectId || "";
   const [selectedProjectId, setSelectedProjectId] = useState(initialProjectId);
@@ -115,6 +133,15 @@ function CreateTaskModalContent({
   }, [selectedProjectId, defaultBaseBranch]);
 
   useEscapeKey(onClose);
+
+  useEffect(() => {
+    const focusableElements = getFocusableElements(dialogRef.current);
+    if (selectedProjectId) {
+      return;
+    }
+
+    focusableElements[0]?.focus();
+  }, [selectedProjectId]);
 
   const branchOptions = baseBranch && !branches.includes(baseBranch)
     ? [baseBranch, ...branches]
@@ -176,8 +203,48 @@ function CreateTaskModalContent({
     event.currentTarget.requestSubmit();
   }
 
+  function handleDialogKeyDownCapture(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+      return;
+    }
+
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    const focusableElements = getFocusableElements(dialogRef.current);
+    if (focusableElements.length === 0) {
+      return;
+    }
+
+    const activeElement = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    const currentIndex = activeElement ? focusableElements.indexOf(activeElement) : -1;
+
+    if (event.shiftKey) {
+      if (currentIndex <= 0) {
+        event.preventDefault();
+        focusableElements[focusableElements.length - 1]?.focus();
+      }
+      return;
+    }
+
+    if (currentIndex === -1 || currentIndex === focusableElements.length - 1) {
+      event.preventDefault();
+      focusableElements[0]?.focus();
+    }
+  }
+
   return (
-    <div className="fixed inset-0 z-[400] flex items-center justify-center bg-bg-overlay">
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 z-[400] flex items-center justify-center bg-bg-overlay"
+      onKeyDownCapture={handleDialogKeyDownCapture}
+    >
       <div className="w-full max-w-md bg-bg-surface rounded-xl border border-border-default shadow-lg p-6">
         <h2 className="text-lg font-semibold text-text-primary mb-4">
           {t("createTitle")}
@@ -206,6 +273,7 @@ function CreateTaskModalContent({
                 branches={branchOptions}
                 value={baseBranch}
                 onChange={setBaseBranch}
+                autoFocus
               />
             </div>
           )}

--- a/src/components/NotificationCenterButton.tsx
+++ b/src/components/NotificationCenterButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { getTaskById } from "@/desktop/renderer/actions/kanban";
 import {
@@ -47,29 +47,55 @@ function shouldIgnoreKeyboardNavigation(eventTarget: EventTarget | null, contain
   return eventTarget.closest('[contenteditable="true"]') !== null;
 }
 
+function getTaskNotificationPath(notification: AppNotification) {
+  return `/${notification.locale}/task/${notification.taskId}`;
+}
+
+function openTaskNotificationInNewWindow(notification: AppNotification) {
+  window.open(`/#${getTaskNotificationPath(notification)}`, "_blank", "noopener,noreferrer");
+}
+
 const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, NotificationCenterButtonProps>(function NotificationCenterButton(
   { buttonClassName = "", panelClassName = "" },
   ref,
 ) {
   const t = useTranslations("common");
   const containerRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [notifications, setNotifications] = useState<AppNotification[]>([]);
-  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [missingTaskNotification, setMissingTaskNotification] = useState<AppNotification | null>(null);
+
+  const closePanel = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const openPanel = useCallback(() => {
+    setHighlightedIndex(0);
+    setIsOpen(true);
+  }, []);
+
+  const togglePanel = useCallback(() => {
+    if (!isOpen) {
+      setHighlightedIndex(0);
+    }
+
+    setIsOpen(!isOpen);
+  }, [isOpen]);
 
   useImperativeHandle(ref, () => ({
     close() {
-      setIsOpen(false);
+      closePanel();
     },
     open() {
-      setIsOpen(true);
+      openPanel();
     },
     toggle() {
-      setIsOpen((current) => !current);
+      togglePanel();
     },
-  }), []);
+  }), [closePanel, openPanel, togglePanel]);
 
   useEffect(() => {
     async function load() {
@@ -85,7 +111,7 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (!containerRef.current?.contains(event.target as Node)) {
-        setIsOpen(false);
+        closePanel();
       }
     }
 
@@ -93,26 +119,69 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, []);
+  }, [closePanel]);
+
+  const highlightedNotificationIndex = isOpen && notifications.length > 0
+    ? Math.min(Math.max(highlightedIndex, 0), notifications.length - 1)
+    : -1;
 
   useEffect(() => {
     if (!isOpen) {
-      setHighlightedIndex(-1);
       return;
     }
 
-    setHighlightedIndex(notifications.length > 0 ? 0 : -1);
-  }, [isOpen, notifications.length]);
+    panelRef.current?.focus();
+  }, [isOpen]);
 
   useEffect(() => {
-    if (highlightedIndex < 0) {
+    if (highlightedNotificationIndex < 0) {
       return;
     }
 
-    itemRefs.current[highlightedIndex]?.scrollIntoView?.({
+    itemRefs.current[highlightedNotificationIndex]?.scrollIntoView?.({
       block: "nearest",
     });
-  }, [highlightedIndex]);
+  }, [highlightedNotificationIndex]);
+
+  const unreadCount = useMemo(() => notifications.filter((notification) => !notification.isRead).length, [notifications]);
+
+  const handleNotificationClick = useCallback(async (
+    notification: AppNotification,
+    { openInNewWindow = false }: { openInNewWindow?: boolean } = {},
+  ) => {
+    if (!notification.isRead) {
+      await markNotificationRead(notification.id);
+      setNotifications((current) => current.map((item) => (
+        item.id === notification.id ? { ...item, isRead: true } : item
+      )));
+    }
+
+    closePanel();
+
+    if (notification.action?.type === "background-sync-review") {
+      await activateNotification(notification.id);
+      return;
+    }
+
+    if (notification.taskId) {
+      const task = await getTaskById(notification.taskId);
+
+      if (!task) {
+        setMissingTaskNotification(notification);
+        return;
+      }
+
+      if (openInNewWindow) {
+        openTaskNotificationInNewWindow(notification);
+        return;
+      }
+
+      redirect(getTaskNotificationPath(notification));
+      return;
+    }
+
+    redirect(notification.relativePath);
+  }, [closePanel]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -140,15 +209,15 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
           setHighlightedIndex((current) => (current > 0 ? current - 1 : notifications.length - 1));
           break;
         case "Enter":
-          if (highlightedIndex < 0 || highlightedIndex >= notifications.length) {
+          if (highlightedNotificationIndex < 0 || highlightedNotificationIndex >= notifications.length) {
             return;
           }
           event.preventDefault();
-          void handleNotificationClick(notifications[highlightedIndex]);
+          void handleNotificationClick(notifications[highlightedNotificationIndex], { openInNewWindow: event.shiftKey });
           break;
         case "Escape":
           event.preventDefault();
-          setIsOpen(false);
+          closePanel();
           break;
       }
     }
@@ -157,39 +226,7 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
     return () => {
       window.removeEventListener("keydown", handleWindowKeyDown);
     };
-  }, [highlightedIndex, isOpen, notifications]);
-
-  const unreadCount = useMemo(() => notifications.filter((notification) => !notification.isRead).length, [notifications]);
-
-  async function handleNotificationClick(notification: AppNotification) {
-    if (!notification.isRead) {
-      await markNotificationRead(notification.id);
-      setNotifications((current) => current.map((item) => (
-        item.id === notification.id ? { ...item, isRead: true } : item
-      )));
-    }
-
-    setIsOpen(false);
-
-    if (notification.action?.type === "background-sync-review") {
-      await activateNotification(notification.id);
-      return;
-    }
-
-    if (notification.taskId) {
-      const task = await getTaskById(notification.taskId);
-
-      if (!task) {
-        setMissingTaskNotification(notification);
-        return;
-      }
-
-      redirect(`/${notification.locale}/task/${notification.taskId}`);
-      return;
-    }
-
-    redirect(notification.relativePath);
-  }
+  }, [closePanel, handleNotificationClick, highlightedNotificationIndex, isOpen, notifications]);
 
   async function handleMarkAllRead() {
     await markAllNotificationsRead();
@@ -200,7 +237,7 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
     <div ref={containerRef} className="relative">
       <button
         type="button"
-        onClick={() => setIsOpen((current) => !current)}
+        onClick={togglePanel}
         className={`relative rounded-md p-1.5 text-text-muted hover:bg-bg-page hover:text-text-primary transition-colors ${buttonClassName}`.trim()}
         title={t("notifications")}
         aria-label={t("notifications")}
@@ -217,7 +254,13 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
       </button>
 
       {isOpen ? (
-        <div className={`absolute right-0 z-50 mt-2 w-96 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-border-default bg-bg-surface shadow-xl ${panelClassName}`.trim()}>
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-label={t("notifications")}
+          tabIndex={-1}
+          className={`absolute right-0 z-50 mt-2 w-96 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-border-default bg-bg-surface shadow-xl ${panelClassName}`.trim()}
+        >
           <div className="flex items-center justify-between border-b border-border-default px-4 py-3">
             <div>
               <h3 className="text-sm font-semibold text-text-primary">{t("notifications")}</h3>
@@ -240,10 +283,10 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
                   itemRefs.current[index] = node;
                 }}
                 type="button"
-                onClick={() => handleNotificationClick(notification)}
+                onClick={(event) => handleNotificationClick(notification, { openInNewWindow: event.shiftKey })}
                 onMouseEnter={() => setHighlightedIndex(index)}
                 className={`w-full border-b border-border-subtle px-4 py-3 text-left transition-colors hover:bg-bg-page ${
-                  index === highlightedIndex
+                  index === highlightedNotificationIndex
                     ? "bg-brand-primary/10"
                     : notification.isRead ? "bg-bg-surface" : "bg-brand-primary/5"
                 }`}

--- a/src/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/components/__tests__/CreateTaskModal.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import CreateTaskModal from "../CreateTaskModal";
 import type { Project } from "@/entities/Project";
@@ -41,10 +42,11 @@ vi.mock("../PrioritySelector", () => ({
 }));
 
 vi.mock("../BranchSearchInput", () => ({
-  default: ({ value, onChange }: { value: string; onChange: (branch: string) => void }) => (
+  default: ({ value, onChange, autoFocus }: { value: string; onChange: (branch: string) => void; autoFocus?: boolean }) => (
     <div>
+      <input aria-label="baseBranch" readOnly value={value} autoFocus={autoFocus} />
       <div data-testid="branch-search-input">{value}</div>
-      <button type="button" onClick={() => onChange("develop")}>
+      <button type="button" tabIndex={-1} onClick={() => onChange("develop")}>
         select develop
       </button>
     </div>
@@ -191,6 +193,73 @@ describe("CreateTaskModal", () => {
 
     // When
     fireEvent.keyDown(window, { key: "Escape" });
+
+    // Then
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("기본 프로젝트가 있으면 베이스 브랜치에서 시작해 Tab과 Shift+Tab으로 주요 입력 사이를 이동한다", async () => {
+    // Given
+    const user = userEvent.setup();
+
+    render(
+      <CreateTaskModal
+        isOpen
+        onClose={vi.fn()}
+        sshHosts={["remote-box"]}
+        projects={[createProject()]}
+        defaultProjectId="project-remote"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetProjectBranches).toHaveBeenCalledWith("project-remote");
+    });
+
+    const baseBranchInput = screen.getByLabelText("baseBranch");
+    const branchNameInput = screen.getByPlaceholderText("branchPlaceholder");
+    const descriptionInput = screen.getByPlaceholderText("descriptionPlaceholder");
+
+    // Then
+    await waitFor(() => {
+      expect(document.activeElement).toBe(baseBranchInput);
+    });
+
+    // When & Then
+    await user.tab();
+    expect(document.activeElement).toBe(branchNameInput);
+
+    await user.tab();
+    expect(document.activeElement).toBe(descriptionInput);
+
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(branchNameInput);
+
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(baseBranchInput);
+  });
+
+  it("포커스가 모달 입력에 있을 때 Escape를 누르면 모달을 닫는다", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <CreateTaskModal
+        isOpen
+        onClose={onClose}
+        sshHosts={["remote-box"]}
+        projects={[createProject()]}
+        defaultProjectId="project-remote"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByLabelText("baseBranch"));
+    });
+
+    // When
+    await user.keyboard("{Escape}");
 
     // Then
     expect(onClose).toHaveBeenCalledTimes(1);

--- a/src/components/__tests__/NotificationCenterButton.test.tsx
+++ b/src/components/__tests__/NotificationCenterButton.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import NotificationCenterButton from "@/components/NotificationCenterButton";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import NotificationCenterButton, { type NotificationCenterButtonHandle } from "@/components/NotificationCenterButton";
 
 const { mockListNotifications, mockMarkNotificationRead, mockMarkAllNotificationsRead, mockActivateNotification, mockGetTaskById, mockRedirect } = vi.hoisted(() => ({
   mockListNotifications: vi.fn(),
@@ -34,12 +35,29 @@ vi.mock("@/desktop/renderer/navigation", () => ({
   redirect: mockRedirect,
 }));
 
+function NotificationShortcutHarness() {
+  const notificationCenterRef = useRef<NotificationCenterButtonHandle>(null);
+
+  return (
+    <>
+      <button type="button" onClick={() => notificationCenterRef.current?.toggle()}>
+        open notification shortcut
+      </button>
+      <NotificationCenterButton ref={notificationCenterRef} />
+    </>
+  );
+}
+
 describe("NotificationCenterButton", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.kanvibeDesktop = {
       onNotificationsChanged: vi.fn(() => undefined),
-    } as any;
+    } as Partial<NonNullable<Window["kanvibeDesktop"]>> as NonNullable<Window["kanvibeDesktop"]>;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("shows a popup instead of redirecting when the task no longer exists", async () => {
@@ -107,6 +125,68 @@ describe("NotificationCenterButton", () => {
     });
   });
 
+  it("focuses the notification panel when opened through the shortcut handle", async () => {
+    mockListNotifications.mockResolvedValue([
+      {
+        id: "n1",
+        title: "Focusable task",
+        body: "Body",
+        taskId: "task-1",
+        relativePath: "/task/task-1",
+        locale: "en",
+        isRead: false,
+        createdAt: new Date().toISOString(),
+        dedupeKey: "k1",
+      },
+    ]);
+
+    render(<NotificationShortcutHarness />);
+
+    await waitFor(() => {
+      expect(mockListNotifications).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "open notification shortcut" }));
+
+    const panel = await screen.findByRole("dialog", { name: "notifications" });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(panel);
+    });
+  });
+
+  it("opens task notifications in a new window with Shift+Click", async () => {
+    const openWindow = vi.spyOn(window, "open").mockImplementation(() => null);
+    mockListNotifications.mockResolvedValue([
+      {
+        id: "n1",
+        title: "Existing task",
+        body: "Body",
+        taskId: "task-1",
+        relativePath: "/task/task-1",
+        locale: "en",
+        isRead: false,
+        createdAt: new Date().toISOString(),
+        dedupeKey: "k1",
+      },
+    ]);
+    mockMarkNotificationRead.mockResolvedValue(undefined);
+    mockGetTaskById.mockResolvedValue({ id: "task-1" });
+
+    render(<NotificationCenterButton />);
+
+    await waitFor(() => {
+      expect(mockListNotifications).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "notifications" }));
+    fireEvent.click(screen.getByRole("button", { name: /Existing task/i }), { shiftKey: true });
+
+    await waitFor(() => {
+      expect(openWindow).toHaveBeenCalledWith("/#/en/task/task-1", "_blank", "noopener,noreferrer");
+    });
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
   it("supports arrow navigation and Enter to open the highlighted notification", async () => {
     mockListNotifications.mockResolvedValue([
       {
@@ -149,6 +229,39 @@ describe("NotificationCenterButton", () => {
       expect(mockGetTaskById).toHaveBeenCalledWith("task-2");
     });
     expect(mockRedirect).toHaveBeenCalledWith("/en/task/task-2");
+  });
+
+  it("opens the highlighted task notification in a new window with Shift+Enter", async () => {
+    const openWindow = vi.spyOn(window, "open").mockImplementation(() => null);
+    mockListNotifications.mockResolvedValue([
+      {
+        id: "n1",
+        title: "First task",
+        body: "Body",
+        taskId: "task-1",
+        relativePath: "/task/task-1",
+        locale: "en",
+        isRead: false,
+        createdAt: new Date().toISOString(),
+        dedupeKey: "k1",
+      },
+    ]);
+    mockMarkNotificationRead.mockResolvedValue(undefined);
+    mockGetTaskById.mockResolvedValue({ id: "task-1" });
+
+    render(<NotificationCenterButton />);
+
+    await waitFor(() => {
+      expect(mockListNotifications).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "notifications" }));
+    fireEvent.keyDown(window, { key: "Enter", shiftKey: true });
+
+    await waitFor(() => {
+      expect(openWindow).toHaveBeenCalledWith("/#/en/task/task-1", "_blank", "noopener,noreferrer");
+    });
+    expect(mockRedirect).not.toHaveBeenCalled();
   });
 
   it("uses activation bridge for background sync review notifications", async () => {


### PR DESCRIPTION
## Related Materials
- Issue: none

## What is this?
- Improve keyboard-driven workflows for creating tasks and handling task notifications in the desktop UI.

## How did you solve it?
**Create task dialog**
- Focus the base branch field when a default project/base branch is available.
- Keep Tab and Shift+Tab navigation inside the dialog.
- Handle Escape from focused form controls so the dialog can be cancelled reliably.

**Notification center**
- Move focus into the notification panel when it opens through the shortcut or imperative handle.
- Preserve existing arrow/Enter notification navigation.
- Open task notifications in a new window when the user uses Shift+Click or Shift+Enter.

**Regression coverage**
- Add tests for create dialog focus flow, Escape cancellation, notification panel focus, and shifted task notification activation.

## Important changes
### Dialog focus management

**Trap dialog tab order**
- **Reason**: Prevent keyboard focus from escaping to the board while the create task dialog is open.
- **Files**: `src/components/CreateTaskModal.tsx`, `src/components/BranchSearchInput.tsx`

**Start on the base branch field**
- **Reason**: Support the requested base branch -> branch name -> description authoring flow.
- **Files**: `src/components/CreateTaskModal.tsx`, `src/components/BranchSearchInput.tsx`

### Notification activation

**Focus notification panel on open**
- **Reason**: Make Cmd+Shift+I immediately usable with keyboard navigation and Escape.
- **Files**: `src/components/NotificationCenterButton.tsx`

**Support shifted task opens**
- **Reason**: Let users open task notifications in a separate Electron window without losing the current context.
- **Files**: `src/components/NotificationCenterButton.tsx`

Co-Authored-By: OpenAI Codex <codex@openai.com>