### PR TITLE
Add platform history navigation shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Each pane can run a custom command (e.g., `vim`, `htop`, `lazygit`, test runner,
 | `Cmd/Ctrl+Shift+O` | Global | Open quick task search by branch or project name (default, configurable) |
 | `Cmd/Ctrl+Shift+P` | Board | Open the project filter dropdown |
 | `Cmd/Ctrl+Shift+I` | Board | Open the notifications dropdown |
+| `Cmd+[` / `Cmd+]` (macOS), `Alt+[` / `Alt+]` (Linux) | Global | Navigate back/forward through app history; back falls back to board home when there is no previous page |
 | `Cmd/Ctrl+N` | Quick task search | Create a new branch TODO from the currently highlighted task |
 | `↑ / ↓ / Enter / Shift+Enter / Esc` | Quick task search | Move selection, open task, open task in a new window, close dialog |
 | `↑ / ↓ / Enter / Esc` | Project filter dropdown | Move selection, toggle project filter, close dropdown |

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -173,6 +173,7 @@ macOS에서 `better-sqlite3` `NODE_MODULE_VERSION` 불일치가 발생하면, Ka
 | `Cmd/Ctrl+Shift+O` | 전역 | 브랜치명/프로젝트명 기준 태스크 빠른 검색 열기 (기본값, 변경 가능) |
 | `Cmd/Ctrl+Shift+P` | 보드 | 프로젝트 필터 드롭다운 열기 |
 | `Cmd/Ctrl+Shift+I` | 보드 | 알림 드롭다운 열기 |
+| `Cmd+[` / `Cmd+]` (macOS), `Alt+[` / `Alt+]` (Linux) | 전역 | 앱 히스토리 뒤로/앞으로 이동. 더 뒤로 갈 곳이 없으면 보드 홈으로 이동 |
 | `Cmd/Ctrl+N` | 태스크 빠른 검색 | 현재 하이라이트된 태스크 기준으로 새 branch TODO 만들기 |
 | `↑ / ↓ / Enter / Shift+Enter / Esc` | 태스크 빠른 검색 | 선택 이동, 태스크 열기, 태스크 새 창 열기, 다이얼로그 닫기 |
 | `↑ / ↓ / Enter / Esc` | 프로젝트 필터 드롭다운 | 선택 이동, 프로젝트 필터 토글, 드롭다운 닫기 |

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -173,6 +173,7 @@ pnpm dist
 | `Cmd/Ctrl+Shift+O` | 全局 | 按分支名或项目名打开任务快速搜索（默认值，可配置） |
 | `Cmd/Ctrl+Shift+P` | 看板 | 打开项目筛选下拉框 |
 | `Cmd/Ctrl+Shift+I` | 看板 | 打开通知下拉框 |
+| `Cmd+[` / `Cmd+]` (macOS), `Alt+[` / `Alt+]` (Linux) | 全局 | 在应用历史中后退/前进；没有上一页时后退到看板首页 |
 | `Cmd/Ctrl+N` | 任务快速搜索 | 基于当前高亮任务创建新的 branch TODO |
 | `↑ / ↓ / Enter / Esc` | 任务快速搜索 | 移动选择、打开任务、关闭对话框 |
 | `↑ / ↓ / Enter / Esc` | 项目筛选下拉框 | 移动选择、切换项目筛选、关闭下拉框 |

--- a/src/desktop/renderer/__tests__/navigation.test.tsx
+++ b/src/desktop/renderer/__tests__/navigation.test.tsx
@@ -34,8 +34,16 @@ function renderRouterProbe(
   );
 }
 
