### PR TITLE
feat(task-search): handle enter task navigation shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Each pane can run a custom command (e.g., `vim`, `htop`, `lazygit`, test runner,
 | `Cmd/Ctrl+Shift+P` | Board | Open the project filter dropdown |
 | `Cmd/Ctrl+Shift+I` | Board | Open the notifications dropdown |
 | `Cmd/Ctrl+N` | Quick task search | Create a new branch TODO from the currently highlighted task |
-| `↑ / ↓ / Enter / Esc` | Quick task search | Move selection, open task, close dialog |
+| `↑ / ↓ / Enter / Shift+Enter / Esc` | Quick task search | Move selection, open task, open task in a new window, close dialog |
 | `↑ / ↓ / Enter / Esc` | Project filter dropdown | Move selection, toggle project filter, close dropdown |
 | `↑ / ↓ / Enter / Esc` | Notifications dropdown | Move selection, open notification target, close dropdown |
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -172,7 +172,7 @@ macOS에서 `better-sqlite3` `NODE_MODULE_VERSION` 불일치가 발생하면, Ka
 | `Cmd/Ctrl+Shift+P` | 보드 | 프로젝트 필터 드롭다운 열기 |
 | `Cmd/Ctrl+Shift+I` | 보드 | 알림 드롭다운 열기 |
 | `Cmd/Ctrl+N` | 태스크 빠른 검색 | 현재 하이라이트된 태스크 기준으로 새 branch TODO 만들기 |
-| `↑ / ↓ / Enter / Esc` | 태스크 빠른 검색 | 선택 이동, 태스크 열기, 다이얼로그 닫기 |
+| `↑ / ↓ / Enter / Shift+Enter / Esc` | 태스크 빠른 검색 | 선택 이동, 태스크 열기, 태스크 새 창 열기, 다이얼로그 닫기 |
 | `↑ / ↓ / Enter / Esc` | 프로젝트 필터 드롭다운 | 선택 이동, 프로젝트 필터 토글, 드롭다운 닫기 |
 | `↑ / ↓ / Enter / Esc` | 알림 드롭다운 | 선택 이동, 알림 대상 열기, 드롭다운 닫기 |
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -177,7 +177,7 @@
     "title": "Quick Task Search",
     "placeholder": "Search by branch or project name...",
     "empty": "No matching tasks found.",
-    "hint": "↑↓ Navigate · Enter Open · Esc Close",
+    "hint": "↑↓ Navigate · Enter Open · Shift+Enter New Window · Esc Close",
     "branchTodoHint": "{shortcut} Create branch TODO"
   },
   "paneLayout": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -177,7 +177,7 @@
     "title": "태스크 빠른 검색",
     "placeholder": "브랜치명 또는 프로젝트명으로 검색...",
     "empty": "일치하는 태스크가 없습니다.",
-    "hint": "↑↓ 이동 · Enter 이동 · Esc 닫기",
+    "hint": "↑↓ 이동 · Enter 이동 · Shift+Enter 새 창 · Esc 닫기",
     "branchTodoHint": "{shortcut} 새 branch TODO"
   },
   "paneLayout": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -176,7 +176,7 @@
     "title": "快速任务搜索",
     "placeholder": "按分支名或项目名搜索...",
     "empty": "没有找到匹配的任务。",
