### PR TITLE
fix(hooks): resolve OpenCode verification path lookup

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -232,6 +232,7 @@ function getMacLocalCommandSearchPaths() {
     "/opt/local/sbin",
     path.join(homeDirectory, ".local", "bin"),
     path.join(homeDirectory, ".cargo", "bin"),
+    path.join(homeDirectory, ".opencode", "bin"),
     path.join(homeDirectory, "Library", "pnpm"),
     path.join(homeDirectory, ".bun", "bin"),
   ];

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -72,6 +72,7 @@ describe("gitOperations.resolvePathForShell", () => {
 
     // Then
     expect(result).toBe("ok");
+    const execOptions = mocks.exec.mock.calls[0]?.[1] as { env?: { PATH?: string } };
     expect(mocks.exec).toHaveBeenCalledWith(
       "command -v tmux",
       expect.objectContaining({
@@ -83,6 +84,9 @@ describe("gitOperations.resolvePathForShell", () => {
       }),
       expect.any(Function),
     );
+    if (process.platform === "darwin") {
+      expect(execOptions.env?.PATH).toContain(".opencode/bin");
+    }
   });
 
   it("원격 명령 실행은 ssh 바이너리와 옵션을 사용한다", async () => {

--- a/src/lib/__tests__/openCodePluginRegistry.test.ts
+++ b/src/lib/__tests__/openCodePluginRegistry.test.ts
@@ -1,7 +1,27 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { extractRegisteredKanvibePluginUrls, extractRegisteredPluginUrls, isKanvibePluginUrl } from "../openCodePluginRegistry";
 
+const mocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      execFile: (...args: unknown[]) => mocks.execFile(...args),
+    },
+    execFile: (...args: unknown[]) => mocks.execFile(...args),
+  };
+});
+
 describe("openCodePluginRegistry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("extracts plugin urls from valid JSON output", () => {
     const output = JSON.stringify({
       plugin: [
@@ -57,5 +77,49 @@ line 2"
     expect(isKanvibePluginUrl("file:///tmp/kanvibe-plugin.ts")).toBe(true);
     expect(isKanvibePluginUrl("file:///tmp/kanvibe-plugin.js")).toBe(true);
     expect(isKanvibePluginUrl("file:///tmp/not-kanvibe.ts")).toBe(false);
+  });
+
+  it("runs opencode debug config with the local shell environment", async () => {
+    const originalHome = process.env.HOME;
+    process.env.HOME = "/home/opencode-user";
+    mocks.execFile.mockImplementation((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: null, result: { stdout: string }) => void,
+    ) => {
+      callback(null, {
+        stdout: JSON.stringify({
+          plugin: ["file:///tmp/kanvibe-plugin.ts"],
+        }),
+      });
+    });
+
+    try {
+      const { getOpenCodeRegisteredKanvibePluginUrls } = await import("../openCodePluginRegistry");
+
+      const result = await getOpenCodeRegisteredKanvibePluginUrls("/workspace/project");
+
+      expect(result).toEqual(["file:///tmp/kanvibe-plugin.ts"]);
+      expect(mocks.execFile).toHaveBeenCalledWith(
+        "opencode",
+        ["debug", "config"],
+        expect.objectContaining({
+          cwd: "/workspace/project",
+          env: expect.objectContaining({
+            PATH: process.platform === "darwin"
+              ? expect.stringContaining("/home/opencode-user/.opencode/bin")
+              : expect.any(String),
+          }),
+        }),
+        expect.any(Function),
+      );
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
   });
 });

--- a/src/lib/openCodePluginRegistry.ts
+++ b/src/lib/openCodePluginRegistry.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { pathToFileURL } from "node:url";
+import { createLocalShellEnvironment } from "@/lib/shellEnvironment";
 
 const execFileAsync = promisify(execFile);
 
@@ -48,6 +49,7 @@ export async function getOpenCodeRegisteredKanvibePluginUrls(repoPath: string): 
   try {
     const { stdout } = await execFileAsync("opencode", ["debug", "config"], {
       cwd: repoPath,
+      env: createLocalShellEnvironment(),
       maxBuffer: 1024 * 1024,
     });
 

--- a/src/lib/shellEnvironment.ts
+++ b/src/lib/shellEnvironment.ts
@@ -14,6 +14,7 @@ function getUserLocalCommandPaths(homeDirectory: string): string[] {
   return [
     path.join(homeDirectory, ".local", "bin"),
     path.join(homeDirectory, ".cargo", "bin"),
+    path.join(homeDirectory, ".opencode", "bin"),
     path.join(homeDirectory, "Library", "pnpm"),
     path.join(homeDirectory, ".bun", "bin"),
   ];


### PR DESCRIPTION
## What is this?
- Fix OpenCode hook status verification so installed plugins are not reported as missing when the desktop process cannot find the `opencode` binary through its default PATH.

## How did you solve it?
**Use the local shell environment for OpenCode registry checks**
- Run `opencode debug config` with `createLocalShellEnvironment()` so verification uses the same PATH expansion as local desktop commands.
- Keep the existing fallback behavior that returns an empty plugin list when OpenCode cannot be executed.

**Add the OpenCode CLI install path to desktop PATH handling**
- Include `~/.opencode/bin` in shared local shell PATH construction.
- Include the same path in Electron main process macOS PATH bootstrapping.

**Cover the regression with focused tests**
- Assert OpenCode registry checks receive a PATH containing `~/.opencode/bin`.
- Assert local command environment tests cover the OpenCode path in addition to existing macOS command paths.

## Important changes
### OpenCode hook verification

**Use a consistent command environment**
- **Why**: OpenCode verification depends on `opencode debug config`, unlike the other hook providers that only inspect repo-local files.
- **Files**: `src/lib/openCodePluginRegistry.ts`, `src/lib/shellEnvironment.ts`, `electron/main.js`

**Prevent false missing status for installed plugins**
- **Why**: The plugin file can be installed correctly while `hasRegisteredPlugin` becomes false if the desktop process cannot resolve `opencode`.
- **Files**: `src/lib/__tests__/openCodePluginRegistry.test.ts`, `src/lib/__tests__/gitOperations.test.ts`

Co-authored-by: OpenAI Codex <codex@openai.com>
