### PR TITLE
perf(task): speed up remote task creation

### DIFF
--- a/src/desktop/main/services/__tests__/hookService.test.ts
+++ b/src/desktop/main/services/__tests__/hookService.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   broadcastHookStatusTargetMissing: vi.fn(),
   broadcastTaskStatusChanged: vi.fn(),
   cleanupTaskResources: vi.fn(),
+  scheduleTaskHookInstall: vi.fn(),
   installKanvibeHooks: vi.fn(),
 }));
 
@@ -53,6 +54,7 @@ vi.mock("@/lib/boardNotifier", () => ({
 
 vi.mock("@/desktop/main/services/kanbanService", () => ({
   cleanupTaskResources: mocks.cleanupTaskResources,
+  scheduleTaskHookInstall: mocks.scheduleTaskHookInstall,
 }));
 
 vi.mock("@/lib/kanvibeHooksInstaller", () => ({
@@ -134,7 +136,7 @@ describe("hookService.startHookTask", () => {
     mocks.taskRepo.create.mockImplementation((value) => value);
   });
 
-  it("원격 worktree task를 만들면 hooks를 자동 설치한다", async () => {
+  it("원격 worktree task를 만들면 hooks 설치를 백그라운드 예약한다", async () => {
     const project = {
       id: "project-1",
       repoPath: "/remote/repo",
@@ -158,10 +160,14 @@ describe("hookService.startHookTask", () => {
       projectId: "project-1",
     });
 
-    expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
+    expect(mocks.scheduleTaskHookInstall).toHaveBeenCalledWith(
       "/remote/repo__worktrees/feature-task",
-      "task-1",
-      "remote-host",
+      {
+        id: "task-1",
+        title: "remote task",
+        sshHost: "remote-host",
+      },
     );
+    expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
   });
 });

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -180,7 +180,7 @@ describe("kanbanService.createTask", () => {
     }
   });
 
-  it("원격 worktree 태스크 생성은 hooks 설치 완료를 기다린다", async () => {
+  it("원격 worktree 태스크 생성은 hooks 설치를 백그라운드로 넘기고 즉시 반환한다", async () => {
     vi.useFakeTimers();
 
     try {
@@ -204,32 +204,29 @@ describe("kanbanService.createTask", () => {
       const { createTask } = await import("@/desktop/main/services/kanbanService");
 
       // When
-      let settled = false;
       const resultPromise = createTask({
         title: "원격 hooks 보장",
         branchName: "fix/remote-hooks",
         projectId: "project-1",
         sessionType: "tmux" as never,
-      }).then((result) => {
-        settled = true;
-        return result;
       });
       for (let index = 0; index < 6; index += 1) {
         await Promise.resolve();
       }
 
       // Then
+      expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
+      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+
+      await expect(resultPromise).resolves.toEqual(expect.objectContaining({ id: "task-1" }));
+
+      await vi.runAllTimersAsync();
       expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
         "/remote/repo-worktrees/task-1",
         "task-1",
         "remote-host",
       );
-      expect(settled).toBe(false);
-
-      if (resolveInstall) {
-        resolveInstall();
-      }
-      await expect(resultPromise).resolves.toEqual(expect.objectContaining({ id: "task-1" }));
+      expect(resolveInstall).toBeDefined();
     } finally {
       vi.useRealTimers();
     }

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -274,6 +274,45 @@ describe("kanbanService.createTask", () => {
     }
   });
 
+  it("백그라운드 hooks 설치가 성공하면 board update를 다시 브로드캐스트한다", async () => {
+    vi.useFakeTimers();
+
+    try {
+      // Given
+      mocks.projectRepo.findOneBy.mockResolvedValue({
+        id: "project-1",
+        repoPath: "/remote/repo",
+        defaultBranch: "main",
+        sshHost: "remote-host",
+      });
+      mocks.createWorktreeWithSession.mockResolvedValue({
+        worktreePath: "/remote/repo-worktrees/task-1",
+        sessionName: "task-1",
+      });
+      mocks.installKanvibeHooks.mockResolvedValue(undefined);
+      mocks.taskRepo.save.mockImplementation(async (value) => ({ id: "task-1", ...value }));
+
+      const { createTask } = await import("@/desktop/main/services/kanbanService");
+
+      // When
+      await createTask({
+        title: "원격 hooks 성공",
+        branchName: "fix/remote-hooks-success",
+        projectId: "project-1",
+        sessionType: "tmux" as never,
+      });
+
+      // Then
+      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+
+      await vi.runAllTimersAsync();
+
+      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("원격 stale task는 안전하지 않은 worktree/브랜치 삭제를 건너뛴다", async () => {
     // Given
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/desktop/main/services/hookService.ts
+++ b/src/desktop/main/services/hookService.ts
@@ -2,8 +2,7 @@ import { TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { getProjectRepository, getTaskRepository } from "@/lib/database";
 import { createWorktreeWithSession } from "@/lib/worktree";
 import { broadcastBoardUpdate, broadcastHookStatusTargetMissing, broadcastTaskStatusChanged } from "@/lib/boardNotifier";
-import { cleanupTaskResources } from "@/desktop/main/services/kanbanService";
-import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
+import { cleanupTaskResources, scheduleTaskHookInstall } from "@/desktop/main/services/kanbanService";
 
 const STATUS_MAP: Record<string, TaskStatus> = {
   todo: TaskStatus.TODO,
@@ -73,11 +72,11 @@ export async function startHookTask(input: HookStartInput) {
   const saved = await repo.save(task);
 
   if (saved.worktreePath) {
-    try {
-      await installKanvibeHooks(saved.worktreePath, saved.id, saved.sshHost);
-    } catch (error) {
-      console.error("Hook task hooks 설정 실패:", error);
-    }
+    scheduleTaskHookInstall(saved.worktreePath, {
+      id: saved.id,
+      title: saved.title,
+      sshHost: saved.sshHost,
+    });
   }
 
   broadcastBoardUpdate();

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -114,7 +114,7 @@ function quoteForShell(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
-function scheduleTaskHookInstall(
+export function scheduleTaskHookInstall(
   targetPath: string,
   task: Pick<KanbanTask, "id" | "title" | "sshHost">,
 ) {
@@ -481,15 +481,11 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
   const saved = await repo.save(task);
 
   if (shouldInstallHooks && hookTargetPath) {
-    if (saved.sshHost) {
-      await installKanvibeHooks(hookTargetPath, saved.id, saved.sshHost);
-    } else {
-      scheduleTaskHookInstall(hookTargetPath, {
-        id: saved.id,
-        title: saved.title,
-        sshHost: saved.sshHost,
-      });
-    }
+    scheduleTaskHookInstall(hookTargetPath, {
+      id: saved.id,
+      title: saved.title,
+      sshHost: saved.sshHost,
+    });
   }
 
   broadcastBoardUpdate();

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -119,23 +119,27 @@ export function scheduleTaskHookInstall(
   task: Pick<KanbanTask, "id" | "title" | "sshHost">,
 ) {
   setTimeout(() => {
-    void installKanvibeHooks(targetPath, task.id, task.sshHost).catch((error) => {
-      const errorMessage = getErrorMessage(error);
+    void installKanvibeHooks(targetPath, task.id, task.sshHost)
+      .then(() => {
+        broadcastBoardUpdate();
+      })
+      .catch((error) => {
+        const errorMessage = getErrorMessage(error);
 
-      console.error("새 태스크 hooks 백그라운드 설치 실패:", {
-        taskId: task.id,
-        taskTitle: task.title,
-        targetPath,
-        sshHost: task.sshHost ?? null,
-        error: errorMessage,
-      });
+        console.error("새 태스크 hooks 백그라운드 설치 실패:", {
+          taskId: task.id,
+          taskTitle: task.title,
+          targetPath,
+          sshHost: task.sshHost ?? null,
+          error: errorMessage,
+        });
 
-      broadcastTaskHookInstallFailed({
-        taskId: task.id,
-        taskTitle: task.title,
-        error: errorMessage,
+        broadcastTaskHookInstallFailed({
+          taskId: task.id,
+          taskTitle: task.title,
+          error: errorMessage,
+        });
       });
-    });
   }, 0);
 }
 

--- a/src/desktop/renderer/components/Terminal.tsx
+++ b/src/desktop/renderer/components/Terminal.tsx
@@ -6,6 +6,65 @@ interface TerminalProps {
   taskId: string;
 }
 
+const NERD_FONT_FAMILY = "JetBrainsMono Nerd Font Mono";
+const NERD_FONT_CDN_BASE = "https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/fonts";
+const FALLBACK_FONT_FAMILY = "monospace";
+const TERMINAL_FONT_FAMILY = `'${NERD_FONT_FAMILY}', ${FALLBACK_FONT_FAMILY}`;
+
+type TerminalModules = [
+  typeof import("@xterm/xterm"),
+  typeof import("@xterm/addon-fit"),
+  typeof import("@xterm/addon-web-links"),
+];
+
+let terminalModulesPromise: Promise<TerminalModules> | null = null;
+let nerdFontLoadPromise: Promise<string | null> | null = null;
+
+function loadTerminalModules() {
+  if (!terminalModulesPromise) {
+    terminalModulesPromise = Promise.all([
+      import("@xterm/xterm"),
+      import("@xterm/addon-fit"),
+      import("@xterm/addon-web-links"),
+    ]);
+  }
+
+  return terminalModulesPromise;
+}
+
+function loadNerdFontFamily(): Promise<string | null> {
+  if (
+    typeof document === "undefined" ||
+    typeof FontFace === "undefined" ||
+    !document.fonts
+  ) {
+    return Promise.resolve(null);
+  }
+
+  if (!nerdFontLoadPromise) {
+    const regular = new FontFace(
+      NERD_FONT_FAMILY,
+      `url(${NERD_FONT_CDN_BASE}/JetBrainsMonoNerdFontMono-Regular.woff2)`,
+      { weight: "400" },
+    );
+    const bold = new FontFace(
+      NERD_FONT_FAMILY,
+      `url(${NERD_FONT_CDN_BASE}/JetBrainsMonoNerdFontMono-Bold.woff2)`,
+      { weight: "700" },
+    );
+
+    document.fonts.add(regular);
+    document.fonts.add(bold);
+
+    nerdFontLoadPromise = Promise.allSettled([regular.load(), bold.load()])
+      .then(() => document.fonts.ready)
+      .then(() => TERMINAL_FONT_FAMILY)
+      .catch(() => null);
+  }
+
+  return nerdFontLoadPromise;
+}
+
 export default function Terminal({ taskId }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -14,47 +73,17 @@ export default function Terminal({ taskId }: TerminalProps) {
       return undefined;
     }
 
-    const nerdFontFamily = "JetBrainsMono Nerd Font Mono";
-    const fontFamily = `'${nerdFontFamily}', monospace`;
-    const cdnBase = "https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/fonts";
-    const regular = new FontFace(nerdFontFamily, `url(${cdnBase}/JetBrainsMonoNerdFontMono-Regular.woff2)`, { weight: "400" });
-    const bold = new FontFace(nerdFontFamily, `url(${cdnBase}/JetBrainsMonoNerdFontMono-Bold.woff2)`, { weight: "700" });
-    document.fonts.add(regular);
-    document.fonts.add(bold);
-    await document.fonts.ready;
-    await Promise.all([regular.load(), bold.load()]);
+    const [{ Terminal: XTerm }, { FitAddon }, { WebLinksAddon }] = await loadTerminalModules();
+    let isTerminalDisposed = false;
 
-    const [{ Terminal: XTerm }, { FitAddon }, { WebLinksAddon }] = await Promise.all([
-      import("@xterm/xterm"),
-      import("@xterm/addon-fit"),
-      import("@xterm/addon-web-links"),
-    ]);
-
-    const terminal = new XTerm(createTerminalOptions(fontFamily));
+    const terminal = new XTerm(createTerminalOptions(FALLBACK_FONT_FAMILY));
 
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(new WebLinksAddon());
     terminal.open(containerRef.current);
     const disposeMacShiftSelectionPatch = installMacShiftSelectionPatch(terminal);
-    terminal.options.fontFamily = "monospace";
-    terminal.options.fontFamily = fontFamily;
-
-    await new Promise<void>((resolve) => {
-      requestAnimationFrame(() => {
-        fitAddon.fit();
-        resolve();
-      });
-    });
-
-    const terminalReady = await window.kanvibeDesktop!.openTerminal(taskId, terminal.cols, terminal.rows);
-    if (!terminalReady.ok) {
-      terminal.writeln(`\r\n\x1b[31m${terminalReady.error || "터미널 연결 실패"}\x1b[0m`);
-      return () => {
-        disposeMacShiftSelectionPatch();
-        terminal.dispose();
-      };
-    }
+    terminal.options.fontFamily = FALLBACK_FONT_FAMILY;
 
     const unsubscribeData = window.kanvibeDesktop!.onTerminalData((event: { taskId: string; data: string }) => {
       if (event.taskId === taskId) {
@@ -68,14 +97,6 @@ export default function Terminal({ taskId }: TerminalProps) {
       }
     });
 
-    terminal.onData((data) => {
-      window.kanvibeDesktop!.writeTerminal(taskId, data);
-    });
-
-    terminal.onResize(({ cols, rows }) => {
-      window.kanvibeDesktop!.resizeTerminal(taskId, cols, rows);
-    });
-
     const syncTerminalSize = () => {
       fitAddon.fit();
       window.kanvibeDesktop!.resizeTerminal(taskId, terminal.cols, terminal.rows);
@@ -86,6 +107,42 @@ export default function Terminal({ taskId }: TerminalProps) {
         syncTerminalSize();
       });
     };
+
+    void loadNerdFontFamily().then((fontFamily) => {
+      if (!fontFamily || isTerminalDisposed) {
+        return;
+      }
+
+      terminal.options.fontFamily = fontFamily;
+      scheduleTerminalSync();
+    });
+
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        fitAddon.fit();
+        resolve();
+      });
+    });
+
+    const terminalReady = await window.kanvibeDesktop!.openTerminal(taskId, terminal.cols, terminal.rows);
+    if (!terminalReady.ok) {
+      terminal.writeln(`\r\n\x1b[31m${terminalReady.error || "터미널 연결 실패"}\x1b[0m`);
+      return () => {
+        isTerminalDisposed = true;
+        disposeMacShiftSelectionPatch();
+        unsubscribeData();
+        unsubscribeClose();
+        terminal.dispose();
+      };
+    }
+
+    terminal.onData((data) => {
+      window.kanvibeDesktop!.writeTerminal(taskId, data);
+    });
+
+    terminal.onResize(({ cols, rows }) => {
+      window.kanvibeDesktop!.resizeTerminal(taskId, cols, rows);
+    });
 
     const focusCurrentTerminal = () => {
       terminal.focus();
@@ -114,6 +171,7 @@ export default function Terminal({ taskId }: TerminalProps) {
     window.addEventListener("focus", handleWindowFocus);
 
     return () => {
+      isTerminalDisposed = true;
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       window.removeEventListener("focus", handleWindowFocus);
       disposeMacShiftSelectionPatch();

--- a/src/desktop/renderer/components/__tests__/Terminal.test.tsx
+++ b/src/desktop/renderer/components/__tests__/Terminal.test.tsx
@@ -2,6 +2,16 @@ import { act, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import Terminal from "../Terminal";
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 const {
   mockOpenTerminal,
   mockFocusTerminal,
@@ -144,5 +154,34 @@ describe("Desktop Terminal", () => {
       expect(mockFit).toHaveBeenCalledTimes(1);
     });
     expect(mockResizeTerminal).toHaveBeenCalledWith("task-1", 80, 24);
+  });
+
+  it("Nerd Font 로딩이 느려도 터미널 연결을 먼저 시작한다", async () => {
+    // Given
+    const fontsReady = createDeferred<void>();
+    const fontLoaded = createDeferred<FontFace>();
+    Object.defineProperty(document, "fonts", {
+      configurable: true,
+      value: {
+        add: vi.fn(),
+        ready: fontsReady.promise,
+      },
+    });
+    vi.stubGlobal(
+      "FontFace",
+      class {
+        load() {
+          return fontLoaded.promise;
+        }
+      },
+    );
+
+    // When
+    render(<Terminal taskId="task-1" />);
+
+    // Then
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", 80, 24);
+    });
   });
 });

--- a/src/lib/__tests__/remoteSessionDependency.test.ts
+++ b/src/lib/__tests__/remoteSessionDependency.test.ts
@@ -69,6 +69,20 @@ describe("remoteSessionDependency", () => {
     expect(mockExecGit).toHaveBeenCalledWith("command -v tmux >/dev/null 2>&1", "remote-a");
   });
 
+  it("성공한 원격 의존성 확인은 같은 호스트와 도구에 재사용한다", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("");
+    const { getSessionDependencyStatus, ensureRemoteSessionDependency } = await import("@/lib/remoteSessionDependency");
+
+    // When
+    await getSessionDependencyStatus(SessionType.TMUX, "remote-a");
+    mockExecGit.mockClear();
+    await ensureRemoteSessionDependency(SessionType.TMUX, "remote-a");
+
+    // Then
+    expect(mockExecGit).not.toHaveBeenCalled();
+  });
+
   it("원격 의존성 확인 중 SSH 연결 실패가 발생하면 설치를 시도하거나 차단하지 않는다", async () => {
     // Given
     mockExecGit.mockRejectedValueOnce(new Error("remote-a 원격 명령 실패: Connection reset by 100.73.171.123 port 22"));

--- a/src/lib/remoteSessionDependency.ts
+++ b/src/lib/remoteSessionDependency.ts
@@ -2,6 +2,8 @@ import { SessionType } from "@/entities/KanbanTask";
 import { execGit, isSSHTransportError } from "@/lib/gitOperations";
 
 const blockedTargets = new Map<string, string>();
+const availableTargets = new Map<string, number>();
+const SESSION_DEPENDENCY_SUCCESS_CACHE_MS = 60_000;
 
 export interface SessionDependencyStatus {
   sessionType: SessionType;
@@ -20,6 +22,28 @@ function buildBlockedTargetKey(toolName: string, sshHost?: string | null): strin
   return `${sshHost || "local"}:${toolName}`;
 }
 
+function getCachedAvailableTarget(toolName: string, sshHost?: string | null): boolean {
+  const cacheKey = buildBlockedTargetKey(toolName, sshHost);
+  const expiresAt = availableTargets.get(cacheKey);
+  if (!expiresAt) {
+    return false;
+  }
+
+  if (Date.now() < expiresAt) {
+    return true;
+  }
+
+  availableTargets.delete(cacheKey);
+  return false;
+}
+
+function rememberAvailableTarget(toolName: string, sshHost?: string | null): void {
+  availableTargets.set(
+    buildBlockedTargetKey(toolName, sshHost),
+    Date.now() + SESSION_DEPENDENCY_SUCCESS_CACHE_MS,
+  );
+}
+
 export function getBlockedRemoteHostReason(sshHost: string): string | null {
   return blockedTargets.get(buildBlockedTargetKey("tmux", sshHost))
     ?? blockedTargets.get(buildBlockedTargetKey("zellij", sshHost))
@@ -27,10 +51,17 @@ export function getBlockedRemoteHostReason(sshHost: string): string | null {
 }
 
 async function hasSessionDependency(toolName: string, sshHost?: string | null): Promise<boolean> {
+  if (getCachedAvailableTarget(toolName, sshHost)) {
+    return true;
+  }
+
   try {
     await execGit(`command -v ${toolName} >/dev/null 2>&1`, sshHost);
+    rememberAvailableTarget(toolName, sshHost);
     return true;
   } catch (error) {
+    availableTargets.delete(buildBlockedTargetKey(toolName, sshHost));
+
     if (sshHost && isSSHTransportError(error)) {
       throw error;
     }
@@ -76,11 +107,15 @@ export async function installSessionDependency(
   const toolName = getToolName(sessionType);
   const blockedTargetKey = buildBlockedTargetKey(toolName, sshHost);
   blockedTargets.delete(blockedTargetKey);
+  availableTargets.delete(blockedTargetKey);
 
   try {
     await execGit(buildInstallCommand(toolName), sshHost);
     await execGit(`command -v ${toolName} >/dev/null 2>&1`, sshHost);
+    rememberAvailableTarget(toolName, sshHost);
   } catch (error) {
+    availableTargets.delete(blockedTargetKey);
+
     if (sshHost && isSSHTransportError(error)) {
       throw error;
     }


### PR DESCRIPTION
## What is this?
- Speed up remote task creation and task-detail terminal startup by removing avoidable blocking work from the foreground path.

## How is it solved?
**Background hook installation**
- Reuse the existing task hook scheduler for both local and remote worktree tasks.
- Apply the same non-blocking behavior to hook-created tasks so API task creation does not wait for remote hook setup.
- Broadcast a board refresh after background hook installation succeeds so hook status cards reload when installation completes.

**Remote dependency reuse**
- Cache successful remote tmux/zellij dependency checks for a short window.
- Avoid duplicate SSH `command -v` probes when the UI has just verified the same remote session tool.

**Terminal startup**
- Open xterm with a fallback monospace font immediately instead of waiting for CDN Nerd Font loading.
- Load Nerd Font asynchronously and refit/resize the terminal after the font becomes available.
- Register terminal data and close listeners before opening the PTY so early output is not missed.

## Important changes
### Remote task creation latency

**Move hook setup out of the synchronous path**
- **Reason**: Remote hook setup performs multiple SSH file operations and can dominate task creation time.
- **Files**: `src/desktop/main/services/kanbanService.ts`, `src/desktop/main/services/hookService.ts`

**Preserve success and failure visibility**
- **Reason**: Background hook installation should report failures and refresh the task-detail UI after successful installation.
- **Files**: `src/desktop/main/services/kanbanService.ts`

### Session dependency checks

**Cache successful remote dependency probes**
- **Reason**: The create flow can ask for the same remote session dependency more than once in quick succession.
- **Files**: `src/lib/remoteSessionDependency.ts`

### Terminal responsiveness

**Remove font loading from the terminal open path**
- **Reason**: Waiting for remote font files delays even simple terminal opening.
- **Files**: `src/desktop/renderer/components/Terminal.tsx`

**Subscribe before opening the terminal session**
- **Reason**: PTY output can arrive immediately after creation, so listeners should be ready first.
- **Files**: `src/desktop/renderer/components/Terminal.tsx`

### Behavior coverage

**Update regression coverage**
- **Reason**: Tests should assert that remote task creation returns before hook installation completes, successful background hook installation refreshes board state, remote dependency checks are reused, and terminal opening is not blocked by slow Nerd Font loading.
- **Files**: `src/desktop/main/services/__tests__/kanbanService.test.ts`, `src/desktop/main/services/__tests__/hookService.test.ts`, `src/lib/__tests__/remoteSessionDependency.test.ts`, `src/desktop/renderer/components/__tests__/Terminal.test.tsx`

Co-Authored-By: OpenAI Codex <codex@openai.com>