### PR TITLE
fix(desktop): preserve shift command n for new windows

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -621,10 +621,18 @@ function attachWindowHandlers(browserWindow) {
       input.shift &&
       (input.control || input.meta) &&
       input.key.toLowerCase() === "i";
+    const isCreateTaskShortcut =
+      input.type === "keyDown" &&
+      !input.isAutoRepeat &&
+      !input.alt &&
+      !input.shift &&
+      (input.control || input.meta) &&
+      input.key.toLowerCase() === "n";
     const isNewWindowShortcut =
       input.type === "keyDown" &&
       !input.isAutoRepeat &&
       !input.alt &&
+      input.shift &&
       (input.control || input.meta) &&
       input.key.toLowerCase() === "n";
     const isRefreshShortcut =
@@ -649,13 +657,19 @@ function attachWindowHandlers(browserWindow) {
       return;
     }
 
-    if (!isNewWindowShortcut) {
+    if (isCreateTaskShortcut) {
+      event.preventDefault();
+
+      browserWindow.webContents.send("kanvibe:create-task-shortcut");
       return;
     }
 
-    event.preventDefault();
+    if (isNewWindowShortcut) {
+      event.preventDefault();
 
-    browserWindow.webContents.send("kanvibe:create-task-shortcut");
+      const currentUrl = browserWindow.webContents.getURL() || getRendererNavigationUrl();
+      void createAppWindow(currentUrl);
+    }
   });
 }
 

--- a/src/desktop/main/__tests__/desktopShortcutRouting.test.ts
+++ b/src/desktop/main/__tests__/desktopShortcutRouting.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readMainSource() {
+  return readFileSync(path.join(process.cwd(), "electron", "main.js"), "utf8");
+}
+
+describe("desktop shortcut routing", () => {
+  it("routes Cmd/Ctrl+N to task creation while preserving Cmd/Ctrl+Shift+N new windows", () => {
+    const source = readMainSource();
+
+    expect(source).toMatch(/const isCreateTaskShortcut =[\s\S]*!input\.shift[\s\S]*input\.key\.toLowerCase\(\) === "n";/);
+    expect(source).toMatch(/const isNewWindowShortcut =[\s\S]*input\.shift[\s\S]*input\.key\.toLowerCase\(\) === "n";/);
+    expect(source).toContain('browserWindow.webContents.send("kanvibe:create-task-shortcut")');
+    expect(source).toContain("void createAppWindow(currentUrl)");
+  });
+});


### PR DESCRIPTION
## What changed
- Restore Cmd/Ctrl+Shift+N to open a new desktop window from the current route.
- Keep Cmd/Ctrl+N routed to the existing task creation shortcut.
- Add a regression test that locks both shortcut routes in `electron/main.js`.

## Why
Cmd/Ctrl+N was recently routed to task creation, but the Electron-level handler also caught Cmd/Ctrl+Shift+N. That prevented the existing new-window shortcut from working.

## Key files
- `electron/main.js`
- `src/desktop/main/__tests__/desktopShortcutRouting.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>