### PR TITLE
Centralize task detail window focus policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,13 @@
 - Shortcut capture UIs must store normalized shortcut strings from the shared capture helper, not hand-built modifier strings.
 - When adding or changing a shortcut, cover the shared command definition, display formatting, Electron input matching, renderer global handling, and any user-configurable capture flow with focused tests.
 
+## Task Navigation
+
+- Route all task-detail transitions through `navigateToTaskDetail()` in `src/desktop/renderer/utils/taskNavigation.ts`.
+- Before navigating the current window to a task detail route, focus an already-open window for the same task detail route when one exists.
+- Keep explicit new-window actions on `openInternalRouteInNewWindow()` or `navigateToTaskDetail(..., { openInNewWindow: true })` so Electron main can reuse its existing-window focus policy.
+- Do not hand-roll `router.push("/task/...")`, `redirect("/.../task/...")`, or `window.location.hash` for task detail transitions in feature components.
+
 ## UI Color Tokens
 
 - Use `#0064FF` as the primary point color for PR buttons, primary actions, selected states, links, focus borders, and other important interactive highlights.

--- a/electron/main.js
+++ b/electron/main.js
@@ -518,6 +518,32 @@ async function focusTaskNotificationWindow(relativePath) {
   }
 }
 
+async function focusExistingInternalRoute(relativePath, sourceWebContents) {
+  const targetUrl = getRendererNavigationUrl(relativePath);
+  const sourceWindow = sourceWebContents ? BrowserWindow.fromWebContents(sourceWebContents) : null;
+  const { resolveExistingNavigationTargetWindow } = getWindowOpenHelpers();
+  const existingWindow = resolveExistingNavigationTargetWindow({
+    targetUrl,
+    rendererDevUrl: RENDERER_DEV_URL,
+    openWindows: getAvailableWindows(),
+    getWindowUrl: (window) => window.webContents.getURL(),
+    excludeWindow: sourceWindow,
+  });
+
+  if (!existingWindow) {
+    return false;
+  }
+
+  mainWindow = existingWindow;
+  focusWindow(existingWindow);
+
+  if (existingWindow.webContents.getURL() !== targetUrl) {
+    await existingWindow.loadURL(targetUrl);
+  }
+
+  return true;
+}
+
 function getNotificationStore() {
   return require(getRuntimeModulePath(path.join("src", "desktop", "main", "notificationStore.ts")));
 }
@@ -747,6 +773,10 @@ function registerDesktopHandlers() {
       });
       throw error;
     }
