### PR TITLE
feat(ui): polish task detail drawer and session UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,11 @@
 - Renderer keyboard events and Electron `before-input-event` inputs must be routed through the same shared matcher so macOS and Linux behavior stays consistent.
 - Shortcut capture UIs must store normalized shortcut strings from the shared capture helper, not hand-built modifier strings.
 - When adding or changing a shortcut, cover the shared command definition, display formatting, Electron input matching, renderer global handling, and any user-configurable capture flow with focused tests.
+
+## UI Color Tokens
+
+- Use `#0064FF` as the primary point color for PR buttons, primary actions, selected states, links, focus borders, and other important interactive highlights.
+- Keep point-color usage behind semantic tokens such as `--color-brand-primary`, `--color-brand-hover`, `--color-brand-active`, `--color-brand-subtle`, and `--color-tag-pr-*` instead of hard-coding hex values in components.
+- Use `#202632` for neutral button-like surfaces that should read as actionable but not alerting, such as compact shortcut buttons, base/project badges, and non-notification controls.
+- Keep neutral button usage behind semantic tokens such as `--color-button-neutral-*`, `--color-tag-project-*`, and `--color-tag-base-*`.
+- Do not use the primary point color for warning, error, success, or notification severity. Keep those on the existing `status-*` semantic tokens.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
   },
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",
+    "@hugeicons/core-free-icons": "^4.1.1",
+    "@hugeicons/react": "^1.1.6",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-switch": "^1.2.6",
     "@xterm/addon-fit": "^0.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@hello-pangea/dnd':
         specifier: ^18.0.1
         version: 18.0.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@hugeicons/core-free-icons':
+        specifier: ^4.1.1
+        version: 4.1.1
+      '@hugeicons/react':
+        specifier: ^1.1.6
+        version: 1.1.6(react@19.2.3)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -552,6 +558,14 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
+
+  '@hugeicons/core-free-icons@4.1.1':
+    resolution: {integrity: sha512-teqIBvPHl90ygIwKyJwTxOH8aNp1X1PjDTcMvLkEwdPxPD+8mssrZ5kXKIAJJFYPsz69a8LYQY0UPid4PAdavg==}
+
+  '@hugeicons/react@1.1.6':
+    resolution: {integrity: sha512-c2LhXJMAW5wN1pC/smBXG0YPqUON6ceR/ZdXHCjEI9KvB+hjtqYjmzIxok5hAQOeXGz0WtORgCQMzqewFKAZwg==}
+    peerDependencies:
+      react: '>=16.0.0'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4752,6 +4766,12 @@ snapshots:
       redux: 5.0.1
     transitivePeerDependencies:
       - '@types/react'
+
+  '@hugeicons/core-free-icons@4.1.1': {}
+
+  '@hugeicons/react@1.1.6(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
 
   '@humanfs/core@0.19.1': {}
 

--- a/src/components/AiSessionsCard.tsx
+++ b/src/components/AiSessionsCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import AiSessionsDialog from "@/components/AiSessionsDialog";
 import type { AggregatedAiSessionsResult } from "@/lib/aiSessions/types";
