### PR TITLE
fix(hooks): validate remote hook status by active port

### DIFF
--- a/src/components/HooksStatusCard.tsx
+++ b/src/components/HooksStatusCard.tsx
@@ -44,7 +44,6 @@ export default function HooksStatusCard({
   initialGeminiStatus,
   initialCodexStatus,
   initialOpenCodeStatus,
-  isRemote,
   onStatusesChange,
 }: HooksStatusCardProps) {
   const t = useTranslations("taskDetail");
@@ -229,7 +228,6 @@ export default function HooksStatusCard({
                       {isInstalled ? t("hooksInstalled") : t("hooksNotInstalled")}
                     </span>
                   </div>
-                  {isRemote ? <p className="mt-0.5 text-xs text-text-muted">{t("hooksRemoteNotSupported")}</p> : null}
                 </div>
                 <button
                   type="button"

--- a/src/components/__tests__/HooksStatusCard.test.tsx
+++ b/src/components/__tests__/HooksStatusCard.test.tsx
@@ -62,6 +62,7 @@ const messages = {
     openCodeHooksInstallSuccess: "OpenCode hooks installed",
     hooksInstallIncomplete: "Hooks were installed, but verification is incomplete.",
     hooksInstallFailed: "Hooks installation failed",
+    hooksRemoteNotSupported: "Remote projects are not supported",
     hooksCurrentTaskId: "Current taskId: {taskId}",
     hooksStatusDialog: {
       reinstall: "Reinstall",
@@ -138,6 +139,19 @@ describe("HooksStatusCard", () => {
     });
 
     expect(screen.getByRole("button", { name: "Reinstall Claude" })).toBeTruthy();
+  });
+
+  it("does not describe remote hook status as unsupported", () => {
+    renderCard({
+      taskId: "task-remote",
+      initialClaudeStatus: null,
+      initialGeminiStatus: null,
+      initialCodexStatus: null,
+      initialOpenCodeStatus: null,
+      isRemote: true,
+    });
+
+    expect(screen.queryByText("Remote projects are not supported")).toBeNull();
   });
 
   it("installs Claude hooks from the inline action and updates local status", async () => {

--- a/src/lib/__tests__/hookServerStatus.test.ts
+++ b/src/lib/__tests__/hookServerStatus.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockExecGit, mockGetHookServerUrl, mockFetch, mockIsSSHTransportError } = vi.hoisted(() => ({
+const { mockExecGit, mockGetHookServerUrl, mockGetHookServerPort, mockFetch, mockIsSSHTransportError } = vi.hoisted(() => ({
   mockExecGit: vi.fn(),
   mockGetHookServerUrl: vi.fn(),
+  mockGetHookServerPort: vi.fn(),
   mockFetch: vi.fn(),
   mockIsSSHTransportError: vi.fn((error: unknown) => /Connection reset/i.test(String(error))),
 }));
@@ -14,12 +15,14 @@ vi.mock("@/lib/gitOperations", () => ({
 
 vi.mock("@/lib/hookEndpoint", () => ({
   getHookServerUrl: (...args: unknown[]) => mockGetHookServerUrl(...args),
+  getHookServerPort: (...args: unknown[]) => mockGetHookServerPort(...args),
 }));
 
 describe("hookServerStatus", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetHookServerUrl.mockResolvedValue("http://localhost:9736");
+    mockGetHookServerPort.mockReturnValue(9736);
     mockExecGit.mockResolvedValue("");
     mockFetch.mockResolvedValue({ ok: true });
     mockIsSSHTransportError.mockImplementation((error: unknown) => /Connection reset/i.test(String(error)));
@@ -49,6 +52,32 @@ describe("hookServerStatus", () => {
       expect.stringContaining("http://100.83.96.29:6379/api/hooks/health"),
       "remote-host",
     );
+  });
+
+  it("accepts remote hook URLs by the active hook server port when the routed local IP cannot be recomputed", async () => {
+    mockGetHookServerUrl.mockRejectedValue(new Error("route unavailable"));
+    const { validateHookServerConfiguration } = await import("@/lib/hookServerStatus");
+
+    const result = await validateHookServerConfiguration(["http://100.83.96.29:9736"], true, "remote-host");
+
+    expect(result.hasExpectedHookServerUrl).toBe(true);
+    expect(result.hasReachableHookServer).toBe(true);
+    expect(result.expectedHookServerUrl).toBe(null);
+    expect(mockExecGit).toHaveBeenCalledWith(
+      expect.stringContaining("http://100.83.96.29:9736/api/hooks/health"),
+      "remote-host",
+    );
+  });
+
+  it("rejects remote hook URLs with a stale port when the routed local IP cannot be recomputed", async () => {
+    mockGetHookServerUrl.mockRejectedValue(new Error("route unavailable"));
+    const { validateHookServerConfiguration } = await import("@/lib/hookServerStatus");
+
+    const result = await validateHookServerConfiguration(["http://100.83.96.29:19736"], true, "remote-host");
+
+    expect(result.hasExpectedHookServerUrl).toBe(false);
+    expect(result.hasReachableHookServer).toBe(false);
+    expect(mockExecGit).not.toHaveBeenCalled();
   });
 
   it("checks hook server reachability from the remote host", async () => {

--- a/src/lib/hookServerStatus.ts
+++ b/src/lib/hookServerStatus.ts
@@ -1,6 +1,6 @@
 import { execGit, isSSHTransportError } from "@/lib/gitOperations";
 import { quoteShellArgument } from "@/lib/hostFileAccess";
-import { getHookServerUrl } from "@/lib/hookEndpoint";
+import { getHookServerPort, getHookServerUrl } from "@/lib/hookEndpoint";
 
 export interface HookServerValidation {
   hasExpectedHookServerUrl: boolean;
@@ -57,6 +57,21 @@ export async function validateHookServerConfiguration(
       () => getHookServerUrl(sshHost),
     );
   } catch {
+    if (sshHost) {
+      const hasExpectedHookServerUrl = definedUrls.every(isRemoteHookServerUrlOnActivePort);
+      const reachableUrl = configuredHookServerUrl ?? definedUrls[0];
+      const hasReachableHookServer = hasExpectedHookServerUrl
+        ? await isHookServerReachable(reachableUrl, sshHost)
+        : false;
+
+      return {
+        hasExpectedHookServerUrl,
+        hasReachableHookServer,
+        expectedHookServerUrl: null,
+        configuredHookServerUrl,
+      };
+    }
+
     return {
       hasExpectedHookServerUrl: false,
       hasReachableHookServer: false,
@@ -160,6 +175,15 @@ function isExpectedHookServerUrl(configuredUrl: string, expectedUrl: string, isR
   }
 
   return normalizeLoopbackHostname(configured.hostname) === normalizeLoopbackHostname(expected.hostname);
+}
+
+function isRemoteHookServerUrlOnActivePort(configuredUrl: string): boolean {
+  const configured = parseHookServerUrl(configuredUrl);
+  if (!configured) {
+    return false;
+  }
+
+  return configured.protocol === "http:" && configured.port === String(getHookServerPort());
 }
 
 function parseHookServerUrl(url: string): URL | null {


### PR DESCRIPTION
## What changed
- Fix remote hook status validation so installed hooks remain valid when KanVibe cannot recompute the routed local IP, as long as the configured URL uses the active hook server port.
- Keep stale remote hook ports invalid and continue checking reachability from the remote host.
- Remove the unsupported-remote copy from the hook status card because remote hooks are supported.

## Implementation details
- Add a remote-only fallback in `validateHookServerConfiguration` that validates against `getHookServerPort()` when `getHookServerUrl(sshHost)` fails.
- Add regression coverage for active-port fallback and stale-port rejection.
- Add UI coverage to ensure remote hook status is not described as unsupported.

Co-Authored-By: OpenAI Codex <codex@openai.com>