-    "hint": "↑↓ 移动 · Enter 打开 · Esc 关闭",
+    "hint": "↑↓ 移动 · Enter 打开 · Shift+Enter 新窗口 · Esc 关闭",
     "branchTodoHint": "{shortcut} 创建分支 TODO"
   },
   "paneLayout": {

--- a/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
+++ b/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
@@ -8,7 +8,7 @@ import {
   type SearchableTask,
 } from "@/desktop/renderer/actions/kanban";
 import { getTaskSearchShortcut } from "@/desktop/renderer/actions/appSettings";
-import { useRouter } from "@/desktop/renderer/navigation";
+import { localizeHref, usePathname, useRouter } from "@/desktop/renderer/navigation";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
 import {
   DEFAULT_TASK_SEARCH_SHORTCUT,
@@ -159,6 +159,7 @@ export default function TaskQuickSearchDialog({
   const t = useTranslations("taskSearch");
   const tc = useTranslations("common");
   const router = useRouter();
+  const pathname = usePathname();
   const refreshSignal = useRefreshSignal(["all", "settings"]);
   const inputRef = useRef<HTMLInputElement>(null);
   const resultsListRef = useRef<HTMLDivElement>(null);
@@ -286,6 +287,13 @@ export default function TaskQuickSearchDialog({
     closeDialog();
   }
 
+  function openTaskInNewWindow(taskId: string) {
+    const currentLocale = pathname.split("/").filter(Boolean)[0];
+    const taskHref = localizeHref(`/task/${taskId}`, currentLocale);
+    window.open(`/#${taskHref}`, "_blank", "noopener,noreferrer");
+    closeDialog();
+  }
+
   const createBranchTodoFromSelection = useCallback(() => {
     const selectedTask = results[selectedResultIndex]?.task;
 
@@ -329,7 +337,13 @@ export default function TaskQuickSearchDialog({
       case "Enter":
         event.preventDefault();
         if (results[selectedResultIndex]) {
-          moveToTask(results[selectedResultIndex].task.id);
+          const selectedTaskId = results[selectedResultIndex].task.id;
+          if (event.shiftKey) {
+            openTaskInNewWindow(selectedTaskId);
+            break;
+          }
+
+          moveToTask(selectedTaskId);
         }
         break;
       case "Escape":

--- a/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
@@ -19,6 +19,10 @@ vi.mock("@/desktop/renderer/actions/kanban", () => ({
 }));
 
 vi.mock("@/desktop/renderer/navigation", () => ({
+  localizeHref: (href: string, currentLocale = "ko") => (
+    href.startsWith("/") ? `/${currentLocale}${href}` : href
+  ),
+  usePathname: () => "/en",
   useRouter: () => ({
     push: (...args: unknown[]) => mocks.push(...args),
   }),
@@ -134,6 +138,32 @@ describe("TaskQuickSearchDialog", () => {
     await waitFor(() => {
       expect(mocks.push).toHaveBeenCalledWith("/task/task-remote");
     });
+  });
+
+  it("검색 결과에서 Shift+Enter로 상세 페이지를 새 창에서 연다", async () => {
+    const openWindow = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<TaskQuickSearchDialog shortcut="Ctrl+K" />);
+
+    fireEvent.keyDown(window, {
+      key: "k",
+      ctrlKey: true,
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, {
+      target: { value: "api" },
+    });
+    fireEvent.keyDown(input, {
+      key: "Enter",
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(openWindow).toHaveBeenCalledWith("/#/en/task/task-remote", "_blank", "noopener,noreferrer");
+    });
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
   it("여러 토큰의 순서가 바뀌어도 같은 task를 검색할 수 있다", async () => {


### PR DESCRIPTION
## What changed?
- Keep Enter in the quick task search dialog as current-window navigation to the selected task detail page.
- Add Shift+Enter in the same dialog to open the selected task detail page in a new window.
- Update quick search hint copy across English, Korean, and Chinese messages.
- Update README shortcut documentation and add unit coverage for both Enter and Shift+Enter behavior.

## How was it solved?
**Quick task search navigation**
- Preserve the existing `router.push('/task/:id')` path for plain Enter.
- Build a locale-aware task detail hash URL with the existing renderer navigation helpers for new-window navigation.
- Open the selected task with `window.open(..., "_blank", "noopener,noreferrer")` only when Shift+Enter is pressed.

**Shortcut discoverability and coverage**
- Document both Enter and Shift+Enter in app hint text and README shortcut tables.
- Keep the existing Enter test for current-window navigation.
- Add a Shift+Enter test that verifies a new window opens and `router.push` is not called.

## Important changes
### Enter and Shift+Enter now map to separate task navigation actions

**Enter current-window navigation**
- **Reason for change**: Users expect plain Enter to open the selected quick-search task in the current KanVibe window.
- **Modified files**: `src/desktop/renderer/components/TaskQuickSearchDialog.tsx`, `src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx`

**Shift+Enter new-window navigation**
- **Reason for change**: Users can inspect a selected task in a separate window without losing their current context.
- **Modified files**: `src/desktop/renderer/components/TaskQuickSearchDialog.tsx`, `src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx`

**Shortcut hint and documentation updates**
- **Reason for change**: The UI and docs should show both available actions clearly.
- **Modified files**: `messages/en.json`, `messages/ko.json`, `messages/zh.json`, `README.md`, `docs/README.ko.md`

Co-authored-by: OpenAI Codex <codex@openai.com>
