### PR TITLE
perf(ssh): reuse remote connections and enable X11 forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Each pane can run a custom command (e.g., `vim`, `htop`, `lazygit`, test runner,
 - **tmux** and **zellij** are both supported as terminal multiplexers
 - Browser-based terminal via xterm.js + WebSocket
 - SSH remote terminal support (reads `~/.ssh/config`)
+- Remote SSH commands reuse an app-local ControlMaster socket under `~/.kanvibe`
+- Remote terminal attach uses trusted X11 forwarding (`ssh -Y`), so tools such as `xclip` can work when local `DISPLAY`, remote `X11Forwarding`, and `xauth` are available
 - Nerd Font rendering support
 
 ### Quick Task Search

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -161,6 +161,8 @@ macOS에서 `better-sqlite3` `NODE_MODULE_VERSION` 불일치가 발생하면, Ka
 - **tmux**와 **zellij** 모두 터미널 멀티플렉서로 지원
 - xterm.js + WebSocket 기반 브라우저 터미널
 - SSH 원격 터미널 지원 (`~/.ssh/config` 읽기)
+- 원격 SSH 명령은 `~/.kanvibe` 아래의 앱 전용 ControlMaster 소켓을 재사용합니다
+- 원격 터미널 attach는 trusted X11 forwarding(`ssh -Y`)을 사용하므로 로컬 `DISPLAY`, 원격 `X11Forwarding`, `xauth`가 준비되어 있으면 `xclip` 같은 도구가 동작할 수 있습니다
 - Nerd Font 렌더링 지원
 
 ### 키보드 단축키

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -161,6 +161,8 @@ pnpm dist
 - 同时支持 **tmux** 和 **zellij** 作为终端复用器
 - 基于 xterm.js + WebSocket 的浏览器终端
 - SSH 远程终端支持（读取 `~/.ssh/config`）
+- 远程 SSH 命令会复用 `~/.kanvibe` 下的应用专用 ControlMaster socket
+- 远程终端 attach 使用 trusted X11 forwarding（`ssh -Y`），因此在本地 `DISPLAY`、远程 `X11Forwarding` 和 `xauth` 可用时，`xclip` 等工具可以工作
 - Nerd Font 渲染支持
 
 ### 键盘快捷键

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -103,7 +103,7 @@ describe("gitOperations.resolvePathForShell", () => {
         "-o",
         "ControlMaster=auto",
         "-o",
-        "ControlPersist=60",
+        "ControlPersist=10m",
         "-o",
         "ControlPath=/home/local-user/.kanvibe/ssh-%C",
       );
@@ -115,6 +115,7 @@ describe("gitOperations.resolvePathForShell", () => {
     );
 
     expect(result).toBe("ok");
+    expect(expectedArgs).not.toContain("-Y");
     expect(mocks.execFile).toHaveBeenCalledWith(
       "ssh",
       expectedArgs,

--- a/src/lib/__tests__/sshConfig.test.ts
+++ b/src/lib/__tests__/sshConfig.test.ts
@@ -59,3 +59,99 @@ describe("sshConfig.parseSSHConfig", () => {
     expect(mocks.readFile).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("sshConfig.buildSSHArgs", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("adds trusted X11 forwarding and forced tty before the SSH destination", async () => {
+    // Given
+    const { buildSSHArgs } = await import("@/lib/sshConfig");
+
+    // When
+    const args = buildSSHArgs({
+      host: "remote-host",
+      hostname: "example.com",
+      port: 2202,
+      username: "tester",
+      privateKeyPath: "/tmp/test-key",
+    }, {
+      trustedX11Forwarding: true,
+      forceTty: true,
+    });
+
+    // Then
+    expect(args).toEqual([
+      "-i",
+      "/tmp/test-key",
+      "-p",
+      "2202",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "IdentitiesOnly=yes",
+      "-Y",
+      "-tt",
+      "remote-host",
+    ]);
+    expect(args.indexOf("-Y")).toBeLessThan(args.indexOf("remote-host"));
+    expect(args.indexOf("-tt")).toBeLessThan(args.indexOf("remote-host"));
+  });
+
+  it("adds connection reuse options before the SSH destination", async () => {
+    // Given
+    const { buildSSHArgs } = await import("@/lib/sshConfig");
+
+    // When
+    const args = buildSSHArgs({
+      host: "remote-host",
+      hostname: "example.com",
+      port: 2202,
+      username: "tester",
+      privateKeyPath: "/tmp/test-key",
+    }, {
+      disableTty: true,
+      connectionReuse: {
+        controlPath: "/home/local-user/.kanvibe/ssh-%C",
+        controlPersist: "10m",
+      },
+    });
+
+    // Then
+    expect(args).toEqual([
+      "-i",
+      "/tmp/test-key",
+      "-p",
+      "2202",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "IdentitiesOnly=yes",
+      "-T",
+      "-o",
+      "ControlMaster=auto",
+      "-o",
+      "ControlPersist=10m",
+      "-o",
+      "ControlPath=/home/local-user/.kanvibe/ssh-%C",
+      "remote-host",
+    ]);
+    expect(args.indexOf("ControlPath=/home/local-user/.kanvibe/ssh-%C")).toBeLessThan(args.indexOf("remote-host"));
+  });
+
+  it("builds KanVibe connection reuse options under the app-local directory", async () => {
+    // Given
+    const { getKanvibeSSHConnectionReuseOptions } = await import("@/lib/sshConfig");
+
+    // When
+    const result = getKanvibeSSHConnectionReuseOptions();
+
+    // Then
+    expect(result).toEqual({
+      controlPath: "/home/local-user/.kanvibe/ssh-%C",
+      controlPersist: "10m",
+    });
+  });
+});

--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -26,6 +26,19 @@ vi.mock("fs", async (importOriginal) => {
   };
 });
 
+const mockHomedir = vi.fn(() => "/home/local-user");
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("os")>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      homedir: mockHomedir,
+    },
+    homedir: mockHomedir,
+  };
+});
+
 const mockPtyWrite = vi.fn();
 const mockPtyOnData = vi.fn();
 const mockPtyOnExit = vi.fn();
