### PR TITLE
fix(desktop): unblock packaged app initial load

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -13,6 +13,8 @@ const DEFAULT_LOCALE = "ko";
 const RENDERER_DEV_URL = process.env.KANVIBE_RENDERER_URL || null;
 const HOOK_SERVER_HOST = "0.0.0.0";
 const HOOK_SERVER_PORT = 9736;
+const RENDERER_ABORT_RECOVERY_TIMEOUT_MS = 1000;
+const RENDERER_ABORT_RECOVERY_INTERVAL_MS = 50;
 const SHOULD_USE_SOURCE_MODULES = Boolean(RENDERER_DEV_URL);
 const originalResolveFilename = Module._resolveFilename;
 
@@ -248,6 +250,41 @@ function getRendererNavigationUrl(target = getDefaultRoute()) {
   }
 
   return `${pathToFileURL(getRendererEntryPath()).href}#${normalizedTarget}`;
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRendererLoadAbort(error) {
+  if (!error) {
+    return false;
+  }
+
+  if (typeof error === "object" && error.code === "ERR_ABORTED") {
+    return true;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("ERR_ABORTED");
+}
+
+async function didRendererRecoverFromLoadAbort(browserWindow, targetUrl) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < RENDERER_ABORT_RECOVERY_TIMEOUT_MS) {
+    if (browserWindow.isDestroyed()) {
+      return false;
+    }
+
+    if (browserWindow.webContents.getURL() === targetUrl) {
+      return true;
+    }
+
+    await delay(RENDERER_ABORT_RECOVERY_INTERVAL_MS);
+  }
+
+  return false;
 }
 
 function getTitleBarOptions() {
@@ -748,6 +785,14 @@ async function loadRenderer(window, targetUrl = getRendererNavigationUrl()) {
     await window.loadURL(targetUrl);
     logDiagnostic("renderer:load-complete", { targetUrl });
   } catch (error) {
+    if (isRendererLoadAbort(error) && await didRendererRecoverFromLoadAbort(window, targetUrl)) {
+      logDiagnostic("renderer:load-aborted-recovered", {
+        targetUrl,
+        error: serializeErrorForLog(error),
+      });
+      return;
+    }
+
     logDiagnostic("renderer:load-failed", {
       targetUrl,
       error: serializeErrorForLog(error),

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -613,18 +613,18 @@ describe("projectService local hook installation", () => {
         },
       ]);
 
+      expect(mocks.listWorktrees).not.toHaveBeenCalled();
       expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
-      const syncBroadcastCount = mocks.broadcastBoardUpdate.mock.calls.length;
-      expect(syncBroadcastCount).toBeGreaterThanOrEqual(1);
+      expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
 
       await vi.runAllTimersAsync();
 
+      expect(mocks.broadcastBoardUpdate).toHaveBeenCalled();
       expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
         "/workspace/api",
         "task-main",
         null,
       );
-      expect(mocks.broadcastBoardUpdate.mock.calls.length).toBeGreaterThan(syncBroadcastCount);
     } finally {
       vi.useRealTimers();
     }

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -82,6 +82,8 @@ function isRemoteConnectionError(error: unknown): boolean {
 
 const projectRootHookRepairJobs = new Map<string, Promise<void>>();
 const projectRootHookRepairScheduled = new Set<string>();
+const projectRootTaskRepairJobs = new Map<string, Promise<void>>();
+const projectRootTaskRepairScheduled = new Set<string>();
 
 function scheduleProjectRootHookRepair(project: Project) {
   const projectPathKey = buildProjectPathKey(project.repoPath, project.sshHost);
@@ -114,6 +116,37 @@ function scheduleProjectRootHookRepair(project: Project) {
     })();
 
     projectRootHookRepairJobs.set(projectPathKey, repairJob);
+  }, 0);
+}
+
+function scheduleProjectRootTaskRepair(project: Project) {
+  const projectPathKey = buildProjectPathKey(project.repoPath, project.sshHost);
+  if (projectRootTaskRepairScheduled.has(projectPathKey)) {
+    return;
+  }
+
+  projectRootTaskRepairScheduled.add(projectPathKey);
+
+  setTimeout(() => {
+    const repairJob = (async () => {
+      try {
+        const { repaired } = await ensureProjectRootTask(project);
+        scheduleProjectRootHookRepair(project);
+
+        if (repaired) {
+          broadcastBoardUpdate();
+        }
+      } catch (error) {
+        if (!isRemoteConnectionError(error)) {
+          console.error(`${project.name} 기본 브랜치 task 백그라운드 복구 실패:`, error);
+        }
+      } finally {
+        projectRootTaskRepairJobs.delete(projectPathKey);
+        projectRootTaskRepairScheduled.delete(projectPathKey);
+      }
+    })();
+
+    projectRootTaskRepairJobs.set(projectPathKey, repairJob);
   }, 0);
 }
 
