### PR TITLE
fix(notifications): start alert focus on newest notification

### DIFF
--- a/src/components/NotificationCenterButton.tsx
+++ b/src/components/NotificationCenterButton.tsx
@@ -57,6 +57,10 @@ function openTaskNotificationInNewWindow(notification: AppNotification) {
   openInternalRouteInNewWindow(getTaskNotificationPath(notification));
 }
 
+function sortNotificationsByNewestFirst(notifications: AppNotification[]) {
+  return [...notifications].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
 const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, NotificationCenterButtonProps>(function NotificationCenterButton(
   { buttonClassName = "", panelClassName = "" },
   ref,
@@ -113,7 +117,7 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
 
   useEffect(() => {
     async function load() {
-      setNotifications(await listNotifications());
+      setNotifications(sortNotificationsByNewestFirst(await listNotifications()));
     }
 
     void load();

--- a/src/components/__tests__/NotificationCenterButton.test.tsx
+++ b/src/components/__tests__/NotificationCenterButton.test.tsx
@@ -155,6 +155,49 @@ describe("NotificationCenterButton", () => {
     });
   });
 
+  it("starts keyboard selection from the newest notification when opened", async () => {
+    mockListNotifications.mockResolvedValue([
+      {
+        id: "n-old",
+        title: "Older task",
+        body: "Body",
+        taskId: "task-old",
+        relativePath: "/task/task-old",
+        locale: "en",
+        isRead: false,
+        createdAt: "2026-05-04T00:00:00.000Z",
+        dedupeKey: "k-old",
+      },
+      {
+        id: "n-new",
+        title: "Newest task",
+        body: "Body",
+        taskId: "task-new",
+        relativePath: "/task/task-new",
+        locale: "en",
+        isRead: false,
+        createdAt: "2026-05-04T00:01:00.000Z",
+        dedupeKey: "k-new",
+      },
+    ]);
+    mockMarkNotificationRead.mockResolvedValue(undefined);
+    mockGetTaskById.mockImplementation(async (taskId: string) => ({ id: taskId }));
+
+    render(<NotificationShortcutHarness />);
+
+    await waitFor(() => {
+      expect(mockListNotifications).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "open notification shortcut" }));
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mockGetTaskById).toHaveBeenCalledWith("task-new");
+    });
+    expect(mockRedirect).toHaveBeenCalledWith("/en/task/task-new");
+  });
+
   it("opens task notifications in a new window with Shift+Click", async () => {
     const openWindow = vi.spyOn(window, "open").mockImplementation(() => null);
     mockListNotifications.mockResolvedValue([


### PR DESCRIPTION
## Summary
- Sort notification center items newest-first in the renderer before opening the alert dialog.
- Keep the existing initial highlighted index at the first rendered item so keyboard focus starts on the latest notification.
- Add regression coverage for unordered notification payloads and immediate keyboard activation.

## Verification
- pnpm test src/components/__tests__/NotificationCenterButton.test.tsx
- pnpm check
- pnpm exec eslint src/components/NotificationCenterButton.tsx src/components/__tests__/NotificationCenterButton.test.tsx

Co-authored-by: Codex <codex@openai.com>