### PR TITLE
modify(ui): simplify task iconography

### DIFF
--- a/src/components/HooksStatusCard.tsx
+++ b/src/components/HooksStatusCard.tsx
@@ -6,7 +6,6 @@ import {
   AlertCircleIcon,
   CheckmarkCircle02Icon,
   Clock01Icon,
-  WebhookIcon,
 } from "@hugeicons/core-free-icons";
 import { useTranslations } from "next-intl";
 import {
@@ -218,7 +217,7 @@ export default function HooksStatusCard({
                   ? "border-status-done/20 bg-status-done/10 text-status-done"
                   : "border-status-error/20 bg-status-error/10 text-status-error"
                 }`}>
-                  <HookToolIcon />
+                  <HookToolIcon tool={item.key} />
                 </span>
                 <div className="min-w-0 flex-1">
                   <div className="flex min-w-0 items-center gap-2">
@@ -307,14 +306,65 @@ function StatusIcon({ status }: { status: "ok" | "partial" | "error" }) {
   );
 }
 
-function HookToolIcon() {
+function HookToolIcon({ tool }: { tool: HookToolKey }) {
+  const iconNameByTool: Record<HookToolKey, string> = {
+    claude: "ClaudeIcon",
+    gemini: "GeminiIcon",
+    codex: "CodexIcon",
+    openCode: "OpenCodeIcon",
+  };
+
+  const commonProps = {
+    width: 17,
+    height: 17,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 1.9,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    "aria-hidden": true,
+    "data-testid": "hook-status-tool-icon",
+    "data-icon-name": iconNameByTool[tool],
+  };
+
+  if (tool === "claude") {
+    return (
+      <svg {...commonProps}>
+        <path d="M12 3.5v17" />
+        <path d="M5.1 7.5l13.8 9" />
+        <path d="M18.9 7.5l-13.8 9" />
+        <circle cx="12" cy="12" r="2.2" fill="currentColor" stroke="none" />
+      </svg>
+    );
+  }
+
+  if (tool === "gemini") {
+    return (
+      <svg {...commonProps}>
+        <path d="M12 3l1.6 5.4L19 10l-5.4 1.6L12 17l-1.6-5.4L5 10l5.4-1.6L12 3Z" fill="currentColor" stroke="none" />
+        <path d="M18 15l.7 2.3L21 18l-2.3.7L18 21l-.7-2.3L15 18l2.3-.7L18 15Z" fill="currentColor" stroke="none" />
+      </svg>
+    );
+  }
+
+  if (tool === "codex") {
+    return (
+      <svg {...commonProps}>
+        <path d="M7.5 5 4 8.5 7.5 12" />
+        <path d="M16.5 5 20 8.5 16.5 12" />
+        <path d="M9 19h6" />
+        <path d="M12 12v7" />
+        <circle cx="12" cy="8.5" r="1.8" fill="currentColor" stroke="none" />
+      </svg>
+    );
+  }
+
   return (
-    <HugeiconsIcon
-      icon={WebhookIcon}
-      size={17}
-      strokeWidth={1.8}
-      aria-hidden="true"
-      data-testid="hook-status-tool-icon"
-    />
+    <svg {...commonProps}>
+      <rect x="4" y="5" width="16" height="14" rx="3" />
+      <path d="m8 10 2.2 2L8 14" />
+      <path d="M13 14h3" />
+    </svg>
   );
 }

--- a/src/components/HooksStatusCard.tsx
+++ b/src/components/HooksStatusCard.tsx
@@ -308,21 +308,17 @@ function StatusIcon({ status }: { status: "ok" | "partial" | "error" }) {
 
 function HookToolIcon({ tool }: { tool: HookToolKey }) {
   const iconNameByTool: Record<HookToolKey, string> = {
-    claude: "ClaudeIcon",
-    gemini: "GeminiIcon",
-    codex: "CodexIcon",
-    openCode: "OpenCodeIcon",
+    claude: "ClaudeLogoIcon",
+    gemini: "GeminiLogoIcon",
+    codex: "CodexLogoIcon",
+    openCode: "OpenCodeLogoIcon",
   };
 
   const commonProps = {
-    width: 17,
-    height: 17,
+    width: 18,
+    height: 18,
     viewBox: "0 0 24 24",
     fill: "none",
-    stroke: "currentColor",
-    strokeWidth: 1.9,
-    strokeLinecap: "round" as const,
-    strokeLinejoin: "round" as const,
     "aria-hidden": true,
     "data-testid": "hook-status-tool-icon",
     "data-icon-name": iconNameByTool[tool],
@@ -331,10 +327,14 @@ function HookToolIcon({ tool }: { tool: HookToolKey }) {
   if (tool === "claude") {
     return (
       <svg {...commonProps}>
-        <path d="M12 3.5v17" />
-        <path d="M5.1 7.5l13.8 9" />
-        <path d="M18.9 7.5l-13.8 9" />
-        <circle cx="12" cy="12" r="2.2" fill="currentColor" stroke="none" />
+        <path d="M12 2.6c1.15 2.9.92 5.15 0 6.72-.92-1.57-1.15-3.82 0-6.72Z" fill="#111111" />
+        <path d="M12 21.4c-1.15-2.9-.92-5.15 0-6.72.92 1.57 1.15 3.82 0 6.72Z" fill="#111111" />
+        <path d="M2.6 12c2.9-1.15 5.15-.92 6.72 0-1.57.92-3.82 1.15-6.72 0Z" fill="#111111" />
+        <path d="M21.4 12c-2.9 1.15-5.15.92-6.72 0 1.57-.92 3.82-1.15 6.72 0Z" fill="#111111" />
+        <path d="M5.35 5.35c2.86 1.24 4.3 2.99 4.76 4.75-1.76-.45-3.51-1.9-4.76-4.75Z" fill="#111111" />
+        <path d="M18.65 18.65c-2.86-1.24-4.3-2.99-4.76-4.75 1.76.45 3.51 1.9 4.76 4.75Z" fill="#111111" />
+        <path d="M18.65 5.35c-1.24 2.86-2.99 4.3-4.75 4.76.45-1.76 1.9-3.51 4.75-4.76Z" fill="#111111" />
+        <path d="M5.35 18.65c1.24-2.86 2.99-4.3 4.75-4.76-.45 1.76-1.9 3.51-4.75 4.76Z" fill="#111111" />
       </svg>
     );
   }
@@ -342,8 +342,8 @@ function HookToolIcon({ tool }: { tool: HookToolKey }) {
   if (tool === "gemini") {
     return (
       <svg {...commonProps}>
-        <path d="M12 3l1.6 5.4L19 10l-5.4 1.6L12 17l-1.6-5.4L5 10l5.4-1.6L12 3Z" fill="currentColor" stroke="none" />
-        <path d="M18 15l.7 2.3L21 18l-2.3.7L18 21l-.7-2.3L15 18l2.3-.7L18 15Z" fill="currentColor" stroke="none" />
+        <path d="M12 2.7 14.58 9.42 21.3 12l-6.72 2.58L12 21.3l-2.58-6.72L2.7 12l6.72-2.58L12 2.7Z" fill="#1A73E8" />
+        <path d="M17.7 3.8 18.55 6 20.8 6.85 18.55 7.7 17.7 9.95 16.85 7.7 14.6 6.85 16.85 6 17.7 3.8Z" fill="#7FC7FF" />
       </svg>
     );
   }
@@ -351,20 +351,22 @@ function HookToolIcon({ tool }: { tool: HookToolKey }) {
   if (tool === "codex") {
     return (
       <svg {...commonProps}>
-        <path d="M7.5 5 4 8.5 7.5 12" />
-        <path d="M16.5 5 20 8.5 16.5 12" />
-        <path d="M9 19h6" />
-        <path d="M12 12v7" />
-        <circle cx="12" cy="8.5" r="1.8" fill="currentColor" stroke="none" />
+        <rect x="3.2" y="4.2" width="17.6" height="15.6" rx="4" fill="#0B5FFF" />
+        <path d="M8.8 9.1 5.9 12l2.9 2.9" stroke="#FFFFFF" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M15.2 9.1 18.1 12l-2.9 2.9" stroke="#FFFFFF" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="m13.2 8.2-2.4 7.6" stroke="#A9D8FF" strokeWidth="1.7" strokeLinecap="round" />
       </svg>
     );
   }
 
   return (
     <svg {...commonProps}>
-      <rect x="4" y="5" width="16" height="14" rx="3" />
-      <path d="m8 10 2.2 2L8 14" />
-      <path d="M13 14h3" />
+      <rect x="3" y="4.5" width="18" height="15" rx="3.5" fill="#0A84FF" />
+      <path d="M3 8h18" stroke="#CFEAFF" strokeWidth="1.5" />
+      <circle cx="6.5" cy="6.4" r="0.7" fill="#FFFFFF" />
+      <circle cx="8.7" cy="6.4" r="0.7" fill="#FFFFFF" />
+      <path d="m8 11 2.2 2L8 15" stroke="#FFFFFF" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M13 15h3.5" stroke="#FFFFFF" strokeWidth="1.8" strokeLinecap="round" />
     </svg>
   );
 }

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -43,22 +43,21 @@ const KANBAN_STATUS_ORDER = [
 
 const TASK_CARD_SELECTOR = "[data-kanban-task-card='true']";
 
-function BaseBranchIcon() {
+function CrownIcon() {
   return (
     <svg
       width="12"
       height="12"
       viewBox="0 0 16 16"
       fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
-      strokeLinejoin="round"
       aria-hidden="true"
+      data-icon-name="CrownIcon"
     >
-      <circle cx="5" cy="3.5" r="1.7" fill="currentColor" stroke="none" />
-      <circle cx="11" cy="12.5" r="1.7" fill="currentColor" stroke="none" />
-      <path d="M5 5.5v2.2c0 2.5 1.8 4.3 4.1 4.3H9" />
+      <path
+        d="M2.2 5.1 5.3 8l2.7-4.1L10.7 8l3.1-2.9-1.2 6.6H3.4L2.2 5.1Z"
+        fill="currentColor"
+      />
+      <path d="M3.7 13h8.6" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
     </svg>
   );
 }
@@ -193,7 +192,7 @@ export default function TaskCard({ task, index, onContextMenu, projectName, proj
               aria-hidden="true"
               data-testid="base-branch-icon"
             >
-              <BaseBranchIcon />
+              <CrownIcon />
             </span>
           )}
 

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -43,6 +43,48 @@ const KANBAN_STATUS_ORDER = [
 
 const TASK_CARD_SELECTOR = "[data-kanban-task-card='true']";
 
+function BaseBranchIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="5" cy="3.5" r="1.7" fill="currentColor" stroke="none" />
+      <circle cx="11" cy="12.5" r="1.7" fill="currentColor" stroke="none" />
+      <path d="M5 5.5v2.2c0 2.5 1.8 4.3 4.1 4.3H9" />
+    </svg>
+  );
+}
+
+function PullRequestIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="6" cy="18" r="3" />
+      <circle cx="18" cy="6" r="3" />
+      <path d="M6 15V6" />
+      <path d="M18 9v1.5A5.5 5.5 0 0 1 12.5 16H9" />
+      <path d="m12 13-3 3 3 3" />
+    </svg>
+  );
+}
+
 function getTaskCards() {
   return Array.from(document.querySelectorAll<HTMLAnchorElement>(TASK_CARD_SELECTOR));
 }
@@ -137,17 +179,22 @@ export default function TaskCard({ task, index, onContextMenu, projectName, proj
             ...provided.draggableProps.style,
             ...cardStyle,
           }}
-          className={`group relative mb-1.5 block overflow-hidden rounded-md border border-border-subtle px-2.5 py-2 transition-colors cursor-pointer outline-none focus:border-brand-primary focus:bg-bg-surface/80 focus:ring-2 focus:ring-brand-primary/30 ${
+          className={`group relative mb-1.5 block overflow-hidden rounded-md border border-border-subtle px-2.5 py-2 transition-colors cursor-pointer outline-none focus:border-brand-primary focus:bg-bg-surface/80 focus:ring-2 focus:ring-brand-primary/30 ${isBaseProject ? "pr-8" : ""} ${
             snapshot.isDragging
               ? "bg-bg-surface shadow-md ring-1 ring-border-brand"
               : "hover:bg-bg-surface/70"
           }`}
         >
-          {/* Base 프로젝트 리본 배지 */}
+          {/* Base branch 표시 */}
           {isBaseProject && (
-            <div className="absolute -right-7 top-2.5 rotate-45 bg-tag-base-bg text-tag-base-text text-[10px] font-bold px-7 py-0.5 pointer-events-none select-none">
-              Base
-            </div>
+            <span
+              className="pointer-events-none absolute right-2 top-2 inline-flex h-5 w-5 items-center justify-center rounded-full border border-border-subtle bg-tag-base-bg text-tag-base-text shadow-sm"
+              title="Base branch"
+              aria-hidden="true"
+              data-testid="base-branch-icon"
+            >
+              <BaseBranchIcon />
+            </span>
           )}
 
           {projectName && (
@@ -191,9 +238,7 @@ export default function TaskCard({ task, index, onContextMenu, projectName, proj
                 }}
                 className={`${badgeClassName} gap-1 bg-tag-pr-bg text-tag-pr-text transition-opacity hover:opacity-80`}
               >
-                <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
-                </svg>
+                <PullRequestIcon />
                 PR
               </span>
             )}

--- a/src/components/__tests__/HooksStatusCard.test.tsx
+++ b/src/components/__tests__/HooksStatusCard.test.tsx
@@ -47,7 +47,6 @@ vi.mock("@hugeicons/core-free-icons", () => ({
   AlertCircleIcon: { __iconName: "AlertCircleIcon" },
   CheckmarkCircle02Icon: { __iconName: "CheckmarkCircle02Icon" },
   Clock01Icon: { __iconName: "Clock01Icon" },
-  WebhookIcon: { __iconName: "WebhookIcon" },
 }));
 
 const messages = {
@@ -106,7 +105,7 @@ describe("HooksStatusCard", () => {
     expect(screen.queryByTestId("hooks-status-dialog")).toBeNull();
   });
 
-  it("uses dedicated webhook resource icons for hook status rows", () => {
+  it("uses dedicated tool icons for hook status rows", () => {
     renderCard({
       taskId: "task-1",
       initialClaudeStatus: null,
@@ -119,7 +118,12 @@ describe("HooksStatusCard", () => {
     const toolIcons = screen.getAllByTestId("hook-status-tool-icon");
 
     expect(toolIcons).toHaveLength(4);
-    expect(toolIcons.every((icon) => icon.getAttribute("data-icon-name") === "WebhookIcon")).toBe(true);
+    expect(toolIcons.map((icon) => icon.getAttribute("data-icon-name"))).toEqual([
+      "ClaudeIcon",
+      "GeminiIcon",
+      "CodexIcon",
+      "OpenCodeIcon",
+    ]);
     expect(screen.getByTestId("hooks-overall-status-icon").getAttribute("data-icon-name")).toBe("AlertCircleIcon");
   });
 

--- a/src/components/__tests__/HooksStatusCard.test.tsx
+++ b/src/components/__tests__/HooksStatusCard.test.tsx
@@ -119,10 +119,10 @@ describe("HooksStatusCard", () => {
 
     expect(toolIcons).toHaveLength(4);
     expect(toolIcons.map((icon) => icon.getAttribute("data-icon-name"))).toEqual([
-      "ClaudeIcon",
-      "GeminiIcon",
-      "CodexIcon",
-      "OpenCodeIcon",
+      "ClaudeLogoIcon",
+      "GeminiLogoIcon",
+      "CodexLogoIcon",
+      "OpenCodeLogoIcon",
     ]);
     expect(screen.getByTestId("hooks-overall-status-icon").getAttribute("data-icon-name")).toBe("AlertCircleIcon");
   });

--- a/src/components/__tests__/TaskCard.test.tsx
+++ b/src/components/__tests__/TaskCard.test.tsx
@@ -154,6 +154,19 @@ describe("TaskCard - Priority Badge", () => {
     expect(remoteBadge.className).not.toContain("ring-1");
   });
 
+  it("should render base branch as a compact icon instead of a ribbon label", () => {
+    const task = createTask();
+
+    render(<TaskCard task={task} index={0} onContextMenu={onContextMenu} isBaseProject />);
+
+    const baseIcon = screen.getByTestId("base-branch-icon");
+
+    expect(baseIcon).toBeTruthy();
+    expect(baseIcon.className).toContain("bg-tag-base-bg");
+    expect(baseIcon.className).toContain("text-tag-base-text");
+    expect(screen.queryByText("Base")).toBeNull();
+  });
+
   it("should render project label above the task title with project color", () => {
     const task = createTask();
 

--- a/src/components/__tests__/TaskCard.test.tsx
+++ b/src/components/__tests__/TaskCard.test.tsx
@@ -164,6 +164,7 @@ describe("TaskCard - Priority Badge", () => {
     expect(baseIcon).toBeTruthy();
     expect(baseIcon.className).toContain("bg-tag-base-bg");
     expect(baseIcon.className).toContain("text-tag-base-text");
+    expect(baseIcon.querySelector("svg")?.getAttribute("data-icon-name")).toBe("CrownIcon");
     expect(screen.queryByText("Base")).toBeNull();
   });
 

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import {
   Chatting01Icon,
-  Clock01Icon,
   InformationCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { useTranslations } from "next-intl";
@@ -82,6 +81,32 @@ function PullRequestIcon() {
       <path d="M6 15V6" />
       <path d="M18 9v1.5A5.5 5.5 0 0 1 12.5 16H9" />
       <path d="m12 13-3 3 3 3" />
+    </svg>
+  );
+}
+
+function AntennaSignalIcon({ testId }: { testId?: string }) {
+  return (
+    <svg
+      width="17"
+      height="17"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      data-testid={testId}
+      data-icon-name="AntennaSignalIcon"
+    >
+      <path d="M12 19v-7" />
+      <path d="m9 22 3-3 3 3" />
+      <circle cx="12" cy="10" r="1.6" fill="currentColor" stroke="none" />
+      <path d="M8.7 13.1a5 5 0 0 1 0-6.2" />
+      <path d="M15.3 6.9a5 5 0 0 1 0 6.2" />
+      <path d="M5.8 15.8a9 9 0 0 1 0-11.6" />
+      <path d="M18.2 4.2a9 9 0 0 1 0 11.6" />
     </svg>
   );
 }
@@ -605,8 +630,8 @@ export default function TaskDetailRoute() {
 
         {([
           { panel: "overview", label: t("info"), icon: InformationCircleIcon },
-          { panel: "status", label: statusPanelLabel, icon: Clock01Icon, iconTestId: "task-status-panel-icon" },
-        ] satisfies Array<{ panel: DetailPanel; label: string; icon: IconSvgElement; iconTestId?: string }>).map(({ panel, label, icon, iconTestId }) => (
+          { panel: "status", label: statusPanelLabel, iconTestId: "task-status-panel-icon" },
+        ] satisfies Array<{ panel: DetailPanel; label: string; icon?: IconSvgElement; iconTestId?: string }>).map(({ panel, label, icon, iconTestId }) => (
           <button
             key={panel}
             type="button"
@@ -619,13 +644,17 @@ export default function TaskDetailRoute() {
             title={label}
             aria-label={label}
           >
-            <HugeiconsIcon
-              icon={icon}
-              size={17}
-              strokeWidth={1.6}
-              aria-hidden="true"
-              data-testid={iconTestId}
-            />
+            {icon ? (
+              <HugeiconsIcon
+                icon={icon}
+                size={17}
+                strokeWidth={1.6}
+                aria-hidden="true"
+                data-testid={iconTestId}
+              />
+            ) : (
+              <AntennaSignalIcon testId={iconTestId} />
+            )}
           </button>
         ))}
 

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import {
   Chatting01Icon,
+  Clock01Icon,
   InformationCircleIcon,
-  Task02Icon,
 } from "@hugeicons/core-free-icons";
 import { useTranslations } from "next-intl";
 import { useParams } from "react-router-dom";
@@ -62,6 +62,29 @@ const AGENT_TAG_STYLES: Record<string, string> = {
 
 type DetailPanel = "overview" | "status";
 type MainView = "terminal" | "chat";
+
+function PullRequestIcon() {
+  return (
+    <svg
+      width="17"
+      height="17"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      data-testid="task-detail-pr-icon"
+    >
+      <circle cx="6" cy="18" r="3" />
+      <circle cx="18" cy="6" r="3" />
+      <path d="M6 15V6" />
+      <path d="M18 9v1.5A5.5 5.5 0 0 1 12.5 16H9" />
+      <path d="m12 13-3 3 3 3" />
+    </svg>
+  );
+}
 
 interface TaskDetailState {
   task: NonNullable<Awaited<ReturnType<typeof getTaskById>>>;
@@ -582,7 +605,7 @@ export default function TaskDetailRoute() {
 
         {([
           { panel: "overview", label: t("info"), icon: InformationCircleIcon },
-          { panel: "status", label: statusPanelLabel, icon: Task02Icon, iconTestId: "task-status-panel-icon" },
+          { panel: "status", label: statusPanelLabel, icon: Clock01Icon, iconTestId: "task-status-panel-icon" },
         ] satisfies Array<{ panel: DetailPanel; label: string; icon: IconSvgElement; iconTestId?: string }>).map(({ panel, label, icon, iconTestId }) => (
           <button
             key={panel}
@@ -630,11 +653,11 @@ export default function TaskDetailRoute() {
             href={state.task.prUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="mb-1 flex h-8 w-8 items-center justify-center rounded-md border border-tag-pr-text/30 bg-tag-pr-bg text-[10px] font-semibold text-tag-pr-text transition-opacity hover:opacity-80"
+            className="mb-1 flex h-8 w-8 items-center justify-center rounded-md border border-tag-pr-text/30 bg-tag-pr-bg text-tag-pr-text transition-opacity hover:opacity-80"
             title="PR"
             aria-label="PR"
           >
-            PR
+            <PullRequestIcon />
           </a>
         ) : null}
 

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -69,8 +69,8 @@ vi.mock("@hugeicons/react", () => ({
 
 vi.mock("@hugeicons/core-free-icons", () => ({
   Chatting01Icon: { __iconName: "Chatting01Icon" },
+  Clock01Icon: { __iconName: "Clock01Icon" },
   InformationCircleIcon: { __iconName: "InformationCircleIcon" },
-  Task02Icon: { __iconName: "Task02Icon" },
 }));
 
 vi.mock("react-router-dom", () => ({
@@ -456,6 +456,7 @@ describe("TaskDetailRoute", () => {
     const prLink = await screen.findByRole("link", { name: "PR" });
     expect(prLink.getAttribute("href")).toBe(prUrl);
     expect(prLink.getAttribute("target")).toBe("_blank");
+    expect(screen.getByTestId("task-detail-pr-icon")).toBeTruthy();
   });
 
   it("채팅 아이콘을 클릭하면 drawer 대신 메인 영역을 AI 채팅 내역으로 전환한다", async () => {
@@ -593,7 +594,7 @@ describe("TaskDetailRoute", () => {
 
     const statusButton = await screen.findByRole("button", { name: "actions · hooksStatus" });
     expect(screen.queryByTestId("hooks-status-card")).toBeNull();
-    expect(screen.getByTestId("task-status-panel-icon").getAttribute("data-icon-name")).toBe("Task02Icon");
+    expect(screen.getByTestId("task-status-panel-icon").getAttribute("data-icon-name")).toBe("Clock01Icon");
 
     fireEvent.click(statusButton);
 

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -69,7 +69,6 @@ vi.mock("@hugeicons/react", () => ({
 
 vi.mock("@hugeicons/core-free-icons", () => ({
   Chatting01Icon: { __iconName: "Chatting01Icon" },
-  Clock01Icon: { __iconName: "Clock01Icon" },
   InformationCircleIcon: { __iconName: "InformationCircleIcon" },
 }));
 
@@ -594,7 +593,7 @@ describe("TaskDetailRoute", () => {
 
     const statusButton = await screen.findByRole("button", { name: "actions · hooksStatus" });
     expect(screen.queryByTestId("hooks-status-card")).toBeNull();
-    expect(screen.getByTestId("task-status-panel-icon").getAttribute("data-icon-name")).toBe("Clock01Icon");
+    expect(screen.getByTestId("task-status-panel-icon").getAttribute("data-icon-name")).toBe("AntennaSignalIcon");
 
     fireEvent.click(statusButton);
 


### PR DESCRIPTION
## What is this?
- Simplify task iconography so base branches, PR links, task status navigation, and hook tools are easier to distinguish at a glance.

## How is it solved?
**Task cards and detail rail**
- Replace the diagonal base branch ribbon with a compact crown icon badge.
- Replace PR text/icon treatments with pull request shaped SVG icons in task cards and the detail rail.
- Switch the task detail status/hooks panel icon to an antenna-style signal glyph.

**Hook status tools**
- Render distinct logo-style icons for Claude, Gemini, Codex, and OpenCode hook rows.
- Update focused component tests to assert the new icon expectations.

## Important changes
### Task icon updates

**Compact base branch marker**
- **Reason**: The previous ribbon was visually heavier than the surrounding card metadata, and the crown glyph communicates the leading/base branch more directly.
- **Modified files**: `src/components/TaskCard.tsx`, `src/components/__tests__/TaskCard.test.tsx`

**Pull request icon treatment**
- **Reason**: PR links should read as pull request actions without relying on plain text alone.
- **Modified files**: `src/components/TaskCard.tsx`, `src/desktop/renderer/routes/TaskDetailRoute.tsx`, `src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx`

**Antenna-style status/hooks panel icon**
- **Reason**: The status/hooks rail button should read more like hook activity or signal monitoring than a generic progress clock.
- **Modified files**: `src/desktop/renderer/routes/TaskDetailRoute.tsx`, `src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx`

### Hook status icon updates

**Tool-specific logo-style hook icons**
- **Reason**: The shared webhook icon made Claude, Gemini, Codex, and OpenCode rows harder to scan.
- **Modified files**: `src/components/HooksStatusCard.tsx`, `src/components/__tests__/HooksStatusCard.test.tsx`

Co-Authored-By: OpenAI Codex <codex@openai.com>
