### PR TITLE
fix(terminal): prevent PTY teardown under React StrictMode in dev

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -674,9 +674,30 @@ function registerDesktopHandlers() {
   });
 
   app.on("web-contents-created", (_createdEvent, webContents) => {
+    if (process.env.KANVIBE_DEBUG_TERMINAL === "true") {
+      console.log(`[터미널-진단] webContents 생성됨: id=${webContents.id}, url=${webContents.getURL?.() || "?"}`);
+    }
     webContents.once("destroyed", () => {
+      if (process.env.KANVIBE_DEBUG_TERMINAL === "true") {
+        console.log(`[터미널-진단] webContents.destroyed → closeWindowTerminals 호출: id=${webContents.id}`);
+      }
       closeWindowTerminals(webContents.id);
     });
+    /** dev 환경에서 vite HMR이 페이지 reload 시 어떤 이벤트를 발생시키는지 추적 */
+    if (process.env.KANVIBE_DEBUG_TERMINAL === "true") {
+      webContents.on("did-start-loading", () => {
+        console.log(`[터미널-진단] webContents.did-start-loading: id=${webContents.id}`);
+      });
+      webContents.on("did-finish-load", () => {
+        console.log(`[터미널-진단] webContents.did-finish-load: id=${webContents.id}, url=${webContents.getURL()}`);
+      });
+      webContents.on("did-navigate", (_evt, url) => {
+        console.log(`[터미널-진단] webContents.did-navigate: id=${webContents.id}, url=${url}`);
+      });
+      webContents.on("render-process-gone", (_evt, details) => {
+        console.log(`[터미널-진단] webContents.render-process-gone: id=${webContents.id}, reason=${details.reason}`);
+      });
+    }
   });
 }
 

