### PR TITLE
fix(refresh): sync desktop refresh with board updates

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -552,11 +552,25 @@ function attachWindowHandlers(browserWindow) {
       !input.alt &&
       (input.control || input.meta) &&
       input.key.toLowerCase() === "n";
+    const isRefreshShortcut =
+      input.type === "keyDown" &&
+      !input.isAutoRepeat &&
+      !input.alt &&
+      !input.shift &&
+      (input.control || input.meta) &&
+      input.key.toLowerCase() === "r";
 
     if (isNotificationShortcut) {
       event.preventDefault();
 
       browserWindow.webContents.send("kanvibe:notification-shortcut");
+      return;
+    }
+
+    if (isRefreshShortcut) {
+      event.preventDefault();
+
+      browserWindow.webContents.send("kanvibe:refresh-shortcut");
       return;
     }
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -132,4 +132,11 @@ contextBridge.exposeInMainWorld("kanvibeDesktop", {
       ipcRenderer.removeListener("kanvibe:create-task-shortcut", handler);
     };
   },
+  onRefreshShortcut(listener) {
+    const handler = () => listener();
+    ipcRenderer.on("kanvibe:refresh-shortcut", handler);
+    return () => {
+      ipcRenderer.removeListener("kanvibe:refresh-shortcut", handler);
+    };
+  },
 });

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -8,9 +8,12 @@ const mocks = vi.hoisted(() => ({
     findOneBy: vi.fn(),
     remove: vi.fn(),
     save: vi.fn(),
+    update: vi.fn(),
   },
   projectRepo: {
+    find: vi.fn(),
     findOneBy: vi.fn(),
+    save: vi.fn(),
   },
   execFile: vi.fn(),
   createWorktreeWithSession: vi.fn(),
@@ -386,6 +389,84 @@ describe("kanbanService.createTask", () => {
     );
     expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
     expect(mocks.taskRepo.remove).toHaveBeenCalledWith(task);
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("task 내용 수정 후 board update를 브로드캐스트한다", async () => {
+    // Given
+    const task = {
+      id: "task-update",
+      title: "Old title",
+      description: null,
+      priority: null,
+    };
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.taskRepo.save.mockImplementation(async (value) => value);
+
+    const { updateTask } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await updateTask("task-update", {
+      description: "Fresh description",
+    });
+
+    // Then
+    expect(result).toEqual(expect.objectContaining({
+      id: "task-update",
+      description: "Fresh description",
+    }));
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("프로젝트 색상 수정 후 board update를 브로드캐스트한다", async () => {
+    // Given
+    const project = {
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      color: null,
+    };
+    mocks.projectRepo.findOneBy.mockResolvedValue(project);
+    mocks.projectRepo.find.mockResolvedValue([]);
+    mocks.projectRepo.save.mockImplementation(async (value) => value);
+
+    const { updateProjectColor } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    await updateProjectColor("project-1", "#93C5FD");
+
+    // Then
+    expect(mocks.projectRepo.save).toHaveBeenCalledWith(expect.objectContaining({
+      id: "project-1",
+      color: "#93C5FD",
+    }));
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("컬럼 내 task 순서 변경 후 board update를 브로드캐스트한다", async () => {
+    // Given
+    mocks.taskRepo.update.mockResolvedValue({ affected: 1 });
+
+    const { reorderTasks } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    await reorderTasks("todo" as never, ["task-a", "task-b"]);
+
+    // Then
+    expect(mocks.taskRepo.update).toHaveBeenCalledTimes(2);
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("다른 컬럼으로 task 이동 후 board update를 브로드캐스트한다", async () => {
+    // Given
+    mocks.taskRepo.update.mockResolvedValue({ affected: 1 });
+
+    const { moveTaskToColumn } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    await moveTaskToColumn("task-a", "review" as never, ["task-b", "task-a"]);
+
+    // Then
+    expect(mocks.taskRepo.update).toHaveBeenCalledWith("task-a", { status: "review" });
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
   });
 

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -533,6 +533,7 @@ export async function updateTask(
   if (updates.priority !== undefined) task.priority = updates.priority;
 
   const saved = await repo.save(task);
+  broadcastBoardUpdate();
   return serialize(saved);
 }
 
@@ -563,6 +564,7 @@ export async function updateProjectColor(
     await repo.save(related);
   }
 
+  broadcastBoardUpdate();
 }
 
 /** 작업에 연결된 worktree, 세션, 브랜치를 정리한다. task 레코드는 삭제하지 않는다 */
@@ -748,6 +750,7 @@ export async function reorderTasks(
   );
 
   await Promise.all(updates);
+  broadcastBoardUpdate();
 }
 
 /** 드래그로 태스크를 다른 컬럼으로 이동할 때 사용한다. revalidation 없이 DB만 갱신한다 */
@@ -778,6 +781,7 @@ export async function moveTaskToColumn(
   );
 
   await Promise.all(reorderUpdates);
+  broadcastBoardUpdate();
 }
 
 /**

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -41,7 +41,7 @@ export default function App() {
   useEffect(() => {
     const unsubscribeBoardEvents = window.kanvibeDesktop?.onBoardEvent?.((event: BoardEventPayload) => {
       if (event.type === "board-updated") {
-        triggerDesktopRefresh("board");
+        triggerDesktopRefresh("all");
       }
     }) ?? (() => {});
 

--- a/src/desktop/renderer/__tests__/App.test.tsx
+++ b/src/desktop/renderer/__tests__/App.test.tsx
@@ -2,8 +2,16 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "@/desktop/renderer/App";
 
+const mocks = vi.hoisted(() => ({
+  triggerDesktopRefresh: vi.fn(),
+}));
+
 vi.mock("@/desktop/renderer/actions/kanban", () => ({
   updateTaskStatus: vi.fn(),
+}));
+
+vi.mock("@/desktop/renderer/utils/refresh", () => ({
+  triggerDesktopRefresh: (...args: unknown[]) => mocks.triggerDesktopRefresh(...args),
 }));
 
 vi.mock("@/desktop/renderer/routes/BoardRoute", () => ({
@@ -39,11 +47,17 @@ vi.mock("@/desktop/renderer/components/BoardEventAlert", () => ({
 }));
 
 describe("App", () => {
+  let boardEventListener: ((event: { type: string }) => void) | null = null;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    boardEventListener = null;
     window.kanvibeDesktop = {
       isDesktop: true,
-      onBoardEvent: vi.fn(() => vi.fn()),
+      onBoardEvent: vi.fn((listener: (event: { type: string }) => void) => {
+        boardEventListener = listener;
+        return vi.fn();
+      }),
     } as unknown as NonNullable<typeof window.kanvibeDesktop>;
   });
 
@@ -55,6 +69,20 @@ describe("App", () => {
     await waitFor(() => {
       expect(screen.getByText("board route")).toBeTruthy();
     });
+  });
+
+  it("refreshes all visible data when a board update event arrives", async () => {
+    window.location.hash = "#/ko/task/task-1";
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("task detail route")).toBeTruthy();
+    });
+
+    boardEventListener?.({ type: "board-updated" });
+
+    expect(mocks.triggerDesktopRefresh).toHaveBeenCalledWith("all");
   });
 
   it("shows a background sync review dialog on the current detail route", async () => {

--- a/src/desktop/renderer/components/BoardCommandProvider.tsx
+++ b/src/desktop/renderer/components/BoardCommandProvider.tsx
@@ -203,6 +203,16 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
     };
   }, [isTaskQuickSearchOpen]);
 
+  useEffect(() => {
+    const unsubscribe = window.kanvibeDesktop?.onRefreshShortcut?.(() => {
+      triggerDesktopRefresh("all");
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, []);
+
   const value = useMemo<BoardCommandContextValue>(() => ({
     canCreateBranchTodo,
     registerBoardHandlers,

--- a/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
+++ b/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
@@ -267,6 +267,34 @@ describe("BoardCommandProvider", () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
+  it("refreshes all kanban data from the desktop refresh shortcut event", () => {
+    let refreshShortcutListener: (() => void) | null = null;
+    const unsubscribe = vi.fn();
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      onRefreshShortcut: vi.fn((listener: () => void) => {
+        refreshShortcutListener = listener;
+        return unsubscribe;
+      }),
+    } as never;
+
+    const { unmount } = renderWithRouter(
+      <BoardCommandProvider>
+        <div />
+      </BoardCommandProvider>,
+    );
+
+    act(() => {
+      refreshShortcutListener?.();
+    });
+
+    expect(window.kanvibeDesktop.onRefreshShortcut).toHaveBeenCalledTimes(1);
+    expect(mocks.triggerDesktopRefresh).toHaveBeenCalledWith("all");
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
   it("refreshes all kanban data from the global refresh shortcut", () => {
     renderWithRouter(
       <BoardCommandProvider>

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -34,6 +34,7 @@ declare global {
       consumePendingNotificationActivation?: () => Promise<AppNotification | null>;
       onNotificationActivated?: (listener: (notification: AppNotification) => void) => () => void;
       onNotificationShortcut?: (listener: () => void) => () => void;
+      onRefreshShortcut?: (listener: () => void) => () => void;
     };
   }
 }

--- a/src/types/kanvibeDesktop.d.ts
+++ b/src/types/kanvibeDesktop.d.ts
@@ -12,6 +12,7 @@ interface KanvibeDesktopApi {
   onNotificationActivated?: (listener: (notification: AppNotification) => void) => () => void;
   onNotificationShortcut?: (listener: () => void) => () => void;
   onCreateTaskShortcut?: (listener: () => void) => () => void;
+  onRefreshShortcut?: (listener: () => void) => () => void;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## What changed
- Make desktop refresh shortcuts reliable by forwarding Cmd+R/Ctrl+R from Electron main to the renderer refresh handler.
- Refresh all renderer scopes when board update events arrive so board and task detail views reload from the current DB state.
- Broadcast board updates after kanban DB mutations that previously only wrote to SQLite, including task edits, project color changes, and drag reorder/move operations.
- Add regression coverage for the desktop refresh bridge, all-scope board update refresh, and mutation broadcasts.

## Why
The board and task detail screens could stay stale after DB writes, and Cmd+R on macOS did not reliably reach the renderer because Electron could intercept the shortcut before the DOM keydown handler.

## Key files
- `electron/main.js`, `electron/preload.js`: add the refresh shortcut IPC bridge.
- `src/desktop/renderer/components/BoardCommandProvider.tsx`: translate the desktop refresh IPC event into a renderer-wide refresh.
- `src/desktop/renderer/App.tsx`: refresh all scopes for board update events.
- `src/desktop/main/services/kanbanService.ts`: broadcast board updates after successful visible kanban mutations.

Co-authored-by: OpenAI Codex <codex@openai.com>
