### PR TITLE
Update kanban task keyboard shortcuts

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -14,6 +14,8 @@ import DoneConfirmDialog from "./DoneConfirmDialog";
 import { reorderTasks, deleteTask, getMoreDoneTasks, moveTaskToColumn } from "@/desktop/renderer/actions/kanban";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
+import { localizeHref } from "@/desktop/renderer/navigation";
+import { openInternalRouteInNewWindow } from "@/desktop/renderer/utils/windowOpen";
 import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import { useAutoRefresh } from "@/desktop/renderer/hooks/useAutoRefresh";
@@ -105,6 +107,31 @@ function shouldIgnoreBoardTaskFocusEvent(event: KeyboardEvent) {
   );
 }
 
+function getTaskCardFromKeyboardEvent(event: KeyboardEvent) {
+  const target = event.target instanceof Element
+    ? event.target
+    : document.activeElement instanceof Element
+      ? document.activeElement
+      : null;
+
+  return target?.closest<HTMLAnchorElement>(TASK_CARD_SELECTOR) ?? null;
+}
+
+function isShiftOnlyKeyboardShortcut(event: KeyboardEvent, key: string) {
+  return event.key === key && event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
+}
+
+function getCurrentBoardLocale() {
+  const firstSegment = window.location.hash.replace(/^#/, "").split("/").filter(Boolean)[0];
+  return SUPPORTED_LOCALES.includes(firstSegment as typeof SUPPORTED_LOCALES[number])
+    ? firstSegment
+    : DEFAULT_LOCALE;
+}
+
+function openTaskDetailInNewWindow(taskId: string) {
+  openInternalRouteInNewWindow(localizeHref(`/task/${taskId}`, getCurrentBoardLocale()));
+}
+
 /** worktree repoPath에서 메인 프로젝트 경로를 추출한다 */
 function extractMainRepoPath(repoPath: string): string | null {
   const worktreeIndex = repoPath.indexOf("__worktrees");
@@ -113,11 +140,7 @@ function extractMainRepoPath(repoPath: string): string | null {
 }
 
 function openSettingsPage() {
-  const firstSegment = window.location.hash.replace(/^#/, "").split("/").filter(Boolean)[0];
-  const locale = SUPPORTED_LOCALES.includes(firstSegment as typeof SUPPORTED_LOCALES[number])
-    ? firstSegment
-    : DEFAULT_LOCALE;
-  window.location.hash = `#/${locale}/settings`;
+  window.location.hash = `#/${getCurrentBoardLocale()}/settings`;
 }
 
 /**
@@ -432,31 +455,33 @@ export default function Board({
   }, [contextMenu.isOpen, isBranchModalOpen, isModalOpen, pendingDoneResult]);
 
   useEffect(() => {
-    function handleWindowTaskContextMenu(event: KeyboardEvent) {
-      if (event.key !== "Enter" || !event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) return;
+    function handleWindowTaskShortcut(event: KeyboardEvent) {
+      const shouldOpenTaskInNewWindow = isShiftOnlyKeyboardShortcut(event, "Enter");
+      const shouldOpenTaskContextMenu = isShiftOnlyKeyboardShortcut(event, "F10");
+      if (!shouldOpenTaskInNewWindow && !shouldOpenTaskContextMenu) return;
       if (contextMenu.isOpen || isModalOpen || isBranchModalOpen || pendingDoneResult) return;
 
-      const target = event.target instanceof Element
-        ? event.target
-        : document.activeElement instanceof Element
-          ? document.activeElement
-          : null;
-      const taskCard = target?.closest<HTMLAnchorElement>(TASK_CARD_SELECTOR);
+      const taskCard = getTaskCardFromKeyboardEvent(event);
       const taskId = taskCard?.dataset.kanbanTaskId;
       if (!taskCard || !taskId) return;
 
-      const task = findTaskById(filteredTasks, taskId);
-      if (!task) return;
-
       event.preventDefault();
       event.stopPropagation();
+
+      if (shouldOpenTaskInNewWindow) {
+        openTaskDetailInNewWindow(taskId);
+        return;
+      }
+
+      const task = findTaskById(filteredTasks, taskId);
+      if (!task) return;
 
       const rect = taskCard.getBoundingClientRect();
       setContextMenu({ isOpen: true, x: rect.left + 12, y: rect.top + 12, task });
     }
 
-    window.addEventListener("keydown", handleWindowTaskContextMenu, true);
-    return () => window.removeEventListener("keydown", handleWindowTaskContextMenu, true);
+    window.addEventListener("keydown", handleWindowTaskShortcut, true);
+    return () => window.removeEventListener("keydown", handleWindowTaskShortcut, true);
   }, [contextMenu.isOpen, filteredTasks, isBranchModalOpen, isModalOpen, pendingDoneResult]);
 
   const handleLoadMoreDone = useCallback(async () => {

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { Draggable } from "@hello-pangea/dnd";
-import { Link } from "@/desktop/renderer/navigation";
+import { useLocale } from "next-intl";
+import { Link, localizeHref } from "@/desktop/renderer/navigation";
+import { openInternalRouteInNewWindow } from "@/desktop/renderer/utils/windowOpen";
 import { TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
 
@@ -74,11 +76,24 @@ function findHorizontalTaskCard(currentStatus: TaskStatus, currentIndex: number,
   return null;
 }
 
+function isShiftOnlyKeyboardShortcut(event: React.KeyboardEvent, key: string) {
+  return event.key === key && event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
+}
+
 export default function TaskCard({ task, index, onContextMenu, projectName, projectColor, isBaseProject }: TaskCardProps) {
   const cardStyle = projectColor ? { borderColor: projectColor } : undefined;
+  const locale = useLocale();
 
   function handleTaskKeyDown(event: React.KeyboardEvent<HTMLAnchorElement>) {
-    if (event.key === "Enter" && event.shiftKey) {
+    if (isShiftOnlyKeyboardShortcut(event, "Enter")) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      openInternalRouteInNewWindow(localizeHref(`/task/${task.id}`, locale));
+      return;
+    }
+
+    if (isShiftOnlyKeyboardShortcut(event, "F10")) {
       event.preventDefault();
       event.stopPropagation();
 

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -395,7 +395,10 @@ describe("Board defaultSessionType sync", () => {
     expect(document.activeElement).toBe(taskLink);
   });
 
-  it("포커스된 task에서 Shift+Enter를 누르면 컨텍스트 메뉴를 연다", async () => {
+  it("포커스된 task에서 Shift+Enter를 누르면 상세 페이지를 새 창에서 연다", async () => {
+    window.location.hash = "#/en";
+    const openWindow = vi.spyOn(window, "open").mockImplementation(() => null);
+
     render(
       <Board
         initialTasks={createTasksWithTodo()}
@@ -416,6 +419,38 @@ describe("Board defaultSessionType sync", () => {
 
     const event = createEvent.keyDown(taskLink, {
       key: "Enter",
+      shiftKey: true,
+    });
+    fireEvent(taskLink, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(openWindow).toHaveBeenCalledWith(`${window.location.origin}/#/en/task/task-1`, "_blank", "noopener,noreferrer");
+    expect(screen.queryByTestId("task-context-menu")).toBeNull();
+
+    openWindow.mockRestore();
+  });
+
+  it("포커스된 task에서 Shift+F10을 누르면 컨텍스트 메뉴를 연다", async () => {
+    render(
+      <Board
+        initialTasks={createTasksWithTodo()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
+      />,
+    );
+
+    const taskLink = await screen.findByRole("link", { name: "Test Task" });
+    taskLink.focus();
+
+    const event = createEvent.keyDown(taskLink, {
+      key: "F10",
       shiftKey: true,
     });
     fireEvent(taskLink, event);

--- a/src/components/__tests__/TaskCard.test.tsx
+++ b/src/components/__tests__/TaskCard.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@hello-pangea/dnd", () => ({
 }));
 
 vi.mock("@/desktop/renderer/navigation", () => ({
+  localizeHref: (href: string, currentLocale = "ko") => href.startsWith("/") ? `/${currentLocale}${href}` : href,
   Link: forwardRef<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }>(
     function MockLink({ children, ...props }, ref) {
       return <a ref={ref} {...props}>{children}</a>;
@@ -251,7 +252,24 @@ describe("TaskCard - Priority Badge", () => {
     expect(document.activeElement).toBe(todoLink);
   });
 
-  it("should open the task context menu with Shift+Enter without following the link", () => {
+  it("should open the task detail in a new window with Shift+Enter without following the link", () => {
+    const task = createTask();
+    const openWindow = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<TaskCard task={task} index={0} onContextMenu={onContextMenu} />);
+
+    const link = screen.getByRole("link");
+    const event = createEvent.keyDown(link, { key: "Enter", shiftKey: true });
+    fireEvent(link, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(openWindow).toHaveBeenCalledWith(`${window.location.origin}/#/ko/task/task-1`, "_blank", "noopener,noreferrer");
+    expect(onContextMenu).not.toHaveBeenCalled();
+
+    openWindow.mockRestore();
+  });
+
+  it("should open the task context menu with Shift+F10 without following the link", () => {
     const task = createTask();
     const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
       x: 40,
@@ -268,7 +286,7 @@ describe("TaskCard - Priority Badge", () => {
     render(<TaskCard task={task} index={0} onContextMenu={onContextMenu} />);
 
     const link = screen.getByRole("link");
-    const event = createEvent.keyDown(link, { key: "Enter", shiftKey: true });
+    const event = createEvent.keyDown(link, { key: "F10", shiftKey: true });
     fireEvent(link, event);
 
     expect(event.defaultPrevented).toBe(true);


### PR DESCRIPTION
## What changed
- Change focused kanban task `Shift+Enter` behavior to open the task detail page in a new window.
- Move the keyboard shortcut for the task context menu to `Shift+F10`.
- Update Board and TaskCard tests to cover both shortcut paths.

## Key implementation details
- Reuse `openInternalRouteInNewWindow` and localized task routes for new-window navigation.
- Keep the existing context menu positioning behavior for the new `Shift+F10` shortcut.
- Preserve arrow-key task focus navigation and existing mouse right-click behavior.

Co-Authored-By: OpenAI Codex <codex@openai.com>
