### PR TITLE
Fix remote hook auto-install reliability

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   removeSessionOnly: vi.fn(),
   detachSession: vi.fn(),
   installKanvibeHooks: vi.fn(),
+  scheduleKanvibeHooksInstall: vi.fn(),
   broadcastBoardUpdate: vi.fn(),
   execGit: vi.fn(),
   pullCurrentBranch: vi.fn(),
@@ -73,6 +74,7 @@ vi.mock("@/lib/terminal", () => ({
 
 vi.mock("@/lib/kanvibeHooksInstaller", () => ({
   installKanvibeHooks: mocks.installKanvibeHooks,
+  scheduleKanvibeHooksInstall: mocks.scheduleKanvibeHooksInstall,
 }));
 
 vi.mock("@/lib/boardNotifier", () => ({
@@ -99,6 +101,18 @@ describe("kanbanService.createTask", () => {
     vi.clearAllMocks();
     mocks.taskRepo.create.mockImplementation((value) => value);
     mocks.installKanvibeHooks.mockResolvedValue(undefined);
+    mocks.scheduleKanvibeHooksInstall.mockImplementation((
+      targetPath: string,
+      taskId: string,
+      sshHost: string | null | undefined,
+      options: { delayMs?: number; onSuccess?: () => void; onFailure?: (error: unknown) => void } = {},
+    ) => {
+      setTimeout(() => {
+        void mocks.installKanvibeHooks(targetPath, taskId, sshHost)
+          .then(() => options.onSuccess?.())
+          .catch((error: unknown) => options.onFailure?.(error));
+      }, options.delayMs ?? 0);
+    });
     mocks.removeSessionOnly.mockResolvedValue(undefined);
     mocks.removeWorktreeAndBranch.mockResolvedValue(undefined);
     mocks.remoteBranchExists.mockResolvedValue(true);

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   aggregateAiSessions: vi.fn(),
   getAiSessionDetail: vi.fn(),
   installKanvibeHooks: vi.fn(),
+  scheduleKanvibeHooksInstall: vi.fn(),
   broadcastBoardUpdate: vi.fn(),
 }));
 
@@ -130,6 +131,7 @@ vi.mock("@/lib/remoteSessionDependency", () => ({
 
 vi.mock("@/lib/kanvibeHooksInstaller", () => ({
   installKanvibeHooks: mocks.installKanvibeHooks,
+  scheduleKanvibeHooksInstall: mocks.scheduleKanvibeHooksInstall,
 }));
 
 describe("projectService.listSubdirectories", () => {
@@ -990,11 +992,16 @@ describe("projectService local hook installation", () => {
 
     expect(result.worktreeTasks).toContain("feature-login");
     expect(mocks.listWorktrees).toHaveBeenCalledWith("/remote/repo", "remote-host");
-    expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
+    expect(mocks.scheduleKanvibeHooksInstall).toHaveBeenCalledWith(
       "/remote/repo__worktrees/feature-login",
       "task-worktree",
       "remote-host",
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onFailure: expect.any(Function),
+      }),
     );
+    expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
   });
 
   it("원격 스캔은 root hook 상태 조회 실패와 무관하게 worktree 등록을 계속 진행한다", async () => {
@@ -1293,6 +1300,80 @@ describe("projectService local hook installation", () => {
       "task-worktree",
       null,
     );
+  });
+
+  it("원격 등록 프로젝트의 새 worktree hooks 설치는 백그라운드로 예약한다", async () => {
+    vi.useFakeTimers();
+
+    try {
+      // Given
+      mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
+      mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
+      mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
+      mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: true });
+      mocks.listWorktrees.mockResolvedValue([
+        {
+          path: "/remote/api__worktrees/feature-sync",
+          branch: "feature-sync",
+          isBare: false,
+        },
+      ]);
+      mocks.formatSessionName.mockReturnValue("api-feature-sync");
+      mocks.isSessionAlive.mockResolvedValue(false);
+
+      mocks.getProjectRepository.mockResolvedValue({
+        find: vi.fn().mockResolvedValue([
+          {
+            id: "project-1",
+            name: "api",
+            repoPath: "/remote/api",
+            defaultBranch: "main",
+            sshHost: "remote-host",
+          },
+        ]),
+      });
+
+      const taskSave = vi.fn(async (value) => ({ id: value.branchName === "main" ? "task-main" : "task-worktree", ...value }));
+      mocks.getTaskRepository.mockResolvedValue({
+        findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => {
+          if (criteria.projectId === "project-1" && criteria.branchName === "main") {
+            return {
+              id: "task-main",
+              branchName: "main",
+              projectId: "project-1",
+              baseBranch: "main",
+              worktreePath: "/remote/api",
+              sshHost: "remote-host",
+            };
+          }
+
+          return null;
+        }),
+        create: vi.fn((value) => value),
+        save: taskSave,
+      });
+
+      const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+      // When
+      const result = await syncRegisteredProjectWorktrees();
+
+      // Then
+      expect(result.worktreeTasks).toContain("feature-sync");
+      expect(mocks.scheduleKanvibeHooksInstall).toHaveBeenCalledWith(
+        "/remote/api__worktrees/feature-sync",
+        "task-worktree",
+        "remote-host",
+        expect.objectContaining({
+          onSuccess: expect.any(Function),
+          onFailure: expect.any(Function),
+        }),
+      );
+      expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("등록된 프로젝트 background sync는 프로젝트별 worktree 조회를 직렬로 실행한다", async () => {

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -12,7 +12,7 @@ import {
   type BackgroundSyncFailurePayload,
   type TaskPrMergedDetectedPayload,
 } from "@/lib/boardNotifier";
-import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
+import { installKanvibeHooks, scheduleKanvibeHooksInstall } from "@/lib/kanvibeHooksInstaller";
 import { execGit, pullCurrentBranch, remoteBranchExists } from "@/lib/gitOperations";
 import { detachSession } from "@/lib/terminal";
 
@@ -137,29 +137,28 @@ export function scheduleTaskHookInstall(
   targetPath: string,
   task: Pick<KanbanTask, "id" | "title" | "sshHost">,
 ) {
-  setTimeout(() => {
-    void installKanvibeHooks(targetPath, task.id, task.sshHost)
-      .then(() => {
-        broadcastBoardUpdate();
-      })
-      .catch((error) => {
-        const errorMessage = getErrorMessage(error);
+  scheduleKanvibeHooksInstall(targetPath, task.id, task.sshHost, {
+    onSuccess: () => {
+      broadcastBoardUpdate();
+    },
+    onFailure: (error) => {
+      const errorMessage = getErrorMessage(error);
 
-        console.error("새 태스크 hooks 백그라운드 설치 실패:", {
-          taskId: task.id,
-          taskTitle: task.title,
-          targetPath,
-          sshHost: task.sshHost ?? null,
-          error: errorMessage,
-        });
-
-        broadcastTaskHookInstallFailed({
-          taskId: task.id,
-          taskTitle: task.title,
-          error: errorMessage,
-        });
+      console.error("새 태스크 hooks 백그라운드 설치 실패:", {
+        taskId: task.id,
+        taskTitle: task.title,
+        targetPath,
+        sshHost: task.sshHost ?? null,
+        error: errorMessage,
       });
-  }, 0);
+
+      broadcastTaskHookInstallFailed({
+        taskId: task.id,
+        taskTitle: task.title,
+        error: errorMessage,
+      });
+    },
+  });
 }
 
 export function prepareOptimisticDoneTransition(

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -16,7 +16,7 @@ import { computeProjectColor } from "@/lib/projectColor";
 import { broadcastBoardUpdate } from "@/lib/boardNotifier";
 import { getAvailableHosts as readAvailableHosts } from "@/lib/sshConfig";
 import { getDefaultSessionType } from "@/desktop/main/services/appSettingsService";
-import { installKanvibeHooks } from "@/lib/kanvibeHooksInstaller";
+import { installKanvibeHooks, scheduleKanvibeHooksInstall } from "@/lib/kanvibeHooksInstaller";
 
 function matchesTaskLocation(task: { worktreePath?: string | null; sshHost?: string | null }, expectedPath: string, sshHost?: string | null): boolean {
   return task.worktreePath === expectedPath && (task.sshHost || null) === (sshHost || null);
@@ -117,6 +117,36 @@ function scheduleProjectRootHookRepair(project: Project) {
 
     projectRootHookRepairJobs.set(projectPathKey, repairJob);
   }, 0);
+}
+
+async function installSyncedWorktreeHooks(
+  project: Project,
+  worktreePath: string,
+  taskId: string,
+  branchName: string,
+  result: Pick<RegisteredProjectWorktreeSyncResult, "errors">,
+): Promise<void> {
+  if (project.sshHost) {
+    scheduleKanvibeHooksInstall(worktreePath, taskId, project.sshHost, {
+      onSuccess: () => {
+        broadcastBoardUpdate();
+      },
+      onFailure: (error) => {
+        if (!isRemoteConnectionError(error)) {
+          console.warn(`${project.name}/${branchName} hooks 백그라운드 설정 실패:`, error);
+        }
+      },
+    });
+    return;
+  }
+
+  try {
+    await installKanvibeHooks(worktreePath, taskId, project.sshHost);
+  } catch (hookError) {
+    result.errors.push(
+      `${project.name}/${branchName} hooks 설정 실패: ${hookError instanceof Error ? hookError.message : "알 수 없는 오류"}`,
+    );
+  }
 }
 
 function scheduleProjectRootTaskRepair(project: Project) {
@@ -546,13 +576,7 @@ async function syncProjectWorktrees(
           existingTask.baseBranch = project.defaultBranch;
           const savedTask = await taskRepo.save(existingTask);
           result.changed = true;
-          try {
-            await installKanvibeHooks(wt.path, savedTask.id, project.sshHost);
-          } catch (hookError) {
-            result.errors.push(
-              `${project.name}/${wt.branch} hooks 설정 실패: ${hookError instanceof Error ? hookError.message : "알 수 없는 오류"}`,
-            );
-          }
+          await installSyncedWorktreeHooks(project, wt.path, savedTask.id, wt.branch, result);
         }
         continue;
       }
@@ -567,13 +591,7 @@ async function syncProjectWorktrees(
         orphanTask.baseBranch = orphanTask.baseBranch || project.defaultBranch;
         const savedTask = await taskRepo.save(orphanTask);
         result.changed = true;
-        try {
-          await installKanvibeHooks(wt.path, savedTask.id, project.sshHost);
-        } catch (hookError) {
-          result.errors.push(
-            `${project.name}/${wt.branch} hooks 설정 실패: ${hookError instanceof Error ? hookError.message : "알 수 없는 오류"}`,
-          );
-        }
+        await installSyncedWorktreeHooks(project, wt.path, savedTask.id, wt.branch, result);
         result.worktreeTasks.push(wt.branch);
         result.registeredWorktrees.push({
           taskId: savedTask.id,
@@ -608,13 +626,7 @@ async function syncProjectWorktrees(
       });
       const savedTask = await taskRepo.save(task);
       result.changed = true;
-      try {
-        await installKanvibeHooks(wt.path, savedTask.id, project.sshHost);
-      } catch (hookError) {
-        result.errors.push(
-          `${project.name}/${wt.branch} hooks 설정 실패: ${hookError instanceof Error ? hookError.message : "알 수 없는 오류"}`,
-        );
-      }
+      await installSyncedWorktreeHooks(project, wt.path, savedTask.id, wt.branch, result);
       result.worktreeTasks.push(wt.branch);
       result.registeredWorktrees.push({
         taskId: savedTask.id,

--- a/src/lib/__tests__/hostFileAccess.test.ts
+++ b/src/lib/__tests__/hostFileAccess.test.ts
@@ -15,6 +15,22 @@ vi.mock("@/lib/gitOperations", () => ({
   execGit: mocks.execGit,
 }));
 
+function quoteForPosixShell(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function wrapLikeRemoteExecGit(command: string): string {
+  const marker = "__KANVIBE_TEST_REMOTE_COMMAND_EXIT__";
+  const wrappedCommand = [
+    `sh -lc ${quoteForPosixShell(command)}`,
+    "__kanvibe_status=$?",
+    `printf '\\n${marker}:%s\\n' "$__kanvibe_status"`,
+    'exit "$__kanvibe_status"',
+  ].join("; ");
+
+  return `sh -lc ${quoteForPosixShell(wrappedCommand)}`;
+}
+
 describe("hostFileAccess.readTextFiles", () => {
   let tempDir: string;
 
@@ -47,5 +63,25 @@ describe("hostFileAccess.readTextFiles", () => {
     expect(files.get(missingPath)).toEqual({ exists: false, content: "" });
     expect(mocks.execGit).toHaveBeenCalledWith(expect.any(String), "remote-host");
     await expect(readFile(filePath, "utf-8")).resolves.toBe(content);
+  });
+
+  it("원격 파일 묶음 읽기 명령은 실제 SSH 이중 shell wrapper에서도 실행 가능해야 한다", async () => {
+    // Given
+    const filePath = path.join(tempDir, "hook file's config.txt");
+    const missingPath = path.join(tempDir, "missing file.txt");
+    const content = "line 1\nline 2\n";
+    await writeFile(filePath, content, "utf-8");
+    mocks.execGit.mockImplementation(async (command: string) => {
+      const { stdout } = await execFileAsync("sh", ["-lc", wrapLikeRemoteExecGit(command)]);
+      return stdout;
+    });
+    const { readTextFiles } = await import("@/lib/hostFileAccess");
+
+    // When
+    const files = await readTextFiles([filePath, missingPath], "remote-host");
+
+    // Then
+    expect(files.get(filePath)).toEqual({ exists: true, content });
+    expect(files.get(missingPath)).toEqual({ exists: false, content: "" });
   });
 });

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -147,6 +147,49 @@ describe("kanvibeHooksInstaller", () => {
     }
   });
 
+  it("같은 target/task/host 동시 설치 요청은 하나의 설치 작업을 공유한다", async () => {
+    // Given
+    let resolveClaudeInstall: (() => void) | undefined;
+    mockSetupClaudeHooks.mockImplementation(() => new Promise<void>((resolve) => {
+      resolveClaudeInstall = resolve;
+    }));
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    const firstInstall = installKanvibeHooks("/repo", "task-1", null);
+    const secondInstall = installKanvibeHooks("/repo", "task-1", null);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Then
+    expect(mockSetupClaudeHooks).toHaveBeenCalledTimes(1);
+    resolveClaudeInstall?.();
+    await expect(Promise.all([firstInstall, secondInstall])).resolves.toEqual([undefined, undefined]);
+  });
+
+  it("백그라운드 스케줄러는 같은 설치 요청을 합치고 모든 callback을 호출한다", async () => {
+    vi.useFakeTimers();
+
+    try {
+      // Given
+      const onSuccessA = vi.fn();
+      const onSuccessB = vi.fn();
+      const { scheduleKanvibeHooksInstall } = await import("@/lib/kanvibeHooksInstaller");
+
+      // When
+      scheduleKanvibeHooksInstall("/repo", "task-1", null, { onSuccess: onSuccessA });
+      scheduleKanvibeHooksInstall("/repo", "task-1", null, { onSuccess: onSuccessB });
+      await vi.runAllTimersAsync();
+
+      // Then
+      expect(mockSetupClaudeHooks).toHaveBeenCalledTimes(1);
+      expect(onSuccessA).toHaveBeenCalledTimes(1);
+      expect(onSuccessB).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("원격 프로젝트면 SSH 명령으로 hook 파일을 설치한다", async () => {
     // Given
     const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");

--- a/src/lib/hostFileAccess.ts
+++ b/src/lib/hostFileAccess.ts
@@ -85,14 +85,15 @@ export async function readTextFiles(
     return new Map<string, TextFileReadResult>(entries);
   }
 
+  const encodedManifest = encodeRemoteTextFileManifest(targetPaths);
   const command = [
-    "for __kanvibe_file in",
-    targetPaths.map(quoteShellArgument).join(" "),
-    "; do",
+    `printf '%s' ${quoteShellArgument(encodedManifest)} | (base64 -d 2>/dev/null || base64 -D) | while IFS= read -r __kanvibe_encoded_file; do`,
+    "test -n \"$__kanvibe_encoded_file\" || continue;",
+    "__kanvibe_file=$(printf '%s' \"$__kanvibe_encoded_file\" | (base64 -d 2>/dev/null || base64 -D));",
     `printf '%s\\t%s\\t' ${quoteShellArgument(REMOTE_FILE_RECORD_PREFIX)} "$__kanvibe_file";`,
     "if test -f \"$__kanvibe_file\"; then",
     "printf '1\\t';",
-    "(base64 -w 0 \"$__kanvibe_file\" 2>/dev/null || base64 \"$__kanvibe_file\" | tr -d '\\n');",
+    "(base64 -w 0 \"$__kanvibe_file\" 2>/dev/null || base64 < \"$__kanvibe_file\" | tr -d '\\n');",
     "else",
     "printf '0\\t';",
     "fi;",
@@ -102,6 +103,11 @@ export async function readTextFiles(
   const output = await execGit(command, sshHost);
 
   return parseRemoteTextFiles(output, targetPaths);
+}
+
+function encodeRemoteTextFileManifest(targetPaths: string[]): string {
+  const encodedPaths = targetPaths.map((targetPath) => Buffer.from(targetPath, "utf-8").toString("base64"));
+  return Buffer.from(encodedPaths.join("\n"), "utf-8").toString("base64");
 }
 
 function parseRemoteTextFiles(

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -26,8 +26,107 @@ import { quoteShellArgument } from "@/lib/hostFileAccess";
 
 const HOOK_INSTALL_MAX_ATTEMPTS = 3;
 const HOOK_INSTALL_RETRY_DELAY_MS = 500;
+const activeHookInstallJobs = new Map<string, Promise<void>>();
+const scheduledHookInstallJobs = new Map<string, ScheduledHookInstallJob>();
+
+interface HookInstallScheduleOptions {
+  delayMs?: number;
+  onSuccess?: () => void;
+  onFailure?: (error: unknown) => void;
+}
+
+interface HookInstallCallbacks {
+  onSuccess?: () => void;
+  onFailure?: (error: unknown) => void;
+}
+
+interface ScheduledHookInstallJob {
+  callbacks: HookInstallCallbacks[];
+}
 
 export async function installKanvibeHooks(
+  targetPath: string,
+  taskId: string,
+  sshHost?: string | null,
+): Promise<void> {
+  const installKey = buildHookInstallKey(targetPath, taskId, sshHost);
+  const activeJob = activeHookInstallJobs.get(installKey);
+  if (activeJob) {
+    return activeJob;
+  }
+
+  const installJob = runKanvibeHooksInstallWithRetry(targetPath, taskId, sshHost)
+    .finally(() => {
+      if (activeHookInstallJobs.get(installKey) === installJob) {
+        activeHookInstallJobs.delete(installKey);
+      }
+    });
+
+  activeHookInstallJobs.set(installKey, installJob);
+  return installJob;
+}
+
+export function scheduleKanvibeHooksInstall(
+  targetPath: string,
+  taskId: string,
+  sshHost?: string | null,
+  options: HookInstallScheduleOptions = {},
+): void {
+  const installKey = buildHookInstallKey(targetPath, taskId, sshHost);
+  const callbacks: HookInstallCallbacks = {
+    onSuccess: options.onSuccess,
+    onFailure: options.onFailure,
+  };
+  const scheduledJob = scheduledHookInstallJobs.get(installKey);
+  if (scheduledJob) {
+    scheduledJob.callbacks.push(callbacks);
+    return;
+  }
+
+  const nextJob: ScheduledHookInstallJob = {
+    callbacks: [callbacks],
+  };
+  scheduledHookInstallJobs.set(installKey, nextJob);
+
+  setTimeout(() => {
+    void installKanvibeHooks(targetPath, taskId, sshHost)
+      .then(() => notifyHookInstallSuccess(nextJob.callbacks))
+      .catch((error) => notifyHookInstallFailure(nextJob.callbacks, error))
+      .finally(() => {
+        if (scheduledHookInstallJobs.get(installKey) === nextJob) {
+          scheduledHookInstallJobs.delete(installKey);
+        }
+      });
+  }, options.delayMs ?? 0);
+}
+
+function buildHookInstallKey(targetPath: string, taskId: string, sshHost?: string | null): string {
+  return [sshHost ?? "", targetPath, taskId].join("\0");
+}
+
+function notifyHookInstallSuccess(callbacks: HookInstallCallbacks[]): void {
+  for (const callback of callbacks) {
+    runHookInstallCallback(() => callback.onSuccess?.());
+  }
+}
+
+function notifyHookInstallFailure(callbacks: HookInstallCallbacks[], error: unknown): void {
+  for (const callback of callbacks) {
+    runHookInstallCallback(() => callback.onFailure?.(error));
+  }
+}
+
+function runHookInstallCallback(callback: () => void): void {
+  try {
+    callback();
+  } catch (error) {
+    console.warn("[hooks] install callback failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function runKanvibeHooksInstallWithRetry(
   targetPath: string,
   taskId: string,
   sshHost?: string | null,


### PR DESCRIPTION
## Summary
- Fix remote hook status file reads by passing paths through a base64 manifest.
- Retry hook installation up to 3 attempts before reporting the final failure.
- Coalesce duplicate hook install requests for the same remote target.
- Schedule remote worktree hook repairs in the background so sync flows are not blocked by SSH delays.

## Validation
- pnpm vitest run src/lib/__tests__/hostFileAccess.test.ts src/lib/__tests__/kanvibeHooksInstaller.test.ts src/desktop/main/services/__tests__/kanbanService.test.ts src/desktop/main/services/__tests__/projectService.test.ts
- pnpm check

Co-Authored-By: Codex <codex@openai.com>