### PR TITLE
fix(task): show background review only from notifications

### DIFF
--- a/src/components/TaskDetailTitleCard.tsx
+++ b/src/components/TaskDetailTitleCard.tsx
@@ -61,7 +61,7 @@ export default function TaskDetailTitleCard({ task, taskId }: TaskDetailTitleCar
     if (e.key === "Escape") {
       handleCancel();
     }
-    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+    if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSave();
     }

--- a/src/components/__tests__/TaskDetailTitleCard.test.tsx
+++ b/src/components/__tests__/TaskDetailTitleCard.test.tsx
@@ -241,6 +241,25 @@ describe("TaskDetailTitleCard - Description Editing", () => {
     expect(mockUpdateTask).toHaveBeenCalledWith("task-1", { description: "컨트롤 저장" });
   });
 
+  it("should call updateTask via Enter key", async () => {
+    // Given
+    const user = userEvent.setup();
+    const task = createTask({ description: "기존 설명" });
+    render(<TaskDetailTitleCard task={task} taskId="task-1" />);
+    fireEvent.click(screen.getByText("기존 설명"));
+
+    // When
+    const textarea = screen.getByRole("textbox");
+    await user.clear(textarea);
+    await user.type(textarea, "엔터 저장");
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: "Enter" });
+    });
+
+    // Then
+    expect(mockUpdateTask).toHaveBeenCalledWith("task-1", { description: "엔터 저장" });
+  });
+
   it("should not call updateTask when description is unchanged", async () => {
     // Given
     const task = createTask({ description: "기존 설명" });

--- a/src/desktop/renderer/__tests__/App.test.tsx
+++ b/src/desktop/renderer/__tests__/App.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "@/desktop/renderer/App";
+import type { AppNotification } from "@/desktop/shared/notifications";
 
 const mocks = vi.hoisted(() => ({
   triggerDesktopRefresh: vi.fn(),
@@ -116,7 +117,7 @@ describe("App", () => {
     }
   });
 
-  it("shows a background sync review dialog on the current detail route", async () => {
+  it("does not show a background sync review dialog from pending activation on route entry", async () => {
     window.location.hash = "#/en/task/task-1";
     window.kanvibeDesktop = {
       isDesktop: true,
@@ -182,6 +183,91 @@ describe("App", () => {
 
     await waitFor(() => {
       expect(screen.getByText("task detail route")).toBeTruthy();
+    });
+    expect(screen.queryByText("Background Sync Review")).toBeNull();
+    expect(window.kanvibeDesktop.consumePendingNotificationActivation).not.toHaveBeenCalled();
+    expect(window.location.hash).toBe("#/en/task/task-1");
+  });
+
+  it("shows a background sync review dialog when a notification is activated", async () => {
+    window.location.hash = "#/en/task/task-1";
+    let activateNotificationListener: ((notification: AppNotification) => void) | null = null;
+    const notification: AppNotification = {
+      id: "n-review",
+      title: "Background sync review",
+      body: "Review pending items",
+      taskId: null,
+      relativePath: "/en",
+      locale: "en",
+      isRead: false,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      dedupeKey: "background-review-1",
+      action: {
+        type: "background-sync-review" as const,
+        payload: {
+          mergedPullRequests: [
+            {
+              taskId: "task-1",
+              taskTitle: "Detail task",
+              branchName: "feature/current-route",
+              prUrl: "https://github.com/kanvibe/kanvibe/pull/410",
+              mergedAt: "2026-05-01T01:00:00Z",
+            },
+          ],
+          registeredWorktrees: [
+            {
+              taskId: "task-worktree",
+              projectName: "kanvibe",
+              branchName: "feature/new-worktree",
+              worktreePath: "/repo/kanvibe__worktrees/feature-new-worktree",
+              sshHost: null,
+            },
+          ],
+          pulledTasks: [
+            {
+              taskId: "task-pull",
+              taskTitle: "Pull target",
+              branchName: "feature/pull-fail",
+              worktreePath: "/repo/kanvibe__worktrees/feature-pull-fail",
+              sshHost: null,
+              status: "failed" as const,
+              summary: "Not possible to fast-forward",
+            },
+          ],
+          failures: [
+            {
+              operation: "pull-request-sync" as const,
+              target: "PR sync target (feature/pr-fail)",
+              reason: "gh auth failed",
+              taskId: "task-pr-fail",
+              branchName: "feature/pr-fail",
+            },
+          ],
+        },
+      },
+    };
+
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      onBoardEvent: vi.fn(() => vi.fn()),
+      consumePendingNotificationActivation: vi.fn(),
+      onNotificationActivated: vi.fn((listener) => {
+        activateNotificationListener = listener;
+        return vi.fn();
+      }),
+    } as unknown as NonNullable<typeof window.kanvibeDesktop>;
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("task detail route")).toBeTruthy();
+    });
+
+    act(() => {
+      activateNotificationListener?.(notification);
+    });
+
+    await waitFor(() => {
       expect(screen.getByText("Background Sync Review")).toBeTruthy();
     });
     expect(screen.getByText("https://github.com/kanvibe/kanvibe/pull/410")).toBeTruthy();
@@ -192,6 +278,7 @@ describe("App", () => {
     expect(screen.getByText("Sync failures")).toBeTruthy();
     expect(screen.getByText("PR sync target (feature/pr-fail)")).toBeTruthy();
     expect(screen.getByText("gh auth failed")).toBeTruthy();
+    expect(window.kanvibeDesktop.consumePendingNotificationActivation).not.toHaveBeenCalled();
     expect(window.location.hash).toBe("#/en/task/task-1");
   });
 });

--- a/src/desktop/renderer/components/BackgroundSyncReviewDialog.tsx
+++ b/src/desktop/renderer/components/BackgroundSyncReviewDialog.tsx
@@ -55,14 +55,6 @@ export default function BackgroundSyncReviewDialog() {
       setSelectedPrMergeEventKeys(payload.mergedPullRequests.map(getMergedPrEventKey));
     };
 
-    void window.kanvibeDesktop?.consumePendingNotificationActivation?.()
-      .then((notification: AppNotification | null) => {
-        applyNotification(notification);
-      })
-      .catch(() => {
-        /* pending activation consume 실패는 무시 */
-      });
-
     const dispose = window.kanvibeDesktop?.onNotificationActivated?.((notification: AppNotification) => {
       applyNotification(notification);
     });


### PR DESCRIPTION
## What is this?
- Keep background sync review results visible only through explicit notification activation instead of opening the dialog automatically when entering a task route.
- Make the task detail description editor save edits on Enter while keeping Shift+Enter available for line breaks.

## How did you solve it?
**Notification-gated background review dialog**
- Remove pending notification activation consumption from `BackgroundSyncReviewDialog` mount.
- Keep `onNotificationActivated` as the dialog entry point for background sync review notifications.

**Description edit save behavior**
- Treat Enter as the save shortcut in the task detail description textarea.
- Preserve Shift+Enter for multiline descriptions.

## Important changes
### Background sync review activation

**Stop route-entry dialog auto-open**
- **Reason**: entering a task route should not force background execution results into a modal.
- **Modified files**: `src/desktop/renderer/components/BackgroundSyncReviewDialog.tsx`, `src/desktop/renderer/__tests__/App.test.tsx`

### Description editing

**Save description edits on Enter**
- **Reason**: description edits should commit when the user presses Enter in the task detail editor.
- **Modified files**: `src/components/TaskDetailTitleCard.tsx`, `src/components/__tests__/TaskDetailTitleCard.test.tsx`

Co-authored-by: OpenAI Codex <codex@openai.com>