### PR TITLE
Restore kanban task focus on board return

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -29,6 +29,7 @@ interface BoardProps {
   initialTasks: TasksByStatus;
   initialDoneTotal: number;
   initialDoneLimit: number;
+  initialFocusTaskId?: string | null;
   sshHosts: string[];
   projects: Project[];
   sidebarDefaultCollapsed: boolean;
@@ -63,6 +64,10 @@ function getBoardTaskCards() {
 function focusBoardTaskCard(card: HTMLAnchorElement) {
   card.focus({ preventScroll: true });
   card.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+}
+
+function findBoardTaskCardById(taskId: string) {
+  return getBoardTaskCards().find((card) => card.dataset.kanbanTaskId === taskId) ?? null;
 }
 
 function findTaskById(tasks: TasksByStatus, taskId: string) {
@@ -271,6 +276,7 @@ export default function Board({
   initialTasks,
   initialDoneTotal,
   initialDoneLimit,
+  initialFocusTaskId,
   sshHosts,
   projects,
   doneAlertDismissed,
@@ -302,6 +308,7 @@ export default function Board({
   const [, startDragPersistenceTransition] = useTransition();
   const notificationCenterRef = useRef<NotificationCenterButtonHandle>(null);
   const projectSelectorRef = useRef<ProjectSelectorHandle>(null);
+  const hasAppliedInitialFocusRef = useRef(false);
 
   /** projectId → 표시할 프로젝트 이름 매핑. worktree 프로젝트는 메인 프로젝트 이름으로 resolve한다 */
   const projectNameMap = useMemo(() => {
@@ -423,6 +430,28 @@ export default function Board({
     const isMacDesktop = navigator.userAgent.includes("Mac") || navigator.platform.toLowerCase().includes("mac");
     setShouldUseMacTitlebarLayout(isDesktopApp && isMacDesktop);
   }, []);
+
+  useEffect(() => {
+    hasAppliedInitialFocusRef.current = false;
+  }, [initialFocusTaskId]);
+
+  useEffect(() => {
+    if (!isMounted || !initialFocusTaskId || hasAppliedInitialFocusRef.current) {
+      return;
+    }
+
+    if (!findTaskById(filteredTasks, initialFocusTaskId)) {
+      return;
+    }
+
+    const targetTaskCard = findBoardTaskCardById(initialFocusTaskId);
+    if (!targetTaskCard) {
+      return;
+    }
+
+    focusBoardTaskCard(targetTaskCard);
+    hasAppliedInitialFocusRef.current = true;
+  }, [filteredTasks, initialFocusTaskId, isMounted]);
 
   useEffect(() => boardCommands.registerBoardHandlers({
     toggleNotificationCenter() {

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -193,7 +193,7 @@ export default function TaskCard({ task, index, onContextMenu, projectName, proj
             ...provided.draggableProps.style,
             ...cardStyle,
           }}
-          className={`group relative mb-1.5 block overflow-hidden rounded-md border border-border-subtle px-2.5 py-2 transition-colors cursor-pointer outline-none focus:border-brand-primary focus:bg-bg-surface/80 focus:ring-2 focus:ring-brand-primary/30 ${isBaseProject ? "pr-8" : ""} ${
+          className={`group relative mb-1.5 block overflow-hidden rounded-md border border-border-subtle px-2.5 py-2 transition-[background-color,border-color,box-shadow] cursor-pointer outline-none focus:border-border-brand focus:bg-bg-surface/90 ${isBaseProject ? "pr-8" : ""} ${
             snapshot.isDragging
               ? "bg-bg-surface shadow-md ring-1 ring-border-brand"
               : "hover:bg-bg-surface/70"

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -193,6 +193,58 @@ function createTasksWithTodo(): TasksByStatus {
   };
 }
 
+function createTasksWithTodoAndProgress(): TasksByStatus {
+  return {
+    [TaskStatus.TODO]: [
+      {
+        id: "task-1",
+        title: "Todo Task",
+        description: null,
+        status: TaskStatus.TODO,
+        branchName: null,
+        worktreePath: null,
+        sessionType: null,
+        sessionName: null,
+        sshHost: null,
+        agentType: null,
+        project: null,
+        projectId: "project-1",
+        baseBranch: null,
+        prUrl: null,
+        priority: null,
+        displayOrder: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+    [TaskStatus.PROGRESS]: [
+      {
+        id: "task-2",
+        title: "Progress Task",
+        description: null,
+        status: TaskStatus.PROGRESS,
+        branchName: null,
+        worktreePath: null,
+        sessionType: null,
+        sessionName: null,
+        sshHost: null,
+        agentType: null,
+        project: null,
+        projectId: "project-1",
+        baseBranch: null,
+        prUrl: null,
+        priority: null,
+        displayOrder: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+    [TaskStatus.PENDING]: [],
+    [TaskStatus.REVIEW]: [],
+    [TaskStatus.DONE]: [],
+  };
+}
+
 function BoardCommandRequester() {
   const boardCommands = useBoardCommands();
 
@@ -393,6 +445,30 @@ describe("Board defaultSessionType sync", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(document.activeElement).toBe(taskLink);
+  });
+
+  it("상세 화면에서 돌아온 task id가 있으면 해당 task로 초기 focus를 시작한다", async () => {
+    render(
+      <Board
+        initialTasks={createTasksWithTodoAndProgress()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
+        initialFocusTaskId="task-2"
+      />,
+    );
+
+    const progressTaskLink = await screen.findByRole("link", { name: "Progress Task" });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(progressTaskLink);
+    });
   });
 
   it("포커스된 task에서 Shift+Enter를 누르면 상세 페이지를 새 창에서 연다", async () => {

--- a/src/desktop/renderer/routes/BoardRoute.tsx
+++ b/src/desktop/renderer/routes/BoardRoute.tsx
@@ -5,6 +5,7 @@ import { getTasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { getAllProjects, getAvailableHosts } from "@/desktop/renderer/actions/project";
 import { buildRouteCacheKey, readRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
+import { consumeBoardFocusTask } from "@/desktop/renderer/utils/boardFocusTarget";
 import { DEFAULT_TASK_SEARCH_SHORTCUT } from "@/desktop/renderer/utils/keyboardShortcut";
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { SessionType, TaskStatus } from "@/entities/KanbanTask";
@@ -119,6 +120,7 @@ function BoardRouteSkeleton() {
 export default function BoardRoute() {
   const refreshSignal = useRefreshSignal(["all", "board"]);
   const [data, setData] = useState<BoardData | null>(() => readRouteCache<BoardData>(BOARD_ROUTE_CACHE_KEY));
+  const [initialFocusTaskId] = useState(() => consumeBoardFocusTask());
 
   useEffect(() => {
     document.title = "";
@@ -182,6 +184,7 @@ export default function BoardRoute() {
       initialTasks={data.tasks.tasks}
       initialDoneTotal={data.tasks.doneTotal}
       initialDoneLimit={data.tasks.doneLimit}
+      initialFocusTaskId={initialFocusTaskId}
       sshHosts={data.sshHosts}
       projects={data.projects}
       sidebarDefaultCollapsed={data.sidebarDefaultCollapsed}

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -32,6 +32,7 @@ import TerminalLoader from "@/desktop/renderer/components/TerminalLoader";
 import { fetchPrUrlWithPrompt } from "@/desktop/renderer/utils/fetchPrUrlWithPrompt";
 import { SHORTCUTS, getCurrentShortcutPlatform, matchShortcutEvent } from "@/desktop/renderer/utils/keyboardShortcut";
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
+import { rememberBoardFocusTask } from "@/desktop/renderer/utils/boardFocusTarget";
 import { buildRouteCacheKey, readRouteCache, removeRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
 import { requestActiveTerminalFocusAfterUiSettles } from "@/desktop/renderer/utils/terminalFocus";
@@ -309,6 +310,12 @@ export default function TaskDetailRoute() {
   const currentTaskIdRef = useRef(id);
   const hasTerminal = !!(state?.task.sessionType && state.task.sessionName);
   const shortcutPlatform = getCurrentShortcutPlatform();
+
+  useEffect(() => {
+    if (id) {
+      rememberBoardFocusTask(id);
+    }
+  }, [id]);
 
   useEffect(() => boardCommands.registerNotificationCenterHandler(() => {
     notificationCenterRef.current?.toggle();

--- a/src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx
@@ -4,6 +4,7 @@ import BoardRoute from "@/desktop/renderer/routes/BoardRoute";
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadingTimeout";
 
 const BOARD_CACHE_KEY = "kanvibe:route-cache:board";
+const BOARD_FOCUS_TASK_CACHE_KEY = "kanvibe:route-cache:board-focus-task";
 
 const mocks = vi.hoisted(() => ({
   getTasksByStatus: vi.fn(),
@@ -28,8 +29,17 @@ function createDeferred<T>() {
 }
 
 vi.mock("@/components/Board", () => ({
-  default: ({ initialTasks }: { initialTasks: Record<string, Array<{ title: string }>> }) => (
-    <div data-testid="board-titles">{Object.values(initialTasks).flat().map((task) => task.title).join(",")}</div>
+  default: ({
+    initialTasks,
+    initialFocusTaskId,
+  }: {
+    initialTasks: Record<string, Array<{ title: string }>>;
+    initialFocusTaskId?: string | null;
+  }) => (
+    <>
+      <div data-testid="board-titles">{Object.values(initialTasks).flat().map((task) => task.title).join(",")}</div>
+      <div data-testid="board-focus-task">{initialFocusTaskId ?? ""}</div>
+    </>
   ),
 }));
 
@@ -140,6 +150,28 @@ describe("BoardRoute", () => {
     await waitFor(() => {
       expect(screen.getByTestId("board-titles").textContent).toBe("fresh board task");
     });
+  });
+
+  it("상세 화면에서 기록한 focus task id를 한 번 소비해서 Board에 전달한다", async () => {
+    sessionStorage.setItem(BOARD_FOCUS_TASK_CACHE_KEY, JSON.stringify("task-2"));
+    mocks.getTasksByStatus.mockResolvedValue({
+      tasks: {
+        todo: [],
+        progress: [{ id: "task-2", title: "focus target task" }],
+        pending: [],
+        review: [],
+        done: [],
+      },
+      doneTotal: 0,
+      doneLimit: 20,
+    });
+
+    render(<BoardRoute />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("board-focus-task").textContent).toBe("task-2");
+    });
+    expect(sessionStorage.getItem(BOARD_FOCUS_TASK_CACHE_KEY)).toBeNull();
   });
 
   it("초기 데이터 로딩이 실패해도 Loading 화면에 고착되지 않는다", async () => {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -6,6 +6,7 @@ import TaskDetailRoute from "@/desktop/renderer/routes/TaskDetailRoute";
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadingTimeout";
 
 const TASK_DETAIL_CACHE_KEY = "kanvibe:route-cache:task-detail:task-1";
+const BOARD_FOCUS_TASK_CACHE_KEY = "kanvibe:route-cache:board-focus-task";
 
 const mocks = vi.hoisted(() => ({
   getTaskById: vi.fn(),
@@ -355,6 +356,31 @@ describe("TaskDetailRoute", () => {
     await waitFor(() => {
       expect(screen.getByTestId("task-title").textContent).toBe("fresh task title");
     });
+  });
+
+  it("현재 task id를 보드 복귀 focus target으로 기록한다", async () => {
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-focus-return",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-focus-return",
+    });
+
+    render(<TaskDetailRoute />);
+
+    await screen.findByTestId("task-title");
+
+    expect(JSON.parse(sessionStorage.getItem(BOARD_FOCUS_TASK_CACHE_KEY) ?? "null")).toBe("task-1");
   });
 
   it("초기 task 조회가 끝나지 않아도 Loading 화면에 고착되지 않는다", async () => {

--- a/src/desktop/renderer/utils/boardFocusTarget.ts
+++ b/src/desktop/renderer/utils/boardFocusTarget.ts
@@ -1,0 +1,22 @@
+import { buildRouteCacheKey, readRouteCache, removeRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
+
+const BOARD_FOCUS_TASK_CACHE_KEY = buildRouteCacheKey("board-focus-task");
+
+function normalizeTaskId(taskId: unknown) {
+  return typeof taskId === "string" && taskId.trim() ? taskId : null;
+}
+
+export function rememberBoardFocusTask(taskId: string) {
+  const normalizedTaskId = normalizeTaskId(taskId);
+  if (!normalizedTaskId) {
+    return;
+  }
+
+  writeRouteCache(BOARD_FOCUS_TASK_CACHE_KEY, normalizedTaskId);
+}
+
+export function consumeBoardFocusTask() {
+  const taskId = normalizeTaskId(readRouteCache<string>(BOARD_FOCUS_TASK_CACHE_KEY));
+  removeRouteCache(BOARD_FOCUS_TASK_CACHE_KEY);
+  return taskId;
+}

--- a/src/styles/__tests__/globals.test.ts
+++ b/src/styles/__tests__/globals.test.ts
@@ -31,4 +31,14 @@ describe("globals.css theme tokens", () => {
     expect(readThemeVar(':root\\[data-theme="light"\\]', "--color-tag-ssh-bg")).toBe("var(--green-50)");
     expect(readThemeVar(':root\\[data-theme="light"\\]', "--color-tag-ssh-text")).toBe("var(--green-700)");
   });
+
+  it("defines a high-contrast focus glow for keyboard-focused kanban task cards", () => {
+    const darkThemeSelector = ':root,\\s*:root\\[data-theme="dark"\\]';
+
+    expect(readThemeVar(":root", "--shadow-kanban-task-focus")).toContain("var(--color-brand-muted)");
+    expect(readThemeVar(darkThemeSelector, "--shadow-kanban-task-focus")).toContain("rgba(0, 100, 255, 0.38)");
+    expect(css).toContain('[data-kanban-task-card="true"]:focus');
+    expect(css).toContain("border-color: var(--color-border-brand) !important;");
+    expect(css).toContain("box-shadow: var(--shadow-kanban-task-focus);");
+  });
 });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -172,6 +172,7 @@
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
   --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.08), 0 2px 4px -2px rgba(0, 0, 0, 0.04);
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -4px rgba(0, 0, 0, 0.04);
+  --shadow-kanban-task-focus: 0 0 0 1px var(--color-border-brand), 0 0 0 5px var(--color-brand-muted), 0 12px 28px rgba(0, 100, 255, 0.22);
 
   /* Border Radius */
   --radius-sm: 0.25rem;
@@ -277,6 +278,7 @@
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.24);
   --shadow-md: 0 12px 30px rgba(0, 0, 0, 0.26);
   --shadow-lg: 0 22px 60px rgba(0, 0, 0, 0.34);
+  --shadow-kanban-task-focus: 0 0 0 1px rgba(0, 100, 255, 0.95), 0 0 0 5px rgba(0, 100, 255, 0.38), 0 16px 36px rgba(0, 100, 255, 0.38);
 
   --radius-sm: 0.1875rem;
   --radius-md: 0.375rem;
@@ -327,6 +329,7 @@
   --shadow-sm: 0 1px 2px rgba(17, 24, 39, 0.06);
   --shadow-md: 0 12px 28px rgba(17, 24, 39, 0.08);
   --shadow-lg: 0 22px 60px rgba(17, 24, 39, 0.14);
+  --shadow-kanban-task-focus: 0 0 0 1px var(--color-border-brand), 0 0 0 5px rgba(0, 100, 255, 0.18), 0 12px 28px rgba(0, 100, 255, 0.22);
 }
 
 @theme inline {
@@ -480,4 +483,10 @@ textarea {
 }
 .xterm-screen {
   height: 100%;
+}
+
+[data-kanban-task-card="true"]:focus {
+  position: relative;
+  border-color: var(--color-border-brand) !important;
+  box-shadow: var(--shadow-kanban-task-focus);
 }


### PR DESCRIPTION
## What is this change?
- Restore keyboard focus to the previously viewed task when returning from a task detail page to the kanban board.
- Make focused task cards visually explicit in dark mode with a stronger border and glow treatment.

## How was it solved?
**Return focus target**
- Add a small route-cache utility that remembers the current task id from the detail route.
- Consume that task id once in the board route and pass it to the board as the initial focus target.

**Kanban focus behavior**
- Focus the matching kanban task card after board cards are mounted.
- Preserve the existing arrow-key board navigation behavior when no return focus target exists.

**Focus visibility**
- Add theme-aware task focus shadow tokens.
- Apply a task-card-specific focus selector that overrides project-colored borders with an explicit focus border and glow.

## Important implementation details
### Task focus restoration

**One-time route-local focus target**
- **Why**: Returning from detail should continue keyboard navigation from the task the user was viewing without adding transient UI state to the URL.
- **Files**: `src/desktop/renderer/utils/boardFocusTarget.ts`, `src/desktop/renderer/routes/TaskDetailRoute.tsx`, `src/desktop/renderer/routes/BoardRoute.tsx`

**DOM focus after board mount**
- **Why**: Task cards are rendered inside the board/DnD tree, so focus must happen after the matching card exists in the document.
- **Files**: `src/components/Board.tsx`

### Focus glow styling

**High-contrast task card focus style**
- **Why**: The previous focus ring was too subtle in dark mode and could be obscured by project-specific card borders.
- **Files**: `src/components/TaskCard.tsx`, `src/styles/globals.css`

**Regression coverage**
- **Why**: The behavior spans route cache, board rendering, task detail rendering, and CSS tokens.
- **Files**: `src/components/__tests__/Board.test.tsx`, `src/desktop/renderer/routes/__tests__/BoardRoute.test.tsx`, `src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx`, `src/styles/__tests__/globals.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>
