### PR TITLE
fix(hooks): unblock task hook status refresh

### DIFF
--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -488,44 +488,69 @@ export default function TaskDetailRoute() {
           })();
         }
 
+        const applySupplementalState = (updates: Partial<Omit<TaskDetailState, "task">>) => {
+          if (cancelled) {
+            return;
+          }
+
+          setState((current) => current && current.task.id === task.id
+            ? {
+                ...current,
+                ...updates,
+              }
+            : current);
+        };
+
         void (async () => {
           try {
             const baseBranchName = task.baseBranch ?? "main";
-            const foundTaskId = task.projectId ? await getTaskIdByProjectAndBranch(task.projectId, baseBranchName) : null;
-            const baseBranchTaskId = foundTaskId !== task.id ? foundTaskId : null;
-            const diffFiles = task.branchName && task.worktreePath ? await getGitDiffFiles(id) : [];
-            const [claudeHooksStatus, geminiHooksStatus, codexHooksStatus, openCodeHooksStatus, aiSessions, projects, defaultSessionType, doneAlertDismissed] = await Promise.all([
-              task.projectId ? getTaskHooksStatus(id) : Promise.resolve(null),
-              task.projectId ? getTaskGeminiHooksStatus(id) : Promise.resolve(null),
-              task.projectId ? getTaskCodexHooksStatus(id) : Promise.resolve(null),
-              task.projectId ? getTaskOpenCodeHooksStatus(id) : Promise.resolve(null),
-              task.projectId ? getTaskAiSessions(id) : Promise.resolve(EMPTY_AI_SESSIONS),
+            const [foundTaskId, diffFiles, projects, defaultSessionType, doneAlertDismissed] = await Promise.all([
+              task.projectId ? getTaskIdByProjectAndBranch(task.projectId, baseBranchName) : Promise.resolve(null),
+              task.branchName && task.worktreePath ? getGitDiffFiles(id) : Promise.resolve([]),
               getAllProjects(),
               getDefaultSessionType(),
               getDoneAlertDismissed(),
             ]);
+            const baseBranchTaskId = foundTaskId !== task.id ? foundTaskId : null;
 
-            if (cancelled) {
-              return;
-            }
-
-            setState((current) => current && current.task.id === task.id
-              ? {
-                  ...current,
-                  baseBranchTaskId,
-                  diffFiles,
-                  claudeHooksStatus,
-                  geminiHooksStatus,
-                  codexHooksStatus,
-                  openCodeHooksStatus,
-                  aiSessions,
-                  projects,
-                  defaultSessionType,
-                  doneAlertDismissed,
-                }
-              : current);
+            applySupplementalState({
+              baseBranchTaskId,
+              diffFiles,
+              projects,
+              defaultSessionType,
+              doneAlertDismissed,
+            });
           } catch (error) {
-            console.error("Failed to load task detail supplemental data:", error);
+            console.error("Failed to load task detail reference data:", error);
+          }
+        })();
+
+        void (async () => {
+          try {
+            const [claudeHooksStatus, geminiHooksStatus, codexHooksStatus, openCodeHooksStatus] = await Promise.all([
+              task.projectId ? getTaskHooksStatus(id) : Promise.resolve(null),
+              task.projectId ? getTaskGeminiHooksStatus(id) : Promise.resolve(null),
+              task.projectId ? getTaskCodexHooksStatus(id) : Promise.resolve(null),
+              task.projectId ? getTaskOpenCodeHooksStatus(id) : Promise.resolve(null),
+            ]);
+
+            applySupplementalState({
+              claudeHooksStatus,
+              geminiHooksStatus,
+              codexHooksStatus,
+              openCodeHooksStatus,
+            });
+          } catch (error) {
+            console.error("Failed to load task hook statuses:", error);
+          }
+        })();
+
+        void (async () => {
+          try {
+            const aiSessions = task.projectId ? await getTaskAiSessions(id) : EMPTY_AI_SESSIONS;
+            applySupplementalState({ aiSessions });
+          } catch (error) {
+            console.error("Failed to load task AI sessions:", error);
           }
         })();
       } catch (error) {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   markAllNotificationsRead: vi.fn(),
   activateNotification: vi.fn(),
   fetchPrUrlWithPrompt: vi.fn(),
+  renderHooksStatusCard: vi.fn(),
   useRefreshSignal: vi.fn(() => 0),
   redirect: vi.fn(),
   push: vi.fn(),
@@ -161,7 +162,24 @@ vi.mock("@/components/DoneStatusButton", () => ({
 }));
 
 vi.mock("@/components/HooksStatusCard", () => ({
-  default: () => <div data-testid="hooks-status-card" />,
+  default: (props: {
+    initialClaudeStatus: { installed: boolean } | null;
+    initialGeminiStatus: { installed: boolean } | null;
+    initialCodexStatus: { installed: boolean } | null;
+    initialOpenCodeStatus: { installed: boolean } | null;
+  }) => {
+    mocks.renderHooksStatusCard(props);
+
+    return (
+      <div
+        data-testid="hooks-status-card"
+        data-claude-installed={String(props.initialClaudeStatus?.installed ?? false)}
+        data-gemini-installed={String(props.initialGeminiStatus?.installed ?? false)}
+        data-codex-installed={String(props.initialCodexStatus?.installed ?? false)}
+        data-opencode-installed={String(props.initialOpenCodeStatus?.installed ?? false)}
+      />
+    );
+  },
 }));
 
 vi.mock("@/components/TaskDetailInfoCard", () => ({
@@ -599,6 +617,41 @@ describe("TaskDetailRoute", () => {
 
     expect(await screen.findByTestId("hooks-status-card")).toBeTruthy();
     expect(screen.getByText("done")).toBeTruthy();
+  });
+
+  it("AI 세션 로드가 느려도 hooks 상태는 먼저 갱신한다", async () => {
+    const codexStatus = { installed: true };
+    const unresolvedAiSessions = createDeferred<Awaited<ReturnType<typeof mocks.getTaskAiSessions>>>();
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(true);
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+    mocks.getTaskCodexHooksStatus.mockResolvedValue(codexStatus);
+    mocks.getTaskAiSessions.mockReturnValue(unresolvedAiSessions.promise);
+
+    render(<TaskDetailRoute />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "actions · hooksStatus" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hooks-status-card").getAttribute("data-codex-installed")).toBe("true");
+    });
+    expect(mocks.renderHooksStatusCard).toHaveBeenLastCalledWith(expect.objectContaining({
+      initialCodexStatus: codexStatus,
+    }));
   });
 
   it("상세 화면 좌측 하단 rail에는 알림 버튼을 렌더링하지 않는다", async () => {


### PR DESCRIPTION
## Related Materials
- Issue: #

## What is this change?
- Fix task detail hook status rendering so installed remote hooks are not shown as missing while slower AI session discovery is still running.

## How was it solved?
**Split supplemental task-detail loading**
- Load reference data, hook statuses, and AI sessions in separate async flows.
- Apply hook status updates as soon as the hook checks finish instead of waiting for AI session aggregation.

**Add regression coverage**
- Extend the task detail route test mock to expose hook card status props.
- Add a test that keeps AI session loading pending and verifies Codex hook status updates first.

## Important changes
### Task detail status loading

**Independent hook status refresh**
- **Reason**: Remote hook verification can finish quickly, but AI session discovery can take much longer and previously blocked the UI update.
- **Modified file**: `src/desktop/renderer/routes/TaskDetailRoute.tsx`

**Regression test for slow AI sessions**
- **Reason**: Prevent hook status cards from regressing to stale `null` state while AI sessions are still pending.
- **Modified file**: `src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx`

Co-Authored-By: Codex <codex@openai.com>
