### PR TITLE
feat(search): support project branch token matching

### DIFF
--- a/src/components/BranchSearchInput.tsx
+++ b/src/components/BranchSearchInput.tsx
@@ -9,8 +9,58 @@ interface BranchSearchInputProps {
   branches: string[];
   value: string;
   onChange: (branch: string) => void;
+  projectName?: string;
   placeholder?: string;
   autoFocus?: boolean;
+}
+
+function tokenizeQuery(query: string) {
+  return query
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function mergeMatchedIndices(matches: FuzzyMatch[]) {
+  return [...new Set(matches.flatMap((match) => match.matchedIndices))].sort(
+    (left, right) => left - right
+  );
+}
+
+function matchBranchSearch(
+  query: string,
+  branch: string,
+  projectName?: string
+): FuzzyMatch | null {
+  const tokens = tokenizeQuery(query);
+
+  if (tokens.length === 0) {
+    return { path: branch, score: 0, matchedIndices: [] };
+  }
+
+  const branchMatches: FuzzyMatch[] = [];
+  let score = 0;
+
+  for (const token of tokens) {
+    const branchMatch = fuzzyMatch(token, branch);
+    const projectMatch = projectName ? fuzzyMatch(token, projectName) : null;
+
+    if (!branchMatch && !projectMatch) {
+      return null;
+    }
+
+    if (branchMatch) {
+      branchMatches.push(branchMatch);
+    }
+
+    score += Math.max(branchMatch?.score ?? 0, projectMatch?.score ?? 0);
+  }
+
+  return {
+    path: branch,
+    score,
+    matchedIndices: mergeMatchedIndices(branchMatches),
+  };
 }
 
 /** 브랜치 목록에서 fuzzy 검색으로 선택할 수 있는 입력 컴포넌트 */
@@ -18,6 +68,7 @@ export default function BranchSearchInput({
   branches,
   value,
   onChange,
+  projectName,
   placeholder,
   autoFocus = false,
 }: BranchSearchInputProps) {
@@ -55,13 +106,13 @@ export default function BranchSearchInput({
     }
 
     const matches = branches
-      .map((branch) => fuzzyMatch(inputValue, branch))
+      .map((branch) => matchBranchSearch(inputValue, branch, projectName))
       .filter((m): m is FuzzyMatch => m !== null)
       .sort((a, b) => b.score - a.score);
 
     setFilteredBranches(matches);
     setSelectedIndex(0);
-  }, [inputValue, branches]);
+  }, [inputValue, branches, projectName]);
 
   /** 선택된 항목이 보이도록 스크롤한다 */
   useEffect(() => {

--- a/src/components/BranchTaskModal.tsx
+++ b/src/components/BranchTaskModal.tsx
@@ -17,6 +17,10 @@ interface BranchTaskModalProps {
   onClose: () => void;
 }
 
+function findProjectDefaultBranch(projects: Project[], projectId: string) {
+  return projects.find((project) => project.id === projectId)?.defaultBranch ?? "";
+}
+
 /** 기존 작업에서 브랜치를 분기하는 모달. 프로젝트, 베이스 브랜치, 새 브랜치명, 세션 타입을 선택한다 */
 export default function BranchTaskModal({
   task,
@@ -31,25 +35,23 @@ export default function BranchTaskModal({
     projects[0]?.id || ""
   );
   const [branches, setBranches] = useState<string[]>([]);
-  const [baseBranch, setBaseBranch] = useState("");
+  const [baseBranch, setBaseBranch] = useState(() =>
+    findProjectDefaultBranch(projects, projects[0]?.id || "")
+  );
   const [branchName, setBranchName] = useState("");
   const [sessionType, setSessionType] = useState<SessionType>(
     (defaultSessionType as SessionType) || SessionType.TMUX
   );
   const [error, setError] = useState<string | null>(null);
+  const selectedProjectName = projects.find((project) => project.id === selectedProjectId)?.name;
 
   useEffect(() => {
     if (!selectedProjectId) return;
 
-    const selectedProject = projects.find((p) => p.id === selectedProjectId);
-    if (selectedProject) {
-      setBaseBranch(selectedProject.defaultBranch);
-    }
-
     getProjectBranches(selectedProjectId).then((result) => {
       setBranches(result);
     });
-  }, [selectedProjectId, projects]);
+  }, [selectedProjectId]);
 
   useEscapeKey(onClose);
 
@@ -86,6 +88,12 @@ export default function BranchTaskModal({
     });
   }
 
+  function handleProjectChange(projectId: string) {
+    setSelectedProjectId(projectId);
+    setBaseBranch(findProjectDefaultBranch(projects, projectId));
+    setBranches([]);
+  }
+
   return (
     <div className="fixed inset-0 z-[400] flex items-center justify-center bg-bg-overlay">
       <div className="w-full max-w-md bg-bg-surface rounded-xl border border-border-default shadow-lg p-6">
@@ -103,7 +111,7 @@ export default function BranchTaskModal({
             </label>
             <select
               value={selectedProjectId}
-              onChange={(e) => setSelectedProjectId(e.target.value)}
+              onChange={(e) => handleProjectChange(e.target.value)}
               className="w-full px-3 py-2 bg-bg-page border border-border-default rounded-md text-text-primary focus:outline-none focus:border-brand-primary transition-colors"
             >
               {projects.length === 0 && (
@@ -126,6 +134,7 @@ export default function BranchTaskModal({
               branches={branches.length > 0 ? branches : baseBranch ? [baseBranch] : []}
               value={baseBranch}
               onChange={setBaseBranch}
+              projectName={selectedProjectName}
             />
           </div>
 

--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -146,6 +146,7 @@ function CreateTaskModalContent({
   const branchOptions = baseBranch && !branches.includes(baseBranch)
     ? [baseBranch, ...branches]
     : branches;
+  const selectedProjectName = projects.find((project) => project.id === selectedProjectId)?.name;
 
   function handleSubmit(formData: FormData) {
     const branchName = formData.get("branchName") as string;
@@ -273,6 +274,7 @@ function CreateTaskModalContent({
                 branches={branchOptions}
                 value={baseBranch}
                 onChange={setBaseBranch}
+                projectName={selectedProjectName}
                 autoFocus
               />
             </div>

--- a/src/components/__tests__/BranchSearchInput.test.tsx
+++ b/src/components/__tests__/BranchSearchInput.test.tsx
@@ -33,4 +33,28 @@ describe("BranchSearchInput", () => {
     // Then
     expect(document.activeElement).toBe(screen.getByLabelText("branch name"));
   });
+
+  it.each(["kanvibe dev", "dev kanvibe"])(
+    "%s 검색어로 프로젝트명과 브랜치명을 함께 찾는다",
+    async (query) => {
+      // Given
+      const user = userEvent.setup();
+      render(
+        <BranchSearchInput
+          branches={["main", "dev", "feature/search"]}
+          projectName="kanvibe"
+          value="main"
+          onChange={vi.fn()}
+        />,
+      );
+
+      // When
+      const input = screen.getByDisplayValue("main");
+      await user.clear(input);
+      await user.type(input, query);
+
+      // Then
+      expect(screen.getByRole("button", { name: "dev" })).toBeTruthy();
+    },
+  );
 });


### PR DESCRIPTION
## What changed
- Allow branch search input to match project and branch tokens independently, so queries like `kanvibe dev` and `dev kanvibe` resolve to the same branch.
- Pass the selected project name from task creation and branch task modals into the branch search input.
- Keep the selected value and dropdown display as the branch name, preserving the existing form contract.

## Implementation details
- Added tokenized branch/project fuzzy matching inside `BranchSearchInput`.
- Added regression coverage for both project-first and branch-first query order.
- Updated `BranchTaskModal` project changes to reset the base branch from the selected project immediately.

Co-authored-by: OpenAI Codex <codex@openai.com>
