### PR TITLE
fix(remote): restore interactive SSH terminal attach

### DIFF
--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -71,17 +71,6 @@ function findExecSyncCall(pattern: string): string | undefined {
     .find((cmd) => cmd.includes(pattern));
 }
 
-function extractRemoteShellPayload(command: string): string {
-  const prefix = "sh -lc ";
-  expect(command.startsWith(prefix)).toBe(true);
-
-  const quotedPayload = command.slice(prefix.length);
-  expect(quotedPayload.startsWith("'")).toBe(true);
-  expect(quotedPayload.endsWith("'")).toBe(true);
-
-  return quotedPayload.slice(1, -1).replace(/'"'"'/g, "'");
-}
-
 function expectValidPosixShellSyntax(command: string): void {
   const result = spawnSync("sh", ["-n", "-c", command], { encoding: "utf-8" });
   expect(result.status, result.stderr).toBe(0);
@@ -455,14 +444,14 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
         "IdentitiesOnly=yes",
         "-tt",
         "remote-host",
-        expect.stringContaining("sh -lc "),
       ]);
       expect(sshArgs).not.toContain("-Y");
       expect(sshArgs).not.toContain("ControlMaster=auto");
-      expect(sshArgs.at(-1)).toContain('tmux has-session -t "remote-session"');
-      expect(sshArgs.at(-1)).toContain('tmux new-session -d -s "remote-session" -c "/remote/worktree"');
-      expect(mockPtyWrite).not.toHaveBeenCalledWith(
+      expect(mockPtyWrite).toHaveBeenCalledWith(
         expect.stringContaining('tmux has-session -t "remote-session"'),
+      );
+      expect(mockPtyWrite).toHaveBeenCalledWith(
+        expect.stringContaining('tmux new-session -d -s "remote-session" -c "/remote/worktree"'),
       );
     } finally {
       if (originalDisplay === undefined) {
@@ -478,7 +467,6 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     const originalDisplay = process.env.DISPLAY;
     delete process.env.DISPLAY;
     const { attachRemoteSession } = await import("@/lib/terminal");
-    const nodePty = await import("node-pty");
 
     try {
       // When
@@ -501,9 +489,51 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
       );
 
       // Then
+      const attachCommand = String(mockPtyWrite.mock.calls[0]?.[0] ?? "").trim();
+      expectValidPosixShellSyntax(attachCommand);
+    } finally {
+      if (originalDisplay === undefined) {
+        delete process.env.DISPLAY;
+      } else {
+        process.env.DISPLAY = originalDisplay;
+      }
+    }
+  });
+
+  it("should start remote tmux through an interactive SSH shell", async () => {
+    // Given
+    const originalDisplay = process.env.DISPLAY;
+    delete process.env.DISPLAY;
+    const { attachRemoteSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
+
+    try {
+      // When
+      await attachRemoteSession(
+        "task-r-interactive",
+        "remote-host",
+        SessionType.TMUX,
+        "remote-session",
+        createMockWs(),
+        {
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        },
+        120,
+        30,
+        "/remote/worktree",
+      );
+
+      // Then
       const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
-      const remoteShellPayload = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
-      expectValidPosixShellSyntax(remoteShellPayload);
+      expect(sshArgs.at(-1)).toBe("remote-host");
+      expect(sshArgs).not.toContain(expect.stringContaining("sh -lc "));
+      expect(mockPtyWrite).toHaveBeenCalledWith(
+        expect.stringContaining('tmux has-session -t "remote-session"'),
+      );
     } finally {
       if (originalDisplay === undefined) {
         delete process.env.DISPLAY;
@@ -552,7 +582,6 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
 
   it("should apply tmux pane layout commands when creating a remote session", async () => {
     const { attachRemoteSession } = await import("@/lib/terminal");
-    const nodePty = await import("node-pty");
 
     await attachRemoteSession(
       "task-r2",
@@ -579,9 +608,14 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
       },
     );
 
-    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
-    expect(sshArgs.at(-1)).toContain('tmux split-window -h -t "remote-session":0 -c "/remote/worktree"');
-    expect(sshArgs.at(-1)).toContain('tmux send-keys -t "remote-session":0.0 "pnpm dev" Enter');
-    expect(sshArgs.at(-1)).toContain('tmux send-keys -t "remote-session":0.1 "pnpm test" Enter');
+    expect(mockPtyWrite).toHaveBeenCalledWith(
+      expect.stringContaining('tmux split-window -h -t "remote-session":0 -c "/remote/worktree"'),
+    );
+    expect(mockPtyWrite).toHaveBeenCalledWith(
+      expect.stringContaining('tmux send-keys -t "remote-session":0.0 "pnpm dev" Enter'),
+    );
+    expect(mockPtyWrite).toHaveBeenCalledWith(
+      expect.stringContaining('tmux send-keys -t "remote-session":0.1 "pnpm test" Enter'),
+    );
   });
 });

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -292,13 +292,10 @@ export async function attachRemoteSession(
   const attachCommand = sessionType === SessionType.TMUX
     ? buildRemoteTmuxAttachCommand(sessionName, worktreePath, tmuxPaneLayout)
     : `exec zellij attach "${sessionName}"`;
-  const args = [
-    ...buildSSHArgs(sshConfig, {
-      forceTty: true,
-      trustedX11Forwarding: hasLocalX11Display(),
-    }),
-    buildRemoteShellCommand(attachCommand),
-  ];
+  const args = buildSSHArgs(sshConfig, {
+    forceTty: true,
+    trustedX11Forwarding: hasLocalX11Display(),
+  });
 
   if (shouldLogTerminalSpawn()) {
     console.log(`[터미널] Remote PTY spawn: shell=ssh, args=${JSON.stringify(args)}`);
@@ -343,7 +340,8 @@ export async function attachRemoteSession(
     detachSession(taskId, "remote-pty-exit");
   });
 
-  debugLog("Remote PTY attachCommand 인자 전달 완료", { taskId, byteLength: attachCommand.length });
+  ptyProcess.write(`${attachCommand}\r`);
+  debugLog("Remote PTY attachCommand 전송 완료", { taskId, byteLength: attachCommand.length });
 
   ws.on("message", (message) => {
     handleTerminalMessage(ptyProcess, message.toString());
@@ -356,14 +354,6 @@ export async function attachRemoteSession(
       detachSession(taskId, "remote-ws-close");
     }
   });
-}
-
-function buildRemoteShellCommand(command: string): string {
-  return `sh -lc ${quoteForPosixShell(command)}`;
-}
-
-function quoteForPosixShell(value: string): string {
-  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 function buildRemoteTmuxAttachCommand(


### PR DESCRIPTION
## What changed
- Restore remote terminal attach to open an interactive SSH PTY first, then send the tmux/zellij attach command through `pty.write()`.
- Stop passing long-running terminal attach commands as inline `sh -lc` SSH arguments.
- Keep the POSIX shell syntax regression coverage and add coverage for the interactive SSH attach contract.

## Why
The previous follow-up fixed the `sh: 1: Syntax error: ";" unexpected` parsing error, but the direct `ssh host sh -lc ...` terminal attach path can still close the SSH session with `server exited unexpectedly`. Remote terminal attach needs the interactive shell behavior that existed before the SSH performance change; non-interactive SSH command optimizations remain separate.

Co-Authored-By: OpenAI Codex <codex@openai.com>