### PR TITLE
fix(hooks): verify remote root tasks with current task id

### DIFF
--- a/src/components/HooksStatusCard.tsx
+++ b/src/components/HooksStatusCard.tsx
@@ -9,6 +9,9 @@ import {
 } from "@hugeicons/core-free-icons";
 import { useTranslations } from "next-intl";
 import {
+  getTaskCodexHooksStatus,
+  getTaskGeminiHooksStatus,
+  getTaskHooksStatus,
   getTaskOpenCodeHooksStatus,
   installTaskCodexHooks,
   installTaskGeminiHooks,
@@ -37,6 +40,12 @@ interface HooksStatusCardProps {
 
 type HookToolKey = "claude" | "gemini" | "codex" | "openCode";
 type InstallMessage = { type: "success" | "error"; text: string };
+type HookStatusUpdates = {
+  claudeStatus?: ClaudeHooksStatus | null;
+  geminiStatus?: GeminiHooksStatus | null;
+  codexStatus?: CodexHooksStatus | null;
+  openCodeStatus?: OpenCodeHooksStatus | null;
+};
 
 export default function HooksStatusCard({
   taskId,
@@ -170,8 +179,52 @@ export default function HooksStatusCard({
     try {
       const result = await install();
       applyResult(result);
+      if (isSuccessfulInstallResult(result)) {
+        await refreshAllHookStatuses().catch(() => undefined);
+      }
     } finally {
       setInstallingTools((current) => current.filter((value) => value !== tool));
+    }
+  }
+
+  async function refreshAllHookStatuses() {
+    const [latestClaudeStatus, latestGeminiStatus, latestCodexStatus, latestOpenCodeStatus] = await Promise.all([
+      getTaskHooksStatus(taskId),
+      getTaskGeminiHooksStatus(taskId),
+      getTaskCodexHooksStatus(taskId),
+      getTaskOpenCodeHooksStatus(taskId),
+    ]);
+
+    applyRefreshedStatuses({
+      claudeStatus: latestClaudeStatus,
+      geminiStatus: latestGeminiStatus,
+      codexStatus: latestCodexStatus,
+      openCodeStatus: latestOpenCodeStatus,
+    });
+  }
+
+  function applyRefreshedStatuses(updates: HookStatusUpdates) {
+    const parentUpdates: HookStatusUpdates = {};
+
+    if (updates.claudeStatus) {
+      setClaudeStatus(updates.claudeStatus);
+      parentUpdates.claudeStatus = updates.claudeStatus;
+    }
+    if (updates.geminiStatus) {
+      setGeminiStatus(updates.geminiStatus);
+      parentUpdates.geminiStatus = updates.geminiStatus;
+    }
+    if (updates.codexStatus) {
+      setCodexStatus(updates.codexStatus);
+      parentUpdates.codexStatus = updates.codexStatus;
+    }
+    if (updates.openCodeStatus) {
+      setOpenCodeStatus(updates.openCodeStatus);
+      parentUpdates.openCodeStatus = updates.openCodeStatus;
+    }
+
+    if (Object.keys(parentUpdates).length > 0) {
+      onStatusesChangeRef.current?.(parentUpdates);
     }
   }
 
@@ -252,6 +305,13 @@ export default function HooksStatusCard({
       </div>
     </div>
   );
+}
+
+function isSuccessfulInstallResult(result: unknown): result is { success: true } {
+  return result !== null
+    && typeof result === "object"
+    && "success" in result
+    && (result as { success?: unknown }).success === true;
 }
 
 function getInstallFailureText(t: ReturnType<typeof useTranslations>, error?: string) {

--- a/src/components/HooksStatusDialog.tsx
+++ b/src/components/HooksStatusDialog.tsx
@@ -7,6 +7,9 @@ import {
   installTaskGeminiHooks,
   installTaskCodexHooks,
   installTaskOpenCodeHooks,
+  getTaskHooksStatus,
+  getTaskGeminiHooksStatus,
+  getTaskCodexHooksStatus,
   getTaskOpenCodeHooksStatus,
 } from "@/desktop/renderer/actions/project";
 import type { ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
@@ -33,6 +36,12 @@ interface HooksStatusDialogProps {
 }
 
 type HookToolKey = "claude" | "gemini" | "codex" | "openCode";
+type HookStatusUpdates = {
+  claudeStatus?: ClaudeHooksStatus | null;
+  geminiStatus?: GeminiHooksStatus | null;
+  codexStatus?: CodexHooksStatus | null;
+  openCodeStatus?: OpenCodeHooksStatus | null;
+};
 
 export default function HooksStatusDialog({
   isOpen,
@@ -182,8 +191,52 @@ export default function HooksStatusDialog({
     try {
       const result = await install();
       applyResult(result);
+      if (isSuccessfulInstallResult(result)) {
+        await refreshAllHookStatuses().catch(() => undefined);
+      }
     } finally {
       setInstallingTools((current) => current.filter((value) => value !== tool));
+    }
+  }
+
+  async function refreshAllHookStatuses() {
+    const [latestClaudeStatus, latestGeminiStatus, latestCodexStatus, latestOpenCodeStatus] = await Promise.all([
+      getTaskHooksStatus(taskId),
+      getTaskGeminiHooksStatus(taskId),
+      getTaskCodexHooksStatus(taskId),
+      getTaskOpenCodeHooksStatus(taskId),
+    ]);
+
+    applyRefreshedStatuses({
+      claudeStatus: latestClaudeStatus,
+      geminiStatus: latestGeminiStatus,
+      codexStatus: latestCodexStatus,
+      openCodeStatus: latestOpenCodeStatus,
+    });
+  }
+
+  function applyRefreshedStatuses(updates: HookStatusUpdates) {
+    const parentUpdates: HookStatusUpdates = {};
+
+    if (updates.claudeStatus) {
+      setLocalClaudeStatus(updates.claudeStatus);
+      parentUpdates.claudeStatus = updates.claudeStatus;
+    }
+    if (updates.geminiStatus) {
+      setLocalGeminiStatus(updates.geminiStatus);
+      parentUpdates.geminiStatus = updates.geminiStatus;
+    }
+    if (updates.codexStatus) {
+      setLocalCodexStatus(updates.codexStatus);
+      parentUpdates.codexStatus = updates.codexStatus;
+    }
+    if (updates.openCodeStatus) {
+      setLocalOpenCodeStatus(updates.openCodeStatus);
+      parentUpdates.openCodeStatus = updates.openCodeStatus;
+    }
+
+    if (Object.keys(parentUpdates).length > 0) {
+      onStatusesChangeRef.current?.(parentUpdates);
     }
   }
 
@@ -350,4 +403,11 @@ export default function HooksStatusDialog({
       </div>
     </div>
   );
+}
+
+function isSuccessfulInstallResult(result: unknown): result is { success: true } {
+  return result !== null
+    && typeof result === "object"
+    && "success" in result
+    && (result as { success?: unknown }).success === true;
 }

--- a/src/components/__tests__/HooksStatusCard.test.tsx
+++ b/src/components/__tests__/HooksStatusCard.test.tsx
@@ -9,12 +9,18 @@ const {
   mockInstallTaskGeminiHooks,
   mockInstallTaskCodexHooks,
   mockInstallTaskOpenCodeHooks,
+  mockGetTaskHooksStatus,
+  mockGetTaskGeminiHooksStatus,
+  mockGetTaskCodexHooksStatus,
   mockGetTaskOpenCodeHooksStatus,
 } = vi.hoisted(() => ({
   mockInstallTaskHooks: vi.fn(),
   mockInstallTaskGeminiHooks: vi.fn(),
   mockInstallTaskCodexHooks: vi.fn(),
   mockInstallTaskOpenCodeHooks: vi.fn(),
+  mockGetTaskHooksStatus: vi.fn(),
+  mockGetTaskGeminiHooksStatus: vi.fn(),
+  mockGetTaskCodexHooksStatus: vi.fn(),
   mockGetTaskOpenCodeHooksStatus: vi.fn(),
 }));
 
@@ -23,6 +29,9 @@ vi.mock("@/desktop/renderer/actions/project", () => ({
   installTaskGeminiHooks: mockInstallTaskGeminiHooks,
   installTaskCodexHooks: mockInstallTaskCodexHooks,
   installTaskOpenCodeHooks: mockInstallTaskOpenCodeHooks,
+  getTaskHooksStatus: mockGetTaskHooksStatus,
+  getTaskGeminiHooksStatus: mockGetTaskGeminiHooksStatus,
+  getTaskCodexHooksStatus: mockGetTaskCodexHooksStatus,
   getTaskOpenCodeHooksStatus: mockGetTaskOpenCodeHooksStatus,
 }));
 
@@ -73,6 +82,9 @@ const messages = {
 describe("HooksStatusCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetTaskHooksStatus.mockResolvedValue(null);
+    mockGetTaskGeminiHooksStatus.mockResolvedValue(null);
+    mockGetTaskCodexHooksStatus.mockResolvedValue(null);
     mockGetTaskOpenCodeHooksStatus.mockResolvedValue(null);
   });
 
@@ -155,10 +167,18 @@ describe("HooksStatusCard", () => {
   });
 
   it("installs Claude hooks from the inline action and updates local status", async () => {
+    const installedClaudeStatus = { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true };
+    const installedGeminiStatus = { installed: true, hasPromptHook: true, hasStopHook: true, hasSettingsEntry: true };
+    const installedCodexStatus = { installed: true, hasPromptHook: true, hasPermissionHook: true, hasPreToolHook: true, hasStopHook: true, hasHooksFile: true, hasHookEntries: true, hasConfigEntry: true };
+    const installedOpenCodeStatus = { installed: true, hasPlugin: true, hasTaskIdBinding: true, hasStatusEndpoint: true, hasEventMappings: true, hasMainSessionGuard: true, hasDuplicateProgressGuard: true };
     mockInstallTaskHooks.mockResolvedValue({
       success: true,
-      status: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
+      status: installedClaudeStatus,
     });
+    mockGetTaskHooksStatus.mockResolvedValue(installedClaudeStatus);
+    mockGetTaskGeminiHooksStatus.mockResolvedValue(installedGeminiStatus);
+    mockGetTaskCodexHooksStatus.mockResolvedValue(installedCodexStatus);
+    mockGetTaskOpenCodeHooksStatus.mockResolvedValue(installedOpenCodeStatus);
     const onStatusesChange = vi.fn();
 
     renderCard({
@@ -176,7 +196,10 @@ describe("HooksStatusCard", () => {
     await waitFor(() => {
       expect(mockInstallTaskHooks).toHaveBeenCalledWith("task-1");
       expect(onStatusesChange).toHaveBeenCalledWith({
-        claudeStatus: { installed: true, hasPromptHook: true, hasStopHook: true, hasQuestionHook: true, hasSettingsEntry: true },
+        claudeStatus: installedClaudeStatus,
+        geminiStatus: installedGeminiStatus,
+        codexStatus: installedCodexStatus,
+        openCodeStatus: installedOpenCodeStatus,
       });
     });
     expect(screen.getByText("Hooks installed successfully")).toBeTruthy();

--- a/src/components/__tests__/HooksStatusDialog.test.tsx
+++ b/src/components/__tests__/HooksStatusDialog.test.tsx
@@ -10,12 +10,18 @@ const {
   mockInstallTaskGeminiHooks,
   mockInstallTaskCodexHooks,
   mockInstallTaskOpenCodeHooks,
+  mockGetTaskHooksStatus,
+  mockGetTaskGeminiHooksStatus,
+  mockGetTaskCodexHooksStatus,
   mockGetTaskOpenCodeHooksStatus,
 } = vi.hoisted(() => ({
   mockInstallTaskHooks: vi.fn(),
   mockInstallTaskGeminiHooks: vi.fn(),
   mockInstallTaskCodexHooks: vi.fn(),
   mockInstallTaskOpenCodeHooks: vi.fn(),
+  mockGetTaskHooksStatus: vi.fn(),
+  mockGetTaskGeminiHooksStatus: vi.fn(),
+  mockGetTaskCodexHooksStatus: vi.fn(),
   mockGetTaskOpenCodeHooksStatus: vi.fn(),
 }));
 
@@ -24,6 +30,9 @@ vi.mock("@/desktop/renderer/actions/project", () => ({
   installTaskGeminiHooks: mockInstallTaskGeminiHooks,
   installTaskCodexHooks: mockInstallTaskCodexHooks,
   installTaskOpenCodeHooks: mockInstallTaskOpenCodeHooks,
+  getTaskHooksStatus: mockGetTaskHooksStatus,
+  getTaskGeminiHooksStatus: mockGetTaskGeminiHooksStatus,
+  getTaskCodexHooksStatus: mockGetTaskCodexHooksStatus,
   getTaskOpenCodeHooksStatus: mockGetTaskOpenCodeHooksStatus,
 }));
 
@@ -39,6 +48,9 @@ vi.mock("next-intl", async () => {
 describe("HooksStatusDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetTaskHooksStatus.mockResolvedValue(null);
+    mockGetTaskGeminiHooksStatus.mockResolvedValue(null);
+    mockGetTaskCodexHooksStatus.mockResolvedValue(null);
     mockGetTaskOpenCodeHooksStatus.mockResolvedValue(null);
   });
 
@@ -681,6 +693,10 @@ describe("HooksStatusDialog", () => {
   it("should report updated hook status to the parent card after installation", async () => {
     const onStatusesChange = vi.fn();
     mockInstallTaskHooks.mockResolvedValue({ success: true, status: verifiedClaudeStatus });
+    mockGetTaskHooksStatus.mockResolvedValue(verifiedClaudeStatus);
+    mockGetTaskGeminiHooksStatus.mockResolvedValue(verifiedGeminiStatus);
+    mockGetTaskCodexHooksStatus.mockResolvedValue(verifiedCodexStatus);
+    mockGetTaskOpenCodeHooksStatus.mockResolvedValue(verifiedOpenCodeStatus);
 
     renderDialog({
       isOpen: true,
@@ -697,7 +713,12 @@ describe("HooksStatusDialog", () => {
     fireEvent.click(screen.getAllByText("installHooks")[0]);
 
     await waitFor(() => {
-      expect(onStatusesChange).toHaveBeenCalledWith({ claudeStatus: verifiedClaudeStatus });
+      expect(onStatusesChange).toHaveBeenCalledWith({
+        claudeStatus: verifiedClaudeStatus,
+        geminiStatus: verifiedGeminiStatus,
+        codexStatus: verifiedCodexStatus,
+        openCodeStatus: verifiedOpenCodeStatus,
+      });
     });
   });
 });

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -1487,6 +1487,49 @@ describe("projectService remote hook and AI session support", () => {
     );
   });
 
+  it("원격 repo root에서 실행 중인 비기본 브랜치 task는 현재 taskId로 hook 상태를 조회한다", async () => {
+    const task = {
+      id: "task-remote",
+      branchName: "feature/login",
+      baseBranch: "main",
+      worktreePath: "/remote/repo",
+      project: {
+        id: "project-1",
+        repoPath: "/remote/repo",
+        defaultBranch: "main",
+        sshHost: "remote-host",
+      },
+    };
+    const findOneBy = vi.fn();
+
+    mocks.getTaskRepository.mockResolvedValue({
+      findOne: vi.fn().mockResolvedValue(task),
+      findOneBy,
+    });
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: true });
+
+    const {
+      getTaskHooksStatus,
+      getTaskGeminiHooksStatus,
+      getTaskCodexHooksStatus,
+      getTaskOpenCodeHooksStatus,
+    } = await import("@/desktop/main/services/projectService");
+
+    await getTaskHooksStatus(task.id);
+    await getTaskGeminiHooksStatus(task.id);
+    await getTaskCodexHooksStatus(task.id);
+    await getTaskOpenCodeHooksStatus(task.id);
+
+    expect(mocks.getClaudeHooksStatus).toHaveBeenCalledWith("/remote/repo", "task-remote", "remote-host");
+    expect(mocks.getGeminiHooksStatus).toHaveBeenCalledWith("/remote/repo", "task-remote", "remote-host");
+    expect(mocks.getCodexHooksStatus).toHaveBeenCalledWith("/remote/repo", "task-remote", "remote-host");
+    expect(mocks.getOpenCodeHooksStatus).toHaveBeenCalledWith("/remote/repo", "task-remote", "remote-host");
+    expect(findOneBy).not.toHaveBeenCalled();
+  });
+
   it("원격 태스크에서 hook 재설치를 누르면 공통 installer를 다시 실행한다", async () => {
     // Given
     const task = {
@@ -1515,6 +1558,45 @@ describe("projectService remote hook and AI session support", () => {
       "task-remote",
       "remote-host",
     );
+  });
+
+  it("원격 repo root에서 실행 중인 비기본 브랜치 task는 현재 taskId로 hook을 재설치한다", async () => {
+    const task = {
+      id: "task-remote",
+      branchName: "feature/login",
+      baseBranch: "main",
+      worktreePath: "/remote/repo",
+      project: {
+        id: "project-1",
+        repoPath: "/remote/repo",
+        defaultBranch: "main",
+        sshHost: "remote-host",
+      },
+    };
+
+    mocks.getTaskRepository.mockResolvedValue({
+      findOne: vi.fn().mockResolvedValue(task),
+      findOneBy: vi.fn(),
+    });
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: true });
+
+    const {
+      installTaskHooks,
+      installTaskGeminiHooks,
+      installTaskCodexHooks,
+      installTaskOpenCodeHooks,
+    } = await import("@/desktop/main/services/projectService");
+
+    await installTaskHooks(task.id);
+    await installTaskGeminiHooks(task.id);
+    await installTaskCodexHooks(task.id);
+    await installTaskOpenCodeHooks(task.id);
+
+    expect(mocks.installKanvibeHooks).toHaveBeenCalledTimes(4);
+    expect(mocks.installKanvibeHooks).toHaveBeenCalledWith("/remote/repo", "task-remote", "remote-host");
   });
 
   it("원격 AI 세션 집계에도 sshHost를 전달한다", async () => {

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -362,6 +362,8 @@ async function ensureProjectRootTask(
 async function resolveTaskHookTarget(task: {
   id: string;
   worktreePath: string | null;
+  branchName?: string | null;
+  baseBranch?: string | null;
   project: Project | null;
 }) {
   if (!task.project) {
@@ -369,7 +371,7 @@ async function resolveTaskHookTarget(task: {
   }
 
   const targetPath = task.worktreePath || task.project.repoPath;
-  if (targetPath !== task.project.repoPath) {
+  if (targetPath !== task.project.repoPath || !isDefaultBranchTask(task, task.project.defaultBranch)) {
     return {
       targetPath,
       taskId: task.id,
@@ -383,6 +385,17 @@ async function resolveTaskHookTarget(task: {
     taskId: projectRootTask?.id ?? task.id,
     sshHost: task.project.sshHost,
   };
+}
+
+function isDefaultBranchTask(
+  task: { branchName?: string | null; baseBranch?: string | null },
+  defaultBranch: string,
+): boolean {
+  if (task.branchName) {
+    return task.branchName === defaultBranch;
+  }
+
+  return !task.baseBranch || task.baseBranch === defaultBranch;
 }
 
 /** 등록된 모든 프로젝트를 반환한다 */


### PR DESCRIPTION
## What does this PR do?
- Fix remote hook status verification when a non-default branch task runs from the repository root path.

## How did you solve it?
**Use the current task id for non-default root tasks**
- Keep default branch root tasks on the existing root-task binding behavior.
- Treat non-default branch tasks as their own hook target even when their working path is the repository root.

**Refresh all hook statuses after installation**
- Re-fetch Claude, Gemini, Codex, and OpenCode hook statuses after any successful hook install action.
- Update the inline card and dialog state with the full refreshed status set.

## Important changes
### Remote hook target resolution

**Preserve the active task binding**
- **Reason**: remote hook scripts can be correctly bound to the current task id but still appear uninstalled if verification substitutes the default branch task id.
- **Files**: `src/desktop/main/services/projectService.ts`, `src/desktop/main/services/__tests__/projectService.test.ts`

### Hook status UI refresh

**Refresh provider statuses as a group**
- **Reason**: the common installer updates every provider, so the UI should not leave the other provider rows stale after installing one provider.
- **Files**: `src/components/HooksStatusCard.tsx`, `src/components/HooksStatusDialog.tsx`, related component tests

Co-Authored-By: OpenAI Codex <codex@openai.com>