@@ -366,11 +379,21 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
         "BatchMode=yes",
         "-o",
         "IdentitiesOnly=yes",
+        "-Y",
         "-tt",
+        "-o",
+        "ControlMaster=auto",
+        "-o",
+        "ControlPersist=10m",
+        "-o",
+        "ControlPath=/home/local-user/.kanvibe/ssh-%C",
         "remote-host",
       ],
       expect.objectContaining({ cwd: expect.any(String) }),
     );
+    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+    expect(sshArgs.indexOf("-Y")).toBeLessThan(sshArgs.indexOf("remote-host"));
+    expect(sshArgs.indexOf("-tt")).toBeLessThan(sshArgs.indexOf("remote-host"));
     expect(mockPtyWrite).toHaveBeenCalledWith(
       expect.stringContaining('tmux has-session -t "remote-session"'),
     );

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -2,8 +2,13 @@ import { exec, execFile } from "child_process";
 import { promisify } from "util";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
-import path from "path";
-import { buildSSHArgs, parseSSHConfig, type SSHHostConfig } from "@/lib/sshConfig";
+import {
+  buildSSHArgs,
+  getKanvibeSSHConnectionReuseOptions,
+  getKanvibeSSHControlDirectory,
+  parseSSHConfig,
+  type SSHHostConfig,
+} from "@/lib/sshConfig";
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -188,24 +193,15 @@ function rememberSSHTransportFailure(sshHost: string, error: Error): void {
 async function buildExecSSHArgs(
   hostConfig: SSHHostConfig,
 ): Promise<string[]> {
-  const args = buildSSHArgs(hostConfig, { disableTty: true });
   if (process.platform === "win32") {
-    return args;
+    return buildSSHArgs(hostConfig, { disableTty: true });
   }
 
-  const controlPath = path.join(homedir(), ".kanvibe", "ssh-%C");
-  await mkdir(path.dirname(controlPath), { recursive: true });
-
-  return [
-    ...args.slice(0, -1),
-    "-o",
-    "ControlMaster=auto",
-    "-o",
-    "ControlPersist=60",
-    "-o",
-    `ControlPath=${controlPath}`,
-    args.at(-1)!,
-  ];
+  await mkdir(getKanvibeSSHControlDirectory(), { recursive: true });
+  return buildSSHArgs(hostConfig, {
+    disableTty: true,
+    connectionReuse: getKanvibeSSHConnectionReuseOptions(),
+  });
 }
 
 function buildRemoteShellCommand(command: string): string {

--- a/src/lib/sshConfig.ts
+++ b/src/lib/sshConfig.ts
@@ -10,7 +10,13 @@ export interface SSHHostConfig {
   privateKeyPath: string;
 }
 
+export interface SSHConnectionReuseOptions {
+  controlPath: string;
+  controlPersist: string;
+}
+
 const SSH_CONFIG_CACHE_TTL_MS = 5000;
+const KANVIBE_SSH_CONTROL_PERSIST = "10m";
 let cachedHosts: SSHHostConfig[] | null = null;
 let cacheExpiresAt = 0;
 let inFlightParse: Promise<SSHHostConfig[]> | null = null;
@@ -28,6 +34,8 @@ export function buildSSHArgs(
   options?: {
     forceTty?: boolean;
     disableTty?: boolean;
+    trustedX11Forwarding?: boolean;
+    connectionReuse?: SSHConnectionReuseOptions;
   },
 ): string[] {
   const args = [
@@ -41,14 +49,40 @@ export function buildSSHArgs(
     "IdentitiesOnly=yes",
   ];
 
+  if (options?.trustedX11Forwarding) {
+    args.push("-Y");
+  }
+
   if (options?.forceTty) {
     args.push("-tt");
   } else if (options?.disableTty) {
     args.push("-T");
   }
 
+  if (options?.connectionReuse) {
+    args.push(
+      "-o",
+      "ControlMaster=auto",
+      "-o",
+      `ControlPersist=${options.connectionReuse.controlPersist}`,
+      "-o",
+      `ControlPath=${options.connectionReuse.controlPath}`,
+    );
+  }
+
   args.push(getSSHDestination(config));
   return args;
+}
+
+export function getKanvibeSSHControlDirectory(): string {
+  return path.join(homedir(), ".kanvibe");
+}
+
+export function getKanvibeSSHConnectionReuseOptions(): SSHConnectionReuseOptions {
+  return {
+    controlPath: path.join(getKanvibeSSHControlDirectory(), "ssh-%C"),
+    controlPersist: KANVIBE_SSH_CONTROL_PERSIST,
+  };
 }
 
 /**

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -5,7 +5,7 @@ import { PaneLayoutType } from "@/entities/PaneLayoutConfig";
 import { ZELLIJ_LAYOUT_FILENAME } from "@/lib/worktree";
 import { execSync } from "child_process";
 import type { WebSocket } from "ws";
-import { buildSSHArgs } from "@/lib/sshConfig";
+import { buildSSHArgs, getKanvibeSSHConnectionReuseOptions } from "@/lib/sshConfig";
 import { buildTmuxSessionBootstrapCommands, type TmuxPaneLayoutConfig } from "@/lib/worktree";
 
 /**
@@ -278,7 +278,11 @@ export async function attachRemoteSession(
   const attachCommand = sessionType === SessionType.TMUX
     ? buildRemoteTmuxAttachCommand(sessionName, worktreePath, tmuxPaneLayout)
     : `exec zellij attach "${sessionName}"`;
-  const args = buildSSHArgs(sshConfig, { forceTty: true });
+  const args = buildSSHArgs(sshConfig, {
+    forceTty: true,
+    trustedX11Forwarding: true,
+    connectionReuse: getKanvibeSSHConnectionReuseOptions(),
+  });
 
   if (shouldLogTerminalSpawn()) {
     console.log(`[터미널] Remote PTY spawn: shell=ssh, args=${JSON.stringify(args)}`);


### PR DESCRIPTION
## Related resources
- Base branch: `dev`

## What changed?
- Improve KanVibe remote SSH command performance by centralizing connection reuse options.
- Enable trusted X11 forwarding for remote terminal attach so tools such as `xclip` can work when the local and remote X11 prerequisites are available.

## How was it solved?
**Centralized SSH argument construction**
- Extend `buildSSHArgs()` with reusable ControlMaster options and trusted X11 forwarding support.
- Add app-local ControlMaster reuse settings under `~/.kanvibe` with `ControlPersist=10m`.

**Remote command and terminal behavior**
- Keep non-interactive remote exec commands on `-T` without X11 forwarding.
- Add `-Y`, `-tt`, and connection reuse to remote terminal attach for tmux/zellij sessions.

**Tests and docs**
- Add unit coverage for SSH argv generation, remote exec args, and remote terminal attach args.
- Document ControlMaster reuse and X11 forwarding prerequisites in README files.

## Important details
### SSH connection reuse
- **Reason**: Repeated remote git/hook/session checks pay repeated SSH setup cost.
- **Files**: `src/lib/sshConfig.ts`, `src/lib/gitOperations.ts`

### Trusted X11 forwarding
- **Reason**: Remote terminal commands such as `xclip` need X11 forwarding to access the local clipboard path.
- **Files**: `src/lib/terminal.ts`, README files

## Validation
- `pnpm exec vitest run src/lib/__tests__/sshConfig.test.ts src/lib/__tests__/gitOperations.test.ts src/lib/__tests__/terminal.test.ts`
- `pnpm check`
- `pnpm exec eslint src/lib/sshConfig.ts src/lib/gitOperations.ts src/lib/terminal.ts src/lib/__tests__/sshConfig.test.ts src/lib/__tests__/gitOperations.test.ts src/lib/__tests__/terminal.test.ts`
- `git diff --check`

Co-Authored-By: OpenAI Codex <codex@openai.com>
