### PR TITLE
fix(notifications): limit background sync alerts to summaries

### DIFF
--- a/src/desktop/shared/__tests__/taskNotifications.test.ts
+++ b/src/desktop/shared/__tests__/taskNotifications.test.ts
@@ -69,7 +69,7 @@ describe("taskNotifications", () => {
     });
   });
 
-  it("background sync review 알림은 pull 결과를 요약하고 action payload에 포함한다", () => {
+  it("background sync review 알림 body는 요약만 포함하고 상세는 action payload에 포함한다", () => {
     // Given
     const payload = {
       locale: "ko",
@@ -110,14 +110,7 @@ describe("taskNotifications", () => {
     const notification = buildBackgroundSyncReviewNotification(payload);
 
     // Then
-    expect(notification.body).toBe(
-      [
-        "pull 완료 1건 / pull 실패 1건 / sync 실패 1건",
-        "pull 실패: Pull B (feature/pull-b): Not possible to fast-forward",
-        "실패: PR sync target (feature/pr-fail): gh auth failed",
-        "알림을 열어 정리 대상을 검토하세요.",
-      ].join("\n"),
-    );
+    expect(notification.body).toBe("pull 완료 1건 / pull 실패 1건 / sync 실패 1건");
     expect(notification.desktopPayload.dedupeKey).toBe(
       "background-sync-review:::::task-pull-a:feature/pull-a:updated:Fast-forward|task-pull-b:feature/pull-b:failed:Not possible to fast-forward::pull-request-sync:task-11:feature/pr-fail:gh auth failed",
     );

--- a/src/desktop/shared/taskNotifications.ts
+++ b/src/desktop/shared/taskNotifications.ts
@@ -14,10 +14,6 @@ const NOTIFICATION_MESSAGES = {
     formatUpdatedPullCount: (count: number) => `pull 완료 ${count}건`,
     formatFailedPullCount: (count: number) => `pull 실패 ${count}건`,
     formatSyncFailureCount: (count: number) => `sync 실패 ${count}건`,
-    formatPullFailureDetail: (target: string, reason: string) => `pull 실패: ${target}: ${reason}`,
-    formatSyncFailureDetail: (target: string, reason: string) => `실패: ${target}: ${reason}`,
-    formatAdditionalFailureCount: (count: number) => `추가 실패 ${count}건`,
-    backgroundSyncReviewPrompt: "알림을 열어 정리 대상을 검토하세요.",
   },
   en: {
     formatStatusChanged: (taskTitle: string, newStatus: string) => `${taskTitle}: changed to ${newStatus}`,
@@ -29,10 +25,6 @@ const NOTIFICATION_MESSAGES = {
     formatUpdatedPullCount: (count: number) => `${count} pull update${count === 1 ? "" : "s"}`,
     formatFailedPullCount: (count: number) => `${count} failed pull${count === 1 ? "" : "s"}`,
     formatSyncFailureCount: (count: number) => `${count} sync failure${count === 1 ? "" : "s"}`,
-    formatPullFailureDetail: (target: string, reason: string) => `Pull failed: ${target}: ${reason}`,
-    formatSyncFailureDetail: (target: string, reason: string) => `Failed: ${target}: ${reason}`,
-    formatAdditionalFailureCount: (count: number) => `${count} more failure${count === 1 ? "" : "s"}`,
-    backgroundSyncReviewPrompt: "Open the notification to review the pending cleanup items.",
   },
   zh: {
     formatStatusChanged: (taskTitle: string, newStatus: string) => `${taskTitle}: 已变更为${newStatus}`,
@@ -44,10 +36,6 @@ const NOTIFICATION_MESSAGES = {
     formatUpdatedPullCount: (count: number) => `pull 完成 ${count} 个`,
     formatFailedPullCount: (count: number) => `pull 失败 ${count} 个`,
     formatSyncFailureCount: (count: number) => `sync 失败 ${count} 个`,
-    formatPullFailureDetail: (target: string, reason: string) => `pull 失败：${target}：${reason}`,
-    formatSyncFailureDetail: (target: string, reason: string) => `失败：${target}：${reason}`,
-    formatAdditionalFailureCount: (count: number) => `另有失败 ${count} 个`,
-    backgroundSyncReviewPrompt: "打开通知以检查待整理项目。",
   },
 } as const;
 
@@ -151,19 +139,7 @@ export function buildBackgroundSyncReviewNotification(payload: BackgroundSyncRev
     summaryLines.push(messages.formatSyncFailureCount(failures.length));
   }
 
-  const failedPullTasks = pulledTasks.filter((item) => item.status === "failed");
-  const detailLines = [
-    ...failedPullTasks.slice(0, 3).map((item) => (
-      messages.formatPullFailureDetail(`${item.taskTitle} (${item.branchName})`, item.summary)
-    )),
-    ...(failedPullTasks.length > 3 ? [messages.formatAdditionalFailureCount(failedPullTasks.length - 3)] : []),
-    ...failures.slice(0, 3).map((item) => messages.formatSyncFailureDetail(item.target, item.reason)),
-    ...(failures.length > 3 ? [messages.formatAdditionalFailureCount(failures.length - 3)] : []),
-  ];
-
-  const body = [summaryLines.join(" / "), ...detailLines, messages.backgroundSyncReviewPrompt]
-    .filter(Boolean)
-    .join("\n");
+  const body = summaryLines.join(" / ");
   const mergedKeys = payload.mergedPullRequests
     .map((item) => `${item.taskId}:${item.prUrl}:${item.mergedAt}`)
     .sort()


### PR DESCRIPTION
## What
- Shorten background sync review notification bodies so desktop alerts show only aggregate summary counts.

## How
**Summary-only notification body**
- Remove detailed failed pull and sync failure lines from the background sync review notification body.
- Keep merged PR, registered worktree, pull update, failed pull, and sync failure counts in the summary line.

**Preserve review details**
- Keep pulled task and failure details in the notification action payload so the review dialog can still show full context after opening the alert.
- Update the unit test to lock the summary-only body contract while asserting detailed payload data remains available.

## Important changes
### Background sync notification formatting

**Reduce alert length**
- **Why**: Long failure details made desktop alerts noisy and hard to scan.
- **Files**: `src/desktop/shared/taskNotifications.ts`

**Keep review payload intact**
- **Why**: Users still need detailed pull and sync failure data after opening the notification.
- **Files**: `src/desktop/shared/taskNotifications.ts`, `src/desktop/shared/__tests__/taskNotifications.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>