### PR TITLE
Improve desktop startup loading fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,442 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title></title>
+    <style>
+      html,
+      body,
+      #root {
+        min-height: 100%;
+        margin: 0;
+        background: #090a0d;
+        color: #717680;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      .kanvibe-initial-board {
+        min-height: 100vh;
+        background: #090a0d;
+      }
+
+      .kanvibe-initial-header {
+        height: 56px;
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 12px;
+        padding: 0 24px;
+        border-bottom: 1px solid #24262d;
+        background: #111216;
+        box-sizing: border-box;
+      }
+
+      .kanvibe-skeleton-filter,
+      .kanvibe-skeleton-button,
+      .kanvibe-skeleton-icon {
+        border-radius: 6px;
+        background: #1a1c22;
+        border: 1px solid #24262d;
+      }
+
+      .kanvibe-skeleton-filter {
+        width: 256px;
+        height: 32px;
+      }
+
+      .kanvibe-skeleton-button {
+        width: 80px;
+        height: 32px;
+        background: rgba(0, 100, 255, 0.26);
+      }
+
+      .kanvibe-skeleton-icon {
+        width: 32px;
+        height: 32px;
+      }
+
+      .kanvibe-initial-main {
+        padding: 24px;
+        overflow-x: auto;
+      }
+
+      .kanvibe-skeleton-columns {
+        display: flex;
+        gap: 12px;
+        min-width: 1420px;
+        animation: kanvibe-skeleton-pulse 1.5s ease-in-out infinite;
+      }
+
+      .kanvibe-skeleton-column {
+        width: 284px;
+        min-height: calc(100vh - 132px);
+        border: 1px solid #24262d;
+        border-radius: 8px;
+        overflow: hidden;
+        box-sizing: border-box;
+      }
+
+      .kanvibe-skeleton-column-header {
+        height: 40px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 0 12px;
+        border-bottom: 1px solid #1a1c22;
+        box-sizing: border-box;
+      }
+
+      .kanvibe-skeleton-status {
+        width: 8px;
+        height: 8px;
+        border-radius: 999px;
+        background: #747985;
+      }
+
+      .kanvibe-skeleton-column:nth-child(2) .kanvibe-skeleton-status {
+        background: #f6c35f;
+      }
+
+      .kanvibe-skeleton-column:nth-child(3) .kanvibe-skeleton-status {
+        background: #9b8cff;
+      }
+
+      .kanvibe-skeleton-column:nth-child(4) .kanvibe-skeleton-status {
+        background: #0064ff;
+      }
+
+      .kanvibe-skeleton-column:nth-child(5) .kanvibe-skeleton-status {
+        background: #65d08a;
+      }
+
+      .kanvibe-skeleton-column-title,
+      .kanvibe-skeleton-column-count,
+      .kanvibe-skeleton-project,
+      .kanvibe-skeleton-title,
+      .kanvibe-skeleton-description,
+      .kanvibe-skeleton-badge {
+        border-radius: 999px;
+        background: #24262d;
+      }
+
+      .kanvibe-skeleton-column-title {
+        width: 80px;
+        height: 12px;
+      }
+
+      .kanvibe-skeleton-column-count {
+        width: 20px;
+        height: 12px;
+        margin-left: auto;
+      }
+
+      .kanvibe-skeleton-task-list {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding: 8px;
+      }
+
+      .kanvibe-skeleton-task {
+        min-height: 86px;
+        padding: 10px;
+        border: 1px solid #1a1c22;
+        border-radius: 6px;
+        box-sizing: border-box;
+      }
+
+      .kanvibe-skeleton-project-row {
+        display: grid;
+        grid-template-columns: 6px minmax(0, 1fr);
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 9px;
+      }
+
+      .kanvibe-skeleton-project-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 999px;
+        background: #353842;
+      }
+
+      .kanvibe-skeleton-project {
+        width: 96px;
+        height: 10px;
+      }
+
+      .kanvibe-skeleton-title {
+        width: 82%;
+        height: 14px;
+      }
+
+      .kanvibe-skeleton-task:nth-child(2) .kanvibe-skeleton-title {
+        width: 68%;
+      }
+
+      .kanvibe-skeleton-task:nth-child(3) .kanvibe-skeleton-title {
+        width: 76%;
+      }
+
+      .kanvibe-skeleton-description {
+        width: 58%;
+        height: 10px;
+        margin-top: 9px;
+        background: #1a1c22;
+      }
+
+      .kanvibe-skeleton-badges {
+        display: flex;
+        gap: 6px;
+        margin-top: 12px;
+      }
+
+      .kanvibe-skeleton-badge {
+        width: 36px;
+        height: 16px;
+        border: 1px solid #24262d;
+        background: #111216;
+        box-sizing: border-box;
+      }
+
+      .kanvibe-skeleton-badge:nth-child(2) {
+        width: 28px;
+      }
+
+      @keyframes kanvibe-skeleton-pulse {
+        0%,
+        100% {
+          opacity: 0.62;
+        }
+
+        50% {
+          opacity: 0.9;
+        }
+      }
+
+      @media (max-width: 720px) {
+        .kanvibe-initial-header {
+          padding: 0 16px;
+        }
+
+        .kanvibe-skeleton-filter {
+          width: 44vw;
+        }
+
+        .kanvibe-skeleton-columns {
+          min-width: 1180px;
+        }
+
+        .kanvibe-skeleton-column {
+          width: 236px;
+        }
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div class="kanvibe-initial-board" aria-hidden="true">
+        <header class="kanvibe-initial-header">
+          <div class="kanvibe-skeleton-filter"></div>
+          <div class="kanvibe-skeleton-button"></div>
+          <div class="kanvibe-skeleton-icon"></div>
+          <div class="kanvibe-skeleton-icon"></div>
+        </header>
+        <main class="kanvibe-initial-main">
+          <div class="kanvibe-skeleton-columns">
+            <section class="kanvibe-skeleton-column">
+              <div class="kanvibe-skeleton-column-header">
+                <span class="kanvibe-skeleton-status"></span>
+                <span class="kanvibe-skeleton-column-title"></span>
+                <span class="kanvibe-skeleton-column-count"></span>
+              </div>
+              <div class="kanvibe-skeleton-task-list">
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section class="kanvibe-skeleton-column">
+              <div class="kanvibe-skeleton-column-header">
+                <span class="kanvibe-skeleton-status"></span>
+                <span class="kanvibe-skeleton-column-title"></span>
+                <span class="kanvibe-skeleton-column-count"></span>
+              </div>
+              <div class="kanvibe-skeleton-task-list">
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section class="kanvibe-skeleton-column">
+              <div class="kanvibe-skeleton-column-header">
+                <span class="kanvibe-skeleton-status"></span>
+                <span class="kanvibe-skeleton-column-title"></span>
+                <span class="kanvibe-skeleton-column-count"></span>
+              </div>
+              <div class="kanvibe-skeleton-task-list">
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section class="kanvibe-skeleton-column">
+              <div class="kanvibe-skeleton-column-header">
+                <span class="kanvibe-skeleton-status"></span>
+                <span class="kanvibe-skeleton-column-title"></span>
+                <span class="kanvibe-skeleton-column-count"></span>
+              </div>
+              <div class="kanvibe-skeleton-task-list">
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section class="kanvibe-skeleton-column">
+              <div class="kanvibe-skeleton-column-header">
+                <span class="kanvibe-skeleton-status"></span>
+                <span class="kanvibe-skeleton-column-title"></span>
+                <span class="kanvibe-skeleton-column-count"></span>
+              </div>
+              <div class="kanvibe-skeleton-task-list">
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+                <div class="kanvibe-skeleton-task">
+                  <div class="kanvibe-skeleton-project-row">
+                    <span class="kanvibe-skeleton-project-dot"></span>
+                    <span class="kanvibe-skeleton-project"></span>
+                  </div>
+                  <div class="kanvibe-skeleton-title"></div>
+                  <div class="kanvibe-skeleton-description"></div>
+                  <div class="kanvibe-skeleton-badges">
+                    <span class="kanvibe-skeleton-badge"></span>
+                    <span class="kanvibe-skeleton-badge"></span>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </main>
+      </div>
+    </div>
     <script type="module" src="/src/desktop/renderer/main.tsx"></script>
   </body>
   </html>

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, type ReactNode } from "react";
 import { IntlProvider } from "next-intl";
 import { HashRouter, Navigate, Outlet, Route, Routes, useParams } from "react-router-dom";
 import { BoardCommandProvider } from "@/desktop/renderer/components/BoardCommandProvider";
