### PR TITLE
Optimize remote SSH execution and session cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ Each pane can run a custom command (e.g., `vim`, `htop`, `lazygit`, test runner,
 - **tmux** and **zellij** are both supported as terminal multiplexers
 - Browser-based terminal via xterm.js + WebSocket
 - SSH remote terminal support (reads `~/.ssh/config`)
-- Remote SSH commands reuse an app-local ControlMaster socket under `~/.kanvibe`
-- Remote terminal attach uses trusted X11 forwarding (`ssh -Y`), so tools such as `xclip` can work when local `DISPLAY`, remote `X11Forwarding`, and `xauth` are available
+- Non-interactive remote SSH commands reuse an app-local ControlMaster socket under `~/.kanvibe` with bounded per-host concurrency
+- Remote terminal attach executes tmux/zellij directly over SSH; trusted X11 forwarding (`ssh -Y`) is requested only when local `DISPLAY`, remote `X11Forwarding`, and `xauth` are available
 - Nerd Font rendering support
 
 ### Quick Task Search

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -161,8 +161,8 @@ macOS에서 `better-sqlite3` `NODE_MODULE_VERSION` 불일치가 발생하면, Ka
 - **tmux**와 **zellij** 모두 터미널 멀티플렉서로 지원
 - xterm.js + WebSocket 기반 브라우저 터미널
 - SSH 원격 터미널 지원 (`~/.ssh/config` 읽기)
-- 원격 SSH 명령은 `~/.kanvibe` 아래의 앱 전용 ControlMaster 소켓을 재사용합니다
-- 원격 터미널 attach는 trusted X11 forwarding(`ssh -Y`)을 사용하므로 로컬 `DISPLAY`, 원격 `X11Forwarding`, `xauth`가 준비되어 있으면 `xclip` 같은 도구가 동작할 수 있습니다
+- 비대화형 원격 SSH 명령은 `~/.kanvibe` 아래의 앱 전용 ControlMaster 소켓을 재사용하며 host별 동시성을 제한합니다
+- 원격 터미널 attach는 SSH에서 tmux/zellij를 직접 실행하며, 로컬 `DISPLAY`, 원격 `X11Forwarding`, `xauth`가 준비된 경우에만 trusted X11 forwarding(`ssh -Y`)을 요청합니다
 - Nerd Font 렌더링 지원
 
 ### 키보드 단축키

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -161,8 +161,8 @@ pnpm dist
 - 同时支持 **tmux** 和 **zellij** 作为终端复用器
 - 基于 xterm.js + WebSocket 的浏览器终端
 - SSH 远程终端支持（读取 `~/.ssh/config`）
-- 远程 SSH 命令会复用 `~/.kanvibe` 下的应用专用 ControlMaster socket
-- 远程终端 attach 使用 trusted X11 forwarding（`ssh -Y`），因此在本地 `DISPLAY`、远程 `X11Forwarding` 和 `xauth` 可用时，`xclip` 等工具可以工作
+- 非交互式远程 SSH 命令会复用 `~/.kanvibe` 下的应用专用 ControlMaster socket，并限制每个 host 的并发数
+- 远程终端 attach 会通过 SSH 直接执行 tmux/zellij；仅在本地 `DISPLAY`、远程 `X11Forwarding` 和 `xauth` 可用时请求 trusted X11 forwarding（`ssh -Y`）
 - Nerd Font 渲染支持
 
 ### 键盘快捷键

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   createWorktreeWithSession: vi.fn(),
   removeWorktreeAndBranch: vi.fn(),
   removeSessionOnly: vi.fn(),
+  detachSession: vi.fn(),
   installKanvibeHooks: vi.fn(),
   broadcastBoardUpdate: vi.fn(),
   execGit: vi.fn(),
@@ -64,6 +65,10 @@ vi.mock("@/lib/worktree", () => ({
   createSessionWithoutWorktree: vi.fn(),
   removeSessionOnly: mocks.removeSessionOnly,
   buildManagedWorktreePath: vi.fn((projectPath: string, branchName: string) => `${projectPath}__worktrees/${branchName}`),
+}));
+
+vi.mock("@/lib/terminal", () => ({
+  detachSession: mocks.detachSession,
 }));
 
 vi.mock("@/lib/kanvibeHooksInstaller", () => ({
@@ -367,6 +372,7 @@ describe("kanbanService.createTask", () => {
     } as never);
 
     // Then
+    expect(mocks.detachSession).toHaveBeenCalledWith("task-2", "cleanup-task-resources");
     expect(mocks.removeSessionOnly).toHaveBeenCalledWith(
       "tmux",
       "prompt-main",
@@ -395,6 +401,7 @@ describe("kanbanService.createTask", () => {
 
     // Then
     expect(mocks.projectRepo.findOneBy).not.toHaveBeenCalled();
+    expect(mocks.detachSession).toHaveBeenCalledWith("task-3", "cleanup-task-resources");
     expect(mocks.removeSessionOnly).toHaveBeenCalledWith(
       "tmux",
       "techtaurant-be-dev",
@@ -426,6 +433,7 @@ describe("kanbanService.createTask", () => {
 
     // Then
     expect(result).toBe(true);
+    expect(mocks.detachSession).toHaveBeenCalledWith("task-remote", "cleanup-task-resources");
     expect(mocks.removeSessionOnly).toHaveBeenCalledWith(
       "tmux",
       "prompt-main",
@@ -434,6 +442,39 @@ describe("kanbanService.createTask", () => {
     expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
     expect(mocks.taskRepo.remove).toHaveBeenCalledWith(task);
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("tmux 세션 정리 전 앱이 붙잡고 있는 활성 터미널 PTY를 먼저 닫는다", async () => {
+    // Given
+    const callOrder: string[] = [];
+    mocks.detachSession.mockImplementation(() => {
+      callOrder.push("detach");
+    });
+    mocks.removeSessionOnly.mockImplementation(async () => {
+      callOrder.push("remove-session");
+    });
+
+    const { cleanupTaskResources } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    await cleanupTaskResources({
+      id: "task-open-terminal",
+      projectId: null,
+      branchName: null,
+      worktreePath: null,
+      sshHost: null,
+      sessionType: "tmux" as never,
+      sessionName: "repo-feat-open",
+    } as never);
+
+    // Then
+    expect(callOrder).toEqual(["detach", "remove-session"]);
+    expect(mocks.detachSession).toHaveBeenCalledWith("task-open-terminal", "cleanup-task-resources");
+    expect(mocks.removeSessionOnly).toHaveBeenCalledWith(
+      "tmux",
+      "repo-feat-open",
+      null,
+    );
   });
 
   it("task 내용 수정 후 board update를 브로드캐스트한다", async () => {

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/boardNotifier";
 import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
 import { execGit, pullCurrentBranch, remoteBranchExists } from "@/lib/gitOperations";
+import { detachSession } from "@/lib/terminal";
 
 export type TasksByStatus = Record<TaskStatus, KanbanTask[]>;
 
@@ -667,6 +668,8 @@ export async function cleanupTaskResources(
   /** 브랜치별 독립 세션 정리 */
   if (task.sessionType && task.sessionName) {
     try {
+      detachSession(task.id, "cleanup-task-resources");
+
       if (cleanupOptions) {
         await removeSessionOnly(
           task.sessionType,

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -189,7 +189,7 @@ describe("gitOperations.resolvePathForShell", () => {
     }
   });
 
-  it("같은 SSH host의 원격 명령은 한 번에 하나씩 실행한다", async () => {
+  it("같은 SSH host의 원격 명령은 제한된 동시성으로 실행한다", async () => {
     // Given
     const startedCommands: string[] = [];
     const pendingCallbacks: Array<(error: null, result: { stdout: string }) => void> = [];
@@ -217,19 +217,39 @@ describe("gitOperations.resolvePathForShell", () => {
     // When
     const first = execGit("first", "remote-host");
     const second = execGit("second", "remote-host");
+    const third = execGit("third", "remote-host");
+    const fourth = execGit("fourth", "remote-host");
+    const fifth = execGit("fifth", "remote-host");
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     // Then
-    expect(startedCommands).toEqual(["sh -lc 'first'"]);
+    expect(startedCommands).toEqual([
+      "sh -lc 'first'",
+      "sh -lc 'second'",
+      "sh -lc 'third'",
+      "sh -lc 'fourth'",
+    ]);
 
     pendingCallbacks.shift()?.(null, { stdout: "one\n" });
     await expect(first).resolves.toBe("one");
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(startedCommands).toEqual(["sh -lc 'first'", "sh -lc 'second'"]);
+    expect(startedCommands).toEqual([
+      "sh -lc 'first'",
+      "sh -lc 'second'",
+      "sh -lc 'third'",
+      "sh -lc 'fourth'",
+      "sh -lc 'fifth'",
+    ]);
 
     pendingCallbacks.shift()?.(null, { stdout: "two\n" });
     await expect(second).resolves.toBe("two");
+    pendingCallbacks.shift()?.(null, { stdout: "three\n" });
+    pendingCallbacks.shift()?.(null, { stdout: "four\n" });
+    pendingCallbacks.shift()?.(null, { stdout: "five\n" });
+    await expect(third).resolves.toBe("three");
+    await expect(fourth).resolves.toBe("four");
+    await expect(fifth).resolves.toBe("five");
   });
 
   it("조용한 probe 명령 실패는 콘솔 에러를 남기지 않는다", async () => {

--- a/src/lib/__tests__/sshConfig.test.ts
+++ b/src/lib/__tests__/sshConfig.test.ts
@@ -2,14 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   readFile: vi.fn(),
+  mkdir: vi.fn(),
   homedir: vi.fn(() => "/home/local-user"),
 }));
 
 vi.mock("fs/promises", () => ({
   default: {
     readFile: mocks.readFile,
+    mkdir: mocks.mkdir,
   },
   readFile: mocks.readFile,
+  mkdir: mocks.mkdir,
 }));
 
 vi.mock("os", () => ({
@@ -153,5 +156,29 @@ describe("sshConfig.buildSSHArgs", () => {
       controlPath: "/home/local-user/.kanvibe/ssh-%C",
       controlPersist: "10m",
     });
+  });
+
+  it("creates the KanVibe SSH control directory with private permissions", async () => {
+    // Given
+    mocks.mkdir.mockResolvedValue(undefined);
+    const { ensureKanvibeSSHControlDirectory } = await import("@/lib/sshConfig");
+
+    // When
+    await ensureKanvibeSSHControlDirectory();
+
+    // Then
+    expect(mocks.mkdir).toHaveBeenCalledWith(
+      "/home/local-user/.kanvibe",
+      { recursive: true, mode: 0o700 },
+    );
+  });
+
+  it("detects local X11 availability from DISPLAY", async () => {
+    // Given
+    const { hasLocalX11Display } = await import("@/lib/sshConfig");
+
+    // When & Then
+    expect(hasLocalX11Display({ DISPLAY: ":0" })).toBe(true);
+    expect(hasLocalX11Display({})).toBe(false);
   });
 });

--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -359,32 +359,39 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
 
   it("should spawn ssh with tty options for remote tmux attach", async () => {
     // Given
+    const originalDisplay = process.env.DISPLAY;
+    delete process.env.DISPLAY;
     const { attachRemoteSession } = await import("@/lib/terminal");
     const nodePty = await import("node-pty");
 
-    // When
-    await attachRemoteSession(
-      "task-r1",
-      "remote-host",
-      SessionType.TMUX,
-      "remote-session",
-      createMockWs(),
-      {
-        host: "remote-host",
-        hostname: "example.com",
-        port: 2202,
-        username: "tester",
-        privateKeyPath: "/tmp/test-key",
-      },
-      120,
-      30,
-      "/remote/worktree",
-    );
+    try {
+      // When
+      await attachRemoteSession(
+        "task-r1",
+        "remote-host",
+        SessionType.TMUX,
+        "remote-session",
+        createMockWs(),
+        {
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        },
+        120,
+        30,
+        "/remote/worktree",
+      );
 
-    // Then
-    expect(nodePty.spawn).toHaveBeenCalledWith(
-      "ssh",
-      [
+      // Then
+      expect(nodePty.spawn).toHaveBeenCalledWith(
+        "ssh",
+        expect.any(Array),
+        expect.objectContaining({ cwd: expect.any(String) }),
+      );
+      const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+      expect(sshArgs).toEqual([
         "-i",
         "/tmp/test-key",
         "-p",
@@ -393,31 +400,66 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
         "BatchMode=yes",
         "-o",
         "IdentitiesOnly=yes",
-        "-Y",
         "-tt",
-        "-o",
-        "ControlMaster=auto",
-        "-o",
-        "ControlPersist=10m",
-        "-o",
-        "ControlPath=/home/local-user/.kanvibe/ssh-%C",
         "remote-host",
-      ],
-      expect.objectContaining({ cwd: expect.any(String) }),
-    );
-    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
-    expect(sshArgs.indexOf("-Y")).toBeLessThan(sshArgs.indexOf("remote-host"));
-    expect(sshArgs.indexOf("-tt")).toBeLessThan(sshArgs.indexOf("remote-host"));
-    expect(mockPtyWrite).toHaveBeenCalledWith(
-      expect.stringContaining('tmux has-session -t "remote-session"'),
-    );
-    expect(mockPtyWrite).toHaveBeenCalledWith(
-      expect.stringContaining('tmux new-session -d -s "remote-session" -c "/remote/worktree"'),
-    );
+        expect.stringContaining("sh -lc "),
+      ]);
+      expect(sshArgs).not.toContain("-Y");
+      expect(sshArgs).not.toContain("ControlMaster=auto");
+      expect(sshArgs.at(-1)).toContain('tmux has-session -t "remote-session"');
+      expect(sshArgs.at(-1)).toContain('tmux new-session -d -s "remote-session" -c "/remote/worktree"');
+      expect(mockPtyWrite).not.toHaveBeenCalledWith(
+        expect.stringContaining('tmux has-session -t "remote-session"'),
+      );
+    } finally {
+      if (originalDisplay === undefined) {
+        delete process.env.DISPLAY;
+      } else {
+        process.env.DISPLAY = originalDisplay;
+      }
+    }
+  });
+
+  it("should request trusted X11 forwarding only when a local DISPLAY exists", async () => {
+    // Given
+    const originalDisplay = process.env.DISPLAY;
+    process.env.DISPLAY = ":0";
+    const { attachRemoteSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
+
+    try {
+      // When
+      await attachRemoteSession(
+        "task-r-x11",
+        "remote-host",
+        SessionType.TMUX,
+        "remote-session",
+        createMockWs(),
+        {
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        },
+      );
+
+      // Then
+      const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+      expect(sshArgs).toContain("-Y");
+      expect(sshArgs.indexOf("-Y")).toBeLessThan(sshArgs.indexOf("remote-host"));
+    } finally {
+      if (originalDisplay === undefined) {
+        delete process.env.DISPLAY;
+      } else {
+        process.env.DISPLAY = originalDisplay;
+      }
+    }
   });
 
   it("should apply tmux pane layout commands when creating a remote session", async () => {
     const { attachRemoteSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
 
     await attachRemoteSession(
       "task-r2",
@@ -444,14 +486,9 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
       },
     );
 
-    expect(mockPtyWrite).toHaveBeenCalledWith(
-      expect.stringContaining('tmux split-window -h -t "remote-session":0 -c "/remote/worktree"'),
-    );
-    expect(mockPtyWrite).toHaveBeenCalledWith(
-      expect.stringContaining('tmux send-keys -t "remote-session":0.0 "pnpm dev" Enter'),
-    );
-    expect(mockPtyWrite).toHaveBeenCalledWith(
-      expect.stringContaining('tmux send-keys -t "remote-session":0.1 "pnpm test" Enter'),
-    );
+    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+    expect(sshArgs.at(-1)).toContain('tmux split-window -h -t "remote-session":0 -c "/remote/worktree"');
+    expect(sshArgs.at(-1)).toContain('tmux send-keys -t "remote-session":0.0 "pnpm dev" Enter');
+    expect(sshArgs.at(-1)).toContain('tmux send-keys -t "remote-session":0.1 "pnpm test" Enter');
   });
 });

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -206,7 +206,7 @@ describe("removeSessionOnly", () => {
 
     // Then
     expect(mockExecGit).toHaveBeenCalledWith(
-      'tmux kill-session -t "feat-branch" 2>/dev/null || true',
+      "tmux kill-session -t 'feat-branch' 2>/dev/null || true",
       undefined,
     );
   });
@@ -221,7 +221,7 @@ describe("removeSessionOnly", () => {
 
     // Then
     expect(mockExecGit).toHaveBeenCalledWith(
-      'zellij kill-session "feat-branch" 2>/dev/null || true; zellij delete-session "feat-branch" 2>/dev/null || true',
+      "zellij kill-sessions 'feat-branch' 2>/dev/null || true; zellij delete-session 'feat-branch' 2>/dev/null || true",
       undefined,
     );
   });
@@ -236,9 +236,45 @@ describe("removeSessionOnly", () => {
 
     // Then
     expect(mockExecGit).toHaveBeenCalledWith(
-      'zellij kill-session "feat-branch" 2>/dev/null || true; zellij delete-session "feat-branch" 2>/dev/null || true',
+      "zellij kill-sessions 'feat-branch' 2>/dev/null || true; zellij delete-session 'feat-branch' 2>/dev/null || true",
       "remote-host",
     );
+  });
+
+  it("should verify zellij cleanup when cleanup errors must be surfaced", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("");
+    const { removeSessionOnly } = await import("@/lib/worktree");
+
+    // When
+    await removeSessionOnly(SessionType.ZELLIJ, "feat-branch", "remote-host", { throwOnError: true });
+
+    // Then
+    const command = mockExecGit.mock.calls[0][0] as string;
+    expect(command).toContain("command -v zellij >/dev/null 2>&1");
+    expect(command).toContain("zellij kill-sessions 'feat-branch'");
+    expect(command).toContain("zellij delete-session 'feat-branch'");
+    expect(command).toContain("zellij list-sessions");
+    expect(command).toContain("grep -Fx -- 'feat-branch'");
+    expect(mockExecGit).toHaveBeenCalledWith(command, "remote-host");
+  });
+
+  it("should verify tmux cleanup by exact session name when cleanup errors must be surfaced", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("");
+    const { removeSessionOnly } = await import("@/lib/worktree");
+
+    // When
+    await removeSessionOnly(SessionType.TMUX, "feat-branch", "remote-host", { throwOnError: true });
+
+    // Then
+    const command = mockExecGit.mock.calls[0][0] as string;
+    expect(command).toContain("command -v tmux >/dev/null 2>&1");
+    expect(command).toContain("tmux kill-session -t 'feat-branch'");
+    expect(command).toContain("tmux list-sessions -F '#{session_name}'");
+    expect(command).toContain("grep -Fx -- 'feat-branch'");
+    expect(command).not.toContain("tmux has-session");
+    expect(mockExecGit).toHaveBeenCalledWith(command, "remote-host");
   });
 
   it("should not throw when session is already terminated", async () => {

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -1,11 +1,10 @@
 import { exec, execFile } from "child_process";
 import { promisify } from "util";
-import { mkdir } from "fs/promises";
 import { homedir } from "os";
 import {
   buildSSHArgs,
+  ensureKanvibeSSHControlDirectory,
   getKanvibeSSHConnectionReuseOptions,
-  getKanvibeSSHControlDirectory,
   parseSSHConfig,
   type SSHHostConfig,
 } from "@/lib/sshConfig";
@@ -37,8 +36,9 @@ const SSH_TRANSPORT_ERROR_PATTERNS = [
 ];
 
 const REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS = 60_000;
-const remoteSSHHostQueues = new Map<string, Promise<void>>();
+const REMOTE_SSH_HOST_MAX_CONCURRENCY = 4;
 const remoteSSHTransportFailures = new Map<string, { until: number; error: Error }>();
+const remoteSSHHostLimiters = new Map<string, { active: number; queue: Array<() => void> }>();
 
 function collectErrorOutput(error: unknown): string {
   const outputs: string[] = [];
@@ -101,7 +101,7 @@ async function execLocal(command: string): Promise<string> {
 
 /** SSH를 통해 원격에서 명령을 실행하고 stdout을 반환한다 */
 async function execRemote(sshHost: string, command: string): Promise<string> {
-  return runQueuedRemoteCommand(sshHost, async () => {
+  return runLimitedRemoteCommand(sshHost, async () => {
     throwIfSSHTransportCooldownActive(sshHost);
 
     const configs = await parseSSHConfig();
@@ -143,27 +143,55 @@ async function execRemote(sshHost: string, command: string): Promise<string> {
   });
 }
 
-async function runQueuedRemoteCommand<T>(
+async function runLimitedRemoteCommand<T>(
   sshHost: string,
   operation: () => Promise<T>,
 ): Promise<T> {
-  const previous = remoteSSHHostQueues.get(sshHost) ?? Promise.resolve();
-  let releaseCurrent: () => void = () => {};
-  const current = new Promise<void>((resolve) => {
-    releaseCurrent = resolve;
-  });
-  const queued = previous.catch(() => undefined).then(() => current);
-  remoteSSHHostQueues.set(sshHost, queued);
-
-  await previous.catch(() => undefined);
+  const release = await acquireRemoteSSHSlot(sshHost);
 
   try {
     return await operation();
   } finally {
-    releaseCurrent();
-    if (remoteSSHHostQueues.get(sshHost) === queued) {
-      remoteSSHHostQueues.delete(sshHost);
+    release();
+  }
+}
+
+function acquireRemoteSSHSlot(sshHost: string): Promise<() => void> {
+  let limiter = remoteSSHHostLimiters.get(sshHost);
+  if (!limiter) {
+    limiter = { active: 0, queue: [] };
+    remoteSSHHostLimiters.set(sshHost, limiter);
+  }
+
+  return new Promise((resolve) => {
+    const start = () => {
+      limiter.active += 1;
+      resolve(() => releaseRemoteSSHSlot(sshHost, limiter));
+    };
+
+    if (limiter.active < REMOTE_SSH_HOST_MAX_CONCURRENCY) {
+      start();
+      return;
     }
+
+    limiter.queue.push(start);
+  });
+}
+
+function releaseRemoteSSHSlot(
+  sshHost: string,
+  limiter: { active: number; queue: Array<() => void> },
+): void {
+  limiter.active -= 1;
+
+  const next = limiter.queue.shift();
+  if (next) {
+    next();
+    return;
+  }
+
+  if (limiter.active === 0) {
+    remoteSSHHostLimiters.delete(sshHost);
   }
 }
 
@@ -201,7 +229,7 @@ async function buildExecSSHArgs(
     return buildSSHArgs(hostConfig, { disableTty: true });
   }
 
-  await mkdir(getKanvibeSSHControlDirectory(), { recursive: true });
+  await ensureKanvibeSSHControlDirectory();
   return buildSSHArgs(hostConfig, {
     disableTty: true,
     connectionReuse: getKanvibeSSHConnectionReuseOptions(),

--- a/src/lib/sshConfig.ts
+++ b/src/lib/sshConfig.ts
@@ -1,4 +1,4 @@
-import { readFile } from "fs/promises";
+import { mkdir, readFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
 
@@ -78,11 +78,19 @@ export function getKanvibeSSHControlDirectory(): string {
   return path.join(homedir(), ".kanvibe");
 }
 
+export async function ensureKanvibeSSHControlDirectory(): Promise<void> {
+  await mkdir(getKanvibeSSHControlDirectory(), { recursive: true, mode: 0o700 });
+}
+
 export function getKanvibeSSHConnectionReuseOptions(): SSHConnectionReuseOptions {
   return {
     controlPath: path.join(getKanvibeSSHControlDirectory(), "ssh-%C"),
     controlPersist: KANVIBE_SSH_CONTROL_PERSIST,
   };
+}
+
+export function hasLocalX11Display(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env.DISPLAY);
 }
 
 /**

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -5,7 +5,7 @@ import { PaneLayoutType } from "@/entities/PaneLayoutConfig";
 import { ZELLIJ_LAYOUT_FILENAME } from "@/lib/worktree";
 import { execSync } from "child_process";
 import type { WebSocket } from "ws";
-import { buildSSHArgs, getKanvibeSSHConnectionReuseOptions } from "@/lib/sshConfig";
+import { buildSSHArgs, hasLocalX11Display } from "@/lib/sshConfig";
 import { buildTmuxSessionBootstrapCommands, type TmuxPaneLayoutConfig } from "@/lib/worktree";
 import { createLocalShellEnvironment } from "@/lib/shellEnvironment";
 
@@ -284,11 +284,13 @@ export async function attachRemoteSession(
   const attachCommand = sessionType === SessionType.TMUX
     ? buildRemoteTmuxAttachCommand(sessionName, worktreePath, tmuxPaneLayout)
     : `exec zellij attach "${sessionName}"`;
-  const args = buildSSHArgs(sshConfig, {
-    forceTty: true,
-    trustedX11Forwarding: true,
-    connectionReuse: getKanvibeSSHConnectionReuseOptions(),
-  });
+  const args = [
+    ...buildSSHArgs(sshConfig, {
+      forceTty: true,
+      trustedX11Forwarding: hasLocalX11Display(),
+    }),
+    buildRemoteShellCommand(attachCommand),
+  ];
 
   if (shouldLogTerminalSpawn()) {
     console.log(`[터미널] Remote PTY spawn: shell=ssh, args=${JSON.stringify(args)}`);
@@ -333,8 +335,7 @@ export async function attachRemoteSession(
     detachSession(taskId, "remote-pty-exit");
   });
 
-  ptyProcess.write(`${attachCommand}\r`);
-  debugLog("Remote PTY attachCommand 전송 완료", { taskId, byteLength: attachCommand.length });
+  debugLog("Remote PTY attachCommand 인자 전달 완료", { taskId, byteLength: attachCommand.length });
 
   ws.on("message", (message) => {
     handleTerminalMessage(ptyProcess, message.toString());
@@ -347,6 +348,14 @@ export async function attachRemoteSession(
       detachSession(taskId, "remote-ws-close");
     }
   });
+}
+
+function buildRemoteShellCommand(command: string): string {
+  return `sh -lc ${quoteForPosixShell(command)}`;
+}
+
+function quoteForPosixShell(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 function buildRemoteTmuxAttachCommand(

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -235,6 +235,10 @@ export function generateZellijLayoutKdl(
 /** Zellij KDL 레이아웃 파일의 기본 파일명 */
 export const ZELLIJ_LAYOUT_FILENAME = ".zellij-layout.kdl";
 
+function quoteForPosixShell(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
 /**
  * KDL 레이아웃 파일을 worktree 디렉토리에 저장한다.
  * 터미널 연결 시 node-pty가 이 파일을 --layout 플래그로 사용한다.
@@ -430,12 +434,12 @@ export async function removeSessionOnly(
   try {
     if (sessionType === SessionType.TMUX) {
       await execGit(
-        `tmux kill-session -t "${sessionName}" 2>/dev/null || true`,
+        buildTmuxSessionCleanupCommand(sessionName, options.throwOnError === true),
         sshHost,
       );
     } else {
       await execGit(
-        `zellij kill-session "${sessionName}" 2>/dev/null || true; zellij delete-session "${sessionName}" 2>/dev/null || true`,
+        buildZellijSessionCleanupCommand(sessionName, options.throwOnError === true),
         sshHost,
       );
     }
@@ -445,6 +449,38 @@ export async function removeSessionOnly(
     }
     // 세션이 이미 종료된 경우 무시
   }
+}
+
+function buildTmuxSessionCleanupCommand(sessionName: string, verifyCleanup: boolean): string {
+  const target = quoteForPosixShell(sessionName);
+
+  if (!verifyCleanup) {
+    return `tmux kill-session -t ${target} 2>/dev/null || true`;
+  }
+
+  return [
+    "command -v tmux >/dev/null 2>&1 || exit 1",
+    `tmux kill-session -t ${target} 2>/dev/null || true`,
+    `if tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -Fx -- ${target} >/dev/null; then exit 1; fi`,
+  ].join("; ");
+}
+
+function buildZellijSessionCleanupCommand(sessionName: string, verifyCleanup: boolean): string {
+  const target = quoteForPosixShell(sessionName);
+  const commands = [
+    `zellij kill-sessions ${target} 2>/dev/null || true`,
+    `zellij delete-session ${target} 2>/dev/null || true`,
+  ];
+
+  if (!verifyCleanup) {
+    return commands.join("; ");
+  }
+
+  return [
+    "command -v zellij >/dev/null 2>&1 || exit 1",
+    ...commands,
+    `if zellij list-sessions 2>/dev/null | awk '{ if ($1 == "EXITED:") print $2; else print $1 }' | grep -Fx -- ${target} >/dev/null; then exit 1; fi`,
+  ].join("; ");
 }
 
 /**


### PR DESCRIPTION
## What changed?
- Optimize non-interactive remote SSH commands with OpenSSH ControlMaster reuse and bounded per-host concurrency.
- Run remote terminal attach commands directly as SSH remote commands without ControlMaster reuse.
- Improve tmux and zellij cleanup when tasks move to done by detaching held PTYs before removing sessions and verifying exact session names.
- Document the remote SSH and terminal attach behavior in README files.

## How was it solved?
- Add a Kanvibe-owned SSH control socket directory and reuse options for command execution paths.
- Replace the per-host serial remote SSH queue with a bounded concurrency limiter.
- Split interactive terminal attach behavior from reusable non-interactive command execution.
- Use exact tmux/zellij session cleanup verification and add regression tests for the cleanup path.

## Important details
- Remote terminal attach intentionally avoids ControlMaster reuse because interactive PTY sessions behave differently from short-lived command execution.
- X11 forwarding is now requested only when a local display is available.
- Task cleanup now detaches the app-held PTY before attempting to kill tmux or zellij sessions.

Co-Authored-By: OpenAI Codex <codex@openai.com>
