### PR TITLE
fix(ui): restore project point color tokens

### DIFF
--- a/src/styles/__tests__/globals.test.ts
+++ b/src/styles/__tests__/globals.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync(resolve(process.cwd(), "src/styles/globals.css"), "utf8");
+
+function readThemeVar(themeSelector: string, variableName: string): string | null {
+  const block = css.match(new RegExp(`${themeSelector} \\{([\\s\\S]*?)\\n\\}`))?.[1];
+  return block?.match(new RegExp(`${variableName}:\\s*([^;]+);`))?.[1].trim() ?? null;
+}
+
+describe("globals.css theme tokens", () => {
+  it("keeps light theme project point tags in Toss Gray", () => {
+    expect(readThemeVar(':root\\[data-theme="light"\\]', "--color-tag-project-bg")).toBe("#202632");
+    expect(readThemeVar(':root\\[data-theme="light"\\]', "--color-tag-project-text")).toBe("#FFFFFF");
+    expect(readThemeVar(':root\\[data-theme="light"\\]', "--color-tag-base-bg")).toBe("#202632");
+    expect(readThemeVar(':root\\[data-theme="light"\\]', "--color-tag-base-text")).toBe("#FFFFFF");
+  });
+});

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -286,9 +286,10 @@
   --color-border-strong: #c8ccd3;
   --color-border-brand: #8f97ee;
 
-  --color-tag-project-bg: #eef0f4;
-  --color-tag-project-text: #3c414a;
-  --color-tag-base-bg: #2f3440;
+  --color-tag-project-bg: #202632;
+  --color-tag-project-text: #FFFFFF;
+  --color-tag-base-bg: #202632;
+  --color-tag-base-text: #FFFFFF;
   --color-group-line: #cdd1d8;
 
   --shadow-xs: 0 1px 1px rgba(17, 24, 39, 0.04);


### PR DESCRIPTION
## What changed?
- Restore the light theme project and base tag point color to Toss Gray `#202632` with white text.
- Add a focused regression test that locks the light theme token values.

## How was it solved?
**Restore point color tokens**
- Update `src/styles/globals.css` so `--color-tag-project-bg` and `--color-tag-base-bg` no longer get overwritten by pale light theme values.
- Explicitly set the matching project/base tag text tokens to white for the restored dark background.

**Cover the regression**
- Add `src/styles/__tests__/globals.test.ts` to assert the light theme project/base tag tokens remain on the expected Toss Gray values.

## Important changes
### Light theme token override

**Project/base tag contrast**
- **Reason**: the light theme override made point-color badges look almost white instead of the original Toss Gray.
- **Files**: `src/styles/globals.css`

**Regression coverage**
- **Reason**: keep future theme changes from silently overriding the point color again.
- **Files**: `src/styles/__tests__/globals.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>