@@ -12,11 +12,8 @@ interface AiSessionsCardProps {
 
 export default function AiSessionsCard({ taskId, data }: AiSessionsCardProps) {
   const t = useTranslations("taskDetail");
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-
-  useEffect(() => {
-    setIsDialogOpen(false);
-  }, [taskId]);
+  const [openTaskId, setOpenTaskId] = useState<string | null>(null);
+  const isDialogOpen = openTaskId === taskId;
 
   const summary = useMemo(() => {
     const providerCount = data.sources.filter((source) => source.sessionCount > 0).length;
@@ -34,31 +31,56 @@ export default function AiSessionsCard({ taskId, data }: AiSessionsCardProps) {
       providers: providerCount,
     });
   }, [data, t]);
+  const previewSessions = useMemo(() => data.sessions.slice(0, 3), [data.sessions]);
 
   return (
     <>
-      <div className="rounded-lg border border-border-default bg-bg-surface p-5 shadow-sm">
-        <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
-          {t("aiSessions.title")}
-        </h3>
-
-        <button
-          onClick={() => setIsDialogOpen(true)}
-          className="flex w-full items-center gap-2 rounded-md border border-border-default bg-bg-page px-3 py-2 text-left transition-colors hover:border-brand-primary"
-        >
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium text-text-primary">{summary}</p>
-            <p className="mt-0.5 text-xs text-text-muted">{t("aiSessions.openDialog")}</p>
+      <button
+        type="button"
+        onClick={() => setOpenTaskId(taskId)}
+        className="block w-full rounded-lg border border-border-default bg-bg-surface p-4 text-left shadow-sm transition-colors hover:border-brand-primary"
+      >
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+              {t("aiSessions.title")}
+            </h3>
+            <p className="mt-1 truncate text-sm font-medium text-text-primary">{summary}</p>
           </div>
-          <span className="text-text-muted">→</span>
-        </button>
-      </div>
+          <span className="shrink-0 text-text-muted">→</span>
+        </div>
+
+        <div
+          data-testid="ai-sessions-chat-preview"
+          className="space-y-2 rounded-md border border-border-default bg-terminal-bg px-3 py-3 shadow-inner"
+        >
+          {previewSessions.length === 0 ? (
+            <p className="font-mono text-xs text-terminal-text">{t("aiSessions.openDialog")}</p>
+          ) : previewSessions.map((session, index) => (
+            <div
+              key={`${session.provider}-${session.id}`}
+              className="animate-[ai-session-line-in_180ms_ease-out_both] rounded border border-white/10 bg-white/[0.03] px-2.5 py-2"
+              style={{ animationDelay: `${index * 70}ms` }}
+            >
+              <div className="mb-1 flex items-center justify-between gap-2">
+                <span className="text-[10px] font-medium uppercase text-terminal-text">{session.provider}</span>
+                <span className="text-[10px] text-terminal-text/70">{session.messageCount}</span>
+              </div>
+              <p className="line-clamp-2 break-words text-xs text-text-primary">
+                {session.firstUserPrompt || session.title || t("aiSessions.untitled")}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <p className="mt-2 text-xs text-text-muted">{t("aiSessions.openDialog")}</p>
+      </button>
 
       <AiSessionsDialog
         key={taskId}
         taskId={taskId}
         isOpen={isDialogOpen}
-        onClose={() => setIsDialogOpen(false)}
+        onClose={() => setOpenTaskId(null)}
         data={data}
       />
     </>

--- a/src/components/AiSessionsDialog.tsx
+++ b/src/components/AiSessionsDialog.tsx
@@ -5,7 +5,6 @@ import * as Switch from "@radix-ui/react-switch";
 import { useTranslations } from "next-intl";
 import { getTaskAiSessionDetail, getTaskAiSessions } from "@/desktop/renderer/actions/project";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
-import { fuzzyMatch } from "@/utils/fuzzySearch";
 import type {
   AggregatedAiMessage,
   AggregatedAiSession,
@@ -73,7 +72,6 @@ export default function AiSessionsDialog({ taskId, isOpen, onClose, data }: AiSe
   }, [data]);
 
   const sessionSearchPlaceholder = translateOptional(t, "aiSessions.searchPlaceholder", "Search sessions...");
-  const messageSearchPlaceholder = translateOptional(t, "aiSessions.messageSearchPlaceholder", "Search messages...");
   const filterUserLabel = translateOptional(t, "aiSessions.filterUser", translateOptional(t, "aiSessions.roles.user", "User"));
   const filterAssistantLabel = translateOptional(t, "aiSessions.filterAssistant", translateOptional(t, "aiSessions.roles.assistant", "AI"));
 
@@ -672,7 +670,7 @@ function SessionPreview({
         </div>
       </div>
 
-      <div className="flex-1 space-y-3 overflow-y-auto p-4">
+      <div className="flex-1 space-y-3 overflow-y-auto bg-terminal-bg p-4">
         {isLoading ? <LoadingDetailState session={session} /> : null}
         {!isLoading && error ? <EmptyState text={error} compact /> : null}
         {!isLoading && !error && messages.length === 0 ? (
@@ -703,12 +701,22 @@ function PreviewMessageCard({ message, index }: { message: AggregatedAiMessage; 
   const [isExpanded, setIsExpanded] = useState(false);
   const displayedText = isExpanded ? message.fullText : message.text;
   const toggleLabel = isExpanded ? t("aiSessions.showLess") : t("aiSessions.showMore");
+  const isUserMessage = message.role === "user";
 
   return (
-    <div className="rounded-lg border border-border-default bg-bg-surface p-3">
+    <div
+      data-testid="ai-session-message-card"
+      className={`animate-[ai-session-line-in_180ms_ease-out_both] rounded-lg border p-3 ${isUserMessage
+        ? "ml-auto max-w-[88%] border-brand-primary/20 bg-brand-primary/10"
+        : "mr-auto max-w-full border-border-default bg-bg-surface"
+      }`}
+      style={{ animationDelay: `${Math.min(index, 8) * 55}ms` }}
+    >
       <div className="flex items-center justify-between gap-2 text-xs text-text-muted">
-        <span className="font-medium text-text-secondary">{t(`aiSessions.roles.${message.role}`)}</span>
-        <span>{formatDate(message.timestamp)}</span>
+        <span className={`font-medium ${isUserMessage ? "text-text-brand" : "text-text-secondary"}`}>
+          {t(`aiSessions.roles.${message.role}`)}
+        </span>
+        <span className="font-mono">{formatDate(message.timestamp)}</span>
       </div>
       <p id={`ai-session-message-${index}`} className="mt-2 whitespace-pre-wrap break-words text-sm text-text-primary">{displayedText}</p>
       {message.isTruncated ? (

--- a/src/components/HooksStatusCard.tsx
+++ b/src/components/HooksStatusCard.tsx
@@ -1,11 +1,24 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  AlertCircleIcon,
+  CheckmarkCircle02Icon,
+  Clock01Icon,
+  WebhookIcon,
+} from "@hugeicons/core-free-icons";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
-import HooksStatusDialog from "@/components/HooksStatusDialog";
+import {
+  getTaskOpenCodeHooksStatus,
+  installTaskCodexHooks,
+  installTaskGeminiHooks,
+  installTaskHooks,
+  installTaskOpenCodeHooks,
+} from "@/desktop/renderer/actions/project";
 import type { ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
-import type { GeminiHooksStatus } from "@/lib/geminiHooksSetup";
 import type { CodexHooksStatus } from "@/lib/codexHooksSetup";
+import type { GeminiHooksStatus } from "@/lib/geminiHooksSetup";
 import type { OpenCodeHooksStatus } from "@/lib/openCodeHooksSetup";
 
 interface HooksStatusCardProps {
@@ -15,7 +28,16 @@ interface HooksStatusCardProps {
   initialCodexStatus: CodexHooksStatus | null;
   initialOpenCodeStatus: OpenCodeHooksStatus | null;
   isRemote: boolean;
+  onStatusesChange?: (updates: {
+    claudeStatus?: ClaudeHooksStatus | null;
+    geminiStatus?: GeminiHooksStatus | null;
+    codexStatus?: CodexHooksStatus | null;
+    openCodeStatus?: OpenCodeHooksStatus | null;
+  }) => void;
 }
+
+type HookToolKey = "claude" | "gemini" | "codex" | "openCode";
+type InstallMessage = { type: "success" | "error"; text: string };
 
 export default function HooksStatusCard({
   taskId,
@@ -24,33 +46,20 @@ export default function HooksStatusCard({
   initialCodexStatus,
   initialOpenCodeStatus,
   isRemote,
+  onStatusesChange,
 }: HooksStatusCardProps) {
   const t = useTranslations("taskDetail");
   const [claudeStatus, setClaudeStatus] = useState(initialClaudeStatus);
   const [geminiStatus, setGeminiStatus] = useState(initialGeminiStatus);
   const [codexStatus, setCodexStatus] = useState(initialCodexStatus);
   const [openCodeStatus, setOpenCodeStatus] = useState(initialOpenCodeStatus);
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [installingTools, setInstallingTools] = useState<HookToolKey[]>([]);
+  const [message, setMessage] = useState<InstallMessage | null>(null);
+  const onStatusesChangeRef = useRef(onStatusesChange);
 
-  function handleStatusesChange(updates: {
-    claudeStatus?: ClaudeHooksStatus | null;
-    geminiStatus?: GeminiHooksStatus | null;
-    codexStatus?: CodexHooksStatus | null;
-    openCodeStatus?: OpenCodeHooksStatus | null;
-  }) {
-    if (updates.claudeStatus !== undefined) {
-      setClaudeStatus(updates.claudeStatus);
-    }
-    if (updates.geminiStatus !== undefined) {
-      setGeminiStatus(updates.geminiStatus);
-    }
-    if (updates.codexStatus !== undefined) {
-      setCodexStatus(updates.codexStatus);
-    }
-    if (updates.openCodeStatus !== undefined) {
-      setOpenCodeStatus(updates.openCodeStatus);
-    }
-  }
+  useEffect(() => {
+    onStatusesChangeRef.current = onStatusesChange;
+  }, [onStatusesChange]);
 
   useEffect(() => {
     setClaudeStatus(initialClaudeStatus);
@@ -68,47 +77,244 @@ export default function HooksStatusCard({
     setOpenCodeStatus(initialOpenCodeStatus);
   }, [initialOpenCodeStatus]);
 
-  // 신호등 상태 계산
-  const getOverallStatus = () => {
-    const installed = [claudeStatus?.installed, geminiStatus?.installed, codexStatus?.installed, openCodeStatus?.installed];
-    const installedCount = installed.filter((x) => x === true).length;
+  useEffect(() => {
+    let cancelled = false;
 
-    if (installedCount === 4) return { icon: "🟢", label: "All OK" };
-    if (installedCount === 0) return { icon: "🔴", label: "Not Installed" };
-    return { icon: "🟡", label: "Partial" };
-  };
+    void (async () => {
+      const latestStatus = await getTaskOpenCodeHooksStatus(taskId);
+      if (cancelled) {
+        return;
+      }
 
-  const overallStatus = getOverallStatus();
+      setOpenCodeStatus(latestStatus);
+      onStatusesChangeRef.current?.({ openCodeStatus: latestStatus });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [taskId]);
+
+  const hookItems = [
+    {
+      key: "claude" as const,
+      title: "Claude",
+      status: claudeStatus,
+      install: () => runInstall("claude", () => installTaskHooks(taskId), (result) => {
+        if (result.success && result.status) {
+          setClaudeStatus(result.status);
+          onStatusesChange?.({ claudeStatus: result.status });
+          setMessage(getResultMessage(result.status.installed, t("hooksInstallSuccess"), t));
+          return;
+        }
+
+        setMessage({ type: "error", text: getInstallFailureText(t, result.error) });
+      }),
+    },
+    {
+      key: "gemini" as const,
+      title: "Gemini",
+      status: geminiStatus,
+      install: () => runInstall("gemini", () => installTaskGeminiHooks(taskId), (result) => {
+        if (result.success && result.status) {
+          setGeminiStatus(result.status);
+          onStatusesChange?.({ geminiStatus: result.status });
+          setMessage(getResultMessage(result.status.installed, t("geminiHooksInstallSuccess"), t));
+          return;
+        }
+
+        setMessage({ type: "error", text: getInstallFailureText(t, result.error) });
+      }),
+    },
+    {
+      key: "codex" as const,
+      title: "Codex",
+      status: codexStatus,
+      install: () => runInstall("codex", () => installTaskCodexHooks(taskId), (result) => {
+        if (result.success && result.status) {
+          setCodexStatus(result.status);
+          onStatusesChange?.({ codexStatus: result.status });
+          setMessage(getResultMessage(result.status.installed, t("codexHooksInstallSuccess"), t));
+          return;
+        }
+
+        setMessage({ type: "error", text: getInstallFailureText(t, result.error) });
+      }),
+    },
+    {
+      key: "openCode" as const,
+      title: "OpenCode",
+      status: openCodeStatus,
+      install: () => runInstall("openCode", () => installTaskOpenCodeHooks(taskId), (result) => {
+        if (result.success && result.status) {
+          setOpenCodeStatus(result.status);
+          onStatusesChange?.({ openCodeStatus: result.status });
+          setMessage(getResultMessage(result.status.installed, t("openCodeHooksInstallSuccess"), t));
+          return;
+        }
+
+        setMessage({ type: "error", text: getInstallFailureText(t, result.error) });
+      }),
+    },
+  ];
+
+  const installedCount = hookItems.filter((item) => item.status?.installed === true).length;
+  const overallStatus = getOverallStatus(installedCount, hookItems.length);
+
+  async function runInstall<T>(
+    tool: HookToolKey,
+    install: () => Promise<T>,
+    applyResult: (result: T) => void,
+  ) {
+    setMessage(null);
+    setInstallingTools((current) => (current.includes(tool) ? current : [...current, tool]));
+
+    try {
+      const result = await install();
+      applyResult(result);
+    } finally {
+      setInstallingTools((current) => current.filter((value) => value !== tool));
+    }
+  }
 
   return (
-    <>
-      <div className="bg-bg-surface rounded-lg p-5 shadow-sm border border-border-default">
-        <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
-          {t("hooksStatus")}
-        </h3>
-
-        <button
-          onClick={() => setIsDialogOpen(true)}
-          className="w-full px-3 py-2 text-sm bg-bg-page border border-border-default hover:border-brand-primary rounded-md transition-colors text-left flex items-center gap-2"
-        >
-          <span className="text-base">{overallStatus.icon}</span>
-          <span className="text-text-primary font-medium">{overallStatus.label}</span>
-          <span className="ml-auto text-text-muted">→</span>
-        </button>
+    <div className="rounded-lg border border-border-default bg-bg-surface p-4 shadow-sm">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+            {t("hooksStatus")}
+          </h3>
+          <p className="mt-1 text-xs text-text-muted">{t("hooksCurrentTaskId", { taskId })}</p>
+        </div>
+        <span className={`inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-medium ${overallStatus.className}`}>
+          <StatusIcon status={overallStatus.kind} />
+          {installedCount}/{hookItems.length}
+        </span>
       </div>
 
-      {/* Hooks Status Dialog */}
-      <HooksStatusDialog
-        isOpen={isDialogOpen}
-        onClose={() => setIsDialogOpen(false)}
-        taskId={taskId}
-        claudeStatus={claudeStatus}
-        geminiStatus={geminiStatus}
-        codexStatus={codexStatus}
-        openCodeStatus={openCodeStatus}
-        isRemote={isRemote}
-        onStatusesChange={handleStatusesChange}
-      />
-    </>
+      {message ? (
+        <div className={`mb-3 rounded-md border px-3 py-2 text-xs ${message.type === "success"
+          ? "border-status-done/20 bg-status-done/10 text-status-done"
+          : "border-status-error/20 bg-status-error/10 text-status-error"
+        }`}>
+          {message.text}
+        </div>
+      ) : null}
+
+      <div className="space-y-2">
+        {hookItems.map((item) => {
+          const isInstalled = item.status?.installed === true;
+          const isInstalling = installingTools.includes(item.key);
+          const actionLabel = isInstalling
+            ? t("installingHooks")
+            : isInstalled
+              ? t("hooksStatusDialog.reinstall")
+              : t("installHooks");
+
+          return (
+            <section key={item.key} className="rounded-md border border-border-default bg-bg-page/60 p-3">
+              <div className="flex items-center gap-3">
+                <span className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-md border ${isInstalled
+                  ? "border-status-done/20 bg-status-done/10 text-status-done"
+                  : "border-status-error/20 bg-status-error/10 text-status-error"
+                }`}>
+                  <HookToolIcon />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <h4 className="truncate text-sm font-semibold text-text-primary">{item.title}</h4>
+                    <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${isInstalled
+                      ? "bg-status-done/15 text-status-done"
+                      : "bg-status-error/15 text-status-error"
+                    }`}>
+                      {isInstalled ? t("hooksInstalled") : t("hooksNotInstalled")}
+                    </span>
+                  </div>
+                  {isRemote ? <p className="mt-0.5 text-xs text-text-muted">{t("hooksRemoteNotSupported")}</p> : null}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!isInstalling) {
+                      void item.install();
+                    }
+                  }}
+                  disabled={isInstalling}
+                  aria-label={`${actionLabel} ${item.title}`}
+                  className={`shrink-0 rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${isInstalled
+                    ? "border border-border-default bg-bg-surface text-text-secondary hover:border-brand-primary hover:text-text-primary"
+                    : "bg-brand-primary text-text-inverse hover:bg-brand-hover"
+                  }`}
+                >
+                  {actionLabel}
+                </button>
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function getInstallFailureText(t: ReturnType<typeof useTranslations>, error?: string) {
+  return error ? t("hooksInstallFailed", { error }) : t("hooksInstallFailed");
+}
+
+function getResultMessage(installed: boolean, successText: string, t: ReturnType<typeof useTranslations>): InstallMessage {
+  return {
+    type: installed ? "success" : "error",
+    text: installed ? successText : t("hooksInstallIncomplete"),
+  };
+}
+
+function getOverallStatus(installedCount: number, totalCount: number) {
+  if (installedCount === totalCount) {
+    return {
+      kind: "ok" as const,
+      className: "border-status-done/20 bg-status-done/15 text-status-done",
+    };
+  }
+
+  if (installedCount === 0) {
+    return {
+      kind: "error" as const,
+      className: "border-status-error/20 bg-status-error/15 text-status-error",
+    };
+  }
+
+  return {
+    kind: "partial" as const,
+    className: "border-status-warning/20 bg-status-warning/15 text-status-warning",
+  };
+}
+
+function StatusIcon({ status }: { status: "ok" | "partial" | "error" }) {
+  const icon = status === "ok"
+    ? CheckmarkCircle02Icon
+    : status === "partial"
+      ? Clock01Icon
+      : AlertCircleIcon;
+
+  return (
+    <HugeiconsIcon
+      icon={icon}
+      size={13}
+      strokeWidth={2}
+      aria-hidden="true"
+      data-testid="hooks-overall-status-icon"
+    />
+  );
+}
+
+function HookToolIcon() {
+  return (
+    <HugeiconsIcon
+      icon={WebhookIcon}
+      size={17}
+      strokeWidth={1.8}
+      aria-hidden="true"
+      data-testid="hook-status-tool-icon"
+    />
   );
 }

--- a/src/components/NotificationCenterButton.tsx
+++ b/src/components/NotificationCenterButton.tsx
@@ -70,6 +70,7 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
   const panelRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const isOpenRef = useRef(false);
+  const highlightedIndexRef = useRef(0);
   const [isOpen, setIsOpen] = useState(false);
   const [notifications, setNotifications] = useState<AppNotification[]>([]);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
@@ -90,6 +91,7 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
   }, [setPanelOpen]);
 
   const openPanel = useCallback(() => {
+    highlightedIndexRef.current = 0;
     setHighlightedIndex(0);
     setPanelOpen(true);
   }, [setPanelOpen]);
@@ -217,22 +219,31 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
             return;
           }
           event.preventDefault();
-          setHighlightedIndex((current) => (current < notifications.length - 1 ? current + 1 : 0));
+          highlightedIndexRef.current = highlightedIndexRef.current < notifications.length - 1
+            ? highlightedIndexRef.current + 1
+            : 0;
+          setHighlightedIndex(highlightedIndexRef.current);
           break;
         case "ArrowUp":
           if (notifications.length === 0) {
             return;
           }
           event.preventDefault();
-          setHighlightedIndex((current) => (current > 0 ? current - 1 : notifications.length - 1));
+          highlightedIndexRef.current = highlightedIndexRef.current > 0
+            ? highlightedIndexRef.current - 1
+            : notifications.length - 1;
+          setHighlightedIndex(highlightedIndexRef.current);
           break;
         case "Enter":
-          if (highlightedNotificationIndex < 0 || highlightedNotificationIndex >= notifications.length) {
+          {
+            const currentHighlightedIndex = Math.min(Math.max(highlightedIndexRef.current, 0), notifications.length - 1);
+            if (currentHighlightedIndex < 0 || currentHighlightedIndex >= notifications.length) {
+              return;
+            }
+            event.preventDefault();
+            void handleNotificationClick(notifications[currentHighlightedIndex], { openInNewWindow: event.shiftKey });
             return;
           }
-          event.preventDefault();
-          void handleNotificationClick(notifications[highlightedNotificationIndex], { openInNewWindow: event.shiftKey });
-          break;
         case "Escape":
           event.preventDefault();
           closePanel();
@@ -303,7 +314,10 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
                 }}
                 type="button"
                 onClick={(event) => handleNotificationClick(notification, { openInNewWindow: event.shiftKey })}
-                onMouseEnter={() => setHighlightedIndex(index)}
+                onMouseEnter={() => {
+                  highlightedIndexRef.current = index;
+                  setHighlightedIndex(index);
+                }}
                 className={`w-full border-b border-border-subtle px-4 py-3 text-left transition-colors hover:bg-bg-page ${
                   index === highlightedNotificationIndex
                     ? "bg-brand-primary/10"

--- a/src/components/__tests__/AiSessionsCard.test.tsx
+++ b/src/components/__tests__/AiSessionsCard.test.tsx
@@ -76,6 +76,38 @@ describe("AiSessionsCard", () => {
     expect(screen.getByText("1 tools / 2 sessions")).toBeTruthy();
   });
 
+  it("should render a terminal-like chat preview for recent sessions", () => {
+    const data: AggregatedAiSessionsResult = {
+      isRemote: false,
+      targetPath: "/repo",
+      repoPath: "/repo",
+      sessions: [
+        {
+          id: "1",
+          provider: "claude",
+          startedAt: null,
+          updatedAt: null,
+          matchedPath: "/repo",
+          matchScope: "repo",
+          title: "Claude planning",
+          firstUserPrompt: "Please review the task detail layout.",
+          messageCount: 4,
+        },
+      ],
+      sources: [{ provider: "claude", available: true, sessionCount: 1, reason: null }],
+    };
+
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <AiSessionsCard taskId="task-1" data={data} />
+      </IntlProvider>
+    );
+
+    const preview = screen.getByTestId("ai-sessions-chat-preview");
+    expect(preview.className).toContain("bg-terminal-bg");
+    expect(screen.getByText("Please review the task detail layout.")).toBeTruthy();
+  });
+
   it("should open dialog when card button is clicked", () => {
     const data: AggregatedAiSessionsResult = {
       isRemote: false,

--- a/src/components/__tests__/AiSessionsDialog.test.tsx
+++ b/src/components/__tests__/AiSessionsDialog.test.tsx
@@ -365,6 +365,57 @@ describe("AiSessionsDialog", () => {
     expect(screen.getByRole("button", { name: "Show less" })).toBeTruthy();
   });
 
+  it("should render loaded messages as animated chat transcript rows", async () => {
+    mockGetTaskAiSessionDetail.mockResolvedValue({
+      sessionId: "claude-1",
+      provider: "claude",
+      title: "Claude session",
+      matchedPath: "/repo",
+      messages: [
+        {
+          role: "assistant",
+          timestamp: "2026-03-11T09:00:00.000Z",
+          text: "I'll update the drawer layout.",
+          fullText: "I'll update the drawer layout.",
+          isTruncated: false,
+        },
+      ],
+      nextCursor: null,
+    } satisfies AggregatedAiSessionDetail);
+
+    const data: AggregatedAiSessionsResult = {
+      isRemote: false,
+      targetPath: "/repo",
+      repoPath: "/repo",
+      sessions: [
+        {
+          id: "claude-1",
+          provider: "claude",
+          title: "Claude session",
+          firstUserPrompt: "Alpha",
+          updatedAt: "2026-03-11T10:00:00.000Z",
+          startedAt: "2026-03-11T09:00:00.000Z",
+          matchedPath: "/repo",
+          matchScope: "worktree",
+          messageCount: 1,
+        },
+      ],
+      sources: [{ provider: "claude", available: true, sessionCount: 1, reason: null }],
+    };
+
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <AiSessionsDialog taskId="task-1" isOpen onClose={() => {}} data={data} />
+      </IntlProvider>
+    );
+
+    fireEvent.click(screen.getByText("Claude session"));
+    const message = await screen.findByText("I'll update the drawer layout.");
+    const card = message.closest("[data-testid='ai-session-message-card']");
+
+    expect(card?.className).toContain("animate-[ai-session-line-in");
+  });
+
   it("should show animated loading details while fetching messages", async () => {
     let resolveDetail: ((value: AggregatedAiSessionDetail) => void) | undefined;
     mockGetTaskAiSessionDetail.mockImplementation(

--- a/src/components/__tests__/HooksStatusCard.test.tsx
+++ b/src/components/__tests__/HooksStatusCard.test.tsx
@@ -1,65 +1,79 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { ComponentProps } from "react";
-import HooksStatusCard from "@/components/HooksStatusCard";
 import { IntlProvider } from "next-intl";
+import HooksStatusCard from "@/components/HooksStatusCard";
 
-interface MockHooksStatusDialogProps {
-  isOpen: boolean;
-  onClose: () => void;
-  taskId: string;
-  isRemote: boolean;
-  onStatusesChange?: (updates: {
-    claudeStatus?: { installed: boolean; hasPromptHook: boolean; hasStopHook: boolean; hasQuestionHook: boolean; hasSettingsEntry: boolean } | null;
-  }) => void;
-}
+const {
+  mockInstallTaskHooks,
+  mockInstallTaskGeminiHooks,
+  mockInstallTaskCodexHooks,
+  mockInstallTaskOpenCodeHooks,
+  mockGetTaskOpenCodeHooksStatus,
+} = vi.hoisted(() => ({
+  mockInstallTaskHooks: vi.fn(),
+  mockInstallTaskGeminiHooks: vi.fn(),
+  mockInstallTaskCodexHooks: vi.fn(),
+  mockInstallTaskOpenCodeHooks: vi.fn(),
+  mockGetTaskOpenCodeHooksStatus: vi.fn(),
+}));
 
-// --- Mocks ---
+vi.mock("@/desktop/renderer/actions/project", () => ({
+  installTaskHooks: mockInstallTaskHooks,
+  installTaskGeminiHooks: mockInstallTaskGeminiHooks,
+  installTaskCodexHooks: mockInstallTaskCodexHooks,
+  installTaskOpenCodeHooks: mockInstallTaskOpenCodeHooks,
+  getTaskOpenCodeHooksStatus: mockGetTaskOpenCodeHooksStatus,
+}));
 
-vi.mock("next-intl", async () => {
-  const actual = await vi.importActual("next-intl");
-  return {
-    ...actual,
-    useTranslations: () => (key: string) => key,
-  };
-});
+vi.mock("@hugeicons/react", () => ({
+  HugeiconsIcon: ({
+    icon,
+    "data-testid": testId = "hugeicons-icon",
+    ...props
+  }: {
+    icon?: { __iconName?: string };
+    "data-testid"?: string;
+  }) => (
+    <svg
+      {...props}
+      data-testid={testId}
+      data-icon-name={icon?.__iconName ?? "unknown"}
+    />
+  ),
+}));
 
-vi.mock("@/components/HooksStatusDialog", () => {
-  const MockDialog = ({ isOpen, onClose, taskId, isRemote, onStatusesChange }: MockHooksStatusDialogProps) =>
-    isOpen ? (
-      <div data-testid="hooks-status-dialog">
-        Dialog: taskId={taskId}, isRemote={String(isRemote)}
-        <button onClick={onClose}>Close Dialog</button>
-        <button
-          onClick={() => onStatusesChange?.({
-            claudeStatus: {
-              installed: true,
-              hasPromptHook: true,
-              hasStopHook: true,
-              hasQuestionHook: true,
-              hasSettingsEntry: true,
-            },
-          })}
-        >
-          Simulate Install
-        </button>
-      </div>
-    ) : null;
-  return {
-    default: MockDialog,
-  };
-});
+vi.mock("@hugeicons/core-free-icons", () => ({
+  AlertCircleIcon: { __iconName: "AlertCircleIcon" },
+  CheckmarkCircle02Icon: { __iconName: "CheckmarkCircle02Icon" },
+  Clock01Icon: { __iconName: "Clock01Icon" },
+  WebhookIcon: { __iconName: "WebhookIcon" },
+}));
 
-// 테스트용 메시지 객체
 const messages = {
   taskDetail: {
     hooksStatus: "Hooks Status",
+    hooksInstalled: "Installed",
+    hooksNotInstalled: "Not Installed",
+    installHooks: "Install Hooks",
+    installingHooks: "Installing...",
+    hooksInstallSuccess: "Hooks installed successfully",
+    geminiHooksInstallSuccess: "Gemini CLI hooks installed",
+    codexHooksInstallSuccess: "Codex CLI hooks installed",
+    openCodeHooksInstallSuccess: "OpenCode hooks installed",
+    hooksInstallIncomplete: "Hooks were installed, but verification is incomplete.",
+    hooksInstallFailed: "Hooks installation failed",
+    hooksCurrentTaskId: "Current taskId: {taskId}",
+    hooksStatusDialog: {
+      reinstall: "Reinstall",
+    },
   },
 };
 
 describe("HooksStatusCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetTaskOpenCodeHooksStatus.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -74,215 +88,80 @@ describe("HooksStatusCard", () => {
     );
   };
 
-  it("should render signal button showing overall status when isRemote is false", () => {
-    // Given
-    const props = {
+  it("renders hook tools inline without opening another dialog", () => {
+    renderCard({
       taskId: "task-1",
       initialClaudeStatus: null,
       initialGeminiStatus: null,
       initialCodexStatus: null,
       initialOpenCodeStatus: null,
       isRemote: false,
-    };
+    });
 
-    // When
-    renderCard(props);
-
-    // Then
-    expect(screen.getByText("Not Installed")).toBeTruthy();
-  });
-
-  it("should show green signal when all hooks are installed", () => {
-    // Given
-    const props = {
-      taskId: "task-1",
-      initialClaudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
-      initialGeminiStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasSettingsEntry: true },
-      initialCodexStatus: { installed: true, hasPromptHook: true, hasPermissionHook: true, hasPreToolHook: true, hasStopHook: true, hasHooksFile: true, hasHookEntries: true, hasConfigEntry: true },
-      initialOpenCodeStatus: { installed: true, hasPlugin: true },
-      isRemote: false,
-    };
-
-    // When
-    renderCard(props);
-
-    // Then
-    expect(screen.getByText("All OK")).toBeTruthy();
-  });
-
-  it("should show red signal when no hooks are installed", () => {
-    // Given
-    const props = {
-      taskId: "task-1",
-      initialClaudeStatus: null,
-      initialGeminiStatus: null,
-      initialCodexStatus: null,
-      initialOpenCodeStatus: null,
-      isRemote: false,
-    };
-
-    // When
-    renderCard(props);
-
-    // Then
-    expect(screen.getByText("Not Installed")).toBeTruthy();
-  });
-
-  it("should show yellow signal when some hooks are installed", () => {
-    // Given
-    const props = {
-      taskId: "task-1",
-      initialClaudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
-      initialGeminiStatus: null,
-      initialCodexStatus: null,
-      initialOpenCodeStatus: null,
-      isRemote: false,
-    };
-
-    // When
-    renderCard(props);
-
-    // Then
-    expect(screen.getByText("Partial")).toBeTruthy();
-  });
-
-  it("should open dialog when signal button is clicked", () => {
-    // Given
-    const props = {
-      taskId: "task-1",
-      initialClaudeStatus: null,
-      initialGeminiStatus: null,
-      initialCodexStatus: null,
-      initialOpenCodeStatus: null,
-      isRemote: false,
-    };
-
-    // When
-    renderCard(props);
-    const signalButton = screen.getByText("Not Installed");
-    fireEvent.click(signalButton);
-
-    // Then
-    expect(screen.getByTestId("hooks-status-dialog")).toBeTruthy();
-  });
-
-  it("should close dialog when close dialog button is clicked", () => {
-    // Given
-    const props = {
-      taskId: "task-1",
-      initialClaudeStatus: null,
-      initialGeminiStatus: null,
-      initialCodexStatus: null,
-      initialOpenCodeStatus: null,
-      isRemote: false,
-    };
-
-    // When
-    renderCard(props);
-    const signalButton = screen.getByText("Not Installed");
-    fireEvent.click(signalButton);
-    expect(screen.getByTestId("hooks-status-dialog")).toBeTruthy();
-
-    const closeButton = screen.getByText("Close Dialog");
-    fireEvent.click(closeButton);
-
-    // Then
+    expect(screen.getByText("Hooks Status")).toBeTruthy();
+    expect(screen.getByText("Claude")).toBeTruthy();
+    expect(screen.getByText("Gemini")).toBeTruthy();
+    expect(screen.getByText("Codex")).toBeTruthy();
+    expect(screen.getByText("OpenCode")).toBeTruthy();
     expect(screen.queryByTestId("hooks-status-dialog")).toBeNull();
   });
 
-  it("should update the overall status when the dialog reports a new hook status", () => {
-    const props = {
+  it("uses dedicated webhook resource icons for hook status rows", () => {
+    renderCard({
       taskId: "task-1",
       initialClaudeStatus: null,
       initialGeminiStatus: null,
       initialCodexStatus: null,
       initialOpenCodeStatus: null,
       isRemote: false,
-    };
+    });
 
-    renderCard(props);
-    fireEvent.click(screen.getByText("Not Installed"));
-    fireEvent.click(screen.getByText("Simulate Install"));
+    const toolIcons = screen.getAllByTestId("hook-status-tool-icon");
 
-    expect(screen.getByText("Partial")).toBeTruthy();
+    expect(toolIcons).toHaveLength(4);
+    expect(toolIcons.every((icon) => icon.getAttribute("data-icon-name") === "WebhookIcon")).toBe(true);
+    expect(screen.getByTestId("hooks-overall-status-icon").getAttribute("data-icon-name")).toBe("AlertCircleIcon");
   });
 
-  it("should pass correct taskId to dialog", () => {
-    // Given
-    const taskId = "task-123";
-    const props = {
-      taskId,
-      initialClaudeStatus: null,
+  it("shows reinstall action immediately when a hook is already installed", () => {
+    renderCard({
+      taskId: "task-1",
+      initialClaudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
       initialGeminiStatus: null,
       initialCodexStatus: null,
       initialOpenCodeStatus: null,
       isRemote: false,
-    };
+    });
 
-    // When
-    renderCard(props);
-    const signalButton = screen.getByText("Not Installed");
-    fireEvent.click(signalButton);
-
-    // Then
-    const dialog = screen.getByTestId("hooks-status-dialog");
-    expect(dialog.textContent).toContain(`taskId=${taskId}`);
+    expect(screen.getByRole("button", { name: "Reinstall Claude" })).toBeTruthy();
   });
 
-  it("should pass isRemote=true to dialog", () => {
-    // Given
-    const props = {
-      taskId: "task-1",
-      initialClaudeStatus: null,
-      initialGeminiStatus: null,
-      initialCodexStatus: null,
-      initialOpenCodeStatus: null,
-      isRemote: true,
-    };
+  it("installs Claude hooks from the inline action and updates local status", async () => {
+    mockInstallTaskHooks.mockResolvedValue({
+      success: true,
+      status: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
+    });
+    const onStatusesChange = vi.fn();
 
-    // When
-    renderCard(props);
-    fireEvent.click(screen.getByText("Not Installed"));
-
-    // Then
-    const dialog = screen.getByTestId("hooks-status-dialog");
-    expect(dialog.textContent).toContain("isRemote=true");
-  });
-
-  it("should open dialog when signal button is clicked for remote tasks", () => {
-    // Given
-    const props = {
-      taskId: "task-1",
-      initialClaudeStatus: null,
-      initialGeminiStatus: null,
-      initialCodexStatus: null,
-      initialOpenCodeStatus: null,
-      isRemote: true,
-    };
-
-    // When
-    renderCard(props);
-    fireEvent.click(screen.getByText("Not Installed"));
-
-    // Then
-    expect(screen.getByTestId("hooks-status-dialog")).toBeTruthy();
-  });
-
-  it("should display Hooks Status heading", () => {
-    // Given
-    const props = {
+    renderCard({
       taskId: "task-1",
       initialClaudeStatus: null,
       initialGeminiStatus: null,
       initialCodexStatus: null,
       initialOpenCodeStatus: null,
       isRemote: false,
-    };
+      onStatusesChange,
+    });
 
-    // When
-    renderCard(props);
+    fireEvent.click(screen.getByRole("button", { name: "Install Hooks Claude" }));
 
-    // Then - useTranslations mock은 key를 그대로 반환하므로 "hooksStatus"가 렌더링됨
-    expect(screen.getByText("hooksStatus")).toBeTruthy();
+    await waitFor(() => {
+      expect(mockInstallTaskHooks).toHaveBeenCalledWith("task-1");
+      expect(onStatusesChange).toHaveBeenCalledWith({
+        claudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
+      });
+    });
+    expect(screen.getByText("Hooks installed successfully")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reinstall Claude" })).toBeTruthy();
   });
 });

--- a/src/components/__tests__/NotificationCenterButton.test.tsx
+++ b/src/components/__tests__/NotificationCenterButton.test.tsx
@@ -241,7 +241,7 @@ describe("NotificationCenterButton", () => {
         relativePath: "/task/task-1",
         locale: "en",
         isRead: false,
-        createdAt: new Date().toISOString(),
+        createdAt: "2026-05-04T00:01:00.000Z",
         dedupeKey: "k1",
       },
       {
@@ -252,7 +252,7 @@ describe("NotificationCenterButton", () => {
         relativePath: "/task/task-2",
         locale: "en",
         isRead: false,
-        createdAt: new Date().toISOString(),
+        createdAt: "2026-05-04T00:00:00.000Z",
         dedupeKey: "k2",
       },
     ]);

--- a/src/desktop/renderer/__tests__/navigation.test.tsx
+++ b/src/desktop/renderer/__tests__/navigation.test.tsx
@@ -107,12 +107,13 @@ describe("useRouter", () => {
     });
   });
 
-  it("Linux에서는 Alt+[와 Alt+] 단축키로 뒤로/앞으로 이동한다", async () => {
+  it("Linux에서는 Ctrl+Shift+[와 Ctrl+Shift+] 단축키로 뒤로/앞으로 이동한다", async () => {
     renderRouterProbe(["/ko", "/ko/task/task-1", "/ko/task/task-2"], 1, { idx: 1 }, true);
 
     fireEvent.keyDown(window, {
       key: "[",
-      altKey: true,
+      ctrlKey: true,
+      shiftKey: true,
     });
 
     await waitFor(() => {
@@ -121,7 +122,8 @@ describe("useRouter", () => {
 
     fireEvent.keyDown(window, {
       key: "]",
-      altKey: true,
+      ctrlKey: true,
+      shiftKey: true,
     });
 
     await waitFor(() => {
@@ -129,13 +131,14 @@ describe("useRouter", () => {
     });
   });
 
-  it("macOS에서는 Cmd+[와 Cmd+] 단축키로 뒤로/앞으로 이동한다", async () => {
+  it("macOS에서는 Cmd+Shift+[와 Cmd+Shift+] 단축키로 뒤로/앞으로 이동한다", async () => {
     setNavigatorPlatform("MacIntel");
     renderRouterProbe(["/ko", "/ko/task/task-1", "/ko/task/task-2"], 1, { idx: 1 }, true);
 
     fireEvent.keyDown(window, {
       key: "[",
       metaKey: true,
+      shiftKey: true,
     });
 
     await waitFor(() => {
@@ -145,6 +148,7 @@ describe("useRouter", () => {
     fireEvent.keyDown(window, {
       key: "]",
       metaKey: true,
+      shiftKey: true,
     });
 
     await waitFor(() => {

--- a/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
+++ b/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
@@ -437,9 +437,6 @@ export default function TaskQuickSearchDialog({
           <div className="flex items-center justify-between gap-3">
             <div>
               <p className="text-sm font-semibold text-text-primary">{t("title")}</p>
-              <p className="text-xs text-text-muted">
-                {formatShortcutForDisplay(effectiveShortcut, shortcutPlatform)}
-              </p>
             </div>
           </div>
           <input

--- a/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
@@ -105,6 +105,22 @@ describe("TaskQuickSearchDialog", () => {
     expect(screen.getByText("feat/api-search")).toBeTruthy();
   });
 
+  it("검색 다이얼로그 헤더에는 실행 단축키 문자열을 별도로 표시하지 않는다", async () => {
+    render(<TaskQuickSearchDialog shortcut="Ctrl+K" />);
+
+    fireEvent.keyDown(window, {
+      key: "k",
+      ctrlKey: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeTruthy();
+    });
+
+    expect(screen.getByText("taskSearch.title")).toBeTruthy();
+    expect(screen.queryByText("Ctrl+K")).toBeNull();
+  });
+
   it("Ctrl+R이 저장된 shortcut이어도 검색 다이얼로그를 열지 않는다", () => {
     render(<TaskQuickSearchDialog shortcut="Ctrl+R" />);
 

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -1,4 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
+import {
+  Chatting01Icon,
+  InformationCircleIcon,
+  Task02Icon,
+} from "@hugeicons/core-free-icons";
 import { useTranslations } from "next-intl";
 import { useParams } from "react-router-dom";
 import AiSessionsCard from "@/components/AiSessionsCard";
@@ -45,7 +51,7 @@ const AGENT_TAG_STYLES: Record<string, string> = {
   codex: "bg-tag-codex-bg text-tag-codex-text",
 };
 
-type DetailPanel = "overview" | "actions" | "hooks" | "sessions";
+type DetailPanel = "overview" | "status" | "sessions";
 
 interface TaskDetailState {
   task: NonNullable<Awaited<ReturnType<typeof getTaskById>>>;
@@ -340,6 +346,7 @@ export default function TaskDetailRoute() {
     () => (state?.task.agentType ? AGENT_TAG_STYLES[state.task.agentType] ?? "bg-tag-neutral-bg text-tag-neutral-text" : null),
     [state?.task.agentType],
   );
+  const statusPanelLabel = `${t("actions")} · ${t("hooksStatus")}`;
 
   useEscapeKey(() => {
     setActivePanel(null);
@@ -409,11 +416,10 @@ export default function TaskDetailRoute() {
         </Link>
 
         {([
-          { panel: "overview", label: t("info"), path: "M8 2.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11Zm0 4.75v3.25M8 5.5h.01" },
-          { panel: "actions", label: t("actions"), path: "M3 4h10M3 8h10M3 12h10" },
-          { panel: "hooks", label: t("hooksStatus"), path: "M5.5 3.5 3 6l2.5 2.5M10.5 3.5 13 6l-2.5 2.5M9.5 2.5l-3 11" },
-          { panel: "sessions", label: t("aiSessions.title"), path: "M3 4.5h10v6H6l-3 2v-8Z" },
-        ] satisfies Array<{ panel: DetailPanel; label: string; path: string }>).map(({ panel, label, path }) => (
+          { panel: "overview", label: t("info"), icon: InformationCircleIcon },
+          { panel: "status", label: statusPanelLabel, icon: Task02Icon, iconTestId: "task-status-panel-icon" },
+          { panel: "sessions", label: t("aiSessions.title"), icon: Chatting01Icon },
+        ] satisfies Array<{ panel: DetailPanel; label: string; icon: IconSvgElement; iconTestId?: string }>).map(({ panel, label, icon, iconTestId }) => (
           <button
             key={panel}
             type="button"
@@ -426,15 +432,17 @@ export default function TaskDetailRoute() {
             title={label}
             aria-label={label}
           >
-            <svg width="17" height="17" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <path d={path} />
-            </svg>
+            <HugeiconsIcon
+              icon={icon}
+              size={17}
+              strokeWidth={1.6}
+              aria-hidden="true"
+              data-testid={iconTestId}
+            />
           </button>
         ))}
 
-        <div className="mt-auto">
-          <NotificationCenterButton ref={notificationCenterRef} buttonClassName="hover:bg-bg-page" panelClassName="left-0 right-auto" />
-        </div>
+        <div className="mt-auto" />
       </aside>
 
       {activePanel ? (
@@ -444,8 +452,7 @@ export default function TaskDetailRoute() {
           <div className="mb-3 flex items-center justify-between border-b border-border-subtle pb-2">
             <h2 className="text-xs font-semibold uppercase text-text-muted">
               {activePanel === "overview" && t("info")}
-              {activePanel === "actions" && t("actions")}
-              {activePanel === "hooks" && t("hooksStatus")}
+              {activePanel === "status" && statusPanelLabel}
               {activePanel === "sessions" && t("aiSessions.title")}
             </h2>
             <button
@@ -473,43 +480,53 @@ export default function TaskDetailRoute() {
             </div>
           ) : null}
 
-          {activePanel === "actions" ? (
-            <div className="rounded-lg border border-border-default bg-bg-surface p-4">
-              <div className="flex flex-wrap gap-2">
-                {STATUS_TRANSITIONS.filter((transition) => transition.status !== state.task.status).map((transition) => (
-                  transition.status === TaskStatus.DONE ? (
-                    <DoneStatusButton
-                      key={transition.status}
-                      statusChangeAction={handleStatusChange}
-                      label={t(transition.labelKey)}
-                      hasCleanableResources={!!(state.task.branchName || state.task.sessionType)}
-                      doneAlertDismissed={state.doneAlertDismissed}
-                    />
-                  ) : (
-                    <form key={transition.status} action={handleStatusChange}>
-                      <input type="hidden" name="status" value={transition.status} />
-                      <button type="submit" className="rounded-md border border-border-default bg-bg-page px-3 py-1.5 text-xs text-text-secondary transition-colors hover:border-brand-primary hover:text-text-brand">
-                        {t(transition.labelKey)}
-                      </button>
-                    </form>
-                  )
-                ))}
+          {activePanel === "status" ? (
+            <div className="space-y-3">
+              <div className="rounded-lg border border-border-default bg-bg-surface p-4">
+                <div className="flex flex-wrap gap-2">
+                  {STATUS_TRANSITIONS.filter((transition) => transition.status !== state.task.status).map((transition) => (
+                    transition.status === TaskStatus.DONE ? (
+                      <DoneStatusButton
+                        key={transition.status}
+                        statusChangeAction={handleStatusChange}
+                        label={t(transition.labelKey)}
+                        hasCleanableResources={!!(state.task.branchName || state.task.sessionType)}
+                        doneAlertDismissed={state.doneAlertDismissed}
+                      />
+                    ) : (
+                      <form key={transition.status} action={handleStatusChange}>
+                        <input type="hidden" name="status" value={transition.status} />
+                        <button type="submit" className="rounded-md border border-border-default bg-bg-page px-3 py-1.5 text-xs text-text-secondary transition-colors hover:border-brand-primary hover:text-text-brand">
+                          {t(transition.labelKey)}
+                        </button>
+                      </form>
+                    )
+                  ))}
+                </div>
+                <div className="mt-3 border-t border-border-subtle pt-3">
+                  <DeleteTaskButton deleteAction={handleDelete} />
+                </div>
               </div>
-              <div className="mt-3 border-t border-border-subtle pt-3">
-                <DeleteTaskButton deleteAction={handleDelete} />
-              </div>
+              <HooksStatusCard
+                taskId={state.task.id}
+                initialClaudeStatus={state.claudeHooksStatus}
+                initialGeminiStatus={state.geminiHooksStatus}
+                initialCodexStatus={state.codexHooksStatus}
+                initialOpenCodeStatus={state.openCodeHooksStatus}
+                isRemote={!!state.task.sshHost}
+                onStatusesChange={(updates) => {
+                  setState((current) => current
+                    ? {
+                        ...current,
+                        claudeHooksStatus: updates.claudeStatus !== undefined ? updates.claudeStatus : current.claudeHooksStatus,
+                        geminiHooksStatus: updates.geminiStatus !== undefined ? updates.geminiStatus : current.geminiHooksStatus,
+                        codexHooksStatus: updates.codexStatus !== undefined ? updates.codexStatus : current.codexHooksStatus,
+                        openCodeHooksStatus: updates.openCodeStatus !== undefined ? updates.openCodeStatus : current.openCodeHooksStatus,
+                      }
+                    : current);
+                }}
+              />
             </div>
-          ) : null}
-
-          {activePanel === "hooks" ? (
-            <HooksStatusCard
-              taskId={state.task.id}
-              initialClaudeStatus={state.claudeHooksStatus}
-              initialGeminiStatus={state.geminiHooksStatus}
-              initialCodexStatus={state.codexHooksStatus}
-              initialOpenCodeStatus={state.openCodeHooksStatus}
-              isRemote={!!state.task.sshHost}
-            />
           ) : null}
 
           {activePanel === "sessions" ? <AiSessionsCard taskId={state.task.id} data={state.aiSessions} /> : null}
@@ -525,7 +542,15 @@ export default function TaskDetailRoute() {
                 <NotificationCenterButton ref={notificationCenterRef} buttonClassName="text-terminal-text hover:text-white hover:bg-white/10" panelClassName="mt-3" />
               </div>
             </div>
-            <div className="flex-1 min-h-0 bg-terminal-bg">
+            <div
+              className="flex-1 min-h-0 bg-terminal-bg"
+              onClick={() => {
+                if (activePanel !== null) {
+                  setActivePanel(null);
+                  requestActiveTerminalFocusAfterUiSettles();
+                }
+              }}
+            >
               <TerminalLoader taskId={state.task.id} />
             </div>
           </div>

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -31,6 +31,7 @@ import {
 import { useBoardCommands, type BranchTodoDefaults } from "@/desktop/renderer/components/BoardCommandProvider";
 import TerminalLoader from "@/desktop/renderer/components/TerminalLoader";
 import { fetchPrUrlWithPrompt } from "@/desktop/renderer/utils/fetchPrUrlWithPrompt";
+import { SHORTCUTS, getCurrentShortcutPlatform, matchShortcutEvent } from "@/desktop/renderer/utils/keyboardShortcut";
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { buildRouteCacheKey, readRouteCache, removeRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
@@ -135,6 +136,7 @@ export default function TaskDetailRoute() {
   const notificationCenterRef = useRef<NotificationCenterButtonHandle>(null);
   const currentTaskIdRef = useRef(id);
   const hasTerminal = !!(state?.task.sessionType && state.task.sessionName);
+  const shortcutPlatform = getCurrentShortcutPlatform();
 
   useEffect(() => boardCommands.registerNotificationCenterHandler(() => {
     notificationCenterRef.current?.toggle();
@@ -155,6 +157,32 @@ export default function TaskDetailRoute() {
       setIsCreateTaskModalOpen(true);
     },
   }), [boardCommands, state?.task.baseBranch, state?.task.branchName, state?.task.projectId]);
+
+  useEffect(() => {
+    function consumeHistoryShortcut(event: KeyboardEvent) {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+    }
+
+    function handlePriorityHistoryShortcut(event: KeyboardEvent) {
+      if (matchShortcutEvent(event, SHORTCUTS.pageBack, shortcutPlatform)) {
+        consumeHistoryShortcut(event);
+        router.back();
+        return;
+      }
+
+      if (matchShortcutEvent(event, SHORTCUTS.pageForward, shortcutPlatform)) {
+        consumeHistoryShortcut(event);
+        router.forward();
+      }
+    }
+
+    window.addEventListener("keydown", handlePriorityHistoryShortcut, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", handlePriorityHistoryShortcut, { capture: true });
+    };
+  }, [router, shortcutPlatform]);
 
   useEffect(() => {
     if (currentTaskIdRef.current === id) {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -32,6 +32,7 @@ const mocks = vi.hoisted(() => ({
   redirect: vi.fn(),
   push: vi.fn(),
   back: vi.fn(),
+  forward: vi.fn(),
 }));
 
 function createDeferred<T>() {
@@ -78,7 +79,7 @@ vi.mock("react-router-dom", () => ({
 vi.mock("@/desktop/renderer/navigation", () => ({
   Link: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   redirect: (...args: unknown[]) => mocks.redirect(...args),
-  useRouter: () => ({ push: mocks.push, back: mocks.back }),
+  useRouter: () => ({ push: mocks.push, back: mocks.back, forward: mocks.forward }),
 }));
 
 vi.mock("@/desktop/renderer/utils/refresh", () => ({
@@ -511,6 +512,59 @@ describe("TaskDetailRoute", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("task-title")).toBeNull();
     });
+  });
+
+  it("상세 화면 페이지 이동 단축키는 터미널 입력보다 먼저 capture 단계에서 처리한다", async () => {
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(
+      <BoardCommandProvider>
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    const terminalInput = await screen.findByLabelText("terminal input");
+    const terminalKeyDown = vi.fn();
+    const windowBubbleKeyDown = vi.fn();
+    terminalInput.addEventListener("keydown", terminalKeyDown);
+    window.addEventListener("keydown", windowBubbleKeyDown);
+
+    const wasNotPrevented = fireEvent.keyDown(terminalInput, {
+      key: "[",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    terminalInput.removeEventListener("keydown", terminalKeyDown);
+    window.removeEventListener("keydown", windowBubbleKeyDown);
+
+    expect(wasNotPrevented).toBe(false);
+    expect(mocks.back).toHaveBeenCalledTimes(1);
+    expect(terminalKeyDown).not.toHaveBeenCalled();
+    expect(windowBubbleKeyDown).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(terminalInput, {
+      key: "]",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(mocks.forward).toHaveBeenCalledTimes(1);
+    expect(mocks.back).toHaveBeenCalledTimes(1);
   });
 
   it("알림 단축키로 상세 화면의 알림 센터를 토글한다", async () => {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -48,6 +48,29 @@ vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
 }));
 
+vi.mock("@hugeicons/react", () => ({
+  HugeiconsIcon: ({
+    icon,
+    "data-testid": testId = "hugeicons-icon",
+    ...props
+  }: {
+    icon?: { __iconName?: string };
+    "data-testid"?: string;
+  }) => (
+    <svg
+      {...props}
+      data-testid={testId}
+      data-icon-name={icon?.__iconName ?? "unknown"}
+    />
+  ),
+}));
+
+vi.mock("@hugeicons/core-free-icons", () => ({
+  Chatting01Icon: { __iconName: "Chatting01Icon" },
+  InformationCircleIcon: { __iconName: "InformationCircleIcon" },
+  Task02Icon: { __iconName: "Task02Icon" },
+}));
+
 vi.mock("react-router-dom", () => ({
   useParams: () => ({ id: "task-1" }),
 }));
@@ -402,7 +425,8 @@ describe("TaskDetailRoute", () => {
     expect(screen.queryByTestId("task-title")).toBeNull();
   });
 
-  it("알림 단축키로 상세 화면의 알림 센터를 토글한다", async () => {
+  it("상태 변경과 hooks 상태는 하나의 status 패널에서 함께 보여준다", async () => {
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(true);
     mocks.getTaskById.mockResolvedValue({
       id: "task-1",
       title: "task title",
@@ -412,6 +436,93 @@ describe("TaskDetailRoute", () => {
       prUrl: null,
       sessionType: null,
       sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(<TaskDetailRoute />);
+
+    const statusButton = await screen.findByRole("button", { name: "actions · hooksStatus" });
+    expect(screen.queryByTestId("hooks-status-card")).toBeNull();
+    expect(screen.getByTestId("task-status-panel-icon").getAttribute("data-icon-name")).toBe("Task02Icon");
+
+    fireEvent.click(statusButton);
+
+    expect(await screen.findByTestId("hooks-status-card")).toBeTruthy();
+    expect(screen.getByText("done")).toBeTruthy();
+  });
+
+  it("상세 화면 좌측 하단 rail에는 알림 버튼을 렌더링하지 않는다", async () => {
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(true);
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(<TaskDetailRoute />);
+
+    await screen.findByRole("button", { name: "info" });
+
+    expect(screen.queryByRole("button", { name: "notifications" })).toBeNull();
+  });
+
+  it("서랍이 열린 상태에서 터미널 히스토리창을 누르면 서랍을 닫는다", async () => {
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(true);
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(<TaskDetailRoute />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "info" }));
+    await screen.findByTestId("task-title");
+
+    fireEvent.click(screen.getByTestId("terminal-loader"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("task-title")).toBeNull();
+    });
+  });
+
+  it("알림 단축키로 상세 화면의 알림 센터를 토글한다", async () => {
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
       sshHost: null,
       projectId: "project-1",
       project: { id: "project-1", name: "kanvibe" },

--- a/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
+++ b/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
@@ -147,7 +147,7 @@ describe("keyboardShortcut", () => {
     }, "Mod+N", "linux")).toBe(false);
   });
 
-  it("Electron 페이지 이동 input도 macOS Cmd와 Linux Alt로 매칭한다", () => {
+  it("Electron 페이지 이동 input도 macOS Cmd와 Linux Ctrl로 매칭한다", () => {
     expect(matchElectronShortcutInput({
       type: "keyDown",
       isAutoRepeat: false,

--- a/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
+++ b/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
@@ -36,35 +36,39 @@ describe("keyboardShortcut", () => {
   });
 
   it("페이지 이동 단축키는 플랫폼별 조합으로 표시한다", () => {
-    expect(formatShortcutForDisplay(SHORTCUTS.pageBack, "mac")).toBe("Cmd+[");
-    expect(formatShortcutForDisplay(SHORTCUTS.pageForward, "mac")).toBe("Cmd+]");
-    expect(formatShortcutForDisplay(SHORTCUTS.pageBack, "linux")).toBe("Alt+[");
-    expect(formatShortcutForDisplay(SHORTCUTS.pageForward, "linux")).toBe("Alt+]");
+    expect(formatShortcutForDisplay(SHORTCUTS.pageBack, "mac")).toBe("Cmd+Shift+[");
+    expect(formatShortcutForDisplay(SHORTCUTS.pageForward, "mac")).toBe("Cmd+Shift+]");
+    expect(formatShortcutForDisplay(SHORTCUTS.pageBack, "linux")).toBe("Ctrl+Shift+[");
+    expect(formatShortcutForDisplay(SHORTCUTS.pageForward, "linux")).toBe("Ctrl+Shift+]");
   });
 
-  it("페이지 이동 단축키는 macOS Cmd와 Linux Alt로 매칭한다", () => {
+  it("페이지 이동 단축키는 플랫폼별 Mod+Shift 조합으로 매칭한다", () => {
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "[",
       metaKey: true,
+      shiftKey: true,
     }), SHORTCUTS.pageBack, "mac")).toBe(true);
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "]",
       metaKey: true,
+      shiftKey: true,
     }), SHORTCUTS.pageForward, "mac")).toBe(true);
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "[",
-      altKey: true,
+      ctrlKey: true,
+      shiftKey: true,
     }), SHORTCUTS.pageBack, "linux")).toBe(true);
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "]",
-      altKey: true,
+      ctrlKey: true,
+      shiftKey: true,
     }), SHORTCUTS.pageForward, "linux")).toBe(true);
   });
 
-  it("Linux 페이지 이동 단축키는 Ctrl 조합으로 매칭하지 않는다", () => {
+  it("Linux 페이지 이동 단축키는 Alt 조합으로 매칭하지 않는다", () => {
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "[",
-      ctrlKey: true,
+      altKey: true,
     }), SHORTCUTS.pageBack, "linux")).toBe(false);
   });
 
@@ -151,7 +155,7 @@ describe("keyboardShortcut", () => {
       meta: true,
       alt: false,
       control: false,
-      shift: false,
+      shift: true,
     }, SHORTCUTS.pageBack, "mac")).toBe(true);
 
     expect(matchElectronShortcutInput({
@@ -161,27 +165,27 @@ describe("keyboardShortcut", () => {
       meta: true,
       alt: false,
       control: false,
-      shift: false,
+      shift: true,
     }, SHORTCUTS.pageForward, "mac")).toBe(true);
 
     expect(matchElectronShortcutInput({
       type: "keyDown",
       isAutoRepeat: false,
       key: "[",
-      alt: true,
+      alt: false,
       meta: false,
-      control: false,
-      shift: false,
+      control: true,
+      shift: true,
     }, SHORTCUTS.pageBack, "linux")).toBe(true);
 
     expect(matchElectronShortcutInput({
       type: "keyDown",
       isAutoRepeat: false,
       key: "]",
-      alt: true,
+      alt: false,
       meta: false,
-      control: false,
-      shift: false,
+      control: true,
+      shift: true,
     }, SHORTCUTS.pageForward, "linux")).toBe(true);
   });
 

--- a/src/desktop/shared/keyboardShortcut.ts
+++ b/src/desktop/shared/keyboardShortcut.ts
@@ -31,14 +31,8 @@ export const SHORTCUTS = {
   boardProjectFilter: "Mod+Shift+P",
   createTask: "Mod+N",
   newWindow: "Mod+Shift+N",
-  pageBack: {
-    mac: "Meta+[",
-    linux: "Alt+[",
-  },
-  pageForward: {
-    mac: "Meta+]",
-    linux: "Alt+]",
-  },
+  pageBack: "Mod+Shift+[",
+  pageForward: "Mod+Shift+]",
   boardPageFind: "Mod+F",
 } as const;
 

--- a/src/styles/__tests__/colorTokens.test.ts
+++ b/src/styles/__tests__/colorTokens.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readProjectFile(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf-8");
+}
+
+describe("UI color tokens", () => {
+  it("keeps point and neutral button colors behind semantic CSS tokens", () => {
+    const css = readProjectFile("src/styles/globals.css");
+
+    expect(css).toContain("--point-blue: #0064FF;");
+    expect(css).toContain("--button-gray: #202632;");
+    expect(css).toContain("--color-brand-primary: var(--point-blue);");
+    expect(css).toContain("--color-tag-pr-text: var(--color-brand-primary);");
+    expect(css).toContain("--color-tag-project-bg: var(--color-button-neutral);");
+    expect(css).toContain("--color-tag-base-bg: var(--color-button-neutral);");
+  });
+
+  it("documents color token usage in agent conventions", () => {
+    const conventions = readProjectFile("CLAUDE.md");
+
+    expect(conventions).toContain("#0064FF");
+    expect(conventions).toContain("#202632");
+    expect(conventions).toContain("--color-brand-primary");
+    expect(conventions).toContain("--color-button-neutral-*");
+  });
+});

--- a/src/styles/__tests__/globals.test.ts
+++ b/src/styles/__tests__/globals.test.ts
@@ -17,4 +17,12 @@ describe("globals.css theme tokens", () => {
     expect(readThemeVar(':root\\[data-theme="light"\\]', "--color-tag-base-bg")).toBe("var(--color-button-neutral)");
     expect(readThemeVar(':root\\[data-theme="light"\\]', "--color-tag-base-text")).toBe("#ffffff");
   });
+
+  it("keeps task session and remote tag text on the point color", () => {
+    expect(readThemeVar(":root", "--color-tag-pr-text")).toBe("var(--color-brand-primary)");
+    expect(readThemeVar(":root", "--color-tag-session-text")).toBe("var(--color-brand-primary)");
+    expect(readThemeVar(":root", "--color-tag-ssh-text")).toBe("var(--color-brand-primary)");
+    expect(readThemeVar(':root\\[data-theme="light"\\]', "--color-tag-session-text")).toBe("var(--color-brand-primary)");
+    expect(readThemeVar(':root\\[data-theme="light"\\]', "--color-tag-ssh-text")).toBe("var(--color-brand-primary)");
+  });
 });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -121,9 +121,9 @@
   --color-tag-codex-bg: var(--green-50);
   --color-tag-codex-text: var(--green-600);
   --color-tag-session-bg: var(--blue-50);
-  --color-tag-session-text: var(--blue-600);
+  --color-tag-session-text: var(--color-brand-primary);
   --color-tag-ssh-bg: var(--green-50);
-  --color-tag-ssh-text: var(--green-600);
+  --color-tag-ssh-text: var(--color-brand-primary);
   --color-tag-project-bg: var(--color-button-neutral);
   --color-tag-project-text: #FFFFFF;
   --color-tag-branch-bg: var(--gray-100);
@@ -241,9 +241,9 @@
   --color-tag-codex-bg: rgba(101, 208, 138, 0.12);
   --color-tag-codex-text: #9be6b4;
   --color-tag-session-bg: rgba(154, 164, 255, 0.12);
-  --color-tag-session-text: #aeb6ff;
+  --color-tag-session-text: var(--color-brand-primary);
   --color-tag-ssh-bg: rgba(101, 208, 138, 0.12);
-  --color-tag-ssh-text: #9be6b4;
+  --color-tag-ssh-text: var(--color-brand-primary);
   --color-tag-project-bg: var(--color-button-neutral);
   --color-tag-project-text: #ffffff;
   --color-tag-branch-bg: rgba(255, 255, 255, 0.06);
@@ -326,6 +326,8 @@
   --color-tag-project-text: #ffffff;
   --color-tag-pr-bg: var(--color-brand-subtle);
   --color-tag-pr-text: var(--color-brand-primary);
+  --color-tag-session-text: var(--color-brand-primary);
+  --color-tag-ssh-text: var(--color-brand-primary);
   --color-tag-base-bg: var(--color-button-neutral);
   --color-tag-base-text: #ffffff;
   --color-group-line: #cdd1d8;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,5 +1,16 @@
 @import "tailwindcss";
 
+@keyframes ai-session-line-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 :root {
   /* Primitive: Gray */
   --gray-50: #FAFAFA;
@@ -13,7 +24,20 @@
   --gray-800: #424242;
   --gray-900: #212121;
 
-  /* Primitive: Google Blue */
+  /* Primitive: Point Blue */
+  --point-blue: #0064FF;
+  --point-blue-hover: #0052D9;
+  --point-blue-active: #0044B8;
+  --point-blue-subtle: #EAF2FF;
+  --point-blue-muted: #D6E6FF;
+
+  /* Primitive: Button Gray */
+  --button-gray: #202632;
+  --button-gray-hover: #2A3242;
+  --button-gray-active: #161B24;
+  --button-gray-subtle: rgba(32, 38, 50, 0.1);
+
+  /* Primitive: Blue */
   --blue-50: #E8F0FE;
   --blue-100: #D2E3FC;
   --blue-200: #AECBFA;
@@ -49,11 +73,15 @@
   --green-700: #188038;
 
   /* Semantic: Brand */
-  --color-brand-primary: var(--blue-500);
-  --color-brand-hover: var(--blue-600);
-  --color-brand-active: var(--blue-700);
-  --color-brand-subtle: var(--blue-50);
-  --color-brand-muted: var(--blue-100);
+  --color-brand-primary: var(--point-blue);
+  --color-brand-hover: var(--point-blue-hover);
+  --color-brand-active: var(--point-blue-active);
+  --color-brand-subtle: var(--point-blue-subtle);
+  --color-brand-muted: var(--point-blue-muted);
+  --color-button-neutral: var(--button-gray);
+  --color-button-neutral-hover: var(--button-gray-hover);
+  --color-button-neutral-active: var(--button-gray-active);
+  --color-button-neutral-subtle: var(--button-gray-subtle);
 
   /* Semantic: Background */
   --color-bg-page: var(--gray-50);
@@ -65,25 +93,25 @@
   --color-text-secondary: #5F6368;
   --color-text-muted: #9AA0A6;
   --color-text-inverse: #FFFFFF;
-  --color-text-brand: var(--blue-600);
-  --color-text-link: var(--blue-600);
+  --color-text-brand: var(--point-blue);
+  --color-text-link: var(--point-blue);
 
   /* Semantic: Border */
   --color-border-default: #DADCE0;
   --color-border-subtle: var(--gray-100);
   --color-border-strong: var(--gray-400);
-  --color-border-brand: var(--blue-500);
+  --color-border-brand: var(--point-blue);
 
   /* Semantic: Status */
   --color-status-todo: var(--gray-500);
   --color-status-progress: var(--yellow-500);
   --color-status-pending: #8B5CF6;
-  --color-status-review: var(--blue-500);
+  --color-status-review: var(--point-blue);
   --color-status-done: var(--green-500);
   --color-status-success: var(--green-500);
   --color-status-warning: var(--yellow-500);
   --color-status-error: var(--red-500);
-  --color-status-info: var(--blue-500);
+  --color-status-info: var(--point-blue);
 
   /* Semantic: Tags - Agent */
   --color-tag-claude-bg: var(--red-50);
@@ -96,15 +124,15 @@
   --color-tag-session-text: var(--blue-600);
   --color-tag-ssh-bg: var(--green-50);
   --color-tag-ssh-text: var(--green-600);
-  --color-tag-project-bg: #202632;
+  --color-tag-project-bg: var(--color-button-neutral);
   --color-tag-project-text: #FFFFFF;
   --color-tag-branch-bg: var(--gray-100);
   --color-tag-branch-text: var(--gray-700);
   --color-tag-neutral-bg: var(--gray-100);
   --color-tag-neutral-text: var(--gray-600);
-  --color-tag-pr-bg: #ddf4ff;
-  --color-tag-pr-text: #0969da;
-  --color-tag-base-bg: #202632;
+  --color-tag-pr-bg: var(--color-brand-subtle);
+  --color-tag-pr-text: var(--color-brand-primary);
+  --color-tag-base-bg: var(--color-button-neutral);
   --color-tag-base-text: #FFFFFF;
 
   /* Semantic: Project Group (pastel) */
@@ -170,11 +198,15 @@
 
 :root,
 :root[data-theme="dark"] {
-  --color-brand-primary: #6e7dfb;
-  --color-brand-hover: #7d8aff;
-  --color-brand-active: #5b68e8;
-  --color-brand-subtle: rgba(110, 125, 251, 0.14);
-  --color-brand-muted: rgba(110, 125, 251, 0.22);
+  --color-brand-primary: var(--point-blue);
+  --color-brand-hover: #2B7DFF;
+  --color-brand-active: #0052D9;
+  --color-brand-subtle: rgba(0, 100, 255, 0.16);
+  --color-brand-muted: rgba(0, 100, 255, 0.24);
+  --color-button-neutral: var(--button-gray);
+  --color-button-neutral-hover: var(--button-gray-hover);
+  --color-button-neutral-active: var(--button-gray-active);
+  --color-button-neutral-subtle: rgba(32, 38, 50, 0.3);
 
   --color-bg-page: #090a0d;
   --color-bg-surface: #111216;
@@ -184,23 +216,23 @@
   --color-text-secondary: #b0b4bd;
   --color-text-muted: #717680;
   --color-text-inverse: #ffffff;
-  --color-text-brand: #9aa4ff;
-  --color-text-link: #9aa4ff;
+  --color-text-brand: var(--point-blue);
+  --color-text-link: var(--point-blue);
 
   --color-border-default: #24262d;
   --color-border-subtle: #1a1c22;
   --color-border-strong: #353842;
-  --color-border-brand: rgba(154, 164, 255, 0.62);
+  --color-border-brand: rgba(0, 100, 255, 0.62);
 
   --color-status-todo: #747985;
   --color-status-progress: #f6c35f;
   --color-status-pending: #9b8cff;
-  --color-status-review: #6ea8ff;
+  --color-status-review: var(--point-blue);
   --color-status-done: #65d08a;
   --color-status-success: #65d08a;
   --color-status-warning: #f6c35f;
   --color-status-error: #ff7d73;
-  --color-status-info: #6ea8ff;
+  --color-status-info: var(--point-blue);
 
   --color-tag-claude-bg: rgba(255, 125, 115, 0.12);
   --color-tag-claude-text: #ffaaa2;
@@ -212,15 +244,15 @@
   --color-tag-session-text: #aeb6ff;
   --color-tag-ssh-bg: rgba(101, 208, 138, 0.12);
   --color-tag-ssh-text: #9be6b4;
-  --color-tag-project-bg: rgba(255, 255, 255, 0.08);
-  --color-tag-project-text: #d7dae1;
+  --color-tag-project-bg: var(--color-button-neutral);
+  --color-tag-project-text: #ffffff;
   --color-tag-branch-bg: rgba(255, 255, 255, 0.06);
   --color-tag-branch-text: #aeb3bd;
   --color-tag-neutral-bg: rgba(255, 255, 255, 0.07);
   --color-tag-neutral-text: #aeb3bd;
-  --color-tag-pr-bg: rgba(110, 168, 255, 0.12);
-  --color-tag-pr-text: #9fc8ff;
-  --color-tag-base-bg: rgba(255, 255, 255, 0.1);
+  --color-tag-pr-bg: var(--color-brand-subtle);
+  --color-tag-pr-text: var(--color-brand-primary);
+  --color-tag-base-bg: var(--color-button-neutral);
   --color-tag-base-text: #ffffff;
 
   --color-group-0-border: rgba(255, 154, 204, 0.4);
@@ -241,8 +273,8 @@
   --color-group-7-bg: rgba(165, 180, 252, 0.08);
   --color-group-line: #3b3f49;
 
-  --color-priority-low-bg: rgba(110, 168, 255, 0.12);
-  --color-priority-low-text: #9fc8ff;
+  --color-priority-low-bg: var(--color-brand-subtle);
+  --color-priority-low-text: var(--color-brand-primary);
   --color-priority-medium-bg: rgba(246, 195, 95, 0.13);
   --color-priority-medium-text: #ffd58a;
   --color-priority-high-bg: rgba(255, 125, 115, 0.13);
@@ -264,11 +296,15 @@
 }
 
 :root[data-theme="light"] {
-  --color-brand-primary: #5e6ad2;
-  --color-brand-hover: #4f5cc4;
-  --color-brand-active: #4651b3;
-  --color-brand-subtle: #eef0ff;
-  --color-brand-muted: #e2e5ff;
+  --color-brand-primary: var(--point-blue);
+  --color-brand-hover: var(--point-blue-hover);
+  --color-brand-active: var(--point-blue-active);
+  --color-brand-subtle: var(--point-blue-subtle);
+  --color-brand-muted: var(--point-blue-muted);
+  --color-button-neutral: var(--button-gray);
+  --color-button-neutral-hover: var(--button-gray-hover);
+  --color-button-neutral-active: var(--button-gray-active);
+  --color-button-neutral-subtle: var(--button-gray-subtle);
 
   --color-bg-page: #f7f8fa;
   --color-bg-surface: #ffffff;
@@ -278,17 +314,19 @@
   --color-text-secondary: #5f636d;
   --color-text-muted: #8a909b;
   --color-text-inverse: #ffffff;
-  --color-text-brand: #4f5cc4;
-  --color-text-link: #4f5cc4;
+  --color-text-brand: var(--point-blue);
+  --color-text-link: var(--point-blue);
 
   --color-border-default: #e2e4e8;
   --color-border-subtle: #eef0f3;
   --color-border-strong: #c8ccd3;
-  --color-border-brand: #8f97ee;
+  --color-border-brand: var(--point-blue);
 
-  --color-tag-project-bg: #eef0f4;
-  --color-tag-project-text: #3c414a;
-  --color-tag-base-bg: #2f3440;
+  --color-tag-project-bg: var(--color-button-neutral);
+  --color-tag-project-text: #ffffff;
+  --color-tag-pr-bg: var(--color-brand-subtle);
+  --color-tag-pr-text: var(--color-brand-primary);
+  --color-tag-base-bg: var(--color-button-neutral);
   --color-group-line: #cdd1d8;
 
   --shadow-xs: 0 1px 1px rgba(17, 24, 39, 0.04);
@@ -304,6 +342,10 @@
   --color-brand-active: var(--color-brand-active);
   --color-brand-subtle: var(--color-brand-subtle);
   --color-brand-muted: var(--color-brand-muted);
+  --color-button-neutral: var(--color-button-neutral);
+  --color-button-neutral-hover: var(--color-button-neutral-hover);
+  --color-button-neutral-active: var(--color-button-neutral-active);
+  --color-button-neutral-subtle: var(--color-button-neutral-subtle);
 
   /* Background */
   --color-bg-page: var(--color-bg-page);


### PR DESCRIPTION
## What
- Polish the task detail drawer so task status actions and hook status/install controls live in one linear status panel.
- Add dedicated task and hook status icon resources through Hugeicons.
- Refresh the AI sessions entry point and dialog with a terminal-like animated chat presentation.
- Update task quick search, history navigation shortcuts, and drawer-close behavior around terminal focus.
- Standardize point and neutral button color tokens and document their usage.

## How
- Replace the nested hook status dialog entry flow with inline hook rows and reinstall actions.
- Add Hugeicons dependencies and assertions for task status and webhook icon resources.
- Update shared shortcut definitions to use `Mod+Shift+[` and `Mod+Shift+]` for history navigation.
- Remove the shortcut explanation from the task quick search dialog title area.
- Add semantic CSS tokens for point color and neutral button surfaces, plus a token regression test.

## Important Changes
### Task Detail Status Panel
- **Reason**: Reduce drawer depth and keep task state and hook health in one scan path.
- **Files**: `src/desktop/renderer/routes/TaskDetailRoute.tsx`, `src/components/HooksStatusCard.tsx`

### AI Sessions Chat UX
- **Reason**: Make AI session history feel closer to a natural chat stream while preserving terminal context.
- **Files**: `src/components/AiSessionsCard.tsx`, `src/components/AiSessionsDialog.tsx`, `src/styles/globals.css`

### Interaction and Design Tokens
- **Reason**: Align shortcuts, quick search copy, and button/PR colors with the intended product interaction model.
- **Files**: `src/desktop/shared/keyboardShortcut.ts`, `src/desktop/renderer/components/TaskQuickSearchDialog.tsx`, `CLAUDE.md`, `src/styles/globals.css`

Co-authored-by: OpenAI Codex <codex@openai.com>
