### PR TITLE
fix(project-scan): skip submodules during project registration

### DIFF
--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -928,6 +928,71 @@ describe("projectService local hook installation", () => {
     );
   });
 
+  it("프로젝트 스캔은 git submodule을 별도 프로젝트로 등록하지 않는다", async () => {
+    // Given
+    mocks.scanGitRepos.mockResolvedValue([
+      "/workspace/app",
+      "/workspace/app/packages/ui",
+    ]);
+    mocks.execGit.mockImplementation(async (command: string) => {
+      if (command.includes("rev-parse --show-superproject-working-tree")) {
+        return command.includes('"/workspace/app/packages/ui"') ? "/workspace/app" : "";
+      }
+
+      if (command.includes("rev-parse --path-format=absolute --git-common-dir")) {
+        return command.includes('"/workspace/app/packages/ui"')
+          ? "/workspace/app/.git/modules/packages/ui"
+          : "/workspace/app/.git";
+      }
+
+      return "";
+    });
+    mocks.getDefaultBranch.mockResolvedValue("main");
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.listWorktrees.mockResolvedValue([]);
+
+    const projectSave = vi.fn(async (value) => ({ id: "project-1", ...value }));
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: "project-1",
+            name: "app",
+            repoPath: "/workspace/app",
+            defaultBranch: "main",
+            sshHost: null,
+          },
+        ]),
+      create: vi.fn((value) => value),
+      save: projectSave,
+      remove: vi.fn(),
+    });
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn().mockResolvedValue(null),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => ({ id: "task-main", ...value })),
+    });
+
+    const { scanAndRegisterProjects } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const result = await scanAndRegisterProjects("/workspace");
+
+    // Then
+    expect(result.registered).toEqual(["app"]);
+    expect(projectSave).toHaveBeenCalledTimes(1);
+    expect(projectSave).toHaveBeenCalledWith(expect.objectContaining({
+      name: "app",
+      repoPath: "/workspace/app",
+    }));
+    expect(mocks.getDefaultBranch).toHaveBeenCalledWith("/workspace/app", null);
+    expect(mocks.getDefaultBranch).not.toHaveBeenCalledWith("/workspace/app/packages/ui", null);
+  });
+
   it("worktree 경로만 스캔돼도 common repo 기준 기존 원격 프로젝트에 TODO 태스크를 등록한다", async () => {
     mocks.scanGitRepos.mockResolvedValue(["/remote/repo__worktrees/feature-login"]);
     mocks.execGit.mockImplementation(async (command: string) => {

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -62,6 +62,19 @@ async function resolveCommonRepoPath(repoPath: string, sshHost?: string | null):
   }
 }
 
+async function isSubmoduleRepoPath(repoPath: string, sshHost?: string | null): Promise<boolean> {
+  try {
+    const superprojectPath = await execGit(
+      `git -C "${repoPath}" rev-parse --show-superproject-working-tree`,
+      sshHost,
+    );
+
+    return superprojectPath.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
 async function resolveProjectDefaultBranchWorktreePath(project: Pick<Project, "repoPath" | "defaultBranch" | "sshHost">): Promise<string | null> {
   try {
     const worktrees = await listWorktrees(project.repoPath, project.sshHost);
@@ -716,9 +729,17 @@ export async function scanAndRegisterProjects(
   const result: ScanResult = { registered: [], skipped: [], errors: [], worktreeTasks: [], registeredWorktrees: [], hooksSetup: [] };
 
   const discoveredRepoPaths = await scanGitRepos(rootPath, sshHost || null);
+  const registerableDiscoveredRepoPaths = (
+    await Promise.all(discoveredRepoPaths.map(async (repoPath) => ({
+      repoPath,
+      isSubmodule: await isSubmoduleRepoPath(repoPath, sshHost || null),
+    })))
+  )
+    .filter(({ isSubmodule }) => !isSubmodule)
+    .map(({ repoPath }) => repoPath);
   const repoPaths = Array.from(
     new Set(
-      await Promise.all(discoveredRepoPaths.map((repoPath) => resolveCommonRepoPath(repoPath, sshHost || null))),
+      await Promise.all(registerableDiscoveredRepoPaths.map((repoPath) => resolveCommonRepoPath(repoPath, sshHost || null))),
     ),
   );
   if (repoPaths.length === 0) {


### PR DESCRIPTION
## What does this do?
- Prevent settings page project scans from registering Git submodules as standalone projects.

## How did you solve it?
**Submodule detection**
- Add a service-level Git check with `git rev-parse --show-superproject-working-tree`.
- Filter submodule paths before common repository path normalization so regular repositories and worktrees keep the existing flow.

**Regression coverage**
- Add a `projectService` regression test for a scan result containing both a parent repository and one nested submodule.

## Important changes
### Project scan filtering

**Skip submodule candidates**
- **Reason**: Submodules belong to a parent repository and should not appear as separate KanVibe projects.
- **Modified files**: `src/desktop/main/services/projectService.ts`

**Cover parent repository plus submodule scans**
- **Reason**: Preserve expected registration for the parent repo while preventing submodule registration from coming back.
- **Modified files**: `src/desktop/main/services/__tests__/projectService.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>
