### PR TITLE
fix(ssh): improve remote command reconnect handling

### DIFF
--- a/src/desktop/main/services/__tests__/diffService.test.ts
+++ b/src/desktop/main/services/__tests__/diffService.test.ts
@@ -42,15 +42,17 @@ describe("diffService remote task support", () => {
     });
     mocks.execGit.mockImplementation(async (command: string, sshHost?: string | null) => {
       expect(sshHost).toBe("remote-host");
-      if (command.includes("--name-status")) {
-        return "M\tsrc/app.ts\n";
-      }
-
-      if (command.includes("--numstat")) {
-        return "3\t1\tsrc/app.ts\n";
-      }
-
-      return "?? docs/new.md\n";
+      expect(command).toContain("git -C '/remote/worktrees/fix-qa' diff 'main...fix/qa' --name-status");
+      expect(command).toContain("git -C '/remote/worktrees/fix-qa' diff 'main...fix/qa' --numstat");
+      expect(command).toContain("git -C '/remote/worktrees/fix-qa' status --porcelain --untracked-files=all");
+      return [
+        "__KANVIBE_DIFF_NAME_STATUS__",
+        "M\tsrc/app.ts",
+        "__KANVIBE_DIFF_NUMSTAT__",
+        "3\t1\tsrc/app.ts",
+        "__KANVIBE_DIFF_WORKING_TREE__",
+        "?? docs/new.md",
+      ].join("\n");
     });
 
     const { getGitDiffFiles } = await import("@/desktop/main/services/diffService");
