### PR TITLE
fix(hooks): align dev hook status detection

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -12,11 +12,13 @@ const { createDesktopDiagnostics, resolveDesktopLogPath, serializeErrorForLog } 
 
 const DEFAULT_LOCALE = "ko";
 const RENDERER_DEV_URL = process.env.KANVIBE_RENDERER_URL || null;
+const SHOULD_USE_SOURCE_MODULES = Boolean(RENDERER_DEV_URL);
 const HOOK_SERVER_HOST = "0.0.0.0";
-const HOOK_SERVER_PORT = 9736;
+const DEV_HOOK_SERVER_PORT = 6379;
+const PACKAGED_HOOK_SERVER_PORT = 9736;
+const HOOK_SERVER_PORT = SHOULD_USE_SOURCE_MODULES ? DEV_HOOK_SERVER_PORT : PACKAGED_HOOK_SERVER_PORT;
 const RENDERER_ABORT_RECOVERY_TIMEOUT_MS = 1000;
 const RENDERER_ABORT_RECOVERY_INTERVAL_MS = 50;
-const SHOULD_USE_SOURCE_MODULES = Boolean(RENDERER_DEV_URL);
 const originalResolveFilename = Module._resolveFilename;
 
 const isHeadlessLinuxRuntime = !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
@@ -821,6 +823,11 @@ function startHookServer() {
   hookServer = createHookServer({ host: HOOK_SERVER_HOST, port: HOOK_SERVER_PORT });
 }
 
+function configureHookEndpointPort() {
+  const { setHookServerPort } = require(getRuntimeModulePath(path.join("src", "lib", "hookEndpoint.ts")));
+  setHookServerPort(HOOK_SERVER_PORT);
+}
+
 async function loadRenderer(window, targetUrl = getRendererNavigationUrl()) {
   logDiagnostic("renderer:load-start", {
     targetUrl,
@@ -885,6 +892,7 @@ app.whenReady().then(async () => {
   });
 
   registerRuntimeAliases();
+  configureHookEndpointPort();
   session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
     callback(permission === "notifications");
   });

--- a/src/desktop/main/__tests__/runtimeEnvironment.test.ts
+++ b/src/desktop/main/__tests__/runtimeEnvironment.test.ts
@@ -23,4 +23,16 @@ describe("desktop runtime environment", () => {
       source.indexOf("process.env.KANVIBE_DESKTOP"),
     );
   });
+
+  it("uses port 6379 for hook server in desktop dev mode", () => {
+    const source = readFileSync(path.join(process.cwd(), "electron", "main.js"), "utf8");
+
+    expect(source).toContain("const DEV_HOOK_SERVER_PORT = 6379");
+    expect(source).toContain("const PACKAGED_HOOK_SERVER_PORT = 9736");
+    expect(source).toContain("const HOOK_SERVER_PORT = SHOULD_USE_SOURCE_MODULES ? DEV_HOOK_SERVER_PORT : PACKAGED_HOOK_SERVER_PORT");
+    expect(source).toContain("setHookServerPort(HOOK_SERVER_PORT)");
+    expect(source.indexOf("configureHookEndpointPort();")).toBeLessThan(
+      source.indexOf("  registerDesktopHandlers();"),
+    );
+  });
 });

--- a/src/lib/__tests__/claudeHooksSetup.test.ts
+++ b/src/lib/__tests__/claudeHooksSetup.test.ts
@@ -99,4 +99,16 @@ describe("claudeHooksSetup", () => {
 
     vi.unstubAllGlobals();
   });