@@ -9,16 +9,29 @@ import TaskQuickSearchDialog from "@/desktop/renderer/components/TaskQuickSearch
 import { DEFAULT_LOCALE, getSafeLocale, isSupportedLocale, messagesByLocale } from "@/desktop/renderer/utils/locales";
 import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
 import BoardRoute from "@/desktop/renderer/routes/BoardRoute";
-import DiffRoute from "@/desktop/renderer/routes/DiffRoute";
-import NotFoundRoute from "@/desktop/renderer/routes/NotFoundRoute";
-import PaneLayoutRoute from "@/desktop/renderer/routes/PaneLayoutRoute";
-import SettingsRoute from "@/desktop/renderer/routes/SettingsRoute";
-import TaskDetailRoute from "@/desktop/renderer/routes/TaskDetailRoute";
 import { getThemePreference, type ThemePreference } from "@/desktop/renderer/actions/appSettings";
 import { applyThemePreference, THEME_PREFERENCE_CHANGED_EVENT } from "@/desktop/renderer/utils/theme";
 import type { BoardEventPayload } from "@/lib/boardNotifier";
 
 const BOARD_REFRESH_DEBOUNCE_MS = 250;
+
+const DiffRoute = lazy(() => import("@/desktop/renderer/routes/DiffRoute"));
+const NotFoundRoute = lazy(() => import("@/desktop/renderer/routes/NotFoundRoute"));
+const PaneLayoutRoute = lazy(() => import("@/desktop/renderer/routes/PaneLayoutRoute"));
+const SettingsRoute = lazy(() => import("@/desktop/renderer/routes/SettingsRoute"));
+const TaskDetailRoute = lazy(() => import("@/desktop/renderer/routes/TaskDetailRoute"));
+
+function RouteLoadingFallback() {
+  return <div className="min-h-screen flex items-center justify-center bg-bg-page text-text-muted">Loading...</div>;
+}
+
+function DeferredRoute({ children }: { children: ReactNode }) {
+  return (
+    <Suspense fallback={<RouteLoadingFallback />}>
+      {children}
+    </Suspense>
+  );
+}
 
 function ThemeController() {
   useEffect(() => {
@@ -118,11 +131,11 @@ export default function App() {
         <Route path="/" element={<Navigate to={`/${DEFAULT_LOCALE}`} replace />} />
         <Route path="/:locale" element={<LocaleShell />}>
           <Route index element={<BoardRoute />} />
-          <Route path="pane-layout" element={<PaneLayoutRoute />} />
-          <Route path="settings" element={<SettingsRoute />} />
-          <Route path="task/:id" element={<TaskDetailRoute />} />
-          <Route path="task/:id/diff" element={<DiffRoute />} />
-          <Route path="*" element={<NotFoundRoute />} />
+          <Route path="pane-layout" element={<DeferredRoute><PaneLayoutRoute /></DeferredRoute>} />
+          <Route path="settings" element={<DeferredRoute><SettingsRoute /></DeferredRoute>} />
+          <Route path="task/:id" element={<DeferredRoute><TaskDetailRoute /></DeferredRoute>} />
+          <Route path="task/:id/diff" element={<DeferredRoute><DiffRoute /></DeferredRoute>} />
+          <Route path="*" element={<DeferredRoute><NotFoundRoute /></DeferredRoute>} />
         </Route>
       </Routes>
     </HashRouter>

--- a/src/desktop/renderer/routes/BoardRoute.tsx
+++ b/src/desktop/renderer/routes/BoardRoute.tsx
@@ -21,6 +21,18 @@ interface BoardData {
 }
 
 const BOARD_ROUTE_CACHE_KEY = buildRouteCacheKey("board");
+const BOARD_SKELETON_COLUMN_COUNT = 5;
+const BOARD_SKELETON_TASK_COUNTS = [3, 2, 3, 2, 2];
+const BOARD_SKELETON_BADGE_WIDTHS = ["w-9", "w-7", "w-9"];
+const BOARD_SKELETON_TITLE_WIDTHS = ["w-11/12", "w-4/5", "w-3/4"];
+const BOARD_SKELETON_DESCRIPTION_WIDTHS = ["w-2/3", "w-1/2", "w-3/5"];
+const BOARD_SKELETON_STATUS_DOT_CLASSES = [
+  "bg-status-todo",
+  "bg-status-progress",
+  "bg-status-pending",
+  "bg-status-review",
+  "bg-status-done",
+];
 
 function createEmptyBoardData(): BoardData {
   return {
@@ -43,6 +55,65 @@ function createEmptyBoardData(): BoardData {
     defaultSessionType: SessionType.TMUX,
     taskSearchShortcut: DEFAULT_TASK_SEARCH_SHORTCUT,
   };
+}
+
+function BoardTaskCardSkeleton({ index }: { index: number }) {
+  return (
+    <div className="rounded-md border border-border-subtle px-2.5 py-2">
+      <div className="mb-2 grid grid-cols-[6px_minmax(0,1fr)] items-center gap-2">
+        <div className="h-1.5 w-1.5 rounded-full bg-border-strong" />
+        <div className="h-3 w-24 rounded bg-border-subtle" />
+      </div>
+      <div className={`h-3.5 rounded bg-border-default ${BOARD_SKELETON_TITLE_WIDTHS[index % BOARD_SKELETON_TITLE_WIDTHS.length]}`} />
+      <div className={`mt-2 h-2.5 rounded bg-border-subtle ${BOARD_SKELETON_DESCRIPTION_WIDTHS[index % BOARD_SKELETON_DESCRIPTION_WIDTHS.length]}`} />
+      <div className="mt-3 flex gap-1.5">
+        {BOARD_SKELETON_BADGE_WIDTHS.map((badgeWidth, badgeIndex) => (
+          <div key={badgeIndex} className={`h-4 rounded border border-border-subtle bg-bg-page ${badgeWidth}`} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BoardColumnSkeleton({ columnIndex }: { columnIndex: number }) {
+  const taskCount = BOARD_SKELETON_TASK_COUNTS[columnIndex] ?? BOARD_SKELETON_TASK_COUNTS[0];
+
+  return (
+    <div className="min-w-[284px] max-w-[340px] flex-1 overflow-hidden rounded-lg border border-border-default">
+      <div className="flex h-10 items-center gap-2 border-b border-border-subtle px-3">
+        <div className={`h-2 w-2 rounded-full ${BOARD_SKELETON_STATUS_DOT_CLASSES[columnIndex] ?? "bg-border-strong"}`} />
+        <div className="h-3 w-20 rounded bg-border-subtle" />
+        <div className="ml-auto h-3 w-5 rounded bg-border-subtle" />
+      </div>
+      <div className="min-h-[calc(100vh-132px)] space-y-1.5 p-2">
+        {Array.from({ length: taskCount }, (_, taskIndex) => (
+          <BoardTaskCardSkeleton key={taskIndex} index={taskIndex + columnIndex} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BoardRouteSkeleton() {
+  return (
+    <div className="min-h-screen bg-bg-page" data-testid="board-route-skeleton" aria-hidden="true">
+      <header className="flex items-center justify-end border-b border-border-default bg-bg-surface px-6 py-3">
+        <div className="flex items-center gap-3">
+          <div className="h-8 w-64 rounded-md border border-border-default bg-bg-page" />
+          <div className="h-8 w-20 rounded-md bg-brand-primary/40" />
+          <div className="h-8 w-8 rounded-md border border-border-default bg-bg-page" />
+          <div className="h-8 w-8 rounded-md border border-border-default bg-bg-page" />
+        </div>
+      </header>
+      <main className="p-6">
+        <div className="flex gap-3 overflow-x-auto pb-2 opacity-80 animate-pulse">
+          {Array.from({ length: BOARD_SKELETON_COLUMN_COUNT }, (_, columnIndex) => (
+            <BoardColumnSkeleton key={columnIndex} columnIndex={columnIndex} />
+          ))}
+        </div>
+      </main>
+    </div>
+  );
 }
 
 export default function BoardRoute() {
@@ -103,7 +174,7 @@ export default function BoardRoute() {
   }, [refreshSignal]);
 
   if (!data) {
-    return <div className="min-h-screen flex items-center justify-center bg-bg-page text-text-muted">Loading...</div>;
+    return <BoardRouteSkeleton />;
   }
 
   return (

--- a/src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx
@@ -71,6 +71,18 @@ describe("BoardRoute", () => {
     vi.useRealTimers();
   });
 
+  it("초기 데이터가 없으면 보드 형태의 skeleton을 즉시 렌더링한다", () => {
+    // Given
+    mocks.getTasksByStatus.mockReturnValue(new Promise(() => {}));
+
+    // When
+    render(<BoardRoute />);
+
+    // Then
+    expect(screen.getByTestId("board-route-skeleton")).toBeTruthy();
+    expect(screen.queryByText("Loading...")).toBeNull();
+  });
+
   it("캐시가 있으면 stale board를 즉시 렌더링하고 이후 최신 데이터로 갱신한다", async () => {
     // Given
     sessionStorage.setItem(BOARD_CACHE_KEY, JSON.stringify({


### PR DESCRIPTION
## What changed?
- Code-split non-board desktop routes so the kanban board is not blocked by detail, diff, and terminal route chunks.
- Replaced empty startup and board loading states with kanban-shaped skeletons.
- Added coverage for the board skeleton fallback.

## Why it matters
- The packaged desktop app shows meaningful board structure immediately instead of a black or empty loading screen.
- Heavy route code is deferred until those screens are visited.

Co-Authored-By: OpenAI Codex <codex@openai.com>