@@ -63,10 +65,7 @@ describe("diffService remote task support", () => {
       expect.stringContaining("git -C '/remote/worktrees/fix-qa' diff 'main...fix/qa' --name-status"),
       "remote-host",
     );
-    expect(mocks.execGit).toHaveBeenCalledWith(
-      expect.stringContaining("git -C '/remote/worktrees/fix-qa' status --porcelain --untracked-files=all"),
-      "remote-host",
-    );
+    expect(mocks.execGit).toHaveBeenCalledTimes(1);
   });
 
   it("원격 태스크의 파일 읽기와 저장을 sshHost로 처리한다", async () => {

--- a/src/desktop/main/services/diffService.ts
+++ b/src/desktop/main/services/diffService.ts
@@ -29,6 +29,54 @@ function buildGitCommand(worktreePath: string, args: string[]) {
   return `git -C ${quoteShellArgument(worktreePath)} ${args.join(" ")}`;
 }
 
+const DIFF_NAME_STATUS_MARKER = "__KANVIBE_DIFF_NAME_STATUS__";
+const DIFF_NUMSTAT_MARKER = "__KANVIBE_DIFF_NUMSTAT__";
+const DIFF_WORKING_TREE_MARKER = "__KANVIBE_DIFF_WORKING_TREE__";
+
+function buildGitDiffFilesCommand(worktreePath: string, baseBranch: string, branchName: string): string {
+  const range = quoteShellArgument(`${baseBranch}...${branchName}`);
+  return [
+    `printf '%s\\n' ${quoteShellArgument(DIFF_NAME_STATUS_MARKER)}`,
+    `${buildGitCommand(worktreePath, ["diff", range, "--name-status"])} || true`,
+    `printf '%s\\n' ${quoteShellArgument(DIFF_NUMSTAT_MARKER)}`,
+    `${buildGitCommand(worktreePath, ["diff", range, "--numstat"])} || true`,
+    `printf '%s\\n' ${quoteShellArgument(DIFF_WORKING_TREE_MARKER)}`,
+    buildGitCommand(worktreePath, ["status", "--porcelain", "--untracked-files=all"]),
+  ].join("; ");
+}
+
+function parseGitDiffFilesCommandOutput(output: string) {
+  const sections = {
+    nameStatus: "",
+    numstat: "",
+    workingTree: "",
+  };
+  let currentSection: keyof typeof sections | null = null;
+
+  for (const line of output.split("\n")) {
+    if (line === DIFF_NAME_STATUS_MARKER) {
+      currentSection = "nameStatus";
+      continue;
+    }
+
+    if (line === DIFF_NUMSTAT_MARKER) {
+      currentSection = "numstat";
+      continue;
+    }
+
+    if (line === DIFF_WORKING_TREE_MARKER) {
+      currentSection = "workingTree";
+      continue;
+    }
+
+    if (currentSection) {
+      sections[currentSection] += `${line}\n`;
+    }
+  }
+
+  return sections;
+}
+
 /**
  * 파일 경로가 worktree 디렉토리 내부에 있는지 검증한다.
  * 경로 탐색 공격(path traversal)을 방지하기 위해 ".." 포함 여부와
@@ -102,43 +150,19 @@ export async function getGitDiffFiles(
     const { worktreePath, branchName, baseBranch, sshHost } =
       await getTaskWorktreeInfo(taskId);
 
-    /**
-     * 커밋된 브랜치 diff(name-status, numstat)와
-     * working directory 상태(git status)를 동시에 조회한다.
-     * git diff는 브랜치가 존재하지 않으면 실패할 수 있으므로 개별 에러를 허용한다.
-     */
-    const emptyResult = { stdout: "" };
-    const [nameStatusResult, numstatResult, workingTreeResult] =
-      await Promise.all([
-        execGit(
-          buildGitCommand(worktreePath, [
-            "diff",
-            quoteShellArgument(`${baseBranch}...${branchName}`),
-            "--name-status",
-          ]),
-          sshHost,
-        ).then((stdout) => ({ stdout })).catch(() => emptyResult),
-        execGit(
-          buildGitCommand(worktreePath, [
-            "diff",
-            quoteShellArgument(`${baseBranch}...${branchName}`),
-            "--numstat",
-          ]),
-          sshHost,
-        ).then((stdout) => ({ stdout })).catch(() => emptyResult),
-        execGit(
-          buildGitCommand(worktreePath, ["status", "--porcelain", "--untracked-files=all"]),
-          sshHost,
-        ).then((stdout) => ({ stdout })),
-      ]);
+    const commandOutput = await execGit(
+      buildGitDiffFilesCommand(worktreePath, baseBranch, branchName),
+      sshHost,
+    );
+    const diffSections = parseGitDiffFilesCommandOutput(commandOutput);
 
     /** numstat 결과를 파일 경로 기준으로 맵핑한다 */
     const statsByPath = new Map<
       string,
       { additions: number; deletions: number }
     >();
-    if (numstatResult.stdout.trim()) {
-      for (const line of numstatResult.stdout.trim().split("\n")) {
+    if (diffSections.numstat.trim()) {
+      for (const line of diffSections.numstat.trim().split("\n")) {
         const [added, deleted, ...pathParts] = line.split("\t");
         const filePath = pathParts.join("\t");
         statsByPath.set(filePath, {
@@ -151,8 +175,8 @@ export async function getGitDiffFiles(
     /** 커밋된 브랜치 diff에서 파일 목록을 구성한다 */
     const fileMap = new Map<string, DiffFile>();
 
-    if (nameStatusResult.stdout.trim()) {
-      for (const line of nameStatusResult.stdout.trim().split("\n")) {
+    if (diffSections.nameStatus.trim()) {
+      for (const line of diffSections.nameStatus.trim().split("\n")) {
         const parts = line.split("\t");
         const statusLetter = parts[0];
         /** rename의 경우 "R100\told\tnew" 형태이므로 마지막 경로를 사용한다 */
@@ -171,7 +195,7 @@ export async function getGitDiffFiles(
     }
 
     /** working directory의 변경/untracked 파일을 추가한다 (커밋된 diff에 없는 파일만) */
-    const workingTreeLines = workingTreeResult.stdout.replace(/\n$/, "");
+    const workingTreeLines = diffSections.workingTree.replace(/\n$/, "");
     if (workingTreeLines) {
       for (const line of workingTreeLines.split("\n")) {
         const xy = line.substring(0, 2);

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   homedir: vi.fn(() => "/home/local-user"),
   exec: vi.fn(),
   execFile: vi.fn(),
+  spawn: vi.fn(),
   mkdir: vi.fn(async () => undefined),
 }));
 
@@ -11,9 +12,11 @@ vi.mock("child_process", () => ({
   default: {
     exec: mocks.exec,
     execFile: mocks.execFile,
+    spawn: mocks.spawn,
   },
   exec: mocks.exec,
   execFile: mocks.execFile,
+  spawn: mocks.spawn,
 }));
 
 vi.mock("os", () => ({
@@ -31,6 +34,83 @@ vi.mock("fs/promises", () => ({
   mkdir: mocks.mkdir,
   readFile: vi.fn(),
 }));
+
+const REMOTE_COMMAND_EXIT_MARKER = "__KANVIBE_REMOTE_COMMAND_EXIT_7b3f6e5d__";
+
+type MockListener = (...args: unknown[]) => void;
+
+class MockReadableStream {
+  private listeners = new Map<string, MockListener[]>();
+
+  setEncoding = vi.fn();
+
+  on(event: string, listener: MockListener): this {
+    this.listeners.set(event, [...(this.listeners.get(event) ?? []), listener]);
+    return this;
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+class MockSSHProcess {
+  stdout = new MockReadableStream();
+  stderr = new MockReadableStream();
+  exitCode: number | null = null;
+  killed = false;
+  kill = vi.fn(() => {
+    this.killed = true;
+    return true;
+  });
+  private listeners = new Map<string, MockListener[]>();
+
+  on(event: string, listener: MockListener): this {
+    this.listeners.set(event, [...(this.listeners.get(event) ?? []), listener]);
+    return this;
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+
+  writeStdout(chunk: string): void {
+    this.stdout.emit("data", chunk);
+  }
+
+  writeStderr(chunk: string): void {
+    this.stderr.emit("data", chunk);
+  }
+
+  emitError(error: Error): void {
+    this.emit("error", error);
+  }
+
+  close(code: number | null = 0, signal: NodeJS.Signals | null = null): void {
+    this.exitCode = code;
+    this.emit("close", code, signal);
+  }
+}
+
+function createMockSSHProcess(): MockSSHProcess {
+  return new MockSSHProcess();
+}
+
+function completeRemoteCommand(child: MockSSHProcess, stdout: string, exitCode = 0): void {
+  child.writeStdout(`${stdout}\n${REMOTE_COMMAND_EXIT_MARKER}:${exitCode}\n`);
+}
+
+function getSpawnedSSHArgs(callIndex = 0): string[] {
+  return mocks.spawn.mock.calls[callIndex]?.[1] as string[] ?? [];
+}
+
+function getSpawnedRemoteCommand(callIndex = 0): string {
+  return getSpawnedSSHArgs(callIndex).at(-1) ?? "";
+}
 
 describe("gitOperations.resolvePathForShell", () => {
   beforeEach(() => {
@@ -87,8 +167,12 @@ describe("gitOperations.resolvePathForShell", () => {
 
   it("원격 명령 실행은 ssh 바이너리와 옵션을 사용한다", async () => {
     // Given
-    mocks.execFile.mockImplementation((_file: string, _args: string[], _options: unknown, callback: (error: null, result: { stdout: string }) => void) => {
-      callback(null, { stdout: "ok\n" });
+    const spawnedChildren: MockSSHProcess[] = [];
+    mocks.spawn.mockImplementation(() => {
+      const child = createMockSSHProcess();
+      spawnedChildren.push(child);
+      queueMicrotask(() => completeRemoteCommand(child, "ok"));
+      return child;
     });
 
     vi.doMock("@/lib/sshConfig", async (importOriginal) => {
@@ -111,7 +195,7 @@ describe("gitOperations.resolvePathForShell", () => {
     const result = await execGit("pwd", "remote-host");
 
     // Then
-    const expectedArgs = [
+    const expectedPrefix = [
       "-i",
       "/tmp/test-key",
       "-p",
@@ -124,7 +208,7 @@ describe("gitOperations.resolvePathForShell", () => {
     ];
 
     if (process.platform !== "win32") {
-      expectedArgs.push(
+      expectedPrefix.push(
         "-o",
         "ControlMaster=auto",
         "-o",
@@ -134,31 +218,50 @@ describe("gitOperations.resolvePathForShell", () => {
       );
     }
 
-    expectedArgs.push(
+    expectedPrefix.push(
+      "-o",
+      "ConnectTimeout=8",
+      "-o",
+      "ServerAliveInterval=5",
+      "-o",
+      "ServerAliveCountMax=2",
+    );
+
+    expectedPrefix.push(
       "remote-host",
-      "sh -lc 'pwd'",
     );
 
     expect(result).toBe("ok");
-    expect(expectedArgs).not.toContain("-Y");
-    expect(mocks.execFile).toHaveBeenCalledWith(
+    expect(spawnedChildren[0]?.killed).toBe(true);
+    expect(expectedPrefix).not.toContain("-Y");
+    expect(mocks.spawn).toHaveBeenCalledWith(
       "ssh",
-      expectedArgs,
-      expect.objectContaining({ maxBuffer: 10 * 1024 * 1024 }),
-      expect.any(Function),
+      expect.arrayContaining(expectedPrefix),
+      expect.objectContaining({
+        env: expect.any(Object),
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
     );
+    expect(getSpawnedRemoteCommand()).toContain("pwd");
+    expect(getSpawnedRemoteCommand()).toContain(REMOTE_COMMAND_EXIT_MARKER);
   });
 
   it("SSH transport 실패 직후 같은 host의 후속 명령은 새 ssh 프로세스를 만들지 않는다", async () => {
     // Given
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    mocks.execFile.mockImplementation((_file: string, _args: string[], _options: unknown, callback: (error: Error & { stderr?: string }) => void) => {
-      const error = new Error("Command failed") as Error & { stderr?: string };
-      error.stderr = [
-        "mux_client_request_session: session request failed: Session open refused by peer",
-        "Connection closed by 100.73.171.123 port 22",
-      ].join("\n");
-      callback(error);
+    mocks.execFile.mockImplementation((_file: string, _args: string[], _options: unknown, callback: (error: null, result: { stdout: string }) => void) => {
+      callback(null, { stdout: "" });
+    });
+    mocks.spawn.mockImplementation(() => {
+      const child = createMockSSHProcess();
+      queueMicrotask(() => {
+        child.writeStderr([
+          "mux_client_request_session: session request failed: Session open refused by peer",
+          "Connection closed by 100.73.171.123 port 22",
+        ].join("\n"));
+        child.close(255);
+      });
+      return child;
     });
 
     vi.doMock("@/lib/sshConfig", async (importOriginal) => {
@@ -183,7 +286,110 @@ describe("gitOperations.resolvePathForShell", () => {
       await expect(execGit("git -C /repo status --short", "remote-host")).rejects.toThrow();
 
       // Then
+      expect(mocks.spawn).toHaveBeenCalledTimes(3);
+      expect(mocks.execFile).toHaveBeenCalledTimes(3);
+      expect(mocks.execFile.mock.calls[0]?.[1]).toEqual(expect.arrayContaining([
+        "-O",
+        "exit",
+        "-S",
+        "/home/local-user/.kanvibe/ssh-%C",
+      ]));
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("원격 SSH 명령이 timeout되면 ControlMaster를 종료하고 후속 명령을 cooldown 처리한다", async () => {
+    // Given
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.execFile.mockImplementation((_file: string, _args: string[], _options: unknown, callback: (error: null, result: { stdout: string }) => void) => {
+      callback(null, { stdout: "" });
+    });
+    mocks.spawn.mockImplementation(() => {
+      const child = createMockSSHProcess();
+      queueMicrotask(() => {
+        const error = new Error("Command timed out") as Error & { killed?: boolean; signal?: string };
+        error.killed = true;
+        error.signal = "SIGTERM";
+        child.emitError(error);
+      });
+      return child;
+    });
+
+    vi.doMock("@/lib/sshConfig", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/sshConfig")>();
+      return {
+        ...actual,
+        parseSSHConfig: vi.fn(async () => [{
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        }]),
+      };
+    });
+
+    const { execGit } = await import("@/lib/gitOperations");
+
+    try {
+      // When & Then
+      await expect(execGit("long-running-command", "remote-host", { timeoutMs: 1000 })).rejects.toThrow(/1초/);
+      await expect(execGit("next-command", "remote-host")).rejects.toThrow(/최근 SSH transport 실패/);
+      expect(mocks.spawn).toHaveBeenCalledTimes(3);
+      expect(mocks.execFile).toHaveBeenCalledTimes(3);
+      expect(mocks.execFile.mock.calls[0]?.[1]).toEqual(expect.arrayContaining(["-O", "exit"]));
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("SSH transport 오류는 3회 안에 성공하면 원격 명령 결과를 반환한다", async () => {
+    // Given
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.execFile.mockImplementation((_file: string, _args: string[], _options: unknown, callback: (error: null, result: { stdout: string }) => void) => {
+      callback(null, { stdout: "" });
+    });
+    mocks.spawn.mockImplementation(() => {
+      const child = createMockSSHProcess();
+      const attempt = mocks.spawn.mock.calls.length;
+      queueMicrotask(() => {
+        if (attempt === 1) {
+          child.writeStderr("Connection reset by peer\n");
+          child.close(255);
+          return;
+        }
+
+        completeRemoteCommand(child, "recovered");
+      });
+      return child;
+    });
+
+    vi.doMock("@/lib/sshConfig", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/sshConfig")>();
+      return {
+        ...actual,
+        parseSSHConfig: vi.fn(async () => [{
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        }]),
+      };
+    });
+
+    const { execGit } = await import("@/lib/gitOperations");
+
+    try {
+      // When
+      const result = await execGit("recoverable-command", "remote-host");
+
+      // Then
+      expect(result).toBe("recovered");
+      expect(mocks.spawn).toHaveBeenCalledTimes(2);
       expect(mocks.execFile).toHaveBeenCalledTimes(1);
+      await expect(execGit("next-command", "remote-host")).resolves.toBe("recovered");
     } finally {
       consoleErrorSpy.mockRestore();
     }
@@ -192,10 +398,12 @@ describe("gitOperations.resolvePathForShell", () => {
   it("같은 SSH host의 원격 명령은 제한된 동시성으로 실행한다", async () => {
     // Given
     const startedCommands: string[] = [];
-    const pendingCallbacks: Array<(error: null, result: { stdout: string }) => void> = [];
-    mocks.execFile.mockImplementation((_file: string, args: string[], _options: unknown, callback: (error: null, result: { stdout: string }) => void) => {
+    const pendingChildren: MockSSHProcess[] = [];
+    mocks.spawn.mockImplementation((_file: string, args: string[]) => {
+      const child = createMockSSHProcess();
       startedCommands.push(args.at(-1) ?? "");
-      pendingCallbacks.push(callback);
+      pendingChildren.push(child);
+      return child;
     });
 
     vi.doMock("@/lib/sshConfig", async (importOriginal) => {
@@ -223,42 +431,95 @@ describe("gitOperations.resolvePathForShell", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     // Then
-    expect(startedCommands).toEqual([
-      "sh -lc 'first'",
-      "sh -lc 'second'",
-      "sh -lc 'third'",
-      "sh -lc 'fourth'",
-    ]);
+    expect(startedCommands).toHaveLength(4);
+    expect(startedCommands[0]).toContain("first");
+    expect(startedCommands[1]).toContain("second");
+    expect(startedCommands[2]).toContain("third");
+    expect(startedCommands[3]).toContain("fourth");
 
-    pendingCallbacks.shift()?.(null, { stdout: "one\n" });
+    completeRemoteCommand(pendingChildren.shift()!, "one");
     await expect(first).resolves.toBe("one");
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(startedCommands).toEqual([
-      "sh -lc 'first'",
-      "sh -lc 'second'",
-      "sh -lc 'third'",
-      "sh -lc 'fourth'",
-      "sh -lc 'fifth'",
-    ]);
+    expect(startedCommands).toHaveLength(5);
+    expect(startedCommands[4]).toContain("fifth");
 
-    pendingCallbacks.shift()?.(null, { stdout: "two\n" });
+    completeRemoteCommand(pendingChildren.shift()!, "two");
     await expect(second).resolves.toBe("two");
-    pendingCallbacks.shift()?.(null, { stdout: "three\n" });
-    pendingCallbacks.shift()?.(null, { stdout: "four\n" });
-    pendingCallbacks.shift()?.(null, { stdout: "five\n" });
+    completeRemoteCommand(pendingChildren.shift()!, "three");
+    completeRemoteCommand(pendingChildren.shift()!, "four");
+    completeRemoteCommand(pendingChildren.shift()!, "five");
     await expect(third).resolves.toBe("three");
     await expect(fourth).resolves.toBe("four");
     await expect(fifth).resolves.toBe("five");
   });
 
+  it("환경변수로 같은 SSH host의 원격 명령 동시성 제한을 늘릴 수 있다", async () => {
+    // Given
+    const originalConcurrency = process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY;
+    process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY = "6";
+    const startedCommands: string[] = [];
+    const pendingChildren: MockSSHProcess[] = [];
+    mocks.spawn.mockImplementation((_file: string, args: string[]) => {
+      const child = createMockSSHProcess();
+      startedCommands.push(args.at(-1) ?? "");
+      pendingChildren.push(child);
+      return child;
+    });
+
+    vi.doMock("@/lib/sshConfig", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/sshConfig")>();
+      return {
+        ...actual,
+        parseSSHConfig: vi.fn(async () => [{
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        }]),
+      };
+    });
+
+    try {
+      const { execGit } = await import("@/lib/gitOperations");
+
+      // When
+      const commands = Array.from({ length: 7 }, (_, index) => execGit(`command-${index}`, "remote-host"));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Then
+      expect(startedCommands).toHaveLength(6);
+      for (let index = 0; index < 6; index += 1) {
+        expect(startedCommands[index]).toContain(`command-${index}`);
+      }
+
+      completeRemoteCommand(pendingChildren.shift()!, "done");
+      await expect(commands[0]).resolves.toBe("done");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(startedCommands).toHaveLength(7);
+      expect(startedCommands[6]).toContain("command-6");
+      for (const [index, command] of commands.slice(1).entries()) {
+        completeRemoteCommand(pendingChildren.shift()!, String(index));
+        await expect(command).resolves.toBe(String(index));
+      }
+    } finally {
+      if (originalConcurrency === undefined) {
+        delete process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY;
+      } else {
+        process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY = originalConcurrency;
+      }
+    }
+  });
+
   it("조용한 probe 명령 실패는 콘솔 에러를 남기지 않는다", async () => {
     // Given
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    mocks.execFile.mockImplementation((_file: string, _args: string[], _options: unknown, callback: (error: Error & { stderr?: string }) => void) => {
-      const error = new Error("Command failed") as Error & { stderr?: string };
-      error.stderr = "";
-      callback(error);
+    mocks.spawn.mockImplementation(() => {
+      const child = createMockSSHProcess();
+      queueMicrotask(() => child.close(255));
+      return child;
     });
 
     vi.doMock("@/lib/sshConfig", async (importOriginal) => {
@@ -287,10 +548,16 @@ describe("gitOperations.resolvePathForShell", () => {
   it("파일 probe 명령 실패도 콘솔 에러를 남기지 않는다", async () => {
     // Given
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    mocks.execFile.mockImplementation((_file: string, _args: string[], _options: unknown, callback: (error: Error & { stderr?: string }) => void) => {
-      const error = new Error("Command failed") as Error & { stderr?: string };
-      error.stderr = "Connection reset by peer\n";
-      callback(error);
+    mocks.execFile.mockImplementation((_file: string, _args: string[], _options: unknown, callback: (error: null, result: { stdout: string }) => void) => {
+      callback(null, { stdout: "" });
+    });
+    mocks.spawn.mockImplementation(() => {
+      const child = createMockSSHProcess();
+      queueMicrotask(() => {
+        child.writeStderr("Connection reset by peer\n");
+        child.close(255);
+      });
+      return child;
     });
 
     vi.doMock("@/lib/sshConfig", async (importOriginal) => {

--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -443,6 +443,12 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
         "-o",
         "IdentitiesOnly=yes",
         "-tt",
+        "-o",
+        "ConnectTimeout=8",
+        "-o",
+        "ServerAliveInterval=5",
+        "-o",
+        "ServerAliveCountMax=2",
         "remote-host",
       ]);
       expect(sshArgs).not.toContain("-Y");

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -1,7 +1,7 @@
 import { writeFile, mkdir, chmod } from "fs/promises";
 import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
-import { pathExists, readTextFile } from "@/lib/hostFileAccess";
+import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
 import { buildShellTaskIdResolver, extractShellTaskId } from "@/lib/hookTaskBinding";
 
@@ -100,7 +100,10 @@ function hasLegacyBranchPayloadBinding(content: string): boolean {
 
 /** 기존 settings.json을 읽거나 빈 객체를 반환한다 */
 async function readSettingsJson(settingsPath: string, sshHost?: string | null): Promise<ClaudeSettings> {
-  const content = await readTextFile(settingsPath, sshHost);
+  return parseSettingsJson(await readTextFile(settingsPath, sshHost));
+}
+
+function parseSettingsJson(content: string): ClaudeSettings {
   if (!content) {
     return {};
   }
@@ -250,15 +253,19 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
   const stopScriptPath = pathModule.join(hooksDir, "kanvibe-stop-hook.sh");
   const questionScriptPath = pathModule.join(hooksDir, "kanvibe-question-hook.sh");
 
-  const promptScriptExists = await pathExists(promptScriptPath, sshHost);
-  const stopScriptExists = await pathExists(stopScriptPath, sshHost);
-  const questionScriptExists = await pathExists(questionScriptPath, sshHost);
-
-  const [promptContent, stopContent, questionContent] = await Promise.all([
-    promptScriptExists ? readTextFile(promptScriptPath, sshHost) : Promise.resolve(""),
-    stopScriptExists ? readTextFile(stopScriptPath, sshHost) : Promise.resolve(""),
-    questionScriptExists ? readTextFile(questionScriptPath, sshHost) : Promise.resolve(""),
-  ]);
+  const files = await readTextFiles([
+    promptScriptPath,
+    stopScriptPath,
+    questionScriptPath,
+    settingsPath,
+  ], sshHost);
+  const promptScript = files.get(promptScriptPath) ?? { exists: false, content: "" };
+  const stopScript = files.get(stopScriptPath) ?? { exists: false, content: "" };
+  const questionScript = files.get(questionScriptPath) ?? { exists: false, content: "" };
+  const settingsFile = files.get(settingsPath) ?? { exists: false, content: "" };
+  const promptContent = promptScript.content;
+  const stopContent = stopScript.content;
+  const questionContent = questionScript.content;
 
   const scriptContents = [promptContent, stopContent, questionContent];
   const boundTaskIds = scriptContents.map(extractShellTaskId).filter((value): value is string => value !== null);
@@ -278,7 +285,7 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
 
   let hasSettingsEntry = false;
   try {
-    const settings = await readSettingsJson(settingsPath, sshHost);
+    const settings = parseSettingsJson(settingsFile.content);
     const hooks = settings.hooks as Record<string, unknown[]> | undefined;
     if (hooks) {
       const hasPrompt = hasCommandHook(hooks.UserPromptSubmit || [], CLAUDE_PROMPT_COMMAND);
@@ -291,9 +298,9 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
     /* settings.json 없음 */
   }
 
-  const installed = promptScriptExists
-    && stopScriptExists
-    && questionScriptExists
+  const installed = promptScript.exists
+    && stopScript.exists
+    && questionScript.exists
     && hasSettingsEntry
     && hasTaskIdBinding
     && hasStatusMappings
@@ -301,9 +308,9 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
 
   return {
     installed,
-    hasPromptHook: promptScriptExists,
-    hasStopHook: stopScriptExists,
-    hasQuestionHook: questionScriptExists,
+    hasPromptHook: promptScript.exists,
+    hasStopHook: stopScript.exists,
+    hasQuestionHook: questionScript.exists,
     hasSettingsEntry,
     hasTaskIdBinding,
     hasStatusMappings,

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -1,7 +1,7 @@
 import { writeFile, mkdir, chmod } from "fs/promises";
 import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
-import { pathExists, readTextFile } from "@/lib/hostFileAccess";
+import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
 import { buildShellTaskIdResolver, extractShellTaskId } from "@/lib/hookTaskBinding";
 
@@ -346,35 +346,26 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
   const preToolScriptPath = pathModule.join(hooksDir, PRE_TOOL_HOOK_SCRIPT_NAME);
   const stopScriptPath = pathModule.join(hooksDir, STOP_HOOK_SCRIPT_NAME);
 
-  const [
-    promptScriptExists,
-    permissionScriptExists,
-    preToolScriptExists,
-    stopScriptExists,
-    hooksFileExists,
-  ] = await Promise.all([
-    pathExists(promptScriptPath, sshHost),
-    pathExists(permissionScriptPath, sshHost),
-    pathExists(preToolScriptPath, sshHost),
-    pathExists(stopScriptPath, sshHost),
-    pathExists(hooksFilePath, sshHost),
-  ]);
-
-  const [
-    promptContent,
-    permissionContent,
-    preToolContent,
-    stopContent,
-    hooksContent,
-    configContent,
-  ] = await Promise.all([
-    promptScriptExists ? readTextFile(promptScriptPath, sshHost) : Promise.resolve(""),
-    permissionScriptExists ? readTextFile(permissionScriptPath, sshHost) : Promise.resolve(""),
-    preToolScriptExists ? readTextFile(preToolScriptPath, sshHost) : Promise.resolve(""),
-    stopScriptExists ? readTextFile(stopScriptPath, sshHost) : Promise.resolve(""),
-    hooksFileExists ? readTextFile(hooksFilePath, sshHost) : Promise.resolve(""),
-    readTextFile(configPath, sshHost),
-  ]);
+  const files = await readTextFiles([
+    promptScriptPath,
+    permissionScriptPath,
+    preToolScriptPath,
+    stopScriptPath,
+    hooksFilePath,
+    configPath,
+  ], sshHost);
+  const promptScript = files.get(promptScriptPath) ?? { exists: false, content: "" };
+  const permissionScript = files.get(permissionScriptPath) ?? { exists: false, content: "" };
+  const preToolScript = files.get(preToolScriptPath) ?? { exists: false, content: "" };
+  const stopScript = files.get(stopScriptPath) ?? { exists: false, content: "" };
+  const hooksFile = files.get(hooksFilePath) ?? { exists: false, content: "" };
+  const configFile = files.get(configPath) ?? { exists: false, content: "" };
+  const promptContent = promptScript.content;
+  const permissionContent = permissionScript.content;
+  const preToolContent = preToolScript.content;
+  const stopContent = stopScript.content;
+  const hooksContent = hooksFile.content;
+  const configContent = configFile.content;
 
   const hookScripts = [promptContent, permissionContent, preToolContent, stopContent];
   const boundTaskId = hookScripts.map((content) => extractShellTaskId(content)).find((value) => value !== null) ?? null;
@@ -397,11 +388,11 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
     && hasCommandHook(hooks.Stop || [], CODEX_STOP_COMMAND);
   const hasConfigEntry = hasCodexFeatureFlag(configContent);
 
-  const installed = promptScriptExists
-    && permissionScriptExists
-    && preToolScriptExists
-    && stopScriptExists
-    && hooksFileExists
+  const installed = promptScript.exists
+    && permissionScript.exists
+    && preToolScript.exists
+    && stopScript.exists
+    && hooksFile.exists
     && hasHookEntries
     && hasConfigEntry
     && hasTaskIdBinding
@@ -410,11 +401,11 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
 
   return {
     installed,
-    hasPromptHook: promptScriptExists,
-    hasPermissionHook: permissionScriptExists,
-    hasPreToolHook: preToolScriptExists,
-    hasStopHook: stopScriptExists,
-    hasHooksFile: hooksFileExists,
+    hasPromptHook: promptScript.exists,
+    hasPermissionHook: permissionScript.exists,
+    hasPreToolHook: preToolScript.exists,
+    hasStopHook: stopScript.exists,
+    hasHooksFile: hooksFile.exists,
     hasHookEntries,
     hasConfigEntry,
     hasTaskIdBinding,

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -1,7 +1,7 @@
 import { writeFile, mkdir, chmod } from "fs/promises";
 import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
-import { pathExists, readTextFile } from "@/lib/hostFileAccess";
+import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
 import { buildShellTaskIdResolver, extractShellTaskId } from "@/lib/hookTaskBinding";
 
@@ -94,7 +94,10 @@ function hasLegacyBranchPayloadBinding(content: string): boolean {
 
 /** 기존 settings.json을 읽거나 빈 객체를 반환한다 */
 async function readSettingsJson(settingsPath: string, sshHost?: string | null): Promise<GeminiSettings> {
-  const content = await readTextFile(settingsPath, sshHost);
+  return parseSettingsJson(await readTextFile(settingsPath, sshHost));
+}
+
+function parseSettingsJson(content: string): GeminiSettings {
   if (!content) {
     return {};
   }
@@ -211,13 +214,16 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
   const promptScriptPath = pathModule.join(hooksDir, "kanvibe-prompt-hook.sh");
   const stopScriptPath = pathModule.join(hooksDir, "kanvibe-stop-hook.sh");
 
-  const promptScriptExists = await pathExists(promptScriptPath, sshHost);
-  const stopScriptExists = await pathExists(stopScriptPath, sshHost);
-
-  const [promptContent, stopContent] = await Promise.all([
-    promptScriptExists ? readTextFile(promptScriptPath, sshHost) : Promise.resolve(""),
-    stopScriptExists ? readTextFile(stopScriptPath, sshHost) : Promise.resolve(""),
-  ]);
+  const files = await readTextFiles([
+    promptScriptPath,
+    stopScriptPath,
+    settingsPath,
+  ], sshHost);
+  const promptScript = files.get(promptScriptPath) ?? { exists: false, content: "" };
+  const stopScript = files.get(stopScriptPath) ?? { exists: false, content: "" };
+  const settingsFile = files.get(settingsPath) ?? { exists: false, content: "" };
+  const promptContent = promptScript.content;
+  const stopContent = stopScript.content;
 
   const scriptContents = [promptContent, stopContent];
   const boundTaskIds = scriptContents.map(extractShellTaskId).filter((value): value is string => value !== null);
@@ -236,7 +242,7 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
 
   let hasSettingsEntry = false;
   try {
-    const settings = await readSettingsJson(settingsPath, sshHost);
+    const settings = parseSettingsJson(settingsFile.content);
     const hooks = settings.hooks as Record<string, unknown[]> | undefined;
     if (hooks) {
       const hasPrompt = hasGeminiHook(hooks.BeforeAgent || [], "*", GEMINI_PROMPT_COMMAND);
@@ -247,8 +253,8 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
     /* settings.json 없음 */
   }
 
-  const installed = promptScriptExists
-    && stopScriptExists
+  const installed = promptScript.exists
+    && stopScript.exists
     && hasSettingsEntry
     && hasTaskIdBinding
     && hasStatusMappings
@@ -256,8 +262,8 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
 
   return {
     installed,
-    hasPromptHook: promptScriptExists,
-    hasStopHook: stopScriptExists,
+    hasPromptHook: promptScript.exists,
+    hasStopHook: stopScript.exists,
     hasSettingsEntry,
     hasTaskIdBinding,
     hasStatusMappings,

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -1,9 +1,10 @@
-import { exec, execFile } from "child_process";
+import { exec, execFile, spawn } from "child_process";
 import { promisify } from "util";
 import { homedir } from "os";
 import {
   buildSSHArgs,
   ensureKanvibeSSHControlDirectory,
+  getKanvibeSSHConnectionHealthOptions,
   getKanvibeSSHConnectionReuseOptions,
   parseSSHConfig,
   type SSHHostConfig,
@@ -20,6 +21,8 @@ const SSH_TRANSPORT_ERROR_PATTERNS = [
   /connection closed by /i,
   /connection refused/i,
   /connection timed out/i,
+  /ssh command timed out/i,
+  /ssh 명령이 .*완료되지 않았/i,
   /operation timed out/i,
   /no route to host/i,
   /network is unreachable/i,
@@ -35,10 +38,21 @@ const SSH_TRANSPORT_ERROR_PATTERNS = [
   /ssh: connect to host/i,
 ];
 
-const REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS = 60_000;
-const REMOTE_SSH_HOST_MAX_CONCURRENCY = 4;
+const DEFAULT_REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS = 5_000;
+const MAX_REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS = 60_000;
+const DEFAULT_REMOTE_SSH_HOST_MAX_CONCURRENCY = 4;
+const MAX_REMOTE_SSH_HOST_MAX_CONCURRENCY = 16;
+const DEFAULT_REMOTE_SSH_COMMAND_TIMEOUT_MS = 45_000;
+const REMOTE_SSH_COMMAND_MAX_ATTEMPTS = 3;
+const REMOTE_SSH_CONTROLMASTER_SHUTDOWN_TIMEOUT_MS = 3_000;
+const REMOTE_COMMAND_EXIT_MARKER = "__KANVIBE_REMOTE_COMMAND_EXIT_7b3f6e5d__";
+const REMOTE_COMMAND_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 const remoteSSHTransportFailures = new Map<string, { until: number; error: Error }>();
 const remoteSSHHostLimiters = new Map<string, { active: number; queue: Array<() => void> }>();
+
+export interface ExecGitOptions {
+  timeoutMs?: number;
+}
 
 function collectErrorOutput(error: unknown): string {
   const outputs: string[] = [];
@@ -91,6 +105,59 @@ function shouldLogRemoteCommandFailure(command: string, stderr: string): boolean
   return true;
 }
 
+function readPositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function getRemoteSSHHostMaxConcurrency(): number {
+  return Math.min(
+    readPositiveInteger(
+      process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY,
+      DEFAULT_REMOTE_SSH_HOST_MAX_CONCURRENCY,
+    ),
+    MAX_REMOTE_SSH_HOST_MAX_CONCURRENCY,
+  );
+}
+
+function getRemoteSSHCommandTimeoutMs(options?: ExecGitOptions): number {
+  return options?.timeoutMs
+    ?? readPositiveInteger(
+      process.env.KANVIBE_REMOTE_SSH_COMMAND_TIMEOUT_MS,
+      DEFAULT_REMOTE_SSH_COMMAND_TIMEOUT_MS,
+    );
+}
+
+function getRemoteSSHTransportFailureCooldownMs(): number {
+  return Math.min(
+    readPositiveInteger(
+      process.env.KANVIBE_REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS,
+      DEFAULT_REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS,
+    ),
+    MAX_REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS,
+  );
+}
+
+function isSSHCommandTimeoutError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const maybeTimeoutError = error as {
+    code?: string;
+    killed?: boolean;
+    signal?: string | null;
+  };
+
+  return maybeTimeoutError.killed === true
+    || maybeTimeoutError.signal === "SIGTERM"
+    || maybeTimeoutError.code === "ETIMEDOUT";
+}
+
 /** 로컬에서 셸 명령을 실행하고 stdout을 반환한다 */
 async function execLocal(command: string): Promise<string> {
   const { stdout } = await execAsync(command, {
@@ -100,10 +167,15 @@ async function execLocal(command: string): Promise<string> {
 }
 
 /** SSH를 통해 원격에서 명령을 실행하고 stdout을 반환한다 */
-async function execRemote(sshHost: string, command: string): Promise<string> {
+async function execRemote(
+  sshHost: string,
+  command: string,
+  options?: ExecGitOptions,
+): Promise<string> {
   return runLimitedRemoteCommand(sshHost, async () => {
     throwIfSSHTransportCooldownActive(sshHost);
 
+    const timeoutMs = getRemoteSSHCommandTimeoutMs(options);
     const configs = await parseSSHConfig();
     const hostConfig = configs.find((c) => c.host === sshHost);
 
@@ -116,31 +188,211 @@ async function execRemote(sshHost: string, command: string): Promise<string> {
       buildRemoteShellCommand(command),
     ];
 
-    try {
-      const { stdout } = await execFileAsync("ssh", sshArgs, {
-        env: createLocalShellEnvironment(),
-        maxBuffer: 10 * 1024 * 1024,
-      });
-      return stdout.trim();
-    } catch (error) {
-      const stderr = error && typeof error === "object" && "stderr" in error
-        ? String((error as { stderr?: string }).stderr || "")
-        : "";
+    let lastError: Error | null = null;
+    for (let attempt = 1; attempt <= REMOTE_SSH_COMMAND_MAX_ATTEMPTS; attempt += 1) {
+      try {
+        return await spawnSSHCommand(sshArgs, timeoutMs);
+      } catch (error) {
+        const isCommandTimeout = isSSHCommandTimeoutError(error);
+        const normalizedError = normalizeSSHExecError(error, sshHost, timeoutMs, isCommandTimeout);
+        const shouldRetry = isRetriableSSHExecError(normalizedError, isCommandTimeout)
+          && attempt < REMOTE_SSH_COMMAND_MAX_ATTEMPTS;
+        lastError = normalizedError;
 
-      if (shouldLogRemoteCommandFailure(command, stderr)) {
-        console.error("[remote-ssh] command failed", {
-          sshHost,
-          command,
-          sshArgs,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        if (isCommandTimeout || isSSHTransportError(normalizedError)) {
+          await closeRemoteSSHControlMaster(hostConfig).catch(() => undefined);
+        }
+
+        if (!shouldRetry) {
+          logRemoteCommandFailure(command, sshHost, sshArgs, error);
+          rememberSSHTransportFailure(sshHost, normalizedError);
+          throw normalizedError;
+        }
+      }
+    }
+
+    throw lastError ?? new Error(`${sshHost} 원격 명령 실패`);
+  });
+}
+
+function logRemoteCommandFailure(
+  command: string,
+  sshHost: string,
+  sshArgs: string[],
+  error: unknown,
+): void {
+  const stderr = error && typeof error === "object" && "stderr" in error
+    ? String((error as { stderr?: string }).stderr || "")
+    : "";
+
+  if (!shouldLogRemoteCommandFailure(command, stderr)) {
+    return;
+  }
+
+  console.error("[remote-ssh] command failed", {
+    sshHost,
+    command,
+    sshArgs,
+    error: error instanceof Error ? error.message : String(error),
+  });
+}
+
+function isRetriableSSHExecError(error: Error, isCommandTimeout: boolean): boolean {
+  return isCommandTimeout || isSSHTransportError(error);
+}
+
+function spawnSSHCommand(sshArgs: string[], timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("ssh", sshArgs, {
+      env: createLocalShellEnvironment(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timeout = setTimeout(() => {
+      finishWithError(createSSHTimeoutError(timeoutMs, stdout, stderr));
+    }, timeoutMs);
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+      rejectIfOutputIsTooLarge();
+
+      const parsed = parseRemoteCommandCompletion(stdout);
+      if (parsed) {
+        finishWithRemoteCompletion(parsed.exitCode, parsed.stdout, stderr);
+      }
+    });
+
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+      rejectIfOutputIsTooLarge();
+    });
+
+    child.on("error", (error) => {
+      finishWithError(attachCommandOutput(error, stdout, stderr));
+    });
+
+    child.on("close", (code, signal) => {
+      if (settled) {
+        return;
       }
 
-      const normalizedError = normalizeSSHExecError(error, sshHost);
-      rememberSSHTransportFailure(sshHost, normalizedError);
-      throw normalizedError;
+      const parsed = parseRemoteCommandCompletion(stdout);
+      if (parsed) {
+        finishWithRemoteCompletion(parsed.exitCode, parsed.stdout, stderr);
+        return;
+      }
+
+      if (code === 0) {
+        finishWithSuccess(stdout.trim());
+        return;
+      }
+
+      finishWithError(createSSHExitError(code, signal, stdout, stderr));
+    });
+
+    function rejectIfOutputIsTooLarge(): void {
+      if (Buffer.byteLength(stdout) + Buffer.byteLength(stderr) <= REMOTE_COMMAND_MAX_BUFFER_BYTES) {
+        return;
+      }
+
+      finishWithError(attachCommandOutput(
+        new Error("SSH command output exceeded maxBuffer"),
+        stdout,
+        stderr,
+      ));
+    }
+
+    function finishWithRemoteCompletion(exitCode: number, completedStdout: string, completedStderr: string): void {
+      if (exitCode === 0) {
+        finishWithSuccess(completedStdout.trim());
+        return;
+      }
+
+      const error = createSSHExitError(exitCode, null, completedStdout, completedStderr);
+      finishWithError(error);
+    }
+
+    function finishWithSuccess(output: string): void {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+      if (child.exitCode === null && !child.killed) {
+        child.kill("SIGTERM");
+      }
+      resolve(output);
+    }
+
+    function finishWithError(error: Error): void {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+      if (child.exitCode === null && !child.killed) {
+        child.kill("SIGTERM");
+      }
+      reject(error);
     }
   });
+}
+
+function parseRemoteCommandCompletion(stdout: string): { stdout: string; exitCode: number } | null {
+  const markerPrefix = `\n${REMOTE_COMMAND_EXIT_MARKER}:`;
+  const markerIndex = stdout.lastIndexOf(markerPrefix);
+  if (markerIndex < 0) {
+    return null;
+  }
+
+  const exitCodeMatch = stdout
+    .slice(markerIndex + markerPrefix.length)
+    .match(/^(\d+)\r?\n/);
+  if (!exitCodeMatch) {
+    return null;
+  }
+
+  return {
+    stdout: stdout.slice(0, markerIndex),
+    exitCode: Number.parseInt(exitCodeMatch[1], 10),
+  };
+}
+
+function createSSHTimeoutError(timeoutMs: number, stdout: string, stderr: string): Error {
+  const error = new Error(`Command timed out after ${timeoutMs}ms`) as Error & {
+    killed?: boolean;
+    signal?: string;
+  };
+  error.killed = true;
+  error.signal = "SIGTERM";
+  return attachCommandOutput(error, stdout, stderr);
+}
+
+function createSSHExitError(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  stdout: string,
+  stderr: string,
+): Error {
+  const error = new Error(`Command failed: ssh exited with ${signal ?? code ?? "unknown"}`) as Error & {
+    code?: number | null;
+    signal?: NodeJS.Signals | null;
+  };
+  error.code = code;
+  error.signal = signal;
+  return attachCommandOutput(error, stdout, stderr);
+}
+
+function attachCommandOutput<T extends Error>(error: T, stdout: string, stderr: string): T {
+  return Object.assign(error, { stdout, stderr });
 }
 
 async function runLimitedRemoteCommand<T>(
@@ -169,7 +421,7 @@ function acquireRemoteSSHSlot(sshHost: string): Promise<() => void> {
       resolve(() => releaseRemoteSSHSlot(sshHost, limiter));
     };
 
-    if (limiter.active < REMOTE_SSH_HOST_MAX_CONCURRENCY) {
+    if (limiter.active < getRemoteSSHHostMaxConcurrency()) {
       start();
       return;
     }
@@ -217,7 +469,7 @@ function rememberSSHTransportFailure(sshHost: string, error: Error): void {
   }
 
   remoteSSHTransportFailures.set(sshHost, {
-    until: Date.now() + REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS,
+    until: Date.now() + getRemoteSSHTransportFailureCooldownMs(),
     error,
   });
 }
@@ -226,25 +478,79 @@ async function buildExecSSHArgs(
   hostConfig: SSHHostConfig,
 ): Promise<string[]> {
   if (process.platform === "win32") {
-    return buildSSHArgs(hostConfig, { disableTty: true });
+    return buildSSHArgs(hostConfig, {
+      disableTty: true,
+      connectionHealth: getKanvibeSSHConnectionHealthOptions(),
+    });
   }
 
   await ensureKanvibeSSHControlDirectory();
   return buildSSHArgs(hostConfig, {
     disableTty: true,
     connectionReuse: getKanvibeSSHConnectionReuseOptions(),
+    connectionHealth: getKanvibeSSHConnectionHealthOptions(),
+  });
+}
+
+async function closeRemoteSSHControlMaster(hostConfig: SSHHostConfig): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  const reuseOptions = getKanvibeSSHConnectionReuseOptions();
+  const baseArgs = buildSSHArgs(hostConfig, {
+    disableTty: true,
+    connectionHealth: {
+      connectTimeoutSeconds: 3,
+      serverAliveIntervalSeconds: 1,
+      serverAliveCountMax: 1,
+    },
+  });
+  const destination = baseArgs.at(-1);
+  if (!destination) {
+    return;
+  }
+
+  const shutdownArgs = [
+    ...baseArgs.slice(0, -1),
+    "-O",
+    "exit",
+    "-S",
+    reuseOptions.controlPath,
+    destination,
+  ];
+
+  await execFileAsync("ssh", shutdownArgs, {
+    env: createLocalShellEnvironment(),
+    timeout: REMOTE_SSH_CONTROLMASTER_SHUTDOWN_TIMEOUT_MS,
   });
 }
 
 function buildRemoteShellCommand(command: string): string {
-  return `sh -lc ${quoteForPosixShell(command)}`;
+  const wrappedCommand = [
+    `sh -lc ${quoteForPosixShell(command)}`,
+    "__kanvibe_status=$?",
+    `printf '\\n${REMOTE_COMMAND_EXIT_MARKER}:%s\\n' "$__kanvibe_status"`,
+    'exit "$__kanvibe_status"',
+  ].join("; ");
+
+  return `sh -lc ${quoteForPosixShell(wrappedCommand)}`;
 }
 
 function quoteForPosixShell(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
-function normalizeSSHExecError(error: unknown, sshHost: string): Error {
+function normalizeSSHExecError(
+  error: unknown,
+  sshHost: string,
+  timeoutMs: number,
+  isCommandTimeout: boolean,
+): Error {
+  if (isCommandTimeout) {
+    return new Error(`${sshHost} 원격 명령 실패: SSH 명령이 ${Math.ceil(timeoutMs / 1000)}초 안에 완료되지 않았습니다.`);
+  }
+
   if (error && typeof error === "object" && "stderr" in error) {
     const stderr = String((error as { stderr?: string }).stderr || "").trim();
     const message = stderr ? summarizeCommandFailure(stderr) : (error instanceof Error ? error.message : "SSH 명령 실패");
@@ -268,9 +574,13 @@ export function resolvePathForShell(targetPath: string, sshHost?: string | null)
 }
 
 /** 로컬 또는 SSH에서 명령을 실행한다. sshHost가 null이면 로컬 실행 */
-export async function execGit(command: string, sshHost?: string | null): Promise<string> {
+export async function execGit(
+  command: string,
+  sshHost?: string | null,
+  options?: ExecGitOptions,
+): Promise<string> {
   if (sshHost) {
-    return execRemote(sshHost, command);
+    return execRemote(sshHost, command, options);
   }
   return execLocal(command);
 }

--- a/src/lib/githubCliDependency.ts
+++ b/src/lib/githubCliDependency.ts
@@ -1,6 +1,9 @@
 import { execGit, isSSHTransportError } from "@/lib/gitOperations";
 
 const blockedTargets = new Map<string, string>();
+const availableTargets = new Map<string, number>();
+const inFlightStatusChecks = new Map<string, Promise<boolean>>();
+const GITHUB_CLI_SUCCESS_CACHE_MS = 60_000;
 
 export interface GitHubCliStatus {
   toolName: "gh";
@@ -14,16 +17,55 @@ function buildBlockedTargetKey(sshHost?: string | null): string {
   return `${sshHost || "local"}:gh`;
 }
 
-async function hasGitHubCli(sshHost?: string | null): Promise<boolean> {
-  try {
-    await execGit("command -v gh >/dev/null 2>&1", sshHost);
-    return true;
-  } catch (error) {
-    if (sshHost && isSSHTransportError(error)) {
-      throw error;
-    }
-
+function isCachedAvailable(sshHost?: string | null): boolean {
+  const checkedAt = availableTargets.get(buildBlockedTargetKey(sshHost));
+  if (!checkedAt) {
     return false;
+  }
+
+  if (Date.now() - checkedAt > GITHUB_CLI_SUCCESS_CACHE_MS) {
+    availableTargets.delete(buildBlockedTargetKey(sshHost));
+    return false;
+  }
+
+  return true;
+}
+
+function rememberAvailable(sshHost?: string | null): void {
+  availableTargets.set(buildBlockedTargetKey(sshHost), Date.now());
+}
+
+async function hasGitHubCli(sshHost?: string | null): Promise<boolean> {
+  if (isCachedAvailable(sshHost)) {
+    return true;
+  }
+
+  const targetKey = buildBlockedTargetKey(sshHost);
+  const inFlightCheck = inFlightStatusChecks.get(targetKey);
+  if (inFlightCheck) {
+    return inFlightCheck;
+  }
+
+  const check = (async () => {
+    try {
+      await execGit("command -v gh >/dev/null 2>&1", sshHost);
+      rememberAvailable(sshHost);
+      return true;
+    } catch (error) {
+      if (sshHost && isSSHTransportError(error)) {
+        throw error;
+      }
+
+      return false;
+    }
+  })();
+
+  inFlightStatusChecks.set(targetKey, check);
+
+  try {
+    return await check;
+  } finally {
+    inFlightStatusChecks.delete(targetKey);
   }
 }
 
@@ -52,10 +94,13 @@ export async function getGitHubCliStatus(sshHost?: string | null): Promise<GitHu
 export async function installGitHubCli(sshHost?: string | null): Promise<void> {
   const blockedTargetKey = buildBlockedTargetKey(sshHost);
   blockedTargets.delete(blockedTargetKey);
+  availableTargets.delete(blockedTargetKey);
+  inFlightStatusChecks.delete(blockedTargetKey);
 
   try {
     await execGit(buildInstallCommand(), sshHost);
     await execGit("command -v gh >/dev/null 2>&1", sshHost);
+    rememberAvailable(sshHost);
   } catch (error) {
     if (sshHost && isSSHTransportError(error)) {
       throw error;

--- a/src/lib/hostFileAccess.ts
+++ b/src/lib/hostFileAccess.ts
@@ -4,6 +4,12 @@ import path from "path";
 import { execGit } from "@/lib/gitOperations";
 
 const remoteHomeDirectoryCache = new Map<string, string>();
+const REMOTE_FILE_RECORD_PREFIX = "__KANVIBE_FILE_RECORD__";
+
+export interface TextFileReadResult {
+  exists: boolean;
+  content: string;
+}
 
 export function quoteShellArgument(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`;
@@ -57,6 +63,74 @@ export async function readTextFile(targetPath: string, sshHost?: string | null):
   } catch {
     return "";
   }
+}
+
+export async function readTextFiles(
+  targetPaths: string[],
+  sshHost?: string | null,
+): Promise<Map<string, TextFileReadResult>> {
+  if (targetPaths.length === 0) {
+    return new Map();
+  }
+
+  if (!sshHost) {
+    const entries: Array<[string, TextFileReadResult]> = await Promise.all(targetPaths.map(async (targetPath) => {
+      try {
+        return [targetPath, { exists: true, content: await readFile(targetPath, "utf-8") }];
+      } catch {
+        return [targetPath, { exists: false, content: "" }];
+      }
+    }));
+
+    return new Map<string, TextFileReadResult>(entries);
+  }
+
+  const command = [
+    "for __kanvibe_file in",
+    targetPaths.map(quoteShellArgument).join(" "),
+    "; do",
+    `printf '%s\\t%s\\t' ${quoteShellArgument(REMOTE_FILE_RECORD_PREFIX)} \"$__kanvibe_file\"`,
+    "if test -f \"$__kanvibe_file\"; then",
+    "printf '1\\t'",
+    "(base64 -w 0 \"$__kanvibe_file\" 2>/dev/null || base64 \"$__kanvibe_file\" | tr -d '\\n')",
+    "else",
+    "printf '0\\t'",
+    "fi",
+    "printf '\\n'",
+    "done",
+  ].join(" ");
+  const output = await execGit(command, sshHost);
+
+  return parseRemoteTextFiles(output, targetPaths);
+}
+
+function parseRemoteTextFiles(
+  output: string,
+  targetPaths: string[],
+): Map<string, TextFileReadResult> {
+  const files = new Map<string, TextFileReadResult>(
+    targetPaths.map((targetPath) => [targetPath, { exists: false, content: "" }]),
+  );
+
+  for (const line of output.split("\n")) {
+    if (!line.startsWith(`${REMOTE_FILE_RECORD_PREFIX}\t`)) {
+      continue;
+    }
+
+    const [, filePath, existsFlag, encodedContent = ""] = line.split("\t");
+    if (!filePath) {
+      continue;
+    }
+
+    files.set(filePath, {
+      exists: existsFlag === "1",
+      content: existsFlag === "1"
+        ? Buffer.from(encodedContent, "base64").toString("utf-8")
+        : "",
+    });
+  }
+
+  return files;
 }
 
 export async function writeTextFile(targetPath: string, content: string, sshHost?: string | null): Promise<void> {

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -2,7 +2,7 @@ import { writeFile, mkdir } from "fs/promises";
 import path from "path";
 import { pathToFileURL } from "node:url";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
-import { pathExists, readTextFile } from "@/lib/hostFileAccess";
+import { readTextFiles } from "@/lib/hostFileAccess";
 import { extractPluginHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
 import { getOpenCodeRegisteredKanvibePluginUrls } from "@/lib/openCodePluginRegistry";
 
@@ -243,7 +243,8 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
   const pluginsDir = pathModule.join(openCodeDir, PLUGIN_DIR_NAME);
   const pluginPath = pathModule.join(pluginsDir, PLUGIN_FILE_NAME);
 
-  const pluginExists = await pathExists(pluginPath, sshHost);
+  const files = await readTextFiles([pluginPath], sshHost);
+  const pluginFile = files.get(pluginPath) ?? { exists: false, content: "" };
 
   let hasPlugin = false;
   let boundTaskId: string | null = null;
@@ -256,9 +257,9 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
   let hasDuplicateKanvibePlugins = false;
   let registeredPluginUrls: string[] = [];
   let configuredHookServerUrl: string | null = null;
-  if (pluginExists) {
+  if (pluginFile.exists) {
     try {
-      const content = await readTextFile(pluginPath, sshHost);
+      const content = pluginFile.content;
       hasPlugin = hasKanvibePlugin(content);
       configuredHookServerUrl = extractPluginHookServerUrl(content);
       boundTaskId = extractPluginTaskId(content);
@@ -288,7 +289,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
     sshHost,
   );
 
-  const installed = pluginExists
+  const installed = pluginFile.exists
     && hasPlugin
     && hasTaskIdBinding
     && hasStatusEndpoint

--- a/src/lib/sshConfig.ts
+++ b/src/lib/sshConfig.ts
@@ -15,8 +15,17 @@ export interface SSHConnectionReuseOptions {
   controlPersist: string;
 }
 
+export interface SSHConnectionHealthOptions {
+  connectTimeoutSeconds: number;
+  serverAliveIntervalSeconds: number;
+  serverAliveCountMax: number;
+}
+
 const SSH_CONFIG_CACHE_TTL_MS = 5000;
 const KANVIBE_SSH_CONTROL_PERSIST = "10m";
+const KANVIBE_SSH_CONNECT_TIMEOUT_SECONDS = 8;
+const KANVIBE_SSH_SERVER_ALIVE_INTERVAL_SECONDS = 5;
+const KANVIBE_SSH_SERVER_ALIVE_COUNT_MAX = 2;
 let cachedHosts: SSHHostConfig[] | null = null;
 let cacheExpiresAt = 0;
 let inFlightParse: Promise<SSHHostConfig[]> | null = null;
@@ -36,6 +45,7 @@ export function buildSSHArgs(
     disableTty?: boolean;
     trustedX11Forwarding?: boolean;
     connectionReuse?: SSHConnectionReuseOptions;
+    connectionHealth?: SSHConnectionHealthOptions;
   },
 ): string[] {
   const args = [
@@ -70,6 +80,17 @@ export function buildSSHArgs(
     );
   }
 
+  if (options?.connectionHealth) {
+    args.push(
+      "-o",
+      `ConnectTimeout=${options.connectionHealth.connectTimeoutSeconds}`,
+      "-o",
+      `ServerAliveInterval=${options.connectionHealth.serverAliveIntervalSeconds}`,
+      "-o",
+      `ServerAliveCountMax=${options.connectionHealth.serverAliveCountMax}`,
+    );
+  }
+
   args.push(getSSHDestination(config));
   return args;
 }
@@ -86,6 +107,14 @@ export function getKanvibeSSHConnectionReuseOptions(): SSHConnectionReuseOptions
   return {
     controlPath: path.join(getKanvibeSSHControlDirectory(), "ssh-%C"),
     controlPersist: KANVIBE_SSH_CONTROL_PERSIST,
+  };
+}
+
+export function getKanvibeSSHConnectionHealthOptions(): SSHConnectionHealthOptions {
+  return {
+    connectTimeoutSeconds: KANVIBE_SSH_CONNECT_TIMEOUT_SECONDS,
+    serverAliveIntervalSeconds: KANVIBE_SSH_SERVER_ALIVE_INTERVAL_SECONDS,
+    serverAliveCountMax: KANVIBE_SSH_SERVER_ALIVE_COUNT_MAX,
   };
 }
 

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -5,7 +5,7 @@ import { PaneLayoutType } from "@/entities/PaneLayoutConfig";
 import { ZELLIJ_LAYOUT_FILENAME } from "@/lib/worktree";
 import { execSync } from "child_process";
 import type { WebSocket } from "ws";
-import { buildSSHArgs, hasLocalX11Display } from "@/lib/sshConfig";
+import { buildSSHArgs, getKanvibeSSHConnectionHealthOptions, hasLocalX11Display } from "@/lib/sshConfig";
 import { buildTmuxSessionBootstrapCommands, type TmuxPaneLayoutConfig } from "@/lib/worktree";
 import { createLocalShellEnvironment } from "@/lib/shellEnvironment";
 
@@ -295,6 +295,7 @@ export async function attachRemoteSession(
   const args = buildSSHArgs(sshConfig, {
     forceTty: true,
     trustedX11Forwarding: hasLocalX11Display(),
+    connectionHealth: getKanvibeSSHConnectionHealthOptions(),
   });
 
   if (shouldLogTerminalSpawn()) {


### PR DESCRIPTION
## Summary
- Retry transient SSH transport failures up to three times and close stale ControlMaster sockets before retrying.
- Detect remote command completion with an explicit marker so successful commands do not wait until timeout.
- Reduce remote timeout pressure by batching hook and diff probes, caching successful gh CLI checks, and adding SSH health options to command and terminal sessions.

## Verification
- npm run check
- npm test

Co-Authored-By: Codex <codex@openai.com>