### PR TITLE
perf(kanban): make Done cleanup optimistic

### DIFF
--- a/src/desktop/main/services/__tests__/hookService.test.ts
+++ b/src/desktop/main/services/__tests__/hookService.test.ts
@@ -28,8 +28,9 @@ const mocks = vi.hoisted(() => ({
   broadcastBoardUpdate: vi.fn(),
   broadcastHookStatusTargetMissing: vi.fn(),
   broadcastTaskStatusChanged: vi.fn(),
-  cleanupTaskResources: vi.fn(),
   scheduleTaskHookInstall: vi.fn(),
+  prepareOptimisticDoneTransition: vi.fn(),
+  scheduleDoneCleanupWithRollback: vi.fn(),
   installKanvibeHooks: vi.fn(),
 }));
 
@@ -53,8 +54,9 @@ vi.mock("@/lib/boardNotifier", () => ({
 }));
 
 vi.mock("@/desktop/main/services/kanbanService", () => ({
-  cleanupTaskResources: mocks.cleanupTaskResources,
   scheduleTaskHookInstall: mocks.scheduleTaskHookInstall,
+  prepareOptimisticDoneTransition: mocks.prepareOptimisticDoneTransition,
+  scheduleDoneCleanupWithRollback: mocks.scheduleDoneCleanupWithRollback,
 }));
 
 vi.mock("@/lib/kanvibeHooksInstaller", () => ({
@@ -65,6 +67,28 @@ describe("hookService.updateHookTaskStatus", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    mocks.prepareOptimisticDoneTransition.mockImplementation((task, options = {}) => {
+      const cleanupTask = { ...task };
+      const rollbackSnapshot = {
+        id: task.id,
+        status: task.status,
+        sessionType: task.sessionType,
+        sessionName: task.sessionName,
+        worktreePath: task.worktreePath,
+        sshHost: task.sshHost,
+      };
+
+      task.status = TaskStatus.DONE;
+      task.sessionType = null;
+      task.sessionName = null;
+      task.worktreePath = null;
+
+      if ((options as { clearSshHost?: boolean }).clearSshHost) {
+        task.sshHost = null;
+      }
+
+      return { cleanupTask, rollbackSnapshot };
+    });
   });
 
   it("taskId로 작업 상태를 변경한다", async () => {

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -82,12 +82,20 @@ vi.mock("@/lib/gitOperations", () => ({
   remoteBranchExists: mocks.remoteBranchExists,
 }));
 
+function nextMacrotask<T>(value: T): Promise<T> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(value), 0);
+  });
+}
+
 describe("kanbanService.createTask", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.taskRepo.create.mockImplementation((value) => value);
     mocks.installKanvibeHooks.mockResolvedValue(undefined);
+    mocks.removeSessionOnly.mockResolvedValue(undefined);
+    mocks.removeWorktreeAndBranch.mockResolvedValue(undefined);
     mocks.remoteBranchExists.mockResolvedValue(true);
     mocks.taskRepo.createQueryBuilder.mockReturnValue({
       select: vi.fn().mockReturnThis(),
@@ -504,6 +512,193 @@ describe("kanbanService.createTask", () => {
     // Then
     expect(mocks.taskRepo.update).toHaveBeenCalledWith("task-a", { status: "review" });
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("Done 상태 변경은 리소스 정리를 기다리지 않고 먼저 저장한다", async () => {
+    // Given
+    const task = {
+      id: "task-done",
+      title: "Remote cleanup",
+      description: null,
+      status: "review",
+      branchName: null,
+      projectId: null,
+      sessionType: "tmux" as never,
+      sessionName: "repo-fix-done",
+      worktreePath: "/remote/repo__worktrees/fix-done",
+      sshHost: "remote-host",
+    };
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.taskRepo.save.mockImplementation(async (value) => value);
+    mocks.removeSessionOnly.mockReturnValue(new Promise(() => {}));
+
+    const { updateTaskStatus } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const resultPromise = updateTaskStatus("task-done", "done" as never);
+    const raceResult = await Promise.race([
+      resultPromise.then(() => "resolved"),
+      nextMacrotask("pending"),
+    ]);
+
+    // Then
+    expect(raceResult).toBe("resolved");
+    expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
+      id: "task-done",
+      status: "done",
+      sessionType: null,
+      sessionName: null,
+      worktreePath: null,
+    }));
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("Done 컬럼 이동은 리소스 정리를 기다리지 않고 status와 순서를 먼저 저장한다", async () => {
+    // Given
+    const task = {
+      id: "task-done",
+      title: "Remote cleanup",
+      description: null,
+      status: "review",
+      branchName: null,
+      projectId: null,
+      sessionType: "tmux" as never,
+      sessionName: "repo-fix-done",
+      worktreePath: "/remote/repo__worktrees/fix-done",
+      sshHost: "remote-host",
+    };
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.taskRepo.update.mockResolvedValue({ affected: 1 });
+    mocks.removeSessionOnly.mockReturnValue(new Promise(() => {}));
+
+    const { moveTaskToColumn } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const resultPromise = moveTaskToColumn("task-done", "done" as never, ["task-a", "task-done"]);
+    const raceResult = await Promise.race([
+      resultPromise.then(() => "resolved"),
+      nextMacrotask("pending"),
+    ]);
+
+    // Then
+    expect(raceResult).toBe("resolved");
+    expect(mocks.taskRepo.update).toHaveBeenCalledWith("task-done", {
+      status: "done",
+      sessionType: null,
+      sessionName: null,
+      worktreePath: null,
+    });
+    expect(mocks.taskRepo.update).toHaveBeenCalledWith("task-a", { displayOrder: 0 });
+    expect(mocks.taskRepo.update).toHaveBeenCalledWith("task-done", { displayOrder: 1 });
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("Done 컬럼 이동 중 순서 저장이 실패하면 이전 상태와 리소스 필드로 롤백한다", async () => {
+    // Given
+    const task = {
+      id: "task-done",
+      title: "Remote cleanup",
+      description: null,
+      status: "review",
+      branchName: null,
+      projectId: null,
+      sessionType: "tmux" as never,
+      sessionName: "repo-fix-done",
+      worktreePath: "/remote/repo__worktrees/fix-done",
+      sshHost: "remote-host",
+    };
+    mocks.taskRepo.findOneBy
+      .mockResolvedValueOnce(task)
+      .mockResolvedValueOnce({
+        ...task,
+        status: "done",
+        sessionType: null,
+        sessionName: null,
+        worktreePath: null,
+      });
+    mocks.taskRepo.update.mockImplementation(async (id, updates) => {
+      if (id === "task-a" && "displayOrder" in updates) {
+        throw new Error("display order failed");
+      }
+
+      return { affected: 1 };
+    });
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { moveTaskToColumn } = await import("@/desktop/main/services/kanbanService");
+
+    // When & Then
+    await expect(moveTaskToColumn("task-done", "done" as never, ["task-a", "task-done"]))
+      .rejects
+      .toThrow("display order failed");
+
+    expect(mocks.taskRepo.update).toHaveBeenCalledWith("task-done", {
+      status: "review",
+      sessionType: "tmux",
+      sessionName: "repo-fix-done",
+      worktreePath: "/remote/repo__worktrees/fix-done",
+      sshHost: "remote-host",
+    });
+    expect(mocks.removeSessionOnly).not.toHaveBeenCalled();
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("백그라운드 Done 정리가 실패하면 이전 상태와 리소스 필드로 롤백한다", async () => {
+    vi.useFakeTimers();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      // Given
+      const task = {
+        id: "task-done",
+        title: "Remote cleanup",
+        description: null,
+        status: "review",
+        branchName: null,
+        projectId: null,
+        sessionType: "tmux" as never,
+        sessionName: "repo-fix-done",
+        worktreePath: "/remote/repo__worktrees/fix-done",
+        sshHost: "remote-host",
+      };
+      mocks.taskRepo.findOneBy
+        .mockResolvedValueOnce(task)
+        .mockResolvedValueOnce({
+          ...task,
+          status: "done",
+          sessionType: null,
+          sessionName: null,
+          worktreePath: null,
+        });
+      mocks.taskRepo.save.mockImplementation(async (value) => value);
+      mocks.taskRepo.update.mockResolvedValue({ affected: 1 });
+      mocks.removeSessionOnly.mockRejectedValueOnce(new Error("ssh failed"));
+
+      const { updateTaskStatus } = await import("@/desktop/main/services/kanbanService");
+
+      // When
+      await updateTaskStatus("task-done", "done" as never);
+      await vi.runAllTimersAsync();
+
+      // Then
+      expect(mocks.taskRepo.update).toHaveBeenCalledWith("task-done", {
+        status: "review",
+        sessionType: "tmux",
+        sessionName: "repo-fix-done",
+        worktreePath: "/remote/repo__worktrees/fix-done",
+        sshHost: "remote-host",
+      });
+      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(2);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    } finally {
+      mocks.taskRepo.findOneBy.mockReset();
+      mocks.removeSessionOnly.mockReset();
+      consoleErrorSpy.mockRestore();
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("PR URL 조회는 셸 없이 gh CLI를 직접 실행한다", async () => {

--- a/src/desktop/main/services/hookService.ts
+++ b/src/desktop/main/services/hookService.ts
@@ -2,7 +2,12 @@ import { TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { getProjectRepository, getTaskRepository } from "@/lib/database";
 import { createWorktreeWithSession } from "@/lib/worktree";
 import { broadcastBoardUpdate, broadcastHookStatusTargetMissing, broadcastTaskStatusChanged } from "@/lib/boardNotifier";
-import { cleanupTaskResources, scheduleTaskHookInstall } from "@/desktop/main/services/kanbanService";
+import {
+  prepareOptimisticDoneTransition,
+  scheduleDoneCleanupWithRollback,
+  scheduleTaskHookInstall,
+  type DoneCleanupPlan,
+} from "@/desktop/main/services/kanbanService";
 
 const STATUS_MAP: Record<string, TaskStatus> = {
   todo: TaskStatus.TODO,
@@ -130,16 +135,14 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
   }
 
   const projectName = task.project?.name || task.projectId || "Unknown project";
+  let doneCleanupPlan: DoneCleanupPlan | null = null;
 
   if (taskStatus === TaskStatus.DONE) {
-    await cleanupTaskResources(task);
-    task.sessionType = null;
-    task.sessionName = null;
-    task.worktreePath = null;
-    task.sshHost = null;
+    doneCleanupPlan = prepareOptimisticDoneTransition(task, { clearSshHost: true });
+  } else {
+    task.status = taskStatus;
   }
 
-  task.status = taskStatus;
   const saved = await taskRepo.save(task);
 
   broadcastBoardUpdate();
@@ -151,6 +154,10 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
     newStatus: taskStatus,
     taskId: saved.id,
   });
+
+  if (doneCleanupPlan) {
+    scheduleDoneCleanupWithRollback(doneCleanupPlan);
+  }
 
   return {
     success: true,

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -48,6 +48,24 @@ const ACTIVE_PULL_TASK_STATUSES = [
 ];
 const notifiedPullFailureKeys = new Set<string>();
 
+interface CleanupTaskResourcesOptions {
+  throwOnError?: boolean;
+}
+
+interface DoneRollbackSnapshot {
+  id: string;
+  status: TaskStatus;
+  sessionType: SessionType | null;
+  sessionName: string | null;
+  worktreePath: string | null;
+  sshHost: string | null;
+}
+
+export interface DoneCleanupPlan {
+  cleanupTask: KanbanTask;
+  rollbackSnapshot: DoneRollbackSnapshot;
+}
+
 interface GitHubPullRequestInfo {
   url: string | null;
   state: string | null;
@@ -141,6 +159,68 @@ export function scheduleTaskHookInstall(
         });
       });
   }, 0);
+}
+
+export function prepareOptimisticDoneTransition(
+  task: KanbanTask,
+  options: { clearSshHost?: boolean } = {},
+): DoneCleanupPlan {
+  const cleanupTask = { ...task } as KanbanTask;
+  const rollbackSnapshot: DoneRollbackSnapshot = {
+    id: task.id,
+    status: task.status,
+    sessionType: task.sessionType,
+    sessionName: task.sessionName,
+    worktreePath: task.worktreePath,
+    sshHost: task.sshHost,
+  };
+
+  task.status = TaskStatus.DONE;
+  task.sessionType = null;
+  task.sessionName = null;
+  task.worktreePath = null;
+
+  if (options.clearSshHost) {
+    task.sshHost = null;
+  }
+
+  return { cleanupTask, rollbackSnapshot };
+}
+
+export function scheduleDoneCleanupWithRollback(plan: DoneCleanupPlan): void {
+  setTimeout(() => {
+    void cleanupTaskResources(plan.cleanupTask, { throwOnError: true })
+      .catch((error) => rollbackDoneTransition(plan.rollbackSnapshot, error));
+  }, 0);
+}
+
+async function rollbackDoneTransition(
+  snapshot: DoneRollbackSnapshot,
+  cleanupError: unknown,
+): Promise<void> {
+  console.error("Done 리소스 백그라운드 정리 실패, 상태를 롤백합니다:", {
+    taskId: snapshot.id,
+    error: getErrorMessage(cleanupError),
+  });
+
+  try {
+    const repo = await getTaskRepository();
+    const current = await repo.findOneBy({ id: snapshot.id });
+    if (!current || current.status !== TaskStatus.DONE) {
+      return;
+    }
+
+    await repo.update(snapshot.id, {
+      status: snapshot.status,
+      sessionType: snapshot.sessionType,
+      sessionName: snapshot.sessionName,
+      worktreePath: snapshot.worktreePath,
+      sshHost: snapshot.sshHost,
+    });
+    broadcastBoardUpdate();
+  } catch (rollbackError) {
+    console.error("Done 상태 롤백 실패:", rollbackError);
+  }
 }
 
 async function getPrUrlFromGitHubCli(branchName: string, cwd: string, sshHost?: string | null): Promise<string | null> {
@@ -507,10 +587,11 @@ export async function updateTaskStatus(
   if (!task) return null;
 
   if (newStatus === TaskStatus.DONE) {
-    await cleanupTaskResources(task);
-    task.sessionType = null;
-    task.sessionName = null;
-    task.worktreePath = null;
+    const doneCleanupPlan = prepareOptimisticDoneTransition(task);
+    const saved = await repo.save(task);
+    broadcastBoardUpdate();
+    scheduleDoneCleanupWithRollback(doneCleanupPlan);
+    return serialize(saved);
   }
 
   task.status = newStatus;
@@ -568,7 +649,10 @@ export async function updateProjectColor(
 }
 
 /** 작업에 연결된 worktree, 세션, 브랜치를 정리한다. task 레코드는 삭제하지 않는다 */
-export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
+export async function cleanupTaskResources(
+  task: KanbanTask,
+  options: CleanupTaskResourcesOptions = {},
+): Promise<void> {
   let project = null;
   if (task.projectId) {
     const projectRepo = await getProjectRepository();
@@ -576,16 +660,31 @@ export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
   }
 
   const sshHost = task.sshHost || project?.sshHost || null;
+  const cleanupOptions = options.throwOnError
+    ? { throwOnError: true }
+    : undefined;
 
   /** 브랜치별 독립 세션 정리 */
   if (task.sessionType && task.sessionName) {
     try {
-      await removeSessionOnly(
-        task.sessionType,
-        task.sessionName,
-        sshHost
-      );
+      if (cleanupOptions) {
+        await removeSessionOnly(
+          task.sessionType,
+          task.sessionName,
+          sshHost,
+          cleanupOptions,
+        );
+      } else {
+        await removeSessionOnly(
+          task.sessionType,
+          task.sessionName,
+          sshHost,
+        );
+      }
     } catch (error) {
+      if (options.throwOnError) {
+        throw error;
+      }
       console.error("세션 정리 실패:", error);
     }
   }
@@ -607,23 +706,39 @@ export async function cleanupTaskResources(task: KanbanTask): Promise<void> {
       && task.worktreePath === expectedWorktreePath;
 
     if (!canCleanupBranch) {
-      console.warn("worktree/브랜치 정리 건너뜀: task 경로와 project 경로가 일치하지 않습니다.", {
+      const warningPayload = {
         taskId: task.id,
         branchName: task.branchName,
         worktreePath: task.worktreePath,
         projectRepoPath: project?.repoPath ?? null,
         sshHost,
-      });
+      };
+      console.warn("worktree/브랜치 정리 건너뜀: task 경로와 project 경로가 일치하지 않습니다.", warningPayload);
+      if (options.throwOnError) {
+        throw new Error("task 경로와 project 경로가 일치하지 않아 worktree/브랜치 정리를 건너뛰었습니다.");
+      }
       return;
     }
 
     try {
-      await removeWorktreeAndBranch(
-        project?.repoPath || process.cwd(),
-        task.branchName,
-        sshHost
-      );
+      if (cleanupOptions) {
+        await removeWorktreeAndBranch(
+          project?.repoPath || process.cwd(),
+          task.branchName,
+          sshHost,
+          cleanupOptions,
+        );
+      } else {
+        await removeWorktreeAndBranch(
+          project?.repoPath || process.cwd(),
+          task.branchName,
+          sshHost,
+        );
+      }
     } catch (error) {
+      if (options.throwOnError) {
+        throw error;
+      }
       console.error("worktree/브랜치 정리 실패:", error);
     }
   }
@@ -760,28 +875,40 @@ export async function moveTaskToColumn(
   destOrderedIds: string[]
 ): Promise<void> {
   const repo = await getTaskRepository();
+  let doneCleanupPlan: DoneCleanupPlan | null = null;
 
-  if (newStatus === TaskStatus.DONE) {
-    const task = await repo.findOneBy({ id: taskId });
-    if (task) {
-        await cleanupTaskResources(task);
+  try {
+    if (newStatus === TaskStatus.DONE) {
+      const task = await repo.findOneBy({ id: taskId });
+      if (task) {
+        doneCleanupPlan = prepareOptimisticDoneTransition(task);
         await repo.update(taskId, {
           status: newStatus,
           sessionType: null,
           sessionName: null,
           worktreePath: null,
         });
+      }
+    } else {
+      await repo.update(taskId, { status: newStatus });
     }
-  } else {
-    await repo.update(taskId, { status: newStatus });
+
+    const reorderUpdates = destOrderedIds.map((id, index) =>
+      repo.update(id, { displayOrder: index })
+    );
+
+    await Promise.all(reorderUpdates);
+    broadcastBoardUpdate();
+  } catch (error) {
+    if (doneCleanupPlan) {
+      await rollbackDoneTransition(doneCleanupPlan.rollbackSnapshot, error);
+    }
+    throw error;
   }
 
-  const reorderUpdates = destOrderedIds.map((id, index) =>
-    repo.update(id, { displayOrder: index })
-  );
-
-  await Promise.all(reorderUpdates);
-  broadcastBoardUpdate();
+  if (doneCleanupPlan) {
+    scheduleDoneCleanupWithRollback(doneCleanupPlan);
+  }
 }
 
 /**

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -382,25 +382,40 @@ export async function createSessionWithoutWorktree(
   }
 }
 
+interface ResourceCleanupOptions {
+  throwOnError?: boolean;
+}
+
 /** worktree와 브랜치를 삭제한다. 세션은 건드리지 않는다 */
 export async function removeWorktreeAndBranch(
   projectPath: string,
   branchName: string,
   sshHost?: string | null,
+  options: ResourceCleanupOptions = {},
 ): Promise<void> {
+  const worktreePath = buildManagedWorktreePath(projectPath, branchName);
+  const worktreeCommand = options.throwOnError
+    ? `if git -C "${projectPath}" worktree list --porcelain | grep -Fxq "worktree ${worktreePath}"; then git -C "${projectPath}" worktree remove "${worktreePath}" --force; fi`
+    : `git -C "${projectPath}" worktree remove "${worktreePath}" --force`;
+  const branchCommand = options.throwOnError
+    ? `if git -C "${projectPath}" show-ref --verify --quiet "refs/heads/${branchName}"; then git -C "${projectPath}" branch -D "${branchName}"; fi`
+    : `git -C "${projectPath}" branch -D "${branchName}"`;
+
   try {
-    const worktreePath = buildManagedWorktreePath(projectPath, branchName);
-    await execGit(
-      `git -C "${projectPath}" worktree remove "${worktreePath}" --force`,
-      sshHost,
-    );
+    await execGit(worktreeCommand, sshHost);
   } catch {
+    if (options.throwOnError) {
+      throw new Error(`worktree 정리 실패: ${worktreePath}`);
+    }
     // worktree가 이미 삭제된 경우 무시
   }
 
   try {
-    await execGit(`git -C "${projectPath}" branch -D "${branchName}"`, sshHost);
+    await execGit(branchCommand, sshHost);
   } catch {
+    if (options.throwOnError) {
+      throw new Error(`브랜치 정리 실패: ${branchName}`);
+    }
     // 브랜치가 이미 삭제된 경우 무시
   }
 }
@@ -410,6 +425,7 @@ export async function removeSessionOnly(
   sessionType: SessionType,
   sessionName: string,
   sshHost?: string | null,
+  options: ResourceCleanupOptions = {},
 ): Promise<void> {
   try {
     if (sessionType === SessionType.TMUX) {
@@ -424,6 +440,9 @@ export async function removeSessionOnly(
       );
     }
   } catch {
+    if (options.throwOnError) {
+      throw new Error(`세션 정리 실패: ${sessionName}`);
+    }
     // 세션이 이미 종료된 경우 무시
   }
 }


### PR DESCRIPTION
## What changed
- Make Done status persistence optimistic so tasks move to Done before remote cleanup finishes.
- Run tmux/zellij session, worktree, and branch cleanup in the background after the board update is persisted.
- Roll back task status and resource fields if background cleanup fails.

## How it works
**Optimistic Done transition**
- Snapshot the task's previous status and resource fields before clearing session/worktree metadata.
- Save the Done status first, broadcast the board update, then schedule cleanup asynchronously.
- Apply the same flow to direct status updates, drag-and-drop column moves, and hook-driven Done updates.

**Cleanup failure handling**
- Add a strict cleanup mode for the rollback path while preserving best-effort cleanup behavior for existing delete/stale-task callers.
- Add regression coverage for non-blocking Done transitions and rollback after cleanup failure.

Co-Authored-By: Codex <codex@openai.com>