+
+  it("현재 task id와 다른 Claude hook은 설치된 것으로 보지 않는다", async () => {
+    const repoPath = tempDir;
+
+    await setupClaudeHooks(repoPath, "task-1", "http://localhost:9736");
+    const status = await getClaudeHooksStatus(repoPath, "task-2");
+
+    expect(status.installed).toBe(false);
+    expect(status.hasTaskIdBinding).toBe(true);
+    expect(status.hasExpectedTaskId).toBe(false);
+    expect(status.boundTaskId).toBe("task-1");
+  });
 });

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -166,6 +166,7 @@ describe("codexHooksSetup", () => {
         hasHookEntries: true,
         hasConfigEntry: true,
         hasTaskIdBinding: true,
+        hasExpectedTaskId: true,
         hasStatusMappings: true,
         hasExpectedHookServerUrl: true,
         hasReachableHookServer: true,
@@ -188,6 +189,18 @@ describe("codexHooksSetup", () => {
       expect(status.hasReachableHookServer).toBe(false);
 
       vi.unstubAllGlobals();
+    });
+
+    it("현재 task id와 다른 Codex hook은 설치된 것으로 보지 않는다", async () => {
+      const repoPath = tempDir;
+      await setupCodexHooks(repoPath, "task-1", "http://localhost:9736");
+
+      const status = await getCodexHooksStatus(repoPath, "task-2");
+
+      expect(status.installed).toBe(false);
+      expect(status.hasTaskIdBinding).toBe(true);
+      expect(status.hasExpectedTaskId).toBe(false);
+      expect(status.boundTaskId).toBe("task-1");
     });
   });
 });

--- a/src/lib/__tests__/geminiHooksSetup.test.ts
+++ b/src/lib/__tests__/geminiHooksSetup.test.ts
@@ -161,5 +161,16 @@ describe("geminiHooksSetup", () => {
       expect(status.hasSettingsEntry).toBe(false);
       expect(status.installed).toBe(false);
     });
+
+    it("현재 task id와 다른 Gemini hook은 설치된 것으로 보지 않는다", async () => {
+      await setupGeminiHooks(tmpDir, "task-1", "http://localhost:9736");
+
+      const status = await getGeminiHooksStatus(tmpDir, "task-2");
+
+      expect(status.installed).toBe(false);
+      expect(status.hasTaskIdBinding).toBe(true);
+      expect(status.hasExpectedTaskId).toBe(false);
+      expect(status.boundTaskId).toBe("task-1");
+    });
   });
 });

