### PR TITLE
perf(session): defer task session setup until terminal attach

### DIFF
--- a/src/components/BranchTaskModal.tsx
+++ b/src/components/BranchTaskModal.tsx
@@ -67,9 +67,11 @@ export default function BranchTaskModal({
     startTransition(async () => {
       try {
         const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
-        const isReady = await ensureSessionDependencyWithPrompt(sessionType, selectedProject?.sshHost, tc);
-        if (!isReady) {
-          return;
+        if (!selectedProject?.sshHost) {
+          const isReady = await ensureSessionDependencyWithPrompt(sessionType, selectedProject?.sshHost, tc);
+          if (!isReady) {
+            return;
+          }
         }
 
         await branchFromTask(

--- a/src/components/BranchTaskModal.tsx
+++ b/src/components/BranchTaskModal.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useTransition } from "react";
 import { useTranslations } from "next-intl";
 import { branchFromTask } from "@/desktop/renderer/actions/kanban";
 import { getProjectBranches } from "@/desktop/renderer/actions/project";
-import { ensureSessionDependencyWithPrompt } from "@/desktop/renderer/utils/sessionDependencyPrompt";
 import { SessionType, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
@@ -66,14 +65,6 @@ export default function BranchTaskModal({
 
     startTransition(async () => {
       try {
-        const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
-        if (!selectedProject?.sshHost) {
-          const isReady = await ensureSessionDependencyWithPrompt(sessionType, selectedProject?.sshHost, tc);
-          if (!isReady) {
-            return;
-          }
-        }
-
         await branchFromTask(
           task.id,
           selectedProjectId,

--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -158,7 +158,7 @@ function CreateTaskModalContent({
         const sessionType = (formData.get("sessionType") as SessionType) || undefined;
         const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
 
-        if (sessionType) {
+        if (sessionType && !selectedProject?.sshHost) {
           const isReady = await ensureSessionDependencyWithPrompt(sessionType, selectedProject?.sshHost, tc);
           if (!isReady) {
             return;

--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -5,7 +5,6 @@ import { useTranslations } from "next-intl";
 import { useRouter } from "@/desktop/renderer/navigation";
 import { createTask } from "@/desktop/renderer/actions/kanban";
 import { getProjectBranches } from "@/desktop/renderer/actions/project";
-import { ensureSessionDependencyWithPrompt } from "@/desktop/renderer/utils/sessionDependencyPrompt";
 import { SessionType } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
 import type { Project } from "@/entities/Project";
@@ -156,14 +155,6 @@ function CreateTaskModalContent({
     startTransition(async () => {
       try {
         const sessionType = (formData.get("sessionType") as SessionType) || undefined;
-        const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
-
-        if (sessionType && !selectedProject?.sshHost) {
-          const isReady = await ensureSessionDependencyWithPrompt(sessionType, selectedProject?.sshHost, tc);
-          if (!isReady) {
-            return;
-          }
-        }
 
         const created = await createTask({
           title: branchName,

--- a/src/components/__tests__/BranchTaskModal.test.tsx
+++ b/src/components/__tests__/BranchTaskModal.test.tsx
@@ -112,4 +112,41 @@ describe("BranchTaskModal", () => {
     expect(mockEnsureSessionDependencyWithPrompt).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("로컬 프로젝트 branch 생성도 세션 도구 프롬프트 없이 분기 요청을 보낸다", async () => {
+    // Given
+    const onClose = vi.fn();
+
+    render(
+      <BranchTaskModal
+        task={createTask()}
+        projects={[createProject({ sshHost: null })]}
+        defaultSessionType="tmux"
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetProjectBranches).toHaveBeenCalledWith("project-remote");
+    });
+
+    // When
+    fireEvent.change(screen.getByPlaceholderText("branchPlaceholder"), {
+      target: { value: "feat/local-fast" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "submit" }));
+
+    // Then
+    await waitFor(() => {
+      expect(mockBranchFromTask).toHaveBeenCalledWith(
+        "task-1",
+        "project-remote",
+        "main",
+        "feat/local-fast",
+        "tmux",
+      );
+    });
+    expect(mockEnsureSessionDependencyWithPrompt).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/__tests__/BranchTaskModal.test.tsx
+++ b/src/components/__tests__/BranchTaskModal.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import BranchTaskModal from "../BranchTaskModal";
+import type { Project } from "@/entities/Project";
+import type { KanbanTask } from "@/entities/KanbanTask";
+
+const { mockBranchFromTask, mockEnsureSessionDependencyWithPrompt, mockGetProjectBranches } = vi.hoisted(() => ({
+  mockBranchFromTask: vi.fn(),
+  mockEnsureSessionDependencyWithPrompt: vi.fn(),
+  mockGetProjectBranches: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/desktop/renderer/actions/kanban", () => ({
+  branchFromTask: (...args: unknown[]) => mockBranchFromTask(...args),
+}));
+
+vi.mock("@/desktop/renderer/actions/project", () => ({
+  getProjectBranches: (...args: unknown[]) => mockGetProjectBranches(...args),
+}));
+
+vi.mock("@/desktop/renderer/utils/sessionDependencyPrompt", () => ({
+  ensureSessionDependencyWithPrompt: (...args: unknown[]) => mockEnsureSessionDependencyWithPrompt(...args),
+}));
+
+vi.mock("../BranchSearchInput", () => ({
+  default: ({ value }: { value: string }) => (
+    <input aria-label="baseBranch" readOnly value={value} />
+  ),
+}));
+
+function createProject(overrides?: Partial<Project>): Project {
+  return {
+    id: "project-remote",
+    name: "kanvibe",
+    repoPath: "/repo/kanvibe",
+    defaultBranch: "main",
+    sshHost: "remote-box",
+    isWorktree: false,
+    color: null,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function createTask(overrides?: Partial<KanbanTask>): KanbanTask {
+  return {
+    id: "task-1",
+    title: "Parent task",
+    description: null,
+    status: "todo",
+    branchName: "main",
+    baseBranch: "main",
+    sessionType: null,
+    sessionName: null,
+    worktreePath: null,
+    sshHost: null,
+    projectId: "project-remote",
+    priority: null,
+    displayOrder: 0,
+    prUrl: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    project: null,
+    ...overrides,
+  } as KanbanTask;
+}
+
+describe("BranchTaskModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProjectBranches.mockResolvedValue(["main", "develop"]);
+    mockBranchFromTask.mockResolvedValue(createTask());
+  });
+
+  it("원격 프로젝트 branch 생성은 세션 도구 프롬프트 없이 분기 요청을 보낸다", async () => {
+    // Given
+    const onClose = vi.fn();
+
+    render(
+      <BranchTaskModal
+        task={createTask()}
+        projects={[createProject()]}
+        defaultSessionType="tmux"
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetProjectBranches).toHaveBeenCalledWith("project-remote");
+    });
+
+    // When
+    fireEvent.change(screen.getByPlaceholderText("branchPlaceholder"), {
+      target: { value: "feat/remote-fast" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "submit" }));
+
+    // Then
+    await waitFor(() => {
+      expect(mockBranchFromTask).toHaveBeenCalledWith(
+        "task-1",
+        "project-remote",
+        "main",
+        "feat/remote-fast",
+        "tmux",
+      );
+    });
+    expect(mockEnsureSessionDependencyWithPrompt).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/components/__tests__/CreateTaskModal.test.tsx
@@ -73,16 +73,17 @@ describe("CreateTaskModal", () => {
     mockGetProjectBranches.mockResolvedValue(["main", "develop"]);
   });
 
-  it("원격 의존성 프롬프트를 취소하면 작업 생성을 진행하지 않는다", async () => {
+  it("로컬 의존성 프롬프트를 취소하면 작업 생성을 진행하지 않는다", async () => {
     // Given
     mockEnsureSessionDependencyWithPrompt.mockResolvedValue(false);
+    const localProject = createProject({ sshHost: null });
 
     render(
       <CreateTaskModal
         isOpen
         onClose={vi.fn()}
         sshHosts={["remote-box"]}
-        projects={[createProject()]}
+        projects={[localProject]}
         defaultProjectId="project-remote"
       />,
     );
@@ -97,7 +98,7 @@ describe("CreateTaskModal", () => {
 
     // Then
     await waitFor(() => {
-      expect(mockEnsureSessionDependencyWithPrompt).toHaveBeenCalledWith("tmux", "remote-box", expect.any(Function));
+      expect(mockEnsureSessionDependencyWithPrompt).toHaveBeenCalledWith("tmux", null, expect.any(Function));
     });
     expect(mockCreateTask).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
@@ -106,13 +107,14 @@ describe("CreateTaskModal", () => {
   it("의존성 확인이 실패하면 오류를 보여주고 생성 요청을 멈춘다", async () => {
     // Given
     mockEnsureSessionDependencyWithPrompt.mockRejectedValue(new Error("tmux 설치 실패"));
+    const localProject = createProject({ sshHost: null });
 
     render(
       <CreateTaskModal
         isOpen
         onClose={vi.fn()}
         sshHosts={["remote-box"]}
-        projects={[createProject()]}
+        projects={[localProject]}
         defaultProjectId="project-remote"
       />,
     );
@@ -130,6 +132,48 @@ describe("CreateTaskModal", () => {
       expect(screen.getByText("tmux 설치 실패")).toBeTruthy();
     });
     expect(mockCreateTask).not.toHaveBeenCalled();
+  });
+
+  it("원격 프로젝트 task 생성은 세션 도구 프롬프트 없이 생성 요청을 보낸다", async () => {
+    // Given
+    const onClose = vi.fn();
+    mockEnsureSessionDependencyWithPrompt.mockResolvedValue(true);
+    mockCreateTask.mockResolvedValue({ id: "task-remote-fast" });
+
+    render(
+      <CreateTaskModal
+        isOpen
+        onClose={onClose}
+        sshHosts={["remote-box"]}
+        projects={[createProject()]}
+        defaultProjectId="project-remote"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetProjectBranches).toHaveBeenCalledWith("project-remote");
+    });
+
+    // When
+    fireEvent.change(screen.getByPlaceholderText("branchPlaceholder"), { target: { value: "fix/remote-fast" } });
+    fireEvent.click(screen.getByRole("button", { name: "create" }));
+
+    // Then
+    await waitFor(() => {
+      expect(mockCreateTask).toHaveBeenCalledWith({
+        title: "fix/remote-fast",
+        description: undefined,
+        branchName: "fix/remote-fast",
+        baseBranch: "main",
+        sessionType: "tmux",
+        sshHost: undefined,
+        projectId: "project-remote",
+        priority: undefined,
+      });
+    });
+    expect(mockEnsureSessionDependencyWithPrompt).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/task/task-remote-fast");
   });
 
   it("의존성 준비가 끝나면 생성한 작업 상세 페이지로 이동한다", async () => {

--- a/src/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/components/__tests__/CreateTaskModal.test.tsx
@@ -73,15 +73,17 @@ describe("CreateTaskModal", () => {
     mockGetProjectBranches.mockResolvedValue(["main", "develop"]);
   });
 
-  it("로컬 의존성 프롬프트를 취소하면 작업 생성을 진행하지 않는다", async () => {
+  it("로컬 프로젝트 task 생성도 세션 도구 프롬프트 없이 생성 요청을 보낸다", async () => {
     // Given
+    const onClose = vi.fn();
     mockEnsureSessionDependencyWithPrompt.mockResolvedValue(false);
+    mockCreateTask.mockResolvedValue({ id: "task-local-fast" });
     const localProject = createProject({ sshHost: null });
 
     render(
       <CreateTaskModal
         isOpen
-        onClose={vi.fn()}
+        onClose={onClose}
         sshHosts={["remote-box"]}
         projects={[localProject]}
         defaultProjectId="project-remote"
@@ -98,40 +100,20 @@ describe("CreateTaskModal", () => {
 
     // Then
     await waitFor(() => {
-      expect(mockEnsureSessionDependencyWithPrompt).toHaveBeenCalledWith("tmux", null, expect.any(Function));
+      expect(mockCreateTask).toHaveBeenCalledWith({
+        title: "fix/session-prompt",
+        description: undefined,
+        branchName: "fix/session-prompt",
+        baseBranch: "main",
+        sessionType: "tmux",
+        sshHost: undefined,
+        projectId: "project-remote",
+        priority: undefined,
+      });
     });
-    expect(mockCreateTask).not.toHaveBeenCalled();
-    expect(mockPush).not.toHaveBeenCalled();
-  });
-
-  it("의존성 확인이 실패하면 오류를 보여주고 생성 요청을 멈춘다", async () => {
-    // Given
-    mockEnsureSessionDependencyWithPrompt.mockRejectedValue(new Error("tmux 설치 실패"));
-    const localProject = createProject({ sshHost: null });
-
-    render(
-      <CreateTaskModal
-        isOpen
-        onClose={vi.fn()}
-        sshHosts={["remote-box"]}
-        projects={[localProject]}
-        defaultProjectId="project-remote"
-      />,
-    );
-
-    await waitFor(() => {
-      expect(mockGetProjectBranches).toHaveBeenCalledWith("project-remote");
-    });
-
-    // When
-    fireEvent.change(screen.getByPlaceholderText("branchPlaceholder"), { target: { value: "fix/session-prompt" } });
-    fireEvent.click(screen.getByRole("button", { name: "create" }));
-
-    // Then
-    await waitFor(() => {
-      expect(screen.getByText("tmux 설치 실패")).toBeTruthy();
-    });
-    expect(mockCreateTask).not.toHaveBeenCalled();
+    expect(mockEnsureSessionDependencyWithPrompt).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/task/task-local-fast");
   });
 
   it("원격 프로젝트 task 생성은 세션 도구 프롬프트 없이 생성 요청을 보낸다", async () => {

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   homedir: vi.fn(() => "/home/tester"),
   validateGitRepo: vi.fn(),
   getDefaultBranch: vi.fn(),
+  listBranches: vi.fn(),
   scanGitRepos: vi.fn(),
   listWorktrees: vi.fn(),
   getProjectRepository: vi.fn(),
@@ -59,7 +60,7 @@ vi.mock("typeorm", () => ({
 vi.mock("@/lib/gitOperations", () => ({
   validateGitRepo: mocks.validateGitRepo,
   getDefaultBranch: mocks.getDefaultBranch,
-  listBranches: vi.fn(),
+  listBranches: mocks.listBranches,
   scanGitRepos: mocks.scanGitRepos,
   listWorktrees: mocks.listWorktrees,
   execGit: mocks.execGit,
@@ -136,6 +137,7 @@ describe("projectService.listSubdirectories", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.execGit.mockResolvedValue("");
+    mocks.listBranches.mockResolvedValue(["main", "develop"]);
     mocks.getDefaultSessionType.mockResolvedValue("tmux");
     mocks.getClaudeHooksStatus.mockResolvedValue({ installed: false });
     mocks.getGeminiHooksStatus.mockResolvedValue({ installed: false });
@@ -189,6 +191,28 @@ describe("projectService.listSubdirectories", () => {
       "remote-host",
     );
     expect(result).toEqual(["projects"]);
+  });
+
+  it("원격 프로젝트 브랜치 목록은 blocking fetch 없이 조회한다", async () => {
+    // Given
+    const findOneBy = vi.fn().mockResolvedValue({
+      id: "project-remote",
+      repoPath: "/remote/repo",
+      sshHost: "remote-host",
+    });
+    mocks.getProjectRepository.mockResolvedValue({ findOneBy });
+    const { getProjectBranches } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const result = await getProjectBranches("project-remote");
+
+    // Then
+    expect(result).toEqual(["main", "develop"]);
+    expect(mocks.listBranches).toHaveBeenCalledWith(
+      "/remote/repo",
+      "remote-host",
+      { refresh: false },
+    );
   });
 });
 

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -831,7 +831,9 @@ export async function getProjectBranches(projectId: string): Promise<string[]> {
   const project = await repo.findOneBy({ id: projectId });
   if (!project) return [];
 
-  return listBranches(project.repoPath, project.sshHost);
+  return listBranches(project.repoPath, project.sshHost, {
+    refresh: !project.sshHost,
+  });
 }
 
 /** 프로젝트의 Claude Code hooks 설치 상태를 조회한다 */

--- a/src/desktop/main/terminalBridge.ts
+++ b/src/desktop/main/terminalBridge.ts
@@ -103,6 +103,10 @@ export async function openTerminal(
   client.once("close", finalizeClient);
 
   try {
+    const tmuxPaneLayout = task.sessionType === SessionType.TMUX
+      ? await getEffectivePaneLayout(task.projectId ?? undefined)
+      : null;
+
     if (task.sshHost) {
       await ensureRemoteSessionDependency(task.sessionType as SessionType, task.sshHost);
 
@@ -113,10 +117,6 @@ export async function openTerminal(
         client.close(1008, `SSH 호스트를 찾을 수 없습니다: ${task.sshHost}`);
         return { ok: false, error: `SSH 호스트를 찾을 수 없습니다: ${task.sshHost}` };
       }
-
-      const tmuxPaneLayout = task.sessionType === SessionType.TMUX
-        ? await getEffectivePaneLayout(task.projectId ?? undefined)
-        : null;
 
       await attachRemoteSession(
         taskId,
@@ -139,6 +139,7 @@ export async function openTerminal(
         task.worktreePath,
         cols,
         rows,
+        tmuxPaneLayout,
       );
     }
 

--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -110,6 +110,42 @@ describe("attachLocalSession — tmux 세션 자동 생성", () => {
     }));
   });
 
+  it("should apply tmux pane layout commands when creating a local session", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) {
+        throw new Error("session not found");
+      }
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-layout",
+      SessionType.TMUX,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+      120,
+      30,
+      {
+        layoutType: PaneLayoutType.VERTICAL_2,
+        panes: [
+          { position: 0, command: "pnpm dev" },
+          { position: 1, command: "pnpm test" },
+        ],
+      },
+    );
+
+    // Then
+    const bootstrapCmd = findExecSyncCall("new-session");
+    expect(bootstrapCmd).toContain('tmux new-session -d -s "feat-login" -c "/workspace"');
+    expect(bootstrapCmd).toContain('tmux split-window -h -t "feat-login":0 -c "/workspace"');
+    expect(bootstrapCmd).toContain('tmux send-keys -t "feat-login":0.0 "pnpm dev" Enter');
+    expect(bootstrapCmd).toContain('tmux send-keys -t "feat-login":0.1 "pnpm test" Enter');
+  });
+
   it("should skip session creation when tmux session already exists", async () => {
     // Given
     const { attachLocalSession } = await import("@/lib/terminal");

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -542,6 +542,28 @@ describe("createWorktreeWithSession — Zellij KDL layout file persistence", () 
     vi.clearAllMocks();
   });
 
+  it("should defer remote tmux dependency checks until terminal attach", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("");
+    const { createWorktreeWithSession } = await import("@/lib/worktree");
+
+    // When
+    await createWorktreeWithSession(
+      "/home/user/kanvibe",
+      "feat-new",
+      "main",
+      SessionType.TMUX,
+      "remote-create-host",
+      "project-1",
+    );
+
+    // Then
+    expect(filterCalls("command -v tmux")).toHaveLength(0);
+    expect(filterCalls("tmux has-session")).toHaveLength(0);
+    expect(filterCalls("tmux new-session")).toHaveLength(0);
+    expect(filterCalls("git -C")).toHaveLength(1);
+  });
+
   it("should write layout file to worktree directory without starting zellij", async () => {
     // Given
     mockGetEffectivePaneLayout.mockResolvedValue({

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -258,7 +258,7 @@ describe("createSessionWithoutWorktree", () => {
 
   it("should return session name derived from branch name", async () => {
     // Given
-    mockExecGit.mockRejectedValueOnce(new Error("no session")).mockResolvedValue("");
+    mockExecGit.mockResolvedValue("");
     const { createSessionWithoutWorktree } = await import("@/lib/worktree");
 
     // When
@@ -272,13 +272,13 @@ describe("createSessionWithoutWorktree", () => {
     expect(result.sessionName).toBe("path-feat-my-feature");
   });
 
-  it("should create tmux session with working directory when session does not exist", async () => {
+  it("should defer local tmux session creation until terminal attach", async () => {
     // Given
-    mockExecGit.mockRejectedValueOnce(new Error("no session")).mockResolvedValue("");
+    mockExecGit.mockResolvedValue("");
     const { createSessionWithoutWorktree } = await import("@/lib/worktree");
 
     // When
-    await createSessionWithoutWorktree(
+    const result = await createSessionWithoutWorktree(
       "/repo/path",
       "feat/test",
       SessionType.TMUX,
@@ -287,13 +287,12 @@ describe("createSessionWithoutWorktree", () => {
     );
 
     // Then
-    expect(mockExecGit).toHaveBeenCalledWith(
-      'tmux new-session -d -s "path-feat-test" -c "/custom/dir"',
-      null,
-    );
+    expect(result.sessionName).toBe("path-feat-test");
+    expect(filterCalls("tmux has-session")).toHaveLength(0);
+    expect(filterCalls("tmux new-session")).toHaveLength(0);
   });
 
-  it("should skip session creation when tmux session already exists", async () => {
+  it("should not probe local tmux session existence before terminal attach", async () => {
     // Given
     mockExecGit.mockResolvedValue("");
     const { createSessionWithoutWorktree } = await import("@/lib/worktree");
@@ -306,15 +305,11 @@ describe("createSessionWithoutWorktree", () => {
     );
 
     // Then
-    /** isSessionAlive → has-session 호출 1회만 발생, new-session은 호출되지 않는다 */
-    expect(mockExecGit).toHaveBeenCalledTimes(1);
-    expect(mockExecGit).toHaveBeenCalledWith(
-      'tmux has-session -t "path-main" 2>/dev/null',
-      undefined,
-    );
+    expect(filterCalls("tmux has-session")).toHaveLength(0);
+    expect(filterCalls("tmux new-session")).toHaveLength(0);
   });
 
-  it("should defer remote tmux creation until terminal attach", async () => {
+  it("should defer remote tmux dependency checks and creation until terminal attach", async () => {
     // Given
     mockExecGit.mockImplementation((command: string, sshHost?: string | null) => {
       if (command === "command -v tmux >/dev/null 2>&1" && sshHost === "remote-host") {
@@ -336,11 +331,7 @@ describe("createSessionWithoutWorktree", () => {
     );
 
     // Then
-    expect(mockExecGit).toHaveBeenCalledTimes(1);
-    expect(mockExecGit).toHaveBeenCalledWith(
-      "command -v tmux >/dev/null 2>&1",
-      "remote-host",
-    );
+    expect(filterCalls("command -v tmux")).toHaveLength(0);
     expect(filterCalls("tmux has-session")).toHaveLength(0);
     expect(filterCalls("tmux new-session")).toHaveLength(0);
   });
@@ -559,6 +550,27 @@ describe("createWorktreeWithSession — Zellij KDL layout file persistence", () 
 
     // Then
     expect(filterCalls("command -v tmux")).toHaveLength(0);
+    expect(filterCalls("tmux has-session")).toHaveLength(0);
+    expect(filterCalls("tmux new-session")).toHaveLength(0);
+    expect(filterCalls("git -C")).toHaveLength(1);
+  });
+
+  it("should defer local tmux session creation until terminal attach", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("");
+    const { createWorktreeWithSession } = await import("@/lib/worktree");
+
+    // When
+    await createWorktreeWithSession(
+      "/home/user/kanvibe",
+      "feat-local",
+      "main",
+      SessionType.TMUX,
+      null,
+      "project-1",
+    );
+
+    // Then
     expect(filterCalls("tmux has-session")).toHaveLength(0);
     expect(filterCalls("tmux new-session")).toHaveLength(0);
     expect(filterCalls("git -C")).toHaveLength(1);

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -290,11 +290,18 @@ export async function remoteBranchExists(
  * remote origin을 먼저 fetch하여 최신 상태를 반영하며,
  * 로컬에 없는 remote-only 브랜치는 `origin/` prefix를 유지한다.
  */
+interface ListBranchesOptions {
+  refresh?: boolean;
+}
+
 export async function listBranches(
   repoPath: string,
-  sshHost?: string | null
+  sshHost?: string | null,
+  options: ListBranchesOptions = {},
 ): Promise<string[]> {
-  await fetchOrigin(repoPath, sshHost);
+  if (options.refresh ?? true) {
+    await fetchOrigin(repoPath, sshHost);
+  }
 
   const output = await execGit(
     `git -C "${repoPath}" branch -a --format='%(refname:short)'`,

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -72,6 +72,7 @@ export async function attachLocalSession(
   cwd?: string | null,
   cols?: number,
   rows?: number,
+  tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
 ): Promise<void> {
   const initialCols = cols ?? 120;
   const initialRows = rows ?? 30;
@@ -119,10 +120,17 @@ export async function attachLocalSession(
     if (!isTmuxSessionAlive(sessionName)) {
       try {
         const dir = cwd || process.env.HOME || "/";
-        execSync(
-          `tmux new-session -d -s "${sessionName}" -c "${dir}"`,
-          { env: terminalEnvironment, timeout: 5000 },
+        const bootstrapCommands = buildTmuxSessionBootstrapCommands(
+          sessionName,
+          dir,
+          tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
+            ? tmuxPaneLayout
+            : null,
         );
+        execSync(bootstrapCommands.join("; "), {
+          env: terminalEnvironment,
+          timeout: 5000,
+        });
       } catch (error) {
         console.error(`[터미널] tmux 세션 자동 생성 실패:`, error);
         ws.close(1008, "tmux 세션 생성에 실패했습니다.");

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -286,8 +286,6 @@ export async function createWorktreeWithSession(
   sshHost?: string | null,
   projectId?: string | null,
 ): Promise<WorktreeSession> {
-  await ensureRemoteSessionDependency(sessionType, sshHost);
-
   const projectName = path.basename(projectPath);
   const worktreePath = buildManagedWorktreePath(projectPath, branchName);
   const sessionName = formatSessionName(projectName, branchName);

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -3,7 +3,6 @@ import { writeFile } from "fs/promises";
 import { SessionType } from "@/entities/KanbanTask";
 import { PaneLayoutType, type PaneCommand } from "@/entities/PaneLayoutConfig";
 import { execGit } from "@/lib/gitOperations";
-import { ensureRemoteSessionDependency } from "@/lib/remoteSessionDependency";
 import { getEffectivePaneLayout } from "@/desktop/main/services/paneLayoutService";
 
 interface WorktreeSession {
@@ -108,31 +107,6 @@ export function buildTmuxSessionBootstrapCommands(
         )
       : []),
   ];
-}
-
-async function createTmuxSession(
-  sessionName: string,
-  workingDir: string,
-  sshHost?: string | null,
-): Promise<void> {
-  await execGit(buildTmuxCreateSessionCommand(sessionName, workingDir), sshHost);
-}
-
-
-/**
- * tmux 세션에 pane 레이아웃을 적용하고 각 pane에 시작 명령어를 실행한다.
- * 분할 실패 시에도 기본 window는 유지된다 (graceful fallback).
- */
-async function applyPaneLayout(
-  sessionName: string,
-  layoutType: PaneLayoutType,
-  panes: PaneCommand[],
-  worktreePath: string,
-  sshHost?: string | null,
-): Promise<void> {
-  for (const command of buildTmuxPaneLayoutCommands(sessionName, layoutType, panes, worktreePath)) {
-    await execGit(command, sshHost);
-  }
 }
 
 /** KDL 문자열 내 특수문자를 이스케이프한다 */
@@ -248,35 +222,9 @@ async function writeLayoutToWorktree(
 }
 
 /**
- * pane 레이아웃을 백그라운드에서 적용한다.
- * task 생성 흐름을 차단하지 않으며, 실패해도 기본 window는 유지된다.
- */
-function applyPaneLayoutAsync(
-  sessionName: string,
-  worktreePath: string,
-  projectId?: string,
-): void {
-  (async () => {
-    try {
-      const layoutConfig = await getEffectivePaneLayout(projectId);
-      if (layoutConfig && layoutConfig.layoutType !== PaneLayoutType.SINGLE) {
-        await applyPaneLayout(
-          sessionName,
-          layoutConfig.layoutType as PaneLayoutType,
-          layoutConfig.panes,
-          worktreePath,
-        );
-      }
-    } catch (error) {
-      console.error("Pane 레이아웃 적용 실패 (기본 window 유지):", error);
-    }
-  })();
-}
-
-/**
  * git worktree를 생성하고 브랜치별 독립 세션을 생성한다.
- * 세션이 없으면 자동 생성한다. sshHost가 지정되면 원격에서 실행한다.
- * 로컬 세션인 경우 projectId를 기반으로 pane 레이아웃 설정을 적용한다.
+ * 세션은 터미널 연결 시점에 생성한다.
+ * 로컬 Zellij 세션인 경우 연결 시점에 사용할 KDL 레이아웃 파일만 준비한다.
  */
 export async function createWorktreeWithSession(
   projectPath: string,
@@ -297,18 +245,6 @@ export async function createWorktreeWithSession(
 
   try {
     if (sessionType === SessionType.TMUX) {
-      /**
-       * 원격 호스트에서는 비대화형 SSH로 tmux 서버를 시작할 수 없으므로
-       * 세션 생성을 터미널 연결 시 PTY가 확보된 후로 미룬다.
-       */
-      if (!sshHost) {
-        const hasSession = await isSessionAlive(sessionType, sessionName, sshHost);
-        if (!hasSession) {
-          await createTmuxSession(sessionName, worktreePath, sshHost);
-        }
-        applyPaneLayoutAsync(sessionName, worktreePath, projectId ?? undefined);
-      }
-
       return { worktreePath, sessionName };
     } else {
       /**
@@ -352,23 +288,16 @@ export async function createSessionWithoutWorktree(
   projectPath: string,
   branchName: string,
   sessionType: SessionType,
-  sshHost?: string | null,
-  workingDir?: string,
+  _sshHost?: string | null,
+  _workingDir?: string,
 ): Promise<{ sessionName: string }> {
-  await ensureRemoteSessionDependency(sessionType, sshHost);
+  void _sshHost;
+  void _workingDir;
 
   const projectName = path.basename(projectPath);
   const sessionName = formatSessionName(projectName, branchName);
-  const cwd = workingDir || projectPath;
 
   if (sessionType === SessionType.TMUX) {
-    if (!sshHost) {
-      const hasSession = await isSessionAlive(sessionType, sessionName, sshHost);
-      if (!hasSession) {
-        await createTmuxSession(sessionName, cwd, sshHost);
-      }
-    }
-
     return { sessionName };
   } else {
     /**


### PR DESCRIPTION
## What changed?
- Speed up task and branch creation by removing tmux/zellij setup from the create path.
- Initialize tmux/zellij sessions at terminal attach time for both local and remote tasks.
- Keep remote branch listing non-blocking by avoiding `git fetch --prune` during remote base-branch lookup.
- Add regression coverage for local and remote create flows, worktree/session helpers, and local tmux attach layout bootstrap.

## How did we solve it?
**Defer session setup**
- Remove create-time session dependency prompts from task and branch modals.
- Make `createWorktreeWithSession` and `createSessionWithoutWorktree` return session metadata without probing or creating tmux/zellij.
- Keep actual dependency checks/session startup in terminal connection paths.

**Move local tmux layout bootstrap to attach**
- Pass effective tmux pane layout into local terminal attach.
- Apply tmux pane layout commands when attach creates a missing local tmux session.
- Keep Zellij layout-file preparation for attach-time startup.

**Avoid blocking remote branch refreshes**
- Add a `refresh` option to `listBranches`.
- Call remote project branch listing with `refresh: false` while preserving local refresh behavior.

## Important changes
### Task creation latency
**Remove session startup from task/branch creation**
- **Reason**: create flows only need worktree/session metadata; the terminal is the point where a tmux/zellij session is actually needed.
- **Files**: `src/components/CreateTaskModal.tsx`, `src/components/BranchTaskModal.tsx`, `src/lib/worktree.ts`

### Terminal attach behavior
**Initialize local tmux sessions and pane layouts on attach**
- **Reason**: local and remote session initialization now follow the same attach-time model.
- **Files**: `src/lib/terminal.ts`, `src/desktop/main/terminalBridge.ts`

### Regression coverage
**Cover local and remote deferred setup**
- **Reason**: prevent create-time dependency prompts or tmux creation from returning.
- **Files**: `src/components/__tests__/CreateTaskModal.test.tsx`, `src/components/__tests__/BranchTaskModal.test.tsx`, `src/lib/__tests__/worktree.test.ts`, `src/lib/__tests__/terminal.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>