### PR TITLE
fix(desktop): resolve hookService path inside packaged asar

### DIFF
--- a/electron/hookServer.js
+++ b/electron/hookServer.js
@@ -2,11 +2,13 @@ const http = require("node:http");
 const path = require("node:path");
 
 function getHookServiceModulePath() {
+  const appRoot = path.join(__dirname, "..");
+
   if (process.env.KANVIBE_RENDERER_URL) {
-    return path.join(process.cwd(), "src", "desktop", "main", "services", "hookService.ts");
+    return path.join(appRoot, "src", "desktop", "main", "services", "hookService.ts");
   }
 
-  return path.join(process.cwd(), "build", "main", "src", "desktop", "main", "services", "hookService.js");
+  return path.join(appRoot, "build", "main", "src", "desktop", "main", "services", "hookService.js");
 }
 
 function readJsonBody(request) {


### PR DESCRIPTION
## Summary

- `pnpm dist`로 빌드한 macOS 앱이 실행해도 창이 전혀 뜨지 않는 critical 버그 수정
- `electron/hookServer.js`가 `process.cwd()`를 기준으로 `hookService.js`를 찾았는데, `electron/main.js`가 패키징 모드에서 cwd를 `process.resourcesPath`(app.asar **바깥**)로 변경하여 모듈 해석 실패 → `require()` 동기 throw → `app.whenReady().then(...)` 체인 reject → `createMainWindow()` 미호출
- `__dirname` 기반으로 `appRoot`를 산출하여 dev/packaged 모두에서 안정적으로 동작하도록 수정

## Root Cause

```
main:unhandled-rejection
Error: Cannot find module '/Applications/KanVibe.app/Contents/Resources/build/main/src/desktop/main/services/hookService.js'
Require stack:
- /Applications/KanVibe.app/Contents/Resources/app.asar/electron/hookServer.js
- /Applications/KanVibe.app/Contents/Resources/app.asar/electron/main.js
```

`build/main/...`은 `app.asar` 내부에 패키징되어 있는데 `process.cwd()`가 asar 바깥인 `Resources`를 가리켜서 발생.

## Changes

- `electron/hookServer.js#getHookServiceModulePath()`: `process.cwd()` → `path.join(__dirname, "..")` 기반 경로 해석. `__dirname`은 dev와 packaged 양쪽에서 모두 `<appRoot>/electron`을 가리킴.

## Test plan

- [x] `pnpm install`로 워크트리 의존성 설치
- [x] `pnpm dist:dir`로 패키징 빌드 (`KanVibe.app` 생성)
- [x] `dist/mac-arm64/KanVibe.app/Contents/MacOS/KanVibe` 직접 실행
- [x] `~/Library/Application Support/kanvibe/logs/kanvibe-desktop.log` 로그 검증
  - `main:startup` `isPackaged: true` 정상 기록
  - `renderer:load-complete` 정상 기록
  - `main:unhandled-rejection` (Cannot find module) **0건** (이전 2건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)