@@ -327,19 +360,8 @@ export async function getAllProjects(): Promise<Project[]> {
   const repo = await getProjectRepository();
   const projects = await repo.find({ order: { createdAt: "ASC" } });
 
-  let repairedAnyProject = false;
   for (const project of projects) {
-    try {
-      const { repaired } = await ensureProjectRootTask(project);
-      repairedAnyProject = repairedAnyProject || repaired;
-      scheduleProjectRootHookRepair(project);
-    } catch (error) {
-      console.error(`${project.name} 기본 브랜치 task 복구 실패:`, error);
-    }
-  }
-
-  if (repairedAnyProject) {
-    broadcastBoardUpdate();
+    scheduleProjectRootTaskRepair(project);
   }
 
   return serialize(projects);

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { IntlProvider } from "next-intl";
 import { HashRouter, Navigate, Outlet, Route, Routes, useParams } from "react-router-dom";
 import { BoardCommandProvider } from "@/desktop/renderer/components/BoardCommandProvider";
@@ -14,6 +14,8 @@ import NotFoundRoute from "@/desktop/renderer/routes/NotFoundRoute";
 import PaneLayoutRoute from "@/desktop/renderer/routes/PaneLayoutRoute";
 import TaskDetailRoute from "@/desktop/renderer/routes/TaskDetailRoute";
 import type { BoardEventPayload } from "@/lib/boardNotifier";
+
+const BOARD_REFRESH_DEBOUNCE_MS = 250;
 
 function LocaleShell() {
   const { locale } = useParams();
@@ -38,15 +40,32 @@ function LocaleShell() {
 }
 
 export default function App() {
+  const boardRefreshTimerRef = useRef<number | null>(null);
+
   useEffect(() => {
+    const scheduleBoardRefresh = () => {
+      if (boardRefreshTimerRef.current !== null) {
+        return;
+      }
+
+      boardRefreshTimerRef.current = window.setTimeout(() => {
+        boardRefreshTimerRef.current = null;
+        triggerDesktopRefresh("board");
+      }, BOARD_REFRESH_DEBOUNCE_MS);
+    };
+
     const unsubscribeBoardEvents = window.kanvibeDesktop?.onBoardEvent?.((event: BoardEventPayload) => {
       if (event.type === "board-updated") {
-        triggerDesktopRefresh("board");
+        scheduleBoardRefresh();
       }
     }) ?? (() => {});
 
     return () => {
       unsubscribeBoardEvents();
+      if (boardRefreshTimerRef.current !== null) {
+        window.clearTimeout(boardRefreshTimerRef.current);
+        boardRefreshTimerRef.current = null;
+      }
     };
   }, []);
 

--- a/src/desktop/renderer/utils/refresh.ts
+++ b/src/desktop/renderer/utils/refresh.ts
@@ -30,8 +30,12 @@ export function subscribeToDesktopRefresh(scopes: DesktopRefreshScope[], listene
 
 export function useRefreshSignal(scopes: DesktopRefreshScope[] = ["all"]) {
   const [signal, setSignal] = useState(0);
+  const scopesKey = scopes.join(",");
 
-  useEffect(() => subscribeToDesktopRefresh(scopes, () => setSignal((value) => value + 1)), [scopes]);
+  useEffect(() => {
+    const stableScopes = scopesKey.split(",") as DesktopRefreshScope[];
+    return subscribeToDesktopRefresh(stableScopes, () => setSignal((value) => value + 1));
+  }, [scopesKey]);
 
   return signal;
 }


### PR DESCRIPTION
## What changed
- Fix packaged desktop startup getting stuck on the initial loading screen.
- Keep project list reads fast by moving root task and hook repair out of the synchronous `getAllProjects` path.
- Debounce board refresh events so background board updates do not repeatedly restart initial route loading.
- Treat recovered Electron renderer `ERR_ABORTED` load events as non-fatal during packaged startup.

## How it works
- `getAllProjects` now returns the ordered project list immediately and schedules root task repair in the background with per-project deduplication.
- Board update events are coalesced before triggering renderer refreshes.
- `useRefreshSignal` subscribes using a stable scope key to avoid unnecessary effect churn.
- Electron startup waits briefly after an `ERR_ABORTED` load error and continues when the renderer has actually reached the target URL.

## Verification
- `pnpm vitest run src/desktop/main/services/__tests__/projectService.test.ts src/desktop/renderer/__tests__/App.test.tsx src/lib/__tests__/desktopDiagnostics.test.ts src/desktop/main/__tests__/runtimeEnvironment.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm exec electron-builder --dir`
- Packaged app smoke run: `project.getAllProjects` completed in 18ms on initial load and 0ms on refresh for the new packaged app process.

Co-authored-by: OpenAI Codex <codex@openai.com>