+  });
+
+  ipcMain.handle("kanvibe:focus-existing-internal-route", async (event, relativePath) => {
+    return focusExistingInternalRoute(relativePath, event.sender);
   });
 
   ipcMain.handle("kanvibe:terminal-open", async (event, taskId, cols, rows) => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -50,6 +50,9 @@ contextBridge.exposeInMainWorld("kanvibeDesktop", {
   invoke(namespace, method, args) {
     return ipcRenderer.invoke("kanvibe:invoke", namespace, method, args);
   },
+  focusExistingInternalRoute(route) {
+    return ipcRenderer.invoke("kanvibe:focus-existing-internal-route", route);
+  },
   onBoardEvent(listener) {
     const handler = (_event, payload) => listener(payload);
     ipcRenderer.on("kanvibe:board-event", handler);

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -14,8 +14,7 @@ import DoneConfirmDialog from "./DoneConfirmDialog";
 import { reorderTasks, deleteTask, getMoreDoneTasks, moveTaskToColumn } from "@/desktop/renderer/actions/kanban";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
-import { localizeHref } from "@/desktop/renderer/navigation";
-import { openInternalRouteInNewWindow } from "@/desktop/renderer/utils/windowOpen";
+import { navigateToTaskDetail } from "@/desktop/renderer/utils/taskNavigation";
 import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import { useAutoRefresh } from "@/desktop/renderer/hooks/useAutoRefresh";
@@ -129,7 +128,10 @@ function getCurrentBoardLocale() {
 }
 
 function openTaskDetailInNewWindow(taskId: string) {
-  openInternalRouteInNewWindow(localizeHref(`/task/${taskId}`, getCurrentBoardLocale()));
+  void navigateToTaskDetail(taskId, {
+    currentLocale: getCurrentBoardLocale(),
+    openInNewWindow: true,
+  });
 }
 
 /** worktree repoPath에서 메인 프로젝트 경로를 추출한다 */

--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useEffect, useTransition, useCallback, useRef } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter } from "@/desktop/renderer/navigation";
+import { usePathname, useRouter } from "@/desktop/renderer/navigation";
 import { createTask } from "@/desktop/renderer/actions/kanban";
 import { getProjectBranches } from "@/desktop/renderer/actions/project";
+import { navigateToTaskDetail } from "@/desktop/renderer/utils/taskNavigation";
 import { SessionType } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
 import type { Project } from "@/entities/Project";
@@ -89,6 +90,7 @@ function CreateTaskModalContent({
   const t = useTranslations("task");
   const tc = useTranslations("common");
   const router = useRouter();
+  const pathname = usePathname();
   const dialogRef = useRef<HTMLDivElement>(null);
   const [isPending, startTransition] = useTransition();
   const initialProjectId = defaultProjectId || "";
@@ -167,7 +169,10 @@ function CreateTaskModalContent({
           priority: priority || undefined,
         });
         onClose();
-        router.push(`/task/${created.id}`);
+        await navigateToTaskDetail(created.id, {
+          currentLocale: pathname.split("/").filter(Boolean)[0],
+          navigate: router.push,
+        });
       } catch (error) {
         setError(error instanceof Error ? error.message : t("createFailed"));
       }

--- a/src/components/NotificationCenterButton.tsx
+++ b/src/components/NotificationCenterButton.tsx
@@ -10,8 +10,8 @@ import {
   markNotificationRead,
 } from "@/desktop/renderer/actions/notifications";
 import { redirect } from "@/desktop/renderer/navigation";
-import { openInternalRouteInNewWindow } from "@/desktop/renderer/utils/windowOpen";
 import { requestActiveTerminalFocusAfterUiSettles } from "@/desktop/renderer/utils/terminalFocus";
+import { navigateToTaskDetail } from "@/desktop/renderer/utils/taskNavigation";
 import type { AppNotification } from "@/desktop/shared/notifications";
 
 interface NotificationCenterButtonProps {
@@ -47,14 +47,6 @@ function shouldIgnoreKeyboardNavigation(eventTarget: EventTarget | null, contain
   }
 
   return eventTarget.closest('[contenteditable="true"]') !== null;
-}
-
-function getTaskNotificationPath(notification: AppNotification) {
-  return `/${notification.locale}/task/${notification.taskId}`;
-}
-
-function openTaskNotificationInNewWindow(notification: AppNotification) {
-  openInternalRouteInNewWindow(getTaskNotificationPath(notification));
 }
 
 function sortNotificationsByNewestFirst(notifications: AppNotification[]) {
@@ -192,11 +184,17 @@ const NotificationCenterButton = forwardRef<NotificationCenterButtonHandle, Noti
       }
 
       if (openInNewWindow) {
-        openTaskNotificationInNewWindow(notification);
+        await navigateToTaskDetail(notification.taskId, {
+          currentLocale: notification.locale,
+          openInNewWindow: true,
+        });
         return;
       }
 
-      redirect(getTaskNotificationPath(notification));
+      await navigateToTaskDetail(notification.taskId, {
+        currentLocale: notification.locale,
+        navigate: redirect,
+      });
       return;
     }
 

--- a/src/components/ProjectBranchTasksModal.tsx
+++ b/src/components/ProjectBranchTasksModal.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter } from "@/desktop/renderer/navigation";
+import { usePathname, useRouter } from "@/desktop/renderer/navigation";
 import { getTasksByStatus } from "@/desktop/renderer/actions/kanban";
+import { navigateToTaskDetail } from "@/desktop/renderer/utils/taskNavigation";
 import { TaskStatus } from "@/entities/KanbanTask";
 import type { KanbanTask } from "@/entities/KanbanTask";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
@@ -22,12 +23,11 @@ const COLUMNS = [
 
 export default function ProjectBranchTasksModal({
   projectId,
-  currentBranchName,
   onClose,
 }: ProjectBranchTasksModalProps) {
   const t = useTranslations("board.columns");
-  const tc = useTranslations("common");
   const router = useRouter();
+  const pathname = usePathname();
   const [tasksByStatus, setTasksByStatus] = useState<Record<TaskStatus, KanbanTask[]>>({
     [TaskStatus.TODO]: [],
     [TaskStatus.PROGRESS]: [],
@@ -68,8 +68,11 @@ export default function ProjectBranchTasksModal({
     })();
   }, [projectId]);
 
-  const handleTaskClick = (taskId: string) => {
-    router.push(`/task/${taskId}`);
+  const handleTaskClick = async (taskId: string) => {
+    await navigateToTaskDetail(taskId, {
+      currentLocale: pathname.split("/").filter(Boolean)[0],
+      navigate: router.push,
+    });
     onClose();
   };
 

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -2,8 +2,11 @@
 
 import { Draggable } from "@hello-pangea/dnd";
 import { useLocale } from "next-intl";
-import { Link, localizeHref } from "@/desktop/renderer/navigation";
-import { openInternalRouteInNewWindow } from "@/desktop/renderer/utils/windowOpen";
+import { Link, useRouter } from "@/desktop/renderer/navigation";
+import {
+  navigateToTaskDetail,
+  shouldHandleTaskNavigationClick,
+} from "@/desktop/renderer/utils/taskNavigation";
 import { TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
 
@@ -126,13 +129,17 @@ function isShiftOnlyKeyboardShortcut(event: React.KeyboardEvent, key: string) {
 export default function TaskCard({ task, index, onContextMenu, projectName, projectColor, isBaseProject }: TaskCardProps) {
   const cardStyle = projectColor ? { borderColor: projectColor } : undefined;
   const locale = useLocale();
+  const router = useRouter();
 
   function handleTaskKeyDown(event: React.KeyboardEvent<HTMLAnchorElement>) {
     if (isShiftOnlyKeyboardShortcut(event, "Enter")) {
       event.preventDefault();
       event.stopPropagation();
 
-      openInternalRouteInNewWindow(localizeHref(`/task/${task.id}`, locale));
+      void navigateToTaskDetail(task.id, {
+        currentLocale: locale,
+        openInNewWindow: true,
+      });
       return;
     }
 
@@ -171,6 +178,18 @@ export default function TaskCard({ task, index, onContextMenu, projectName, proj
     }
   }
 
+  function handleTaskClick(event: React.MouseEvent<HTMLAnchorElement>) {
+    if (!shouldHandleTaskNavigationClick(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    void navigateToTaskDetail(task.id, {
+      currentLocale: locale,
+      navigate: router.push,
+    });
+  }
+
   return (
     <Draggable draggableId={task.id} index={index}>
       {(provided, snapshot) => (
@@ -184,6 +203,7 @@ export default function TaskCard({ task, index, onContextMenu, projectName, proj
           data-kanban-task-id={task.id}
           data-kanban-status={task.status}
           data-kanban-index={index}
+          onClick={handleTaskClick}
           onKeyDown={handleTaskKeyDown}
           onContextMenu={(e) => {
             e.preventDefault();

--- a/src/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/components/__tests__/CreateTaskModal.test.tsx
@@ -16,6 +16,9 @@ vi.mock("next-intl", () => ({
 }));
 
 vi.mock("@/desktop/renderer/navigation", () => ({
+  localizeHref: (href: string, currentLocale = "ko") => href.startsWith("/") ? `/${currentLocale}${href}` : href,
+  redirect: (...args: unknown[]) => mockPush(...args),
+  usePathname: () => "/ko",
   useRouter: () => ({ push: mockPush }),
 }));
 
@@ -113,7 +116,7 @@ describe("CreateTaskModal", () => {
     });
     expect(mockEnsureSessionDependencyWithPrompt).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
-    expect(mockPush).toHaveBeenCalledWith("/task/task-local-fast");
+    expect(mockPush).toHaveBeenCalledWith("/ko/task/task-local-fast");
   });
 
   it("원격 프로젝트 task 생성은 세션 도구 프롬프트 없이 생성 요청을 보낸다", async () => {
@@ -155,7 +158,7 @@ describe("CreateTaskModal", () => {
     });
     expect(mockEnsureSessionDependencyWithPrompt).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
-    expect(mockPush).toHaveBeenCalledWith("/task/task-remote-fast");
+    expect(mockPush).toHaveBeenCalledWith("/ko/task/task-remote-fast");
   });
 
   it("의존성 준비가 끝나면 생성한 작업 상세 페이지로 이동한다", async () => {
@@ -196,7 +199,7 @@ describe("CreateTaskModal", () => {
       });
     });
     expect(onClose).toHaveBeenCalled();
-    expect(mockPush).toHaveBeenCalledWith("/task/task-2");
+    expect(mockPush).toHaveBeenCalledWith("/ko/task/task-2");
   });
 
   it("Escape를 누르면 모달을 닫는다", async () => {
@@ -330,7 +333,7 @@ describe("CreateTaskModal", () => {
       });
     });
     expect(onClose).toHaveBeenCalled();
-    expect(mockPush).toHaveBeenCalledWith("/task/task-enter");
+    expect(mockPush).toHaveBeenCalledWith("/ko/task/task-enter");
   });
 
   it("프로젝트 목록이 새로고침되어도 사용자가 선택한 베이스 브랜치를 유지한다", async () => {

--- a/src/components/__tests__/NotificationCenterButton.test.tsx
+++ b/src/components/__tests__/NotificationCenterButton.test.tsx
@@ -32,6 +32,9 @@ vi.mock("@/desktop/renderer/actions/kanban", () => ({
 }));
 
 vi.mock("@/desktop/renderer/navigation", () => ({
+  localizeHref: (href: string, currentLocale = "ko") => (
+    href.startsWith("/") ? `/${currentLocale}${href}` : href
+  ),
   redirect: mockRedirect,
 }));
 
@@ -124,6 +127,44 @@ describe("NotificationCenterButton", () => {
     await waitFor(() => {
       expect(mockRedirect).toHaveBeenCalledWith("/en/task/task-1");
     });
+  });
+
+  it("focuses an existing task window instead of redirecting when opening a task notification", async () => {
+    const focusExistingInternalRoute = vi.fn().mockResolvedValue(true);
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      onNotificationsChanged: vi.fn(() => undefined),
+      focusExistingInternalRoute,
+    } as Partial<NonNullable<Window["kanvibeDesktop"]>> as NonNullable<Window["kanvibeDesktop"]>;
+    mockListNotifications.mockResolvedValue([
+      {
+        id: "n1",
+        title: "Existing task",
+        body: "Body",
+        taskId: "task-1",
+        relativePath: "/task/task-1",
+        locale: "en",
+        isRead: false,
+        createdAt: new Date().toISOString(),
+        dedupeKey: "k1",
+      },
+    ]);
+    mockMarkNotificationRead.mockResolvedValue(undefined);
+    mockGetTaskById.mockResolvedValue({ id: "task-1" });
+
+    render(<NotificationCenterButton />);
+
+    await waitFor(() => {
+      expect(mockListNotifications).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "notifications" }));
+    fireEvent.click(screen.getByRole("button", { name: /Existing task/i }));
+
+    await waitFor(() => {
+      expect(focusExistingInternalRoute).toHaveBeenCalledWith("/en/task/task-1");
+    });
+    expect(mockRedirect).not.toHaveBeenCalled();
   });
 
   it("focuses the notification panel when opened through the shortcut handle", async () => {

--- a/src/components/__tests__/TaskCard.test.tsx
+++ b/src/components/__tests__/TaskCard.test.tsx
@@ -1,10 +1,14 @@
 import { forwardRef } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import { createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import TaskCard from "../TaskCard";
 import { TaskPriority } from "@/entities/TaskPriority";
 import { SessionType, TaskStatus } from "@/entities/KanbanTask";
 import type { KanbanTask } from "@/entities/KanbanTask";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+}));
 
 vi.mock("@hello-pangea/dnd", () => ({
   Draggable: ({ children }: { children: (provided: unknown, snapshot: unknown) => React.ReactNode }) =>
@@ -23,6 +27,10 @@ vi.mock("@hello-pangea/dnd", () => ({
 
 vi.mock("@/desktop/renderer/navigation", () => ({
   localizeHref: (href: string, currentLocale = "ko") => href.startsWith("/") ? `/${currentLocale}${href}` : href,
+  redirect: (...args: unknown[]) => mocks.push(...args),
+  useRouter: () => ({
+    push: (...args: unknown[]) => mocks.push(...args),
+  }),
   Link: forwardRef<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }>(
     function MockLink({ children, ...props }, ref) {
       return <a ref={ref} {...props}>{children}</a>;
@@ -63,6 +71,10 @@ describe("TaskCard - Priority Badge", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      focusExistingInternalRoute: vi.fn().mockResolvedValue(false),
+    } as unknown as NonNullable<typeof window.kanvibeDesktop>;
   });
 
   it("should not render priority badge when priority is null", () => {
@@ -328,5 +340,23 @@ describe("TaskCard - Priority Badge", () => {
 
     openSpy.mockRestore();
     delete window.kanvibeDesktop;
+  });
+
+  it("should focus an existing task detail window before following a plain task click", async () => {
+    const task = createTask();
+    const focusExistingInternalRoute = vi.fn().mockResolvedValue(true);
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      focusExistingInternalRoute,
+    } as unknown as NonNullable<typeof window.kanvibeDesktop>;
+
+    render(<TaskCard task={task} index={0} onContextMenu={onContextMenu} />);
+
+    fireEvent.click(screen.getByRole("link"));
+
+    await waitFor(() => {
+      expect(focusExistingInternalRoute).toHaveBeenCalledWith("/ko/task/task-1");
+    });
+    expect(mocks.push).not.toHaveBeenCalled();
   });
 });

--- a/src/desktop/main/__tests__/windowOpen.test.ts
+++ b/src/desktop/main/__tests__/windowOpen.test.ts
@@ -162,6 +162,27 @@ describe("resolveExistingNavigationTargetWindow", () => {
 
     expect(result).toBeNull();
   });
+
+  it("제외할 현재 창이 같은 route여도 다른 열린 상세 route 창을 선택한다", () => {
+    const currentWindow = {
+      id: "window-1",
+      url: "http://localhost:3000/#/ko/task/task-1",
+    };
+    const detailWindow = {
+      id: "window-2",
+      url: "http://localhost:3000/#/ko/task/task-1",
+    };
+
+    const result = resolveExistingNavigationTargetWindow({
+      targetUrl: "http://localhost:3000/#/ko/task/task-1",
+      rendererDevUrl: "http://localhost:3000",
+      openWindows: [currentWindow, detailWindow],
+      getWindowUrl: (windowRecord) => windowRecord.url,
+      excludeWindow: currentWindow,
+    });
+
+    expect(result).toBe(detailWindow);
+  });
 });
 
 describe("shouldKeepCurrentRouteForNotificationActivation", () => {

--- a/src/desktop/main/windowOpen.ts
+++ b/src/desktop/main/windowOpen.ts
@@ -27,6 +27,7 @@ interface ResolveNavigationTargetWindowOptions<T> {
   rendererDevUrl: string | null;
   openWindows: readonly T[];
   getWindowUrl: (window: T) => string;
+  excludeWindow?: T | null;
 }
 
 interface NotificationActivationLike {
@@ -144,12 +145,14 @@ export function resolveNavigationTargetWindow<T>({
   rendererDevUrl,
   openWindows,
   getWindowUrl,
+  excludeWindow = null,
 }: ResolveNavigationTargetWindowOptions<T>): T | null {
   const { existingWindow } = findExistingInternalWindow({
     targetUrl,
     rendererDevUrl,
     openWindows,
     getWindowUrl,
+    excludeWindow,
   });
 
   return existingWindow ?? preferredWindow;
@@ -160,12 +163,14 @@ export function resolveExistingNavigationTargetWindow<T>({
   rendererDevUrl,
   openWindows,
   getWindowUrl,
+  excludeWindow = null,
 }: ResolveNavigationTargetWindowOptions<T>): T | null {
   const { existingWindow } = findExistingInternalWindow({
     targetUrl,
     rendererDevUrl,
     openWindows,
     getWindowUrl,
+    excludeWindow,
   });
 
   return existingWindow;

--- a/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
+++ b/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
@@ -8,9 +8,9 @@ import {
   type SearchableTask,
 } from "@/desktop/renderer/actions/kanban";
 import { getTaskSearchShortcut } from "@/desktop/renderer/actions/appSettings";
-import { localizeHref, usePathname, useRouter } from "@/desktop/renderer/navigation";
+import { usePathname, useRouter } from "@/desktop/renderer/navigation";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
-import { openInternalRouteInNewWindow } from "@/desktop/renderer/utils/windowOpen";
+import { navigateToTaskDetail } from "@/desktop/renderer/utils/taskNavigation";
 import {
   DEFAULT_TASK_SEARCH_SHORTCUT,
   formatShortcutForDisplay,
@@ -336,15 +336,24 @@ export default function TaskQuickSearchDialog({
 
   useEscapeKey(closeDialog, { enabled: isOpen });
 
-  function moveToTask(taskId: string) {
-    router.push(`/task/${taskId}`);
+  function getCurrentLocale() {
+    const currentLocale = pathname.split("/").filter(Boolean)[0];
+    return currentLocale;
+  }
+
+  async function moveToTask(taskId: string) {
+    await navigateToTaskDetail(taskId, {
+      currentLocale: getCurrentLocale(),
+      navigate: router.push,
+    });
     closeDialog();
   }
 
   function openTaskInNewWindow(taskId: string) {
-    const currentLocale = pathname.split("/").filter(Boolean)[0];
-    const taskHref = localizeHref(`/task/${taskId}`, currentLocale);
-    openInternalRouteInNewWindow(taskHref);
+    void navigateToTaskDetail(taskId, {
+      currentLocale: getCurrentLocale(),
+      openInNewWindow: true,
+    });
     closeDialog();
   }
 

--- a/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
@@ -5,6 +5,7 @@ import TaskQuickSearchDialog from "@/desktop/renderer/components/TaskQuickSearch
 const mocks = vi.hoisted(() => ({
   getSearchableTasks: vi.fn(),
   push: vi.fn(),
+  focusExistingInternalRoute: vi.fn(),
   requestCreateBranchTodo: vi.fn(),
   scrollIntoView: vi.fn(),
   setTaskQuickSearchOpen: vi.fn(),
@@ -22,6 +23,7 @@ vi.mock("@/desktop/renderer/navigation", () => ({
   localizeHref: (href: string, currentLocale = "ko") => (
     href.startsWith("/") ? `/${currentLocale}${href}` : href
   ),
+  redirect: (...args: unknown[]) => mocks.push(...args),
   usePathname: () => "/en",
   useRouter: () => ({
     push: (...args: unknown[]) => mocks.push(...args),
@@ -41,6 +43,10 @@ describe("TaskQuickSearchDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.history.replaceState({}, "", "/#/en");
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      focusExistingInternalRoute: mocks.focusExistingInternalRoute.mockResolvedValue(false),
+    } as unknown as NonNullable<typeof window.kanvibeDesktop>;
     Object.defineProperty(Element.prototype, "scrollIntoView", {
       configurable: true,
       value: mocks.scrollIntoView,
@@ -166,8 +172,31 @@ describe("TaskQuickSearchDialog", () => {
     fireEvent.keyDown(input, { key: "Enter" });
 
     await waitFor(() => {
-      expect(mocks.push).toHaveBeenCalledWith("/task/task-remote");
+      expect(mocks.push).toHaveBeenCalledWith("/en/task/task-remote");
     });
+  });
+
+  it("Enter로 이동할 task가 다른 윈도우에 열려 있으면 해당 윈도우 focus를 우선한다", async () => {
+    mocks.focusExistingInternalRoute.mockResolvedValue(true);
+
+    render(<TaskQuickSearchDialog shortcut="Ctrl+K" />);
+
+    fireEvent.keyDown(window, {
+      key: "k",
+      ctrlKey: true,
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, {
+      target: { value: "api" },
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mocks.focusExistingInternalRoute).toHaveBeenCalledWith("/en/task/task-remote");
+    });
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
   it("검색 결과에서 상세 페이지로 이동할 때 terminal focus 요청을 보낸다", async () => {
@@ -188,7 +217,7 @@ describe("TaskQuickSearchDialog", () => {
     fireEvent.keyDown(input, { key: "Enter" });
 
     await waitFor(() => {
-      expect(mocks.push).toHaveBeenCalledWith("/task/task-remote");
+      expect(mocks.push).toHaveBeenCalledWith("/en/task/task-remote");
     });
     await waitFor(() => {
       expect(focusListener).toHaveBeenCalled();
@@ -238,7 +267,7 @@ describe("TaskQuickSearchDialog", () => {
     fireEvent.keyDown(input, { key: "Enter" });
 
     await waitFor(() => {
-      expect(mocks.push).toHaveBeenCalledWith("/task/task-alert");
+      expect(mocks.push).toHaveBeenCalledWith("/en/task/task-alert");
     });
   });
 
@@ -257,7 +286,7 @@ describe("TaskQuickSearchDialog", () => {
     fireEvent.keyDown(input, { key: "Enter" });
 
     await waitFor(() => {
-      expect(mocks.push).toHaveBeenCalledWith("/task/task-dev-kanvibe");
+      expect(mocks.push).toHaveBeenCalledWith("/en/task/task-dev-kanvibe");
     });
   });
 

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -17,6 +17,7 @@ declare global {
       isDesktop: boolean;
       logRendererError?: (event: string, payload?: Record<string, unknown>) => void;
       invoke: (namespace: DesktopServiceNamespace, method: string, args: unknown[]) => Promise<unknown>;
+      focusExistingInternalRoute?: (route: string) => Promise<boolean>;
       onBoardEvent: (listener: (event: BoardEventPayload) => void) => () => void;
       openTerminal: (taskId: string, cols: number, rows: number) => Promise<{ ok: boolean; error?: string }>;
       writeTerminal: (taskId: string, data: string) => void;

--- a/src/desktop/renderer/routes/DiffRoute.tsx
+++ b/src/desktop/renderer/routes/DiffRoute.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useParams } from "react-router-dom";
-import { Link, useRouter } from "@/desktop/renderer/navigation";
+import { Link, usePathname, useRouter } from "@/desktop/renderer/navigation";
 import { getGitDiffFiles } from "@/desktop/renderer/actions/diff";
 import { getTaskById } from "@/desktop/renderer/actions/kanban";
 import DiffPageClient from "@/desktop/renderer/components/DiffPageClient";
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
+import {
+  navigateToTaskDetail,
+  shouldHandleTaskNavigationClick,
+} from "@/desktop/renderer/utils/taskNavigation";
 
 interface DiffRouteState {
   task: Awaited<ReturnType<typeof getTaskById>>;
@@ -24,8 +28,22 @@ export default function DiffRoute() {
   const { id = "" } = useParams();
   const t = useTranslations("diffView");
   const router = useRouter();
+  const pathname = usePathname();
   const refreshSignal = useRefreshSignal(["all", "diff"]);
   const [state, setState] = useState<DiffRouteState | null>(null);
+  const currentLocale = pathname.split("/").filter(Boolean)[0];
+
+  function handleTaskDetailLinkClick(event: React.MouseEvent<HTMLAnchorElement>) {
+    if (!shouldHandleTaskNavigationClick(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    void navigateToTaskDetail(id, {
+      currentLocale,
+      navigate: router.push,
+    });
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -96,7 +114,7 @@ export default function DiffRoute() {
     return (
       <div className="h-screen flex flex-col items-center justify-center bg-bg-page gap-4">
         <p className="text-text-muted text-sm">{t("noBranch")}</p>
-        <Link href={`/task/${id}`} className="text-sm text-text-brand hover:underline">{t("backToTask")}</Link>
+        <Link href={`/task/${id}`} onClick={handleTaskDetailLinkClick} className="text-sm text-text-brand hover:underline">{t("backToTask")}</Link>
       </div>
     );
   }
@@ -105,7 +123,7 @@ export default function DiffRoute() {
     return (
       <div className="h-screen flex flex-col items-center justify-center bg-bg-page gap-4">
         <p className="text-text-muted text-sm">{t("noWorktree")}</p>
-        <Link href={`/task/${id}`} className="text-sm text-text-brand hover:underline">{t("backToTask")}</Link>
+        <Link href={`/task/${id}`} onClick={handleTaskDetailLinkClick} className="text-sm text-text-brand hover:underline">{t("backToTask")}</Link>
       </div>
     );
   }
@@ -113,7 +131,7 @@ export default function DiffRoute() {
   return (
     <div className="h-screen flex flex-col bg-bg-page">
       <header className="shrink-0 flex items-center gap-3 px-4 py-2.5 bg-bg-surface border-b border-border-default">
-        <Link href={`/task/${id}`} className="flex items-center gap-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors">
+        <Link href={`/task/${id}`} onClick={handleTaskDetailLinkClick} className="flex items-center gap-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="shrink-0">
             <path d="M10 12L6 8L10 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
           </svg>

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -79,7 +79,9 @@ vi.mock("react-router-dom", () => ({
 
 vi.mock("@/desktop/renderer/navigation", () => ({
   Link: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  localizeHref: (href: string, currentLocale = "ko") => href.startsWith("/") ? `/${currentLocale}${href}` : href,
   redirect: (...args: unknown[]) => mocks.redirect(...args),
+  usePathname: () => "/ko/task/task-1",
   useRouter: () => ({ push: mocks.push, back: mocks.back, forward: mocks.forward }),
 }));
 

--- a/src/desktop/renderer/utils/__tests__/taskNavigation.test.ts
+++ b/src/desktop/renderer/utils/__tests__/taskNavigation.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { navigateToTaskDetail } from "@/desktop/renderer/utils/taskNavigation";
+
+describe("navigateToTaskDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, "", "/#/en");
+  });
+
+  it("focuses an existing task detail window before falling back to in-window navigation", async () => {
+    const navigate = vi.fn();
+    const focusExistingInternalRoute = vi.fn().mockResolvedValue(true);
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      focusExistingInternalRoute,
+    } as unknown as NonNullable<typeof window.kanvibeDesktop>;
+
+    await navigateToTaskDetail("task-1", {
+      currentLocale: "en",
+      navigate,
+    });
+
+    expect(focusExistingInternalRoute).toHaveBeenCalledWith("/en/task/task-1");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("navigates in the current window when no existing task detail window is focused", async () => {
+    const navigate = vi.fn();
+    const focusExistingInternalRoute = vi.fn().mockResolvedValue(false);
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      focusExistingInternalRoute,
+    } as unknown as NonNullable<typeof window.kanvibeDesktop>;
+
+    await navigateToTaskDetail("task-1", {
+      currentLocale: "en",
+      navigate,
+    });
+
+    expect(focusExistingInternalRoute).toHaveBeenCalledWith("/en/task/task-1");
+    expect(navigate).toHaveBeenCalledWith("/en/task/task-1");
+  });
+});

--- a/src/desktop/renderer/utils/taskNavigation.ts
+++ b/src/desktop/renderer/utils/taskNavigation.ts
@@ -1,0 +1,64 @@
+import { localizeHref, redirect } from "@/desktop/renderer/navigation";
+import { openInternalRouteInNewWindow } from "@/desktop/renderer/utils/windowOpen";
+
+interface NavigateToTaskDetailOptions {
+  currentLocale?: string;
+  navigate?: (href: string) => void;
+  openInNewWindow?: boolean;
+}
+
+interface TaskNavigationClickEvent {
+  defaultPrevented: boolean;
+  button: number;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+}
+
+export function shouldHandleTaskNavigationClick(event: TaskNavigationClickEvent) {
+  return (
+    !event.defaultPrevented
+    && event.button === 0
+    && !event.altKey
+    && !event.ctrlKey
+    && !event.metaKey
+  );
+}
+
+export function getTaskDetailHref(taskId: string, currentLocale?: string) {
+  return localizeHref(`/task/${taskId}`, currentLocale);
+}
+
+export async function focusExistingTaskDetailWindow(taskId: string, currentLocale?: string) {
+  const focusExistingInternalRoute = window.kanvibeDesktop?.focusExistingInternalRoute;
+  if (!focusExistingInternalRoute) {
+    return false;
+  }
+
+  try {
+    return await focusExistingInternalRoute(getTaskDetailHref(taskId, currentLocale));
+  } catch {
+    return false;
+  }
+}
+
+export async function navigateToTaskDetail(
+  taskId: string,
+  {
+    currentLocale,
+    navigate = redirect,
+    openInNewWindow = false,
+  }: NavigateToTaskDetailOptions = {},
+) {
+  const href = getTaskDetailHref(taskId, currentLocale);
+
+  if (openInNewWindow) {
+    openInternalRouteInNewWindow(href);
+    return;
+  }
+
+  const didFocusExistingWindow = await focusExistingTaskDetailWindow(taskId, currentLocale);
+  if (!didFocusExistingWindow) {
+    navigate(href);
+  }
+}

--- a/src/types/kanvibeDesktop.d.ts
+++ b/src/types/kanvibeDesktop.d.ts
@@ -12,6 +12,7 @@ interface KanvibeDesktopApi {
   onNotificationActivated?: (listener: (notification: AppNotification) => void) => () => void;
   onNotificationShortcut?: (listener: () => void) => () => void;
   onCreateTaskShortcut?: (listener: () => void) => () => void;
+  focusExistingInternalRoute?: (route: string) => Promise<boolean>;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## What changed
- Added a shared task-detail navigation helper that focuses an already-open task detail window before navigating the current window.
- Wired the shared policy into quick search, notification task redirects, task cards, task creation, branch task modals, board new-window shortcuts, and diff back-to-task links.
- Added an Electron bridge for focusing an existing internal route while excluding the sender window.
- Documented the task navigation convention in `CLAUDE.md`.
- Added focused regression coverage for the shared navigation helper, notification redirects, task card clicks, quick search, and window route matching.

## Notes
- Explicit new-window actions still use the new-window path so the existing Electron duplicate-window focus policy remains intact.

Co-Authored-By: OpenAI Codex <codex@openai.com>