### PR TITLE
feat(board): add keyboard status dropdown to task actions

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -118,6 +118,7 @@
   "contextMenu": {
     "branchOff": "Branch off",
     "createBranchTodo": "Create branch TODO",
+    "changeStatus": "Change status",
     "delete": "Delete"
   },
   "settings": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -118,6 +118,7 @@
   "contextMenu": {
     "branchOff": "브랜치 분기",
     "createBranchTodo": "브랜치 기반 TODO 생성",
+    "changeStatus": "상태 변경하기",
     "delete": "삭제"
   },
   "settings": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -117,6 +117,7 @@
   "contextMenu": {
     "branchOff": "创建分支",
     "createBranchTodo": "创建分支TODO",
+    "changeStatus": "更改状态",
     "delete": "删除"
   },
   "settings": {

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -132,6 +132,34 @@ function openTaskDetailInNewWindow(taskId: string) {
   openInternalRouteInNewWindow(localizeHref(`/task/${taskId}`, getCurrentBoardLocale()));
 }
 
+function buildStatusMoveResult(
+  task: KanbanTask,
+  destinationStatus: TaskStatus,
+  currentTasks: TasksByStatus,
+  filteredTasks: TasksByStatus,
+): DropResult | null {
+  if (task.status === destinationStatus) return null;
+
+  const sourceIndex = currentTasks[task.status].findIndex((candidate) => candidate.id === task.id);
+  if (sourceIndex === -1) return null;
+
+  return {
+    draggableId: task.id,
+    type: "DEFAULT",
+    source: {
+      droppableId: task.status,
+      index: sourceIndex,
+    },
+    destination: {
+      droppableId: destinationStatus,
+      index: filteredTasks[destinationStatus].length,
+    },
+    reason: "DROP",
+    mode: "FLUID",
+    combine: null,
+  };
+}
+
 /** worktree repoPath에서 메인 프로젝트 경로를 추출한다 */
 function extractMainRepoPath(repoPath: string): string | null {
   const worktreeIndex = repoPath.indexOf("__worktrees");
@@ -602,6 +630,39 @@ export default function Board({
     handleCloseContextMenu();
   }, [contextMenu.task, handleCloseContextMenu, tt]);
 
+  const handleStatusChangeFromCard = useCallback(
+    (newStatus: TaskStatus) => {
+      const task = contextMenu.task;
+      if (!task) return;
+
+      const result = buildStatusMoveResult(task, newStatus, tasks, filteredTasks);
+      handleCloseContextMenu();
+
+      if (!result) return;
+
+      const shouldConfirmDoneMove =
+        newStatus === TaskStatus.DONE &&
+        task.status !== TaskStatus.DONE &&
+        !isDoneAlertDismissed &&
+        !!(task.branchName || task.sessionType);
+
+      if (shouldConfirmDoneMove) {
+        setPendingDoneResult(result);
+        return;
+      }
+
+      executeDragMove(result);
+    },
+    [
+      contextMenu.task,
+      executeDragMove,
+      filteredTasks,
+      handleCloseContextMenu,
+      isDoneAlertDismissed,
+      tasks,
+    ],
+  );
+
   const headerClassName = shouldUseMacTitlebarLayout
     ? "flex items-center justify-end bg-bg-page px-6 pb-3 pl-20 pr-6 pt-10 [-webkit-app-region:drag]"
     : "flex items-center justify-end border-b border-border-default bg-bg-surface px-6 py-3";
@@ -707,8 +768,15 @@ export default function Board({
           onClose={handleCloseContextMenu}
           onBranch={handleBranchFromCard}
           onCreateBranchTodo={handleCreateBranchTodo}
+          onStatusChange={handleStatusChangeFromCard}
           onDelete={handleDeleteFromCard}
           hasBranch={!!contextMenu.task.branchName}
+          currentStatus={contextMenu.task.status}
+          statusOptions={COLUMNS.map((column) => ({
+            status: column.status,
+            label: t(`columns.${column.labelKey}`),
+            colorClass: column.colorClass,
+          }))}
         />
       )}
 

--- a/src/components/TaskContextMenu.tsx
+++ b/src/components/TaskContextMenu.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
+import type { TaskStatus } from "@/entities/KanbanTask";
+
+interface TaskContextMenuStatusOption {
+  status: TaskStatus;
+  label: string;
+  colorClass: string;
+}
 
 interface TaskContextMenuProps {
   x: number;
@@ -9,8 +16,11 @@ interface TaskContextMenuProps {
   onClose: () => void;
   onBranch: () => void;
   onCreateBranchTodo: () => void;
+  onStatusChange: (status: TaskStatus) => void;
   onDelete: () => void;
   hasBranch: boolean;
+  currentStatus: TaskStatus;
+  statusOptions: TaskContextMenuStatusOption[];
 }
 
 /** 칸반 카드 우클릭 시 표시되는 컨텍스트 메뉴 */
@@ -20,12 +30,19 @@ export default function TaskContextMenu({
   onClose,
   onBranch,
   onCreateBranchTodo,
+  onStatusChange,
   onDelete,
   hasBranch,
+  currentStatus,
+  statusOptions,
 }: TaskContextMenuProps) {
+  const [isStatusDropdownOpen, setIsStatusDropdownOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const statusOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const t = useTranslations("contextMenu");
+  const currentStatusOption = statusOptions.find((option) => option.status === currentStatus);
+  const currentStatusLabel = currentStatusOption?.label ?? currentStatus;
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -42,7 +59,80 @@ export default function TaskContextMenu({
     menuItemRefs.current[0]?.focus();
   }, [hasBranch]);
 
+  useEffect(() => {
+    if (!isStatusDropdownOpen) return;
+
+    statusOptionRefs.current[0]?.focus();
+  }, [isStatusDropdownOpen]);
+
+  function closeStatusDropdown({ restoreFocus = true } = {}) {
+    setIsStatusDropdownOpen(false);
+
+    if (restoreFocus) {
+      requestAnimationFrame(() => {
+        menuItemRefs.current[1]?.focus();
+      });
+    }
+  }
+
+  function handleStatusSelect(status: TaskStatus) {
+    setIsStatusDropdownOpen(false);
+
+    if (status === currentStatus) {
+      requestAnimationFrame(() => {
+        menuItemRefs.current[1]?.focus();
+      });
+      return;
+    }
+
+    onStatusChange(status);
+  }
+
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (isStatusDropdownOpen) {
+      const statusItems = statusOptionRefs.current.filter(
+        (item): item is HTMLButtonElement => item !== null,
+      );
+      const currentIndex = statusItems.indexOf(document.activeElement as HTMLButtonElement);
+
+      switch (event.key) {
+        case "ArrowDown": {
+          event.preventDefault();
+          const nextIndex = currentIndex >= 0 ? (currentIndex + 1) % statusItems.length : 0;
+          statusItems[nextIndex]?.focus();
+          break;
+        }
+        case "ArrowUp": {
+          event.preventDefault();
+          const nextIndex = currentIndex > 0 ? currentIndex - 1 : statusItems.length - 1;
+          statusItems[nextIndex]?.focus();
+          break;
+        }
+        case "Home":
+          event.preventDefault();
+          statusItems[0]?.focus();
+          break;
+        case "End":
+          event.preventDefault();
+          statusItems[statusItems.length - 1]?.focus();
+          break;
+        case "Enter":
+        case " ":
+          if (currentIndex >= 0) {
+            event.preventDefault();
+            statusItems[currentIndex].click();
+          }
+          break;
+        case "ArrowLeft":
+        case "Escape":
+          event.preventDefault();
+          closeStatusDropdown();
+          break;
+      }
+
+      return;
+    }
+
     const menuItems = menuItemRefs.current.filter(
       (item): item is HTMLButtonElement => item !== null,
     );
@@ -61,7 +151,14 @@ export default function TaskContextMenu({
         menuItems[nextIndex]?.focus();
         break;
       }
+      case "ArrowRight":
+        if (document.activeElement === menuItemRefs.current[1]) {
+          event.preventDefault();
+          setIsStatusDropdownOpen(true);
+        }
+        break;
       case "Enter":
+      case " ":
         if (currentIndex >= 0) {
           event.preventDefault();
           menuItems[currentIndex].click();
@@ -80,7 +177,7 @@ export default function TaskContextMenu({
       role="menu"
       tabIndex={-1}
       onKeyDown={handleKeyDown}
-      className="fixed z-[500] min-w-[160px] bg-bg-surface border border-border-default rounded-lg shadow-lg py-1"
+      className="fixed z-[500] min-w-[220px] rounded-lg border border-border-default bg-bg-surface py-1 shadow-lg"
       style={{ left: x, top: y }}
     >
       {!hasBranch && (
@@ -112,6 +209,66 @@ export default function TaskContextMenu({
       <button
         ref={(node) => {
           menuItemRefs.current[1] = node;
+        }}
+        type="button"
+        role="menuitem"
+        aria-haspopup="menu"
+        aria-expanded={isStatusDropdownOpen}
+        aria-label={`${t("changeStatus")} ${currentStatusLabel}`}
+        onClick={() => setIsStatusDropdownOpen((current) => !current)}
+        className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-text-primary transition-colors hover:bg-bg-page focus:bg-bg-page focus:outline-none"
+      >
+        <span className="min-w-0 flex-1">{t("changeStatus")}</span>
+        <span className="inline-flex max-w-[96px] items-center gap-1.5 truncate rounded-md border border-border-subtle bg-bg-page px-1.5 py-0.5 text-xs text-text-secondary">
+          {currentStatusOption ? (
+            <span
+              aria-hidden="true"
+              className={`h-1.5 w-1.5 shrink-0 rounded-full ${currentStatusOption.colorClass}`}
+            />
+          ) : null}
+          <span className="truncate">{currentStatusLabel}</span>
+        </span>
+        <span aria-hidden="true" className="text-xs text-text-muted">
+          {isStatusDropdownOpen ? "⌃" : "⌄"}
+        </span>
+      </button>
+      {isStatusDropdownOpen && (
+        <div
+          role="menu"
+          aria-label={t("changeStatus")}
+          className="mx-1 mb-1 rounded-md border border-border-subtle bg-bg-page p-1 shadow-inner"
+        >
+          {statusOptions.map((option, index) => (
+            <button
+              key={option.status}
+              ref={(node) => {
+                statusOptionRefs.current[index] = node;
+              }}
+              type="button"
+              role="menuitemradio"
+              aria-checked={option.status === currentStatus}
+              onClick={() => handleStatusSelect(option.status)}
+              className={`flex w-full items-center gap-2 rounded px-2.5 py-1.5 text-left text-sm transition-colors focus:outline-none ${
+                option.status === currentStatus
+                  ? "bg-brand-subtle text-text-brand"
+                  : "text-text-primary hover:bg-bg-surface focus:bg-bg-surface"
+              }`}
+            >
+              <span
+                aria-hidden="true"
+                className={`h-2 w-2 shrink-0 rounded-full ${option.colorClass}`}
+              />
+              <span className="min-w-0 flex-1 truncate">{option.label}</span>
+              {option.status === currentStatus ? (
+                <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-brand-primary" />
+              ) : null}
+            </button>
+          ))}
+        </div>
+      )}
+      <button
+        ref={(node) => {
+          menuItemRefs.current[2] = node;
         }}
         type="button"
         role="menuitem"

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import Board from "../Board";
-import { reorderTasks } from "@/desktop/renderer/actions/kanban";
+import { moveTaskToColumn, reorderTasks } from "@/desktop/renderer/actions/kanban";
 import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
@@ -110,7 +110,17 @@ vi.mock("../NotificationCenterButton", () => ({
 }));
 
 vi.mock("../TaskContextMenu", () => ({
-  default: () => <div data-testid="task-context-menu" />,
+  default: ({
+    onStatusChange,
+  }: {
+    onStatusChange: (status: TaskStatus) => void;
+  }) => (
+    <div data-testid="task-context-menu">
+      <button type="button" onClick={() => onStatusChange(TaskStatus.REVIEW)}>
+        change-status-review
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("../DoneConfirmDialog", () => ({
@@ -458,6 +468,37 @@ describe("Board defaultSessionType sync", () => {
     expect(event.defaultPrevented).toBe(true);
     await waitFor(() => {
       expect(screen.getByTestId("task-context-menu")).toBeTruthy();
+    });
+  });
+
+  it("컨텍스트 메뉴에서 상태를 선택하면 대상 컬럼 마지막으로 task를 이동한다", async () => {
+    render(
+      <Board
+        initialTasks={createTasksWithTodo()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
+      />,
+    );
+
+    const taskLink = await screen.findByRole("link", { name: "Test Task" });
+    taskLink.focus();
+
+    fireEvent.keyDown(taskLink, {
+      key: "F10",
+      shiftKey: true,
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "change-status-review" }));
+
+    await waitFor(() => {
+      expect(moveTaskToColumn).toHaveBeenCalledWith("task-1", TaskStatus.REVIEW, ["task-1"]);
     });
   });
 

--- a/src/components/__tests__/TaskContextMenu.test.tsx
+++ b/src/components/__tests__/TaskContextMenu.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import TaskContextMenu from "../TaskContextMenu";
+import { TaskStatus } from "@/entities/KanbanTask";
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
@@ -13,8 +14,17 @@ function renderMenu(overrides: Partial<React.ComponentProps<typeof TaskContextMe
     onClose: vi.fn(),
     onBranch: vi.fn(),
     onCreateBranchTodo: vi.fn(),
+    onStatusChange: vi.fn(),
     onDelete: vi.fn(),
     hasBranch: false,
+    currentStatus: TaskStatus.TODO,
+    statusOptions: [
+      { status: TaskStatus.TODO, label: "Todo", colorClass: "bg-status-todo" },
+      { status: TaskStatus.PROGRESS, label: "Progress", colorClass: "bg-status-progress" },
+      { status: TaskStatus.PENDING, label: "Pending", colorClass: "bg-status-pending" },
+      { status: TaskStatus.REVIEW, label: "Review", colorClass: "bg-status-review" },
+      { status: TaskStatus.DONE, label: "Done", colorClass: "bg-status-done" },
+    ],
     ...overrides,
   };
 
@@ -29,9 +39,13 @@ describe("TaskContextMenu keyboard interaction", () => {
 
     const menu = screen.getByRole("menu");
     const branchItem = screen.getByRole("menuitem", { name: "branchOff" });
+    const statusItem = screen.getByRole("menuitem", { name: "changeStatus Todo" });
     const deleteItem = screen.getByRole("menuitem", { name: "delete" });
 
     expect(document.activeElement).toBe(branchItem);
+
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(statusItem);
 
     fireEvent.keyDown(menu, { key: "ArrowDown" });
     expect(document.activeElement).toBe(deleteItem);
@@ -48,9 +62,13 @@ describe("TaskContextMenu keyboard interaction", () => {
 
     const menu = screen.getByRole("menu");
     const createBranchTodoItem = screen.getByRole("menuitem", { name: "createBranchTodo" });
+    const statusItem = screen.getByRole("menuitem", { name: "changeStatus Todo" });
     const deleteItem = screen.getByRole("menuitem", { name: "delete" });
 
     expect(document.activeElement).toBe(createBranchTodoItem);
+
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(statusItem);
 
     fireEvent.keyDown(menu, { key: "ArrowDown" });
     expect(document.activeElement).toBe(deleteItem);
@@ -60,5 +78,33 @@ describe("TaskContextMenu keyboard interaction", () => {
 
     fireEvent.keyDown(deleteItem, { key: "Escape" });
     expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the status dropdown and changes status with keyboard only", () => {
+    const props = renderMenu();
+
+    const menu = screen.getByRole("menu");
+    const statusItem = screen.getByRole("menuitem", { name: "changeStatus Todo" });
+
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(statusItem);
+
+    fireEvent.keyDown(statusItem, { key: "Enter" });
+
+    const statusOptions = screen.getAllByRole("menuitemradio");
+    expect(statusOptions.map((option) => option.textContent)).toEqual([
+      "Todo",
+      "Progress",
+      "Pending",
+      "Review",
+      "Done",
+    ]);
+    expect(document.activeElement).toBe(statusOptions[0]);
+
+    fireEvent.keyDown(statusOptions[0], { key: "ArrowDown" });
+    expect(document.activeElement).toBe(statusOptions[1]);
+
+    fireEvent.keyDown(statusOptions[1], { key: "Enter" });
+    expect(props.onStatusChange).toHaveBeenCalledWith(TaskStatus.PROGRESS);
   });
 });


### PR DESCRIPTION
## Related materials
- None

## What is this?
- Adds a keyboard-accessible status-change dropdown to the Kanban task action menu opened from task cards.
- Lets users change a task to any board status without leaving the Shift+F10 action flow.

## How did you solve it?
**Task action menu**
- Added current-status metadata and status options to `TaskContextMenu`.
- Added a Linear-style inline dropdown with `menuitemradio` options for Todo, Progress, Pending, Review, and Done.
- Supports keyboard-only operation with arrow navigation, Enter/Space selection, Home/End, Escape, and ArrowLeft.

**Board integration**
- Reuses the existing board move flow by translating a menu status selection into the same move plan used by drag-and-drop.
- Moves the task to the end of the destination column and preserves existing Done confirmation behavior for cleanable resources.

**Coverage**
- Added focused tests for menu keyboard interaction and board status move wiring.

Co-authored-by: OpenAI Codex <codex@openai.com>