+function setNavigatorPlatform(platform: string) {
+  Object.defineProperty(window.navigator, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
+
 describe("useRouter", () => {
   beforeEach(() => {
+    setNavigatorPlatform("Linux x86_64");
     window.history.replaceState(null, "", "/");
   });
 
@@ -69,6 +77,16 @@ describe("useRouter", () => {
     });
   });
 
+  it("현재 locale의 칸반 홈에서 뒤로 갈 히스토리가 없으면 경로를 유지한다", async () => {
+    renderRouterProbe(["/ko"], 0, { idx: 0 });
+
+    fireEvent.click(screen.getByRole("button", { name: "back" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pathname").textContent).toBe("/ko");
+    });
+  });
+
   it("브라우저 history index가 있어도 앱 내부 이전 경로가 없으면 현재 locale의 칸반 홈으로 이동한다", async () => {
     renderRouterProbe(["/en/task/task-1"], 0, { idx: 1 });
 
@@ -89,12 +107,12 @@ describe("useRouter", () => {
     });
   });
 
-  it("Ctrl+[와 Ctrl+] 단축키로 뒤로/앞으로 이동한다", async () => {
+  it("Linux에서는 Alt+[와 Alt+] 단축키로 뒤로/앞으로 이동한다", async () => {
     renderRouterProbe(["/ko", "/ko/task/task-1", "/ko/task/task-2"], 1, { idx: 1 }, true);
 
     fireEvent.keyDown(window, {
       key: "[",
-      ctrlKey: true,
+      altKey: true,
     });
 
     await waitFor(() => {
@@ -103,7 +121,30 @@ describe("useRouter", () => {
 
     fireEvent.keyDown(window, {
       key: "]",
-      ctrlKey: true,
+      altKey: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pathname").textContent).toBe("/ko/task/task-1");
+    });
+  });
+
+  it("macOS에서는 Cmd+[와 Cmd+] 단축키로 뒤로/앞으로 이동한다", async () => {
+    setNavigatorPlatform("MacIntel");
+    renderRouterProbe(["/ko", "/ko/task/task-1", "/ko/task/task-2"], 1, { idx: 1 }, true);
+
+    fireEvent.keyDown(window, {
+      key: "[",
+      metaKey: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pathname").textContent).toBe("/ko");
+    });
+
+    fireEvent.keyDown(window, {
+      key: "]",
+      metaKey: true,
     });
 
     await waitFor(() => {

--- a/src/desktop/renderer/navigation.tsx
+++ b/src/desktop/renderer/navigation.tsx
@@ -49,6 +49,10 @@ export function localizeHref(href: string, currentLocale?: string): string {
   return `/${locale}${href}`;
 }
 
+function isLocalizedHomePath(pathname: string, currentLocale: string): boolean {
+  return pathname === localizeHref("/", currentLocale);
+}
+
 interface LinkProps extends PropsWithChildren<Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href">> {
   href: string;
   prefetch?: boolean;
@@ -88,7 +92,13 @@ export function useRouter() {
   return useMemo(
     () => ({
       back: () => {
-        const fallbackToHome = () => navigate(localizeHref("/", currentLocale), { replace: true });
+        const fallbackToHome = () => {
+          if (isLocalizedHomePath(latestLocationRef.current.pathname, currentLocale)) {
+            return;
+          }
+
+          navigate(localizeHref("/", currentLocale), { replace: true });
+        };
 
         if (!canNavigateBack()) {
           fallbackToHome();

--- a/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
+++ b/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  SHORTCUTS,
   captureShortcutFromEvent,
   formatShortcutForDisplay,
   getShortcutPlatformFromNavigator,
@@ -32,6 +33,39 @@ describe("keyboardShortcut", () => {
     });
 
     expect(matchShortcutEvent(event, "Mod+Shift+O", true)).toBe(true);
+  });
+
+  it("페이지 이동 단축키는 플랫폼별 조합으로 표시한다", () => {
+    expect(formatShortcutForDisplay(SHORTCUTS.pageBack, "mac")).toBe("Cmd+[");
+    expect(formatShortcutForDisplay(SHORTCUTS.pageForward, "mac")).toBe("Cmd+]");
+    expect(formatShortcutForDisplay(SHORTCUTS.pageBack, "linux")).toBe("Alt+[");
+    expect(formatShortcutForDisplay(SHORTCUTS.pageForward, "linux")).toBe("Alt+]");
+  });
+
+  it("페이지 이동 단축키는 macOS Cmd와 Linux Alt로 매칭한다", () => {
+    expect(matchShortcutEvent(new KeyboardEvent("keydown", {
+      key: "[",
+      metaKey: true,
+    }), SHORTCUTS.pageBack, "mac")).toBe(true);
+    expect(matchShortcutEvent(new KeyboardEvent("keydown", {
+      key: "]",
+      metaKey: true,
+    }), SHORTCUTS.pageForward, "mac")).toBe(true);
+    expect(matchShortcutEvent(new KeyboardEvent("keydown", {
+      key: "[",
+      altKey: true,
+    }), SHORTCUTS.pageBack, "linux")).toBe(true);
+    expect(matchShortcutEvent(new KeyboardEvent("keydown", {
+      key: "]",
+      altKey: true,
+    }), SHORTCUTS.pageForward, "linux")).toBe(true);
+  });
+
+  it("Linux 페이지 이동 단축키는 Ctrl 조합으로 매칭하지 않는다", () => {
+    expect(matchShortcutEvent(new KeyboardEvent("keydown", {
+      key: "[",
+      ctrlKey: true,
+    }), SHORTCUTS.pageBack, "linux")).toBe(false);
   });
 
   it("추가 modifier가 있으면 단축키가 일치하지 않는다", () => {
@@ -107,6 +141,48 @@ describe("keyboardShortcut", () => {
       alt: false,
       shift: false,
     }, "Mod+N", "linux")).toBe(false);
+  });
+
+  it("Electron 페이지 이동 input도 macOS Cmd와 Linux Alt로 매칭한다", () => {
+    expect(matchElectronShortcutInput({
+      type: "keyDown",
+      isAutoRepeat: false,
+      key: "[",
+      meta: true,
+      alt: false,
+      control: false,
+      shift: false,
+    }, SHORTCUTS.pageBack, "mac")).toBe(true);
+
+    expect(matchElectronShortcutInput({
+      type: "keyDown",
+      isAutoRepeat: false,
+      key: "]",
+      meta: true,
+      alt: false,
+      control: false,
+      shift: false,
+    }, SHORTCUTS.pageForward, "mac")).toBe(true);
+
+    expect(matchElectronShortcutInput({
+      type: "keyDown",
+      isAutoRepeat: false,
+      key: "[",
+      alt: true,
+      meta: false,
+      control: false,
+      shift: false,
+    }, SHORTCUTS.pageBack, "linux")).toBe(true);
+
+    expect(matchElectronShortcutInput({
+      type: "keyDown",
+      isAutoRepeat: false,
+      key: "]",
+      alt: true,
+      meta: false,
+      control: false,
+      shift: false,
+    }, SHORTCUTS.pageForward, "linux")).toBe(true);
   });
 
   it("Cmd/Ctrl+R은 앱에서 차단할 shortcut으로 판별한다", () => {

--- a/src/desktop/shared/keyboardShortcut.ts
+++ b/src/desktop/shared/keyboardShortcut.ts
@@ -1,5 +1,6 @@
 export type ShortcutPlatform = "mac" | "linux";
 export type ShortcutPlatformInput = ShortcutPlatform | boolean;
+export type ShortcutDefinition = string | Record<ShortcutPlatform, string>;
 
 type ShortcutInput = Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey">;
 
@@ -30,8 +31,14 @@ export const SHORTCUTS = {
   boardProjectFilter: "Mod+Shift+P",
   createTask: "Mod+N",
   newWindow: "Mod+Shift+N",
-  pageBack: "Mod+[",
-  pageForward: "Mod+]",
+  pageBack: {
+    mac: "Meta+[",
+    linux: "Alt+[",
+  },
+  pageForward: {
+    mac: "Meta+]",
+    linux: "Alt+]",
+  },
   boardPageFind: "Mod+F",
 } as const;
 
@@ -53,6 +60,17 @@ function normalizeShortcutPlatform(platform: ShortcutPlatformInput): ShortcutPla
   }
 
   return platform === "mac" ? "mac" : "linux";
+}
+
+function resolveShortcutForPlatform(
+  shortcut: ShortcutDefinition,
+  platform: ShortcutPlatformInput,
+): string {
+  if (typeof shortcut === "string") {
+    return shortcut;
+  }
+
+  return shortcut[normalizeShortcutPlatform(platform)];
 }
 
 export function getShortcutPlatformFromNavigator(
@@ -170,9 +188,10 @@ function getNormalizedModifierState(event: ShortcutInput) {
   };
 }
 
-export function formatShortcutForDisplay(shortcut: string, platform: ShortcutPlatformInput): string {
+export function formatShortcutForDisplay(shortcut: ShortcutDefinition, platform: ShortcutPlatformInput): string {
   const shortcutPlatform = normalizeShortcutPlatform(platform);
-  const { modifiers, key } = normalizeShortcutParts(shortcut);
+  const resolvedShortcut = resolveShortcutForPlatform(shortcut, shortcutPlatform);
+  const { modifiers, key } = normalizeShortcutParts(resolvedShortcut);
   const displayParts: string[] = modifiers.map((modifier) => {
     if (modifier === "Mod") {
       return shortcutPlatform === "mac" ? "Cmd" : "Ctrl";
@@ -194,11 +213,12 @@ export function formatShortcutForDisplay(shortcut: string, platform: ShortcutPla
 
 export function matchShortcutEvent(
   event: ShortcutInput,
-  shortcut: string,
+  shortcut: ShortcutDefinition,
   platform: ShortcutPlatformInput,
 ): boolean {
   const shortcutPlatform = normalizeShortcutPlatform(platform);
-  const { modifiers, key } = normalizeShortcutParts(shortcut);
+  const resolvedShortcut = resolveShortcutForPlatform(shortcut, shortcutPlatform);
+  const { modifiers, key } = normalizeShortcutParts(resolvedShortcut);
   const normalizedKey = normalizeEventKey(event.key);
 
   if (!key || key !== normalizedKey) {
@@ -222,7 +242,7 @@ export function matchShortcutEvent(
 
 export function matchElectronShortcutInput(
   input: ElectronShortcutInput,
-  shortcut: string,
+  shortcut: ShortcutDefinition,
   platform: ShortcutPlatformInput,
 ): boolean {
   if (input.type !== "keyDown" || input.isAutoRepeat) {


### PR DESCRIPTION
## What changed
- Add platform-specific app history shortcuts: `Cmd+[` / `Cmd+]` on macOS and `Alt+[` / `Alt+]` on Linux.
- Keep back navigation on the localized board home when there is no previous app page.
- Document the shortcuts in English, Korean, and Chinese README files.

## How it works
**Shared shortcut definitions**
- Extend the shared shortcut utility to support platform-specific shortcut definitions.
- Keep formatting, browser event matching, and Electron input matching behind the same shared shortcut interface.

**Navigation behavior**
- Route global back/forward shortcuts through the existing board command provider and router methods.
- Make the back fallback a no-op when the current route is already the localized board home.

**Coverage**
- Add focused tests for display formatting, browser keyboard matching, Electron input matching, and renderer navigation behavior.

Co-Authored-By: OpenAI Codex <codex@openai.com>
