### PR TITLE
fix: restore terminal focus after task navigation

### DIFF
--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -243,6 +243,7 @@ function CreateTaskModalContent({
   return (
     <div
       ref={dialogRef}
+      data-terminal-focus-blocker="true"
       className="fixed inset-0 z-[400] flex items-center justify-center bg-bg-overlay"
       onKeyDownCapture={handleDialogKeyDownCapture}
     >

--- a/src/components/NotificationCenterButton.tsx
+++ b/src/components/NotificationCenterButton.tsx
@@ -10,6 +10,7 @@ import {
   markNotificationRead,
 } from "@/desktop/renderer/actions/notifications";
 import { redirect } from "@/desktop/renderer/navigation";
+import { requestActiveTerminalFocusAfterUiSettles } from "@/desktop/renderer/utils/terminalFocus";
 import type { AppNotification } from "@/desktop/shared/notifications";
 
 interface NotificationCenterButtonProps {
@@ -63,27 +64,39 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
   const containerRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const isOpenRef = useRef(false);
   const [isOpen, setIsOpen] = useState(false);
   const [notifications, setNotifications] = useState<AppNotification[]>([]);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [missingTaskNotification, setMissingTaskNotification] = useState<AppNotification | null>(null);
 
-  const closePanel = useCallback(() => {
-    setIsOpen(false);
+  const setPanelOpen = useCallback((nextIsOpen: boolean) => {
+    isOpenRef.current = nextIsOpen;
+    setIsOpen(nextIsOpen);
   }, []);
+
+  const closePanel = useCallback(() => {
+    if (!isOpenRef.current) {
+      return;
+    }
+
+    setPanelOpen(false);
+    requestActiveTerminalFocusAfterUiSettles();
+  }, [setPanelOpen]);
 
   const openPanel = useCallback(() => {
     setHighlightedIndex(0);
-    setIsOpen(true);
-  }, []);
+    setPanelOpen(true);
+  }, [setPanelOpen]);
 
   const togglePanel = useCallback(() => {
-    if (!isOpen) {
-      setHighlightedIndex(0);
+    if (isOpenRef.current) {
+      closePanel();
+      return;
     }
 
-    setIsOpen(!isOpen);
-  }, [isOpen]);
+    openPanel();
+  }, [closePanel, openPanel]);
 
   useImperativeHandle(ref, () => ({
     close() {
@@ -259,6 +272,7 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
           role="dialog"
           aria-label={t("notifications")}
           tabIndex={-1}
+          data-terminal-focus-blocker="true"
           className={`absolute right-0 z-50 mt-2 w-96 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-border-default bg-bg-surface shadow-xl ${panelClassName}`.trim()}
         >
           <div className="flex items-center justify-between border-b border-border-default px-4 py-3">
@@ -308,7 +322,7 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
       ) : null}
 
       {missingTaskNotification ? (
-        <div className="fixed inset-0 z-[500] flex items-center justify-center bg-bg-overlay px-4">
+        <div data-terminal-focus-blocker="true" className="fixed inset-0 z-[500] flex items-center justify-center bg-bg-overlay px-4">
           <div className="w-full max-w-sm rounded-xl border border-border-default bg-bg-surface p-6 shadow-lg">
             <h2 className="text-lg font-semibold text-text-primary">{t("notificationTaskMissingTitle")}</h2>
             <p className="mt-2 whitespace-pre-wrap text-sm text-text-secondary">{t("notificationTaskMissingBody")}</p>

--- a/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
+++ b/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
@@ -15,6 +15,7 @@ import {
   formatShortcutForDisplay,
   matchShortcutEvent,
 } from "@/desktop/renderer/utils/keyboardShortcut";
+import { requestActiveTerminalFocusAfterUiSettles } from "@/desktop/renderer/utils/terminalFocus";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { fuzzyMatch, type FuzzyMatch } from "@/utils/fuzzySearch";
 import { CREATE_BRANCH_TODO_SHORTCUT, useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
@@ -238,6 +239,7 @@ export default function TaskQuickSearchDialog({
     setQuery("");
     setSelectedIndex(0);
     setIsLoading(false);
+    requestActiveTerminalFocusAfterUiSettles();
   }, []);
 
   useEffect(() => {
@@ -416,7 +418,7 @@ export default function TaskQuickSearchDialog({
   ].filter(Boolean).join(" · ");
 
   return (
-    <div className="fixed inset-0 z-[500] flex items-start justify-center bg-black/45 px-4 pt-24">
+    <div data-terminal-focus-blocker="true" className="fixed inset-0 z-[500] flex items-start justify-center bg-black/45 px-4 pt-24">
       <button
         type="button"
         aria-label={tc("close")}

--- a/src/desktop/renderer/components/Terminal.tsx
+++ b/src/desktop/renderer/components/Terminal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { createTerminalOptions, installMacShiftSelectionPatch } from "@/lib/terminalMouseSelection";
+import { REQUEST_ACTIVE_TERMINAL_FOCUS_EVENT, hasTerminalFocusBlocker } from "@/desktop/renderer/utils/terminalFocus";
 
 interface TerminalProps {
   taskId: string;
@@ -88,6 +89,10 @@ export default function Terminal({ taskId }: TerminalProps) {
     };
 
     const focusCurrentTerminal = () => {
+      if (hasTerminalFocusBlocker()) {
+        return;
+      }
+
       terminal.focus();
     };
 
@@ -110,12 +115,19 @@ export default function Terminal({ taskId }: TerminalProps) {
       scheduleTerminalSync();
     };
 
+    const handleRequestTerminalFocus = () => {
+      focusCurrentTerminal();
+      scheduleTerminalSync();
+    };
+
     document.addEventListener("visibilitychange", handleVisibilityChange);
     window.addEventListener("focus", handleWindowFocus);
+    window.addEventListener(REQUEST_ACTIVE_TERMINAL_FOCUS_EVENT, handleRequestTerminalFocus);
 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       window.removeEventListener("focus", handleWindowFocus);
+      window.removeEventListener(REQUEST_ACTIVE_TERMINAL_FOCUS_EVENT, handleRequestTerminalFocus);
       disposeMacShiftSelectionPatch();
       resizeObserver.disconnect();
       unsubscribeData();

--- a/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
@@ -140,6 +140,33 @@ describe("TaskQuickSearchDialog", () => {
     });
   });
 
+  it("검색 결과에서 상세 페이지로 이동할 때 terminal focus 요청을 보낸다", async () => {
+    const focusListener = vi.fn();
+    window.addEventListener("kanvibe:request-terminal-focus", focusListener);
+
+    render(<TaskQuickSearchDialog shortcut="Ctrl+K" />);
+
+    fireEvent.keyDown(window, {
+      key: "k",
+      ctrlKey: true,
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, {
+      target: { value: "api" },
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mocks.push).toHaveBeenCalledWith("/task/task-remote");
+    });
+    await waitFor(() => {
+      expect(focusListener).toHaveBeenCalled();
+    });
+
+    window.removeEventListener("kanvibe:request-terminal-focus", focusListener);
+  });
+
   it("검색 결과에서 Shift+Enter로 상세 페이지를 새 창에서 연다", async () => {
     const openWindow = vi.spyOn(window, "open").mockImplementation(() => null);
 

--- a/src/desktop/renderer/components/__tests__/Terminal.test.tsx
+++ b/src/desktop/renderer/components/__tests__/Terminal.test.tsx
@@ -145,4 +145,41 @@ describe("Desktop Terminal", () => {
     });
     expect(mockResizeTerminal).toHaveBeenCalledWith("task-1", 80, 24);
   });
+
+  it("active terminal focus 요청을 받으면 xterm 입력 포커스를 맞춘다", async () => {
+    render(<Terminal taskId="task-1" />);
+
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", 80, 24);
+    });
+    mockTerminalFocus.mockClear();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("kanvibe:request-terminal-focus"));
+    });
+
+    await waitFor(() => {
+      expect(mockTerminalFocus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("terminal focus blocker가 열려 있으면 active terminal focus 요청을 무시한다", async () => {
+    render(<Terminal taskId="task-1" />);
+
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", 80, 24);
+    });
+    mockTerminalFocus.mockClear();
+
+    const blocker = document.createElement("div");
+    blocker.setAttribute("data-terminal-focus-blocker", "true");
+    document.body.appendChild(blocker);
+
+    await act(async () => {
+      window.dispatchEvent(new Event("kanvibe:request-terminal-focus"));
+    });
+
+    expect(mockTerminalFocus).not.toHaveBeenCalled();
+    blocker.remove();
+  });
 });

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -29,6 +29,7 @@ import { fetchPrUrlWithPrompt } from "@/desktop/renderer/utils/fetchPrUrlWithPro
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { buildRouteCacheKey, readRouteCache, removeRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
+import { requestActiveTerminalFocusAfterUiSettles } from "@/desktop/renderer/utils/terminalFocus";
 import { SessionType, TaskStatus } from "@/entities/KanbanTask";
 
 const STATUS_TRANSITIONS = [
@@ -103,6 +104,7 @@ export default function TaskDetailRoute() {
   const [createTaskDefaults, setCreateTaskDefaults] = useState<BranchTodoDefaults | null>(null);
   const [needsMacDesktopHeaderOffset, setNeedsMacDesktopHeaderOffset] = useState(false);
   const notificationCenterRef = useRef<NotificationCenterButtonHandle>(null);
+  const hasTerminal = !!(state?.task.sessionType && state.task.sessionName);
 
   useEffect(() => boardCommands.registerNotificationCenterHandler(() => {
     notificationCenterRef.current?.toggle();
@@ -141,6 +143,14 @@ export default function TaskDetailRoute() {
 
     document.title = [state.task.branchName, state.task.project?.name].filter(Boolean).join(" - ");
   }, [state]);
+
+  useEffect(() => {
+    if (!hasTerminal || isCreateTaskModalOpen) {
+      return;
+    }
+
+    requestActiveTerminalFocusAfterUiSettles();
+  }, [hasTerminal, id, isCreateTaskModalOpen]);
 
   useEffect(() => {
     if (!id) {
@@ -314,8 +324,6 @@ export default function TaskDetailRoute() {
     );
   }
 
-  const hasTerminal = !!(state.task.sessionType && state.task.sessionName);
-
   async function handleStatusChange(formData: FormData) {
     const newStatus = formData.get("status") as TaskStatus;
     const updatedTask = await updateTaskStatus(id, newStatus);
@@ -340,6 +348,12 @@ export default function TaskDetailRoute() {
   async function handleDelete() {
     await deleteTask(id);
     router.push("/");
+  }
+
+  function closeCreateTaskModal() {
+    setIsCreateTaskModalOpen(false);
+    setCreateTaskDefaults(null);
+    requestActiveTerminalFocusAfterUiSettles();
   }
 
   return (
@@ -446,10 +460,7 @@ export default function TaskDetailRoute() {
 
       <CreateTaskModal
         isOpen={isCreateTaskModalOpen}
-        onClose={() => {
-          setIsCreateTaskModalOpen(false);
-          setCreateTaskDefaults(null);
-        }}
+        onClose={closeCreateTaskModal}
         sshHosts={[]}
         projects={state.projects}
         defaultProjectId={createTaskDefaults?.projectId ?? state.task.projectId ?? ""}

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -115,19 +115,22 @@ vi.mock("@/components/ConnectTerminalForm", () => ({
 vi.mock("@/components/CreateTaskModal", () => ({
   default: ({
     isOpen,
+    onClose,
     defaultProjectId,
     defaultBaseBranch,
     defaultSessionType,
   }: {
     isOpen: boolean;
+    onClose: () => void;
     defaultProjectId?: string;
     defaultBaseBranch?: string;
     defaultSessionType?: string;
   }) => isOpen ? (
-    <div data-testid="create-task-modal">
+    <div data-testid="create-task-modal" data-terminal-focus-blocker="true">
       <div data-testid="create-task-default-project">{defaultProjectId ?? ""}</div>
       <div data-testid="create-task-default-base-branch">{defaultBaseBranch ?? ""}</div>
       <div data-testid="create-task-default-session">{defaultSessionType ?? ""}</div>
+      <button type="button" onClick={onClose}>close create modal</button>
     </div>
   ) : null,
 }));
@@ -156,9 +159,32 @@ vi.mock("@/components/TaskDetailTitleCard", () => ({
   ),
 }));
 
-vi.mock("@/desktop/renderer/components/TerminalLoader", () => ({
-  default: () => <div data-testid="terminal-loader" />,
-}));
+vi.mock("@/desktop/renderer/components/TerminalLoader", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    default: function MockTerminalLoader() {
+      const inputRef = React.useRef<HTMLInputElement>(null);
+
+      React.useEffect(() => {
+        function handleRequestTerminalFocus() {
+          if (document.querySelector('[data-terminal-focus-blocker="true"]')) {
+            return;
+          }
+
+          inputRef.current?.focus();
+        }
+
+        window.addEventListener("kanvibe:request-terminal-focus", handleRequestTerminalFocus);
+        return () => {
+          window.removeEventListener("kanvibe:request-terminal-focus", handleRequestTerminalFocus);
+        };
+      }, []);
+
+      return <input data-testid="terminal-loader" ref={inputRef} aria-label="terminal input" />;
+    },
+  };
+});
 
 describe("TaskDetailRoute", () => {
   beforeEach(() => {
@@ -374,6 +400,89 @@ describe("TaskDetailRoute", () => {
       expect(screen.getByTestId("create-task-default-project").textContent).toBe("project-1");
       expect(screen.getByTestId("create-task-default-base-branch").textContent).toBe("feat/detail-shortcut");
       expect(screen.getByTestId("create-task-default-session").textContent).toBe("tmux");
+    });
+  });
+
+  it("새 task 모달이 닫히면 terminal 입력 포커스로 복귀한다", async () => {
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(
+      <BoardCommandProvider>
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    const terminalInput = await screen.findByLabelText("terminal input");
+
+    fireEvent.keyDown(window, {
+      key: "n",
+      ctrlKey: true,
+    });
+    await screen.findByTestId("create-task-modal");
+
+    fireEvent.click(screen.getByRole("button", { name: "close create modal" }));
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(terminalInput);
+    });
+  });
+
+  it("알림 dropdown이 닫히면 terminal 입력 포커스로 복귀한다", async () => {
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(
+      <BoardCommandProvider>
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    const terminalInput = await screen.findByLabelText("terminal input");
+
+    fireEvent.keyDown(window, {
+      key: "i",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    const panel = await screen.findByRole("dialog", { name: "notifications" });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(panel);
+    });
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(terminalInput);
     });
   });
 });

--- a/src/desktop/renderer/utils/terminalFocus.ts
+++ b/src/desktop/renderer/utils/terminalFocus.ts
@@ -1,0 +1,35 @@
+export const REQUEST_ACTIVE_TERMINAL_FOCUS_EVENT = "kanvibe:request-terminal-focus";
+export const TERMINAL_FOCUS_BLOCKER_ATTRIBUTE = "data-terminal-focus-blocker";
+
+export function hasTerminalFocusBlocker() {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  return document.querySelector(`[${TERMINAL_FOCUS_BLOCKER_ATTRIBUTE}="true"]`) !== null;
+}
+
+export function requestActiveTerminalFocus() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(new Event(REQUEST_ACTIVE_TERMINAL_FOCUS_EVENT));
+}
+
+export function requestActiveTerminalFocusAfterUiSettles() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const dispatchFocusRequest = () => {
+    requestActiveTerminalFocus();
+  };
+
+  if (typeof window.requestAnimationFrame === "function") {
+    window.requestAnimationFrame(dispatchFocusRequest);
+    return;
+  }
+
+  window.setTimeout(dispatchFocusRequest, 0);
+}


### PR DESCRIPTION
## What changed?
- Restore active terminal focus after task detail navigation and overlay close flows.
- Add a shared terminal focus request event and blocker attribute.
- Mark task search, create task modal, and notification overlays as focus blockers.
- Cover focus restore and blocker behavior with regression tests.

## Why?
- Task detail should be immediately typeable in the terminal unless task creation or notification UI is open.

## Implementation notes
- Terminal listens for a renderer-level focus request event and ignores it while blockers are present.
- Task detail, quick search, create task modal, and notification center request terminal focus after their UI settles.

Co-Authored-By: Codex <codex@openai.com>