--- a/src/desktop/main/terminalBridge.ts
+++ b/src/desktop/main/terminalBridge.ts
@@ -13,6 +13,12 @@ const CLOSED = 3;
 class ElectronTerminalClient extends EventEmitter {
   readonly OPEN = OPEN;
   readyState = OPEN;
+  /**
+   * 동일 (webContentsId, taskId) 조합으로 openTerminal이 중첩 호출되는 횟수를 추적한다.
+   * React StrictMode dev 환경에서 useEffect가 mount → cleanup → remount로 두 번 도는 경우,
+   * 첫 mount의 cleanup이 두 번째 mount가 사용 중인 PTY를 죽이지 않도록 보호한다.
+   */
+  refCount = 1;
 
   constructor(
     private readonly webContents: WebContents,
@@ -75,6 +81,7 @@ export async function openTerminal(
 ) {
   const existingClient = getClient(webContents.id, taskId);
   if (existingClient) {
+    existingClient.refCount += 1;
     existingClient.emitMessage(`\x01${JSON.stringify({ type: "resize", cols, rows })}`);
     return { ok: true };
   }
@@ -159,12 +166,24 @@ export function focusTerminal(taskId: string) {
 }
 
 export function closeTerminal(webContentsId: number, taskId: string) {
-  getClient(webContentsId, taskId)?.close();
+  const client = getClient(webContentsId, taskId);
+  if (!client) {
+    return;
+  }
+
+  client.refCount -= 1;
+  if (client.refCount > 0) {
+    return;
+  }
+
+  client.close();
 }
 
+/** 윈도우(webContents) 자체가 destroy되는 경로이므로 refCount와 무관하게 모든 client를 강제 정리한다 */
 export function closeWindowTerminals(webContentsId: number) {
   for (const [key, client] of terminalClients.entries()) {
     if (key.startsWith(`${webContentsId}:`)) {
+      client.refCount = 0;
       client.close();
     }
   }

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -25,6 +25,16 @@ function shouldLogTerminalSpawn(): boolean {
   return process.env.KANVIBE_DEBUG_TERMINAL === "true";
 }
 
+/** 진단 로그 헬퍼. KANVIBE_DEBUG_TERMINAL=true일 때만 출력된다 */
+function debugLog(message: string, payload?: Record<string, unknown>): void {
+  if (!shouldLogTerminalSpawn()) return;
+  if (payload === undefined) {
+    console.log(`[터미널-진단] ${message}`);
+    return;
+  }
+  console.log(`[터미널-진단] ${message}`, JSON.stringify(payload));
+}
+
 /** tmux 세션이 존재하는지 확인한다 */
 function isTmuxSessionAlive(sessionName: string): boolean {
   try {
@@ -83,9 +93,10 @@ export async function attachLocalSession(
     });
 
     ws.on("close", () => {
+      debugLog("Local ws.close 발생 (기존 세션)", { taskId, remainingClients: existing.clients.size - 1 });
       existing.clients.delete(ws);
       if (existing.clients.size === 0) {
-        detachSession(taskId);
+        detachSession(taskId, "local-ws-close-existing");
       }
     });
 
@@ -182,7 +193,12 @@ export async function attachLocalSession(
   const entry: TerminalEntry = { pty: ptyProcess, clients: new Set([ws]), sessionType, sessionName };
   activeTerminals.set(taskId, entry);
 
+  let firstLocalDataLogged = false;
   ptyProcess.onData((data) => {
+    if (!firstLocalDataLogged) {
+      firstLocalDataLogged = true;
+      debugLog("Local PTY 첫 데이터 수신", { taskId, sample: data.slice(0, 200) });
+    }
     for (const client of entry.clients) {
       if (client.readyState === client.OPEN) {
         client.send(data);
@@ -190,8 +206,9 @@ export async function attachLocalSession(
     }
   });
 
-  ptyProcess.onExit(() => {
-    detachSession(taskId);
+  ptyProcess.onExit(({ exitCode, signal }) => {
+    debugLog("Local PTY onExit", { taskId, exitCode, signal });
+    detachSession(taskId, "local-pty-exit");
   });
 
   ws.on("message", (message) => {
@@ -213,9 +230,10 @@ export async function attachLocalSession(
   });
 
   ws.on("close", () => {
+    debugLog("Local ws.close 발생", { taskId, remainingClients: entry.clients.size - 1 });
     entry.clients.delete(ws);
     if (entry.clients.size === 0) {
-      detachSession(taskId);
+      detachSession(taskId, "local-ws-close");
     }
   });
 }
@@ -247,9 +265,10 @@ export async function attachRemoteSession(
     existing.clients.add(ws);
     ws.on("message", (message) => handleTerminalMessage(existing.pty, message.toString()));
     ws.on("close", () => {
+      debugLog("Remote ws.close 발생 (기존 세션)", { taskId, remainingClients: existing.clients.size - 1 });
       existing.clients.delete(ws);
       if (existing.clients.size === 0) {
-        detachSession(taskId);
+        detachSession(taskId, "remote-ws-close-existing");
       }
     });
     return;
@@ -264,6 +283,7 @@ export async function attachRemoteSession(
   if (shouldLogTerminalSpawn()) {
     console.log(`[터미널] Remote PTY spawn: shell=ssh, args=${JSON.stringify(args)}`);
   }
+  debugLog("attachRemoteSession 시작", { taskId, sshHost, sessionName, sessionType, worktreePath, attachCommand });
 
   let ptyProcess: import("node-pty").IPty;
   try {
@@ -284,10 +304,17 @@ export async function attachRemoteSession(
     return;
   }
 
+  debugLog("Remote PTY spawn 성공", { taskId, pid: ptyProcess.pid });
+
   const entry: TerminalEntry = { pty: ptyProcess, clients: new Set([ws]), sessionType, sessionName };
   activeTerminals.set(taskId, entry);
 
+  let firstDataLogged = false;
   ptyProcess.onData((data) => {
+    if (!firstDataLogged) {
+      firstDataLogged = true;
+      debugLog("Remote PTY 첫 데이터 수신", { taskId, sample: data.slice(0, 200) });
+    }
     for (const client of entry.clients) {
       if (client.readyState === client.OPEN) {
         client.send(data);
@@ -295,20 +322,23 @@ export async function attachRemoteSession(
     }
   });
 
-  ptyProcess.onExit(() => {
-    detachSession(taskId);
+  ptyProcess.onExit(({ exitCode, signal }) => {
+    debugLog("Remote PTY onExit", { taskId, exitCode, signal });
+    detachSession(taskId, "remote-pty-exit");
   });
 
   ptyProcess.write(`${attachCommand}\r`);
+  debugLog("Remote PTY attachCommand 전송 완료", { taskId, byteLength: attachCommand.length });
 
   ws.on("message", (message) => {
     handleTerminalMessage(ptyProcess, message.toString());
   });
 
   ws.on("close", () => {
+    debugLog("Remote ws.close 발생", { taskId, remainingClients: entry.clients.size - 1 });
     entry.clients.delete(ws);
     if (entry.clients.size === 0) {
-      detachSession(taskId);
+      detachSession(taskId, "remote-ws-close");
     }
   });
 }
@@ -363,10 +393,18 @@ export function focusSession(taskId: string): void {
   return;
 }
 
-/** 터미널 세션을 분리하고 PTY 프로세스를 종료한다. 모든 연결된 클라이언트를 닫는다 */
-export function detachSession(taskId: string): void {
+/**
+ * 터미널 세션을 분리하고 PTY 프로세스를 종료한다. 모든 연결된 클라이언트를 닫는다.
+ * @param triggerLabel 누가 detach를 호출했는지 표시 (진단용). 예: "remote-pty-exit", "remote-ws-close", "closeWindowTerminals"
+ */
+export function detachSession(taskId: string, triggerLabel?: string): void {
   const entry = activeTerminals.get(taskId);
-  if (!entry) return;
+  if (!entry) {
+    debugLog("detachSession 호출 (entry 없음)", { taskId, triggerLabel });
+    return;
+  }
+
+  debugLog("detachSession 진입", { taskId, triggerLabel, sessionName: entry.sessionName, clients: entry.clients.size });
 
   try {
     entry.pty.kill();


### PR DESCRIPTION
## Summary

Terminal sessions failed to open in `pnpm dev` while working fine in `pnpm start`. Root cause: React 19 `StrictMode` runs effects twice in dev (Vite serves React in development mode), and `Terminal.tsx`'s useEffect cleanup calls `closeTerminal` IPC which immediately killed the PTY — leaving the second mount attached to a dead session.

The Vite production bundle from `pnpm build` has `process.env.NODE_ENV === "production"` baked in, so React doesn't double-invoke effects there, which is why `pnpm start` worked.

## Changes

- `src/desktop/main/terminalBridge.ts`: add `refCount` to `ElectronTerminalClient`. Nested `openTerminal` calls for the same `(webContentsId, taskId)` increment the count; `closeTerminal` only tears the PTY down when the count reaches zero. `closeWindowTerminals` keeps force-closing because the `webContents` itself is being destroyed in that path.
- `electron/main.js`, `src/lib/terminal.ts`: add diagnostic logs gated by `KANVIBE_DEBUG_TERMINAL=true` (webContents lifecycle, PTY first-data/exit, detach trigger labels) used to triangulate the issue. Off by default.

## Behavior under StrictMode dev

- Case A (2nd open arrives before 1st close): count 1 → 2 → 1, PTY survives.
- Case B (1st close arrives first): count 1 → 0, PTY killed; 2nd open spawns a fresh PTY.
- Window destroy / HMR reload: `closeWindowTerminals` force-closes regardless of count, no leaks.

## Test plan

- [ ] `pkill -f "Electron.*kanvibe" && KANVIBE_DEBUG_TERMINAL=true pnpm dev`
- [ ] Click an SSH terminal task → terminal opens and accepts input
- [ ] Click a local tmux/zellij task → terminal opens and accepts input
- [ ] Switch between task tabs → existing sessions stay alive
- [ ] Close a task / window → confirm `detachSession` fires with the expected `triggerLabel`
- [ ] `pnpm build && pnpm start` → confirm no regression in prod-style runs