### PR TITLE
fix(navigation): fallback to home when back is unavailable

### DIFF
--- a/src/desktop/renderer/__tests__/navigation.test.tsx
+++ b/src/desktop/renderer/__tests__/navigation.test.tsx
@@ -69,6 +69,16 @@ describe("useRouter", () => {
     });
   });
 
+  it("브라우저 history index가 있어도 앱 내부 이전 경로가 없으면 현재 locale의 칸반 홈으로 이동한다", async () => {
+    renderRouterProbe(["/en/task/task-1"], 0, { idx: 1 });
+
+    fireEvent.click(screen.getByRole("button", { name: "back" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pathname").textContent).toBe("/en");
+    });
+  });
+
   it("forward 호출 시 다음 페이지로 이동한다", async () => {
     renderRouterProbe(["/ko", "/ko/task/task-1", "/ko/task/task-2"], 1, { idx: 1 });
 

--- a/src/desktop/renderer/navigation.tsx
+++ b/src/desktop/renderer/navigation.tsx
@@ -1,7 +1,9 @@
-import { useMemo, type AnchorHTMLAttributes, type PropsWithChildren } from "react";
+import { useEffect, useMemo, useRef, type AnchorHTMLAttributes, type PropsWithChildren } from "react";
 import { Link as RouterLink, useLocation, useNavigate } from "react-router-dom";
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES, getSafeLocale, type SupportedLocale } from "@/desktop/renderer/utils/locales";
 import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
+
+const BACK_NAVIGATION_FALLBACK_DELAY_MS = 100;
 
 function getRefreshScope(pathname: string) {
   if (pathname.includes("/task/") && pathname.endsWith("/diff")) {
@@ -70,16 +72,46 @@ export function useRouter() {
   const navigate = useNavigate();
   const location = useLocation();
   const currentLocale = getLocaleFromPathname(location.pathname);
+  const latestLocationRef = useRef(location);
+  const backFallbackTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    latestLocationRef.current = location;
+  }, [location]);
+
+  useEffect(() => () => {
+    if (backFallbackTimerRef.current !== null) {
+      window.clearTimeout(backFallbackTimerRef.current);
+    }
+  }, []);
 
   return useMemo(
     () => ({
       back: () => {
-        if (canNavigateBack()) {
-          navigate(-1);
+        const fallbackToHome = () => navigate(localizeHref("/", currentLocale), { replace: true });
+
+        if (!canNavigateBack()) {
+          fallbackToHome();
           return;
         }
 
-        navigate(localizeHref("/", currentLocale), { replace: true });
+        const beforeBackLocation = latestLocationRef.current;
+        navigate(-1);
+
+        if (backFallbackTimerRef.current !== null) {
+          window.clearTimeout(backFallbackTimerRef.current);
+        }
+
+        backFallbackTimerRef.current = window.setTimeout(() => {
+          backFallbackTimerRef.current = null;
+          const currentLocation = latestLocationRef.current;
+          if (
+            currentLocation.key === beforeBackLocation.key
+            && currentLocation.pathname === beforeBackLocation.pathname
+          ) {
+            fallbackToHome();
+          }
+        }, BACK_NAVIGATION_FALLBACK_DELAY_MS);
       },
       forward: () => navigate(1),
       push: (href: string) => navigate(localizeHref(href, currentLocale)),


### PR DESCRIPTION
## Related Materials
- None

## What Changed?
- Fix back navigation so detail/error screens do not appear stuck when there is no previous in-app route.

## How Was It Solved?
**Back navigation fallback**
- Keep track of the latest React Router location.
- Attempt normal back navigation when browser history indicates a previous entry.
- If the route remains unchanged after the back attempt, replace the route with the localized home page.

**Regression coverage**
- Add a navigation test for the case where browser history has an index but the app router has no previous entry.

## Important Changes
### Navigation fallback

**Detect no-op back navigation**
- **Reason**: `window.history.state.idx` can indicate a previous browser entry even when React Router has no useful in-app route to navigate to.
- **Modified files**: `src/desktop/renderer/navigation.tsx`

**Add regression coverage**
- **Reason**: Preserve the expected fallback behavior for direct-entry detail routes.
- **Modified files**: `src/desktop/renderer/__tests__/navigation.test.tsx`

Co-Authored-By: OpenAI Codex <codex@openai.com>