--- a/src/lib/__tests__/hookEndpoint.test.ts
+++ b/src/lib/__tests__/hookEndpoint.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   const socket = {
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => {
     close: vi.fn(),
   };
 
-  socket.once.mockImplementation((_event: string, _handler: () => void) => socket);
+  socket.once.mockImplementation(() => socket);
   socket.connect.mockImplementation((_port: number, _host: string, callback: () => void) => {
     callback();
     return socket;
@@ -49,11 +49,9 @@ vi.mock("@/lib/sshConfig", () => ({
 }));
 
 describe("hookEndpoint", () => {
-  const originalExternalHost = process.env.KANVIBE_EXTERNAL_HOST;
-
   beforeEach(() => {
     vi.resetModules();
-    delete process.env.KANVIBE_EXTERNAL_HOST;
+    delete globalThis.__KANVIBE_HOOK_SERVER_PORT__;
     mocks.networkInterfaces.mockReset();
     mocks.parseSSHConfig.mockReset();
     mocks.lookup.mockReset();
@@ -61,24 +59,16 @@ describe("hookEndpoint", () => {
     mocks.socket.address.mockReturnValue({ address: "10.0.0.8", family: "IPv4", port: 2202 });
   });
 
-  afterEach(() => {
-    if (originalExternalHost === undefined) {
-      delete process.env.KANVIBE_EXTERNAL_HOST;
-    } else {
-      process.env.KANVIBE_EXTERNAL_HOST = originalExternalHost;
-    }
-  });
-
-  it("원격 호스트가 있으면 명시된 외부 주소를 hook 서버 경로로 사용한다", async () => {
+  it("desktop main이 설정한 hook server port를 hook URL에 사용한다", async () => {
     // Given
-    process.env.KANVIBE_EXTERNAL_HOST = "192.168.0.5";
-    const { getHookServerUrl } = await import("@/lib/hookEndpoint");
+    const { getHookServerUrl, setHookServerPort } = await import("@/lib/hookEndpoint");
+    setHookServerPort(6379);
 
     // When
-    const result = await getHookServerUrl("remote-devbox");
+    const result = await getHookServerUrl(null);
 
     // Then
-    expect(result).toBe("http://192.168.0.5:9736");
+    expect(result).toBe("http://localhost:6379");
   });
 
   it("원격 hook 주소는 SSH 연결에 사용한 로컬 출발 IP를 우선 사용한다", async () => {
@@ -102,6 +92,28 @@ describe("hookEndpoint", () => {
     expect(mocks.createSocket).toHaveBeenCalledWith("udp4");
     expect(mocks.socket.connect).toHaveBeenCalledWith(2202, "203.0.113.20", expect.any(Function));
     expect(result).toBe("http://10.0.0.8:9736");
+  });
+
+  it("설정된 hook server port를 원격 hook 주소에도 반영한다", async () => {
+    // Given
+    mocks.parseSSHConfig.mockResolvedValue([
+      {
+        host: "remote-devbox",
+        hostname: "ssh.example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/tmp/test-key",
+      },
+    ]);
+    mocks.lookup.mockResolvedValue({ address: "203.0.113.20", family: 4 });
+    const { getHookServerUrl, setHookServerPort } = await import("@/lib/hookEndpoint");
+    setHookServerPort(6379);
+
+    // When
+    const result = await getHookServerUrl("remote-devbox");
+
+    // Then
+    expect(result).toBe("http://10.0.0.8:6379");
   });
 
   it("원격 호스트 경로를 해석하지 못하면 내부망 IPv4 주소를 사용한다", async () => {

--- a/src/lib/__tests__/hookServerStatus.test.ts
+++ b/src/lib/__tests__/hookServerStatus.test.ts
@@ -26,7 +26,8 @@ describe("hookServerStatus", () => {
     vi.stubGlobal("fetch", mockFetch);
   });
 
-  it("marks stale configured hook URLs as invalid", async () => {
+  it("marks remote hook URLs with a mismatched port as invalid", async () => {
+    mockGetHookServerUrl.mockResolvedValue("http://10.0.0.4:6379");
     const { validateHookServerConfiguration } = await import("@/lib/hookServerStatus");
 
     const result = await validateHookServerConfiguration(["http://192.168.0.8:9736"], true, "remote-host");
@@ -34,6 +35,20 @@ describe("hookServerStatus", () => {
     expect(result.hasExpectedHookServerUrl).toBe(false);
     expect(result.hasReachableHookServer).toBe(false);
     expect(mockExecGit).not.toHaveBeenCalled();
+  });
+
+  it("accepts remote hook URLs with a different host when the port matches", async () => {
+    mockGetHookServerUrl.mockResolvedValue("http://10.0.0.4:6379");
+    const { validateHookServerConfiguration } = await import("@/lib/hookServerStatus");
+
+    const result = await validateHookServerConfiguration(["http://100.83.96.29:6379"], true, "remote-host");
+
+    expect(result.hasExpectedHookServerUrl).toBe(true);
+    expect(result.hasReachableHookServer).toBe(true);
+    expect(mockExecGit).toHaveBeenCalledWith(
+      expect.stringContaining("http://100.83.96.29:6379/api/hooks/health"),
+      "remote-host",
+    );
   });
 
   it("checks hook server reachability from the remote host", async () => {

--- a/src/lib/__tests__/hookTaskBinding.test.ts
+++ b/src/lib/__tests__/hookTaskBinding.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildShellTaskIdResolver,
   extractShellTaskId,
+  getShellTaskIdBindingStatus,
 } from "@/lib/hookTaskBinding";
 
 describe("hookTaskBinding", () => {
@@ -29,5 +30,59 @@ describe("hookTaskBinding", () => {
 
     // Then
     expect(taskId).toBe("task-123");
+  });
+
+  it("모든 shell hook이 같은 현재 task id를 가리키는지 판정한다", () => {
+    // Given
+    const scripts = [
+      ['TASK_ID="task-123"', 'curl -d "{\\"taskId\\": \\"${TASK_ID}\\"}"'].join("\n"),
+      ['TASK_ID="task-123"', 'curl -d "{\\"taskId\\": \\"${TASK_ID}\\"}"'].join("\n"),
+    ];
+
+    // When
+    const status = getShellTaskIdBindingStatus(scripts, "task-123");
+
+    // Then
+    expect(status).toEqual({
+      hasTaskIdBinding: true,
+      hasExpectedTaskId: true,
+      boundTaskId: "task-123",
+    });
+  });
+
+  it("shell hook의 task id가 현재 task와 다르면 expected 판정을 실패시킨다", () => {
+    // Given
+    const scripts = [
+      ['TASK_ID="task-123"', 'curl -d "{\\"taskId\\": \\"${TASK_ID}\\"}"'].join("\n"),
+      ['TASK_ID="task-123"', 'curl -d "{\\"taskId\\": \\"${TASK_ID}\\"}"'].join("\n"),
+    ];
+
+    // When
+    const status = getShellTaskIdBindingStatus(scripts, "task-999");
+
+    // Then
+    expect(status).toEqual({
+      hasTaskIdBinding: true,
+      hasExpectedTaskId: false,
+      boundTaskId: "task-123",
+    });
+  });
+
+  it("shell hook끼리 서로 다른 task id를 가지면 binding 판정을 실패시킨다", () => {
+    // Given
+    const scripts = [
+      ['TASK_ID="task-123"', 'curl -d "{\\"taskId\\": \\"${TASK_ID}\\"}"'].join("\n"),
+      ['TASK_ID="task-999"', 'curl -d "{\\"taskId\\": \\"${TASK_ID}\\"}"'].join("\n"),
+    ];
+
+    // When
+    const status = getShellTaskIdBindingStatus(scripts, "task-123");
+
+    // Then
+    expect(status).toEqual({
+      hasTaskIdBinding: false,
+      hasExpectedTaskId: false,
+      boundTaskId: null,
+    });
   });
 });

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -246,5 +246,20 @@ export const KanvibePlugin: Plugin = async ({ $ }) => {
       expect(status.hasDuplicateKanvibePlugins).toBe(true);
       expect(status.registeredPluginUrls).toHaveLength(2);
     });
+
+    it("현재 task id와 다른 OpenCode hook은 설치된 것으로 보지 않는다", async () => {
+      // Given
+      const repoPath = tempDir;
+      await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:9736");
+
+      // When
+      const status = await getOpenCodeHooksStatus(repoPath, "task-2");
+
+      // Then
+      expect(status.installed).toBe(false);
+      expect(status.hasTaskIdBinding).toBe(true);
+      expect(status.hasExpectedTaskId).toBe(false);
+      expect(status.boundTaskId).toBe("task-1");
+    });
   });
 });

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { buildShellTaskIdResolver, extractShellTaskId } from "@/lib/hookTaskBinding";
+import { buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
 export function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
@@ -78,25 +78,6 @@ interface MatcherHookEntry extends HookEntry {
 const CLAUDE_PROMPT_COMMAND = '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh';
 const CLAUDE_STOP_COMMAND = '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-stop-hook.sh';
 const CLAUDE_QUESTION_COMMAND = '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-question-hook.sh';
-
-function hasTaskIdPayloadBinding(content: string, taskId?: string): boolean {
-  const boundTaskId = extractShellTaskId(content);
-  const hasTaskIdPayload = content.includes("taskId") && content.includes("${TASK_ID}");
-  if (!hasTaskIdPayload) return false;
-
-  if (!taskId) {
-    return boundTaskId !== null;
-  }
-
-  return boundTaskId === taskId;
-}
-
-function hasLegacyBranchPayloadBinding(content: string): boolean {
-  return content.includes('BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD')
-    && content.includes('PROJECT_NAME="')
-    && content.includes('\\\"branchName\\\": \\\"${BRANCH_NAME}\\\"')
-    && content.includes('\\\"projectName\\\": \\\"${PROJECT_NAME}\\\"');
-}
 
 /** 기존 settings.json을 읽거나 빈 객체를 반환한다 */
 async function readSettingsJson(settingsPath: string, sshHost?: string | null): Promise<ClaudeSettings> {
@@ -235,6 +216,7 @@ export interface ClaudeHooksStatus {
   hasQuestionHook: boolean;
   hasSettingsEntry: boolean;
   hasTaskIdBinding?: boolean;
+  hasExpectedTaskId?: boolean;
   hasStatusMappings?: boolean;
   hasExpectedHookServerUrl?: boolean;
   hasReachableHookServer?: boolean;
@@ -268,11 +250,7 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
   const questionContent = questionScript.content;
 
   const scriptContents = [promptContent, stopContent, questionContent];
-  const boundTaskIds = scriptContents.map(extractShellTaskId).filter((value): value is string => value !== null);
-  const boundTaskId = boundTaskIds.length > 0 && boundTaskIds.every((value) => value === boundTaskIds[0])
-    ? boundTaskIds[0]
-    : null;
-  const hasTaskIdBinding = scriptContents.every((content) => hasTaskIdPayloadBinding(content, taskId));
+  const { boundTaskId, hasTaskIdBinding, hasExpectedTaskId } = getShellTaskIdBindingStatus(scriptContents, taskId);
   const hookServerValidation = await validateHookServerConfiguration(
     scriptContents.map(extractShellHookServerUrl),
     Boolean(taskId),
@@ -303,6 +281,7 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
     && questionScript.exists
     && hasSettingsEntry
     && hasTaskIdBinding
+    && hasExpectedTaskId
     && hasStatusMappings
     && hookServerValidation.hasExpectedHookServerUrl;
 
@@ -313,6 +292,7 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
     hasQuestionHook: questionScript.exists,
     hasSettingsEntry,
     hasTaskIdBinding,
+    hasExpectedTaskId,
     hasStatusMappings,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
     hasReachableHookServer: hookServerValidation.hasReachableHookServer,

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { buildShellTaskIdResolver, extractShellTaskId } from "@/lib/hookTaskBinding";
+import { buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
 
 /**
  * Codex CLI 최신 hooks 설정은 `.codex/config.toml`의 feature flag와
@@ -101,18 +101,6 @@ export function generateStopHookScript(kanvibeUrl: string, taskId: string): stri
     kanvibeUrl,
     taskId,
   );
-}
-
-function hasTaskIdPayloadBinding(content: string, taskId?: string): boolean {
-  const boundTaskId = extractShellTaskId(content);
-  const hasTaskIdPayload = content.includes("taskId") && content.includes("${TASK_ID}");
-  if (!hasTaskIdPayload) return false;
-
-  if (!taskId) {
-    return boundTaskId !== null;
-  }
-
-  return boundTaskId === taskId;
 }
 
 function parseHooksJson(content: string): CodexHooksFile {
@@ -326,6 +314,7 @@ export interface CodexHooksStatus {
   hasHookEntries: boolean;
   hasConfigEntry: boolean;
   hasTaskIdBinding?: boolean;
+  hasExpectedTaskId?: boolean;
   hasStatusMappings?: boolean;
   hasExpectedHookServerUrl?: boolean;
   hasReachableHookServer?: boolean;
@@ -368,8 +357,7 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
   const configContent = configFile.content;
 
   const hookScripts = [promptContent, permissionContent, preToolContent, stopContent];
-  const boundTaskId = hookScripts.map((content) => extractShellTaskId(content)).find((value) => value !== null) ?? null;
-  const hasTaskIdBinding = hookScripts.every((content) => hasTaskIdPayloadBinding(content, taskId));
+  const { boundTaskId, hasTaskIdBinding, hasExpectedTaskId } = getShellTaskIdBindingStatus(hookScripts, taskId);
   const hasStatusMappings = promptContent.includes('\\\"status\\\": \\\"progress\\\"')
     && permissionContent.includes('\\\"status\\\": \\\"pending\\\"')
     && preToolContent.includes('\\\"status\\\": \\\"progress\\\"')
@@ -396,6 +384,7 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
     && hasHookEntries
     && hasConfigEntry
     && hasTaskIdBinding
+    && hasExpectedTaskId
     && hasStatusMappings
     && hookServerValidation.hasExpectedHookServerUrl;
 
@@ -409,6 +398,7 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
     hasHookEntries,
     hasConfigEntry,
     hasTaskIdBinding,
+    hasExpectedTaskId,
     hasStatusMappings,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
     hasReachableHookServer: hookServerValidation.hasReachableHookServer,

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { buildShellTaskIdResolver, extractShellTaskId } from "@/lib/hookTaskBinding";
+import { buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
 
 /**
  * Gemini CLI hooks는 stdout에 반드시 JSON만 출력해야 한다.
@@ -72,25 +72,6 @@ interface GeminiHookEntry {
 
 const GEMINI_PROMPT_COMMAND = '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-prompt-hook.sh';
 const GEMINI_STOP_COMMAND = '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-stop-hook.sh';
-
-function hasTaskIdPayloadBinding(content: string, taskId?: string): boolean {
-  const boundTaskId = extractShellTaskId(content);
-  const hasTaskIdPayload = content.includes("taskId") && content.includes("${TASK_ID}");
-  if (!hasTaskIdPayload) return false;
-
-  if (!taskId) {
-    return boundTaskId !== null;
-  }
-
-  return boundTaskId === taskId;
-}
-
-function hasLegacyBranchPayloadBinding(content: string): boolean {
-  return content.includes('BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD')
-    && content.includes('PROJECT_NAME="')
-    && content.includes('\\\"branchName\\\": \\\"${BRANCH_NAME}\\\"')
-    && content.includes('\\\"projectName\\\": \\\"${PROJECT_NAME}\\\"');
-}
 
 /** 기존 settings.json을 읽거나 빈 객체를 반환한다 */
 async function readSettingsJson(settingsPath: string, sshHost?: string | null): Promise<GeminiSettings> {
@@ -197,6 +178,7 @@ export interface GeminiHooksStatus {
   hasStopHook: boolean;
   hasSettingsEntry: boolean;
   hasTaskIdBinding?: boolean;
+  hasExpectedTaskId?: boolean;
   hasStatusMappings?: boolean;
   hasExpectedHookServerUrl?: boolean;
   hasReachableHookServer?: boolean;
@@ -226,11 +208,7 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
   const stopContent = stopScript.content;
 
   const scriptContents = [promptContent, stopContent];
-  const boundTaskIds = scriptContents.map(extractShellTaskId).filter((value): value is string => value !== null);
-  const boundTaskId = boundTaskIds.length > 0 && boundTaskIds.every((value) => value === boundTaskIds[0])
-    ? boundTaskIds[0]
-    : null;
-  const hasTaskIdBinding = scriptContents.every((content) => hasTaskIdPayloadBinding(content, taskId));
+  const { boundTaskId, hasTaskIdBinding, hasExpectedTaskId } = getShellTaskIdBindingStatus(scriptContents, taskId);
   const hookServerValidation = await validateHookServerConfiguration(
     scriptContents.map(extractShellHookServerUrl),
     Boolean(taskId),
@@ -257,6 +235,7 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
     && stopScript.exists
     && hasSettingsEntry
     && hasTaskIdBinding
+    && hasExpectedTaskId
     && hasStatusMappings
     && hookServerValidation.hasExpectedHookServerUrl;
 
@@ -266,6 +245,7 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
     hasStopHook: stopScript.exists,
     hasSettingsEntry,
     hasTaskIdBinding,
+    hasExpectedTaskId,
     hasStatusMappings,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
     hasReachableHookServer: hookServerValidation.hasReachableHookServer,

--- a/src/lib/hookEndpoint.ts
+++ b/src/lib/hookEndpoint.ts
@@ -5,21 +5,33 @@ import os from "node:os";
 import { parseSSHConfig } from "@/lib/sshConfig";
 
 export const KANVIBE_HOOK_SERVER_PORT = 9736;
+export const KANVIBE_DEV_HOOK_SERVER_PORT = 6379;
+
+declare global {
+  var __KANVIBE_HOOK_SERVER_PORT__: number | undefined;
+}
+
+export function setHookServerPort(port: number): void {
+  globalThis.__KANVIBE_HOOK_SERVER_PORT__ = port;
+}
+
+export function getHookServerPort(): number {
+  return globalThis.__KANVIBE_HOOK_SERVER_PORT__ ?? KANVIBE_HOOK_SERVER_PORT;
+}
 
 export function getLocalHookServerUrl(): string {
-  return `http://localhost:${KANVIBE_HOOK_SERVER_PORT}`;
+  return `http://localhost:${getHookServerPort()}`;
 }
 
 export async function getRemoteHookServerUrl(sshHost?: string | null): Promise<string> {
-  const preferredHost = process.env.KANVIBE_EXTERNAL_HOST
-    || await getSshRouteIpv4Address(sshHost)
+  const preferredHost = await getSshRouteIpv4Address(sshHost)
     || getPreferredIpv4Address();
 
   if (!preferredHost) {
-    throw new Error("로컬 Hook 서버에 접근할 수 있는 IP를 찾지 못했습니다. KANVIBE_EXTERNAL_HOST를 설정해 주세요.");
+    throw new Error("원격 환경에서 로컬 Hook 서버에 접근할 수 있는 경로를 찾지 못했습니다.");
   }
 
-  return `http://${preferredHost}:${KANVIBE_HOOK_SERVER_PORT}`;
+  return `http://${preferredHost}:${getHookServerPort()}`;
 }
 
 export async function getHookServerUrl(sshHost?: string | null): Promise<string> {

--- a/src/lib/hookServerStatus.ts
+++ b/src/lib/hookServerStatus.ts
@@ -65,9 +65,13 @@ export async function validateHookServerConfiguration(
     };
   }
 
-  const hasExpectedHookServerUrl = definedUrls.every((value) => value === expectedHookServerUrl);
+  const hasExpectedHookServerUrl = definedUrls.every((value) => isExpectedHookServerUrl(
+    value,
+    expectedHookServerUrl,
+    Boolean(sshHost),
+  ));
   const hasReachableHookServer = hasExpectedHookServerUrl
-    ? await isHookServerReachable(expectedHookServerUrl, sshHost)
+    ? await isHookServerReachable(configuredHookServerUrl, sshHost)
     : false;
 
   return {
@@ -138,4 +142,34 @@ async function getCachedValue<T>(
 
 function ensureTrailingSlash(url: string) {
   return url.endsWith("/") ? url : `${url}/`;
+}
+
+function isExpectedHookServerUrl(configuredUrl: string, expectedUrl: string, isRemote: boolean): boolean {
+  const configured = parseHookServerUrl(configuredUrl);
+  const expected = parseHookServerUrl(expectedUrl);
+  if (!configured || !expected) {
+    return false;
+  }
+
+  if (configured.protocol !== expected.protocol || configured.port !== expected.port) {
+    return false;
+  }
+
+  if (isRemote) {
+    return true;
+  }
+
+  return normalizeLoopbackHostname(configured.hostname) === normalizeLoopbackHostname(expected.hostname);
+}
+
+function parseHookServerUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeLoopbackHostname(hostname: string): string {
+  return hostname === "127.0.0.1" ? "localhost" : hostname;
 }

--- a/src/lib/hookTaskBinding.ts
+++ b/src/lib/hookTaskBinding.ts
@@ -18,3 +18,31 @@ export function extractShellTaskId(content: string): string | null {
   const match = content.match(/^TASK_ID="((?:\\.|[^"\\])*)"$/m);
   return match ? unescapeShellDoubleQuotedValue(match[1]) : null;
 }
+
+export interface ShellTaskIdBindingStatus {
+  hasTaskIdBinding: boolean;
+  hasExpectedTaskId: boolean;
+  boundTaskId: string | null;
+}
+
+export function getShellTaskIdBindingStatus(
+  contents: string[],
+  expectedTaskId?: string,
+): ShellTaskIdBindingStatus {
+  const hasTaskIdPayloadBindings = contents.every((content) => (
+    content.includes("taskId") && content.includes("${TASK_ID}")
+  ));
+  const boundTaskIds = contents.map(extractShellTaskId);
+  const firstTaskId = boundTaskIds[0] ?? null;
+  const boundTaskId = firstTaskId && boundTaskIds.every((value) => value === firstTaskId)
+    ? firstTaskId
+    : null;
+  const hasTaskIdBinding = hasTaskIdPayloadBindings && boundTaskId !== null;
+  const hasExpectedTaskId = hasTaskIdBinding && (!expectedTaskId || boundTaskId === expectedTaskId);
+
+  return {
+    hasTaskIdBinding,
+    hasExpectedTaskId,
+    boundTaskId,
+  };
+}

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -222,6 +222,7 @@ export interface OpenCodeHooksStatus {
   hasRegisteredPlugin?: boolean;
   hasDuplicateKanvibePlugins?: boolean;
   hasTaskIdBinding?: boolean;
+  hasExpectedTaskId?: boolean;
   hasStatusEndpoint?: boolean;
   hasEventMappings?: boolean;
   hasMainSessionGuard?: boolean;
@@ -257,6 +258,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
   let hasDuplicateKanvibePlugins = false;
   let registeredPluginUrls: string[] = [];
   let configuredHookServerUrl: string | null = null;
+  let hasExpectedTaskId = false;
   if (pluginFile.exists) {
     try {
       const content = pluginFile.content;
@@ -265,8 +267,8 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
       boundTaskId = extractPluginTaskId(content);
       hasTaskIdBinding =
         boundTaskId !== null
-        && content.includes("taskId: TASK_ID")
-        && (!taskId || boundTaskId === taskId);
+        && content.includes("taskId: TASK_ID");
+      hasExpectedTaskId = hasTaskIdBinding && (!taskId || boundTaskId === taskId);
       hasStatusEndpoint = content.includes("/api/hooks/status");
       hasEventMappings = ["progress", "pending", "review", "done", "message.updated", "question.asked", "question.replied", "session.idle", "session.deleted"].every((fragment) => content.includes(fragment));
       hasMainSessionGuard = content.includes("isMainSession(message)") && content.includes("isMainSession(event.properties)");
@@ -292,6 +294,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
   const installed = pluginFile.exists
     && hasPlugin
     && hasTaskIdBinding
+    && hasExpectedTaskId
     && hasStatusEndpoint
     && hasEventMappings
     && hasMainSessionGuard
@@ -305,6 +308,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
     hasRegisteredPlugin,
     hasDuplicateKanvibePlugins,
     hasTaskIdBinding,
+    hasExpectedTaskId,
     hasStatusEndpoint,
     hasEventMappings,
     hasMainSessionGuard,


### PR DESCRIPTION
## What is this?
- Fix hook status detection for remote environments when the desktop app runs from source with `pnpm dev`.
- Make installed hook checks respect the current task id instead of only checking that a hook payload exists.

## How did this solve it?
**Dev hook endpoint**
- Use port `6379` for the desktop hook server in dev mode and keep `9736` for packaged builds.
- Propagate the selected desktop hook server port into hook URL generation.

**Remote hook status validation**
- Treat remote hook URLs as valid when protocol and port match, even if the detected host differs.
- Keep port mismatches invalid so stale dev/package hook URLs still require reinstalling.
- Run remote health checks against the hook URL that is actually configured in the hook file.

**Task binding validation**
- Add shared task id binding diagnostics for shell hooks.
- Require Claude, Gemini, Codex, and OpenCode hooks to target the current task id before reporting `installed: true`.

## Important changes
### Hook server port selection

**Why**
- `pnpm dev` should receive hook calls on the dev port, while packaged builds should keep the production desktop port.

**Files**
- `electron/main.js`
- `src/lib/hookEndpoint.ts`
- `src/desktop/main/__tests__/runtimeEnvironment.test.ts`

### Remote hook URL matching

**Why**
- Remote hosts can have a configured reachable IP that differs from the locally recalculated outbound IP.

**Files**
- `src/lib/hookServerStatus.ts`
- `src/lib/__tests__/hookServerStatus.test.ts`

### Task id installation checks

**Why**
- Hooks installed for a different task should not be reported as installed for the current task.

**Files**
- `src/lib/hookTaskBinding.ts`
- `src/lib/claudeHooksSetup.ts`
- `src/lib/geminiHooksSetup.ts`
- `src/lib/codexHooksSetup.ts`
- `src/lib/openCodeHooksSetup.ts`
- related hook setup tests

Co-Authored-By: OpenAI Codex <codex@openai.com>
