### PR TITLE
feat(task-detail): add dock shortcuts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@
 - Renderer keyboard events and Electron `before-input-event` inputs must be routed through the same shared matcher so macOS and Linux behavior stays consistent.
 - Shortcut capture UIs must store normalized shortcut strings from the shared capture helper, not hand-built modifier strings.
 - When adding or changing a shortcut, cover the shared command definition, display formatting, Electron input matching, renderer global handling, and any user-configurable capture flow with focused tests.
+- Task detail dock shortcuts must use the shared dock shortcut helpers: macOS uses `Cmd+Shift+{number}` and Linux uses `Alt+Shift+{number}`. Electron `before-input-event` must intercept these before terminal input receives them.
+- Task detail dock numbering excludes the back-to-board button and must be derived from the dock item array order, not hard-coded per item. Keep PR as the conditional slot after the first three dock items: with PR it is slot 4 and later items shift to 5+, without PR the next dock item gets slot 4.
 
 ## UI Color Tokens
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 - Renderer keyboard events and Electron `before-input-event` inputs must be routed through the same shared matcher so macOS and Linux behavior stays consistent.
 - Shortcut capture UIs must store normalized shortcut strings from the shared capture helper, not hand-built modifier strings.
 - When adding or changing a shortcut, cover the shared command definition, display formatting, Electron input matching, renderer global handling, and any user-configurable capture flow with focused tests.
-- Task detail dock shortcuts must use the shared dock shortcut helpers: macOS uses `Cmd+Shift+{number}` and Linux uses `Alt+Shift+{number}`. Electron `before-input-event` must intercept these before terminal input receives them.
+- Task detail dock shortcuts must use the shared dock shortcut helpers: macOS uses `Cmd+{number}` and Linux uses `Alt+{number}`. Electron `before-input-event` must intercept these before terminal input receives them.
 - Task detail dock numbering excludes the back-to-board button and must be derived from the dock item array order, not hard-coded per item. Keep PR as the conditional slot after the first three dock items: with PR it is slot 4 and later items shift to 5+, without PR the next dock item gets slot 4.
 
 ## UI Color Tokens

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ Each pane can run a custom command (e.g., `vim`, `htop`, `lazygit`, test runner,
 | `Cmd/Ctrl+Shift+P` | Board | Open the project filter dropdown |
 | `Cmd/Ctrl+Shift+I` | Board | Open the notifications dropdown |
 | `Cmd+[` / `Cmd+]` (macOS), `Alt+[` / `Alt+]` (Linux) | Global | Navigate back/forward through app history; back falls back to board home when there is no previous page |
-| `Cmd+Shift+1/2/3` (macOS), `Alt+Shift+1/2/3` (Linux) | Task detail | Activate the numbered detail dock items: info, status/hooks, and AI chat. These shortcuts are intercepted before terminal input |
-| `Cmd+Shift+4` (macOS), `Alt+Shift+4` (Linux) | Task detail | Open the task PR in the browser when a PR exists; otherwise the shortcut belongs to the fourth numbered dock item when present |
+| `Cmd+1/2/3` (macOS), `Alt+1/2/3` (Linux) | Task detail | Activate the numbered detail dock items: info, status/hooks, and AI chat. These shortcuts are intercepted before terminal input |
+| `Cmd+4` (macOS), `Alt+4` (Linux) | Task detail | Open the task PR in the browser when a PR exists; otherwise the shortcut belongs to the fourth numbered dock item when present |
 | `Cmd/Ctrl+N` | Quick task search | Create a new branch TODO from the currently highlighted task |
 | `↑ / ↓ / Enter / Shift+Enter / Esc` | Quick task search | Move selection, open task, open task in a new window, close dialog |
 | `↑ / ↓ / Enter / Esc` | Project filter dropdown | Move selection, toggle project filter, close dropdown |

--- a/README.md
+++ b/README.md
@@ -182,10 +182,14 @@ Each pane can run a custom command (e.g., `vim`, `htop`, `lazygit`, test runner,
 | `Cmd/Ctrl+Shift+P` | Board | Open the project filter dropdown |
 | `Cmd/Ctrl+Shift+I` | Board | Open the notifications dropdown |
 | `Cmd+[` / `Cmd+]` (macOS), `Alt+[` / `Alt+]` (Linux) | Global | Navigate back/forward through app history; back falls back to board home when there is no previous page |
+| `Cmd+Shift+1/2/3` (macOS), `Alt+Shift+1/2/3` (Linux) | Task detail | Activate the numbered detail dock items: info, status/hooks, and AI chat. These shortcuts are intercepted before terminal input |
+| `Cmd+Shift+4` (macOS), `Alt+Shift+4` (Linux) | Task detail | Open the task PR in the browser when a PR exists; otherwise the shortcut belongs to the fourth numbered dock item when present |
 | `Cmd/Ctrl+N` | Quick task search | Create a new branch TODO from the currently highlighted task |
 | `↑ / ↓ / Enter / Shift+Enter / Esc` | Quick task search | Move selection, open task, open task in a new window, close dialog |
 | `↑ / ↓ / Enter / Esc` | Project filter dropdown | Move selection, toggle project filter, close dropdown |
 | `↑ / ↓ / Enter / Esc` | Notifications dropdown | Move selection, open notification target, close dropdown |
+
+Task detail dock numbering excludes the back-to-board button and follows the visible dock item order. If a task has a PR URL, PR takes slot 4 and later dock items shift to 5+; without a PR, the next dock item uses slot 4.
 
 ### AI Agent Hooks - Automatic Status Tracking
 KanVibe integrates with **Claude Code Hooks**, **Gemini CLI Hooks**, **Codex CLI**, and **OpenCode** to automatically track task status. Tasks are managed through 5 statuses:

--- a/electron/main.js
+++ b/electron/main.js
@@ -286,6 +286,10 @@ function getDefaultRoute() {
   return `/${DEFAULT_LOCALE}`;
 }
 
+function isTaskDetailRouteUrl(url) {
+  return /#\/[^/]+\/task\/[^/?#]+(?:[?#]|$)/.test(url || "");
+}
+
 function getRendererNavigationUrl(target = getDefaultRoute()) {
   if (target.startsWith("http://") || target.startsWith("https://") || target.startsWith("file://")) {
     return target;
@@ -631,12 +635,16 @@ function attachWindowHandlers(browserWindow) {
       getShortcutPlatformFromProcessPlatform,
       isBlockedElectronShortcutInput,
       matchElectronShortcutInput,
+      matchTaskDetailDockShortcutInput,
     } = getKeyboardShortcutHelpers();
     const shortcutPlatform = getShortcutPlatformFromProcessPlatform(process.platform);
     const isBlockedShortcut = isBlockedElectronShortcutInput(input, shortcutPlatform);
     const isNotificationShortcut = matchElectronShortcutInput(input, DESKTOP_SHORTCUTS.notificationCenter, shortcutPlatform);
     const isCreateTaskShortcut = matchElectronShortcutInput(input, DESKTOP_SHORTCUTS.createTask, shortcutPlatform);
     const isNewWindowShortcut = matchElectronShortcutInput(input, DESKTOP_SHORTCUTS.newWindow, shortcutPlatform);
+    const taskDetailDockShortcutIndex = isTaskDetailRouteUrl(browserWindow.webContents.getURL())
+      ? matchTaskDetailDockShortcutInput(input, shortcutPlatform)
+      : null;
 
     if (isBlockedShortcut) {
       event.preventDefault();
@@ -662,6 +670,12 @@ function attachWindowHandlers(browserWindow) {
 
       const currentUrl = browserWindow.webContents.getURL() || getRendererNavigationUrl();
       void createAppWindow(currentUrl);
+    }
+
+    if (taskDetailDockShortcutIndex !== null) {
+      event.preventDefault();
+
+      browserWindow.webContents.send("kanvibe:task-detail-dock-shortcut", taskDetailDockShortcutIndex);
     }
   });
 }

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -132,4 +132,11 @@ contextBridge.exposeInMainWorld("kanvibeDesktop", {
       ipcRenderer.removeListener("kanvibe:create-task-shortcut", handler);
     };
   },
+  onTaskDetailDockShortcut(listener) {
+    const handler = (_event, shortcutIndex) => listener(shortcutIndex);
+    ipcRenderer.on("kanvibe:task-detail-dock-shortcut", handler);
+    return () => {
+      ipcRenderer.removeListener("kanvibe:task-detail-dock-shortcut", handler);
+    };
+  },
 });

--- a/src/desktop/main/__tests__/desktopShortcutRouting.test.ts
+++ b/src/desktop/main/__tests__/desktopShortcutRouting.test.ts
@@ -13,7 +13,9 @@ describe("desktop shortcut routing", () => {
     expect(source).toContain("matchElectronShortcutInput");
     expect(source).toContain("DESKTOP_SHORTCUTS.createTask");
     expect(source).toContain("DESKTOP_SHORTCUTS.newWindow");
+    expect(source).toContain("matchTaskDetailDockShortcutInput");
     expect(source).toContain('browserWindow.webContents.send("kanvibe:create-task-shortcut")');
+    expect(source).toContain('browserWindow.webContents.send("kanvibe:task-detail-dock-shortcut"');
     expect(source).toContain("void createAppWindow(currentUrl)");
   });
 

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
 import {
   Chatting01Icon,
   InformationCircleIcon,
@@ -30,7 +30,15 @@ import {
 import { useBoardCommands, type BranchTodoDefaults } from "@/desktop/renderer/components/BoardCommandProvider";
 import TerminalLoader from "@/desktop/renderer/components/TerminalLoader";
 import { fetchPrUrlWithPrompt } from "@/desktop/renderer/utils/fetchPrUrlWithPrompt";
-import { SHORTCUTS, getCurrentShortcutPlatform, matchShortcutEvent } from "@/desktop/renderer/utils/keyboardShortcut";
+import {
+  SHORTCUTS,
+  TASK_DETAIL_DOCK_SHORTCUT_INDEXES,
+  createTaskDetailDockShortcut,
+  formatShortcutForDisplay,
+  getCurrentShortcutPlatform,
+  matchShortcutEvent,
+  matchTaskDetailDockShortcutEvent,
+} from "@/desktop/renderer/utils/keyboardShortcut";
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { buildRouteCacheKey, readRouteCache, removeRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
 import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
@@ -61,6 +69,16 @@ const AGENT_TAG_STYLES: Record<string, string> = {
 
 type DetailPanel = "overview" | "status";
 type MainView = "terminal" | "chat";
+type TaskDetailDockItem = {
+  id: string;
+  label: string;
+  isActive: boolean;
+  renderIcon: () => ReactNode;
+  onActivate: () => void;
+  href?: string;
+};
+
+const PR_DOCK_INSERT_INDEX = 3;
 
 function PullRequestIcon() {
   return (
@@ -309,6 +327,96 @@ export default function TaskDetailRoute() {
   const currentTaskIdRef = useRef(id);
   const hasTerminal = !!(state?.task.sessionType && state.task.sessionName);
   const shortcutPlatform = getCurrentShortcutPlatform();
+  const statusPanelLabel = `${t("actions")} · ${t("hooksStatus")}`;
+
+  const toggleDetailPanel = useCallback((panel: DetailPanel) => {
+    setActivePanel((current) => current === panel ? null : panel);
+  }, []);
+
+  const toggleChatView = useCallback(() => {
+    setMainView((current) => {
+      const nextView = current === "chat" ? "terminal" : "chat";
+      if (nextView === "chat") {
+        setActivePanel(null);
+      } else {
+        requestActiveTerminalFocusAfterUiSettles();
+      }
+      return nextView;
+    });
+  }, []);
+
+  const dockItems = useMemo<TaskDetailDockItem[]>(() => {
+    if (!state) {
+      return [];
+    }
+
+    const items: TaskDetailDockItem[] = [
+      {
+        id: "overview",
+        label: t("info"),
+        isActive: activePanel === "overview",
+        renderIcon: () => (
+          <HugeiconsIcon
+            icon={InformationCircleIcon}
+            size={17}
+            strokeWidth={1.6}
+            aria-hidden="true"
+          />
+        ),
+        onActivate: () => toggleDetailPanel("overview"),
+      },
+      {
+        id: "status",
+        label: statusPanelLabel,
+        isActive: activePanel === "status",
+        renderIcon: () => <AntennaSignalIcon testId="task-status-panel-icon" />,
+        onActivate: () => toggleDetailPanel("status"),
+      },
+      {
+        id: "chat",
+        label: t("aiSessions.inlineChat"),
+        isActive: mainView === "chat",
+        renderIcon: () => (
+          <HugeiconsIcon
+            icon={Chatting01Icon}
+            size={17}
+            strokeWidth={1.6}
+            aria-hidden="true"
+          />
+        ),
+        onActivate: toggleChatView,
+      },
+    ];
+
+    if (state.task.prUrl) {
+      items.splice(PR_DOCK_INSERT_INDEX, 0, {
+        id: "pull-request",
+        label: "PR",
+        isActive: false,
+        renderIcon: () => <PullRequestIcon />,
+        onActivate: () => {
+          window.open(state.task.prUrl!, "_blank", "noopener,noreferrer");
+        },
+        href: state.task.prUrl,
+      });
+    }
+
+    return items;
+  }, [activePanel, mainView, state, statusPanelLabel, t, toggleChatView, toggleDetailPanel]);
+
+  const activateDockItem = useCallback((shortcutIndex: number) => {
+    if (!Number.isInteger(shortcutIndex)) {
+      return false;
+    }
+
+    const item = dockItems[shortcutIndex - 1];
+    if (!item) {
+      return false;
+    }
+
+    item.onActivate();
+    return true;
+  }, [dockItems]);
 
   useEffect(() => boardCommands.registerNotificationCenterHandler(() => {
     notificationCenterRef.current?.toggle();
@@ -355,6 +463,39 @@ export default function TaskDetailRoute() {
       window.removeEventListener("keydown", handlePriorityHistoryShortcut, { capture: true });
     };
   }, [router, shortcutPlatform]);
+
+  useEffect(() => {
+    function consumeDockShortcut(event: KeyboardEvent) {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+    }
+
+    function handlePriorityDockShortcut(event: KeyboardEvent) {
+      const shortcutIndex = matchTaskDetailDockShortcutEvent(event, shortcutPlatform);
+      if (shortcutIndex === null) {
+        return;
+      }
+
+      const handled = activateDockItem(shortcutIndex);
+      if (!handled) {
+        return;
+      }
+
+      consumeDockShortcut(event);
+    }
+
+    window.addEventListener("keydown", handlePriorityDockShortcut, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", handlePriorityDockShortcut, { capture: true });
+    };
+  }, [activateDockItem, shortcutPlatform]);
+
+  useEffect(() => (
+    window.kanvibeDesktop?.onTaskDetailDockShortcut?.((shortcutIndex: number) => {
+      activateDockItem(shortcutIndex);
+    }) ?? undefined
+  ), [activateDockItem]);
 
   useEffect(() => {
     if (currentTaskIdRef.current === id) {
@@ -572,7 +713,6 @@ export default function TaskDetailRoute() {
     () => (state?.task.agentType ? AGENT_TAG_STYLES[state.task.agentType] ?? "bg-tag-neutral-bg text-tag-neutral-text" : null),
     [state?.task.agentType],
   );
-  const statusPanelLabel = `${t("actions")} · ${t("hooksStatus")}`;
 
   useEscapeKey(() => {
     setActivePanel(null);
@@ -632,18 +772,6 @@ export default function TaskDetailRoute() {
     requestActiveTerminalFocusAfterUiSettles();
   }
 
-  function toggleChatView() {
-    setMainView((current) => {
-      const nextView = current === "chat" ? "terminal" : "chat";
-      if (nextView === "chat") {
-        setActivePanel(null);
-      } else {
-        requestActiveTerminalFocusAfterUiSettles();
-      }
-      return nextView;
-    });
-  }
-
   return (
     <div className="relative h-screen overflow-hidden bg-bg-page p-3">
       <aside className={`absolute bottom-3 left-3 top-3 z-40 flex w-12 flex-col items-center rounded-lg border border-border-default bg-bg-surface/95 p-1.5 shadow-sm ${needsMacDesktopHeaderOffset ? "pt-10" : ""}`}>
@@ -653,67 +781,46 @@ export default function TaskDetailRoute() {
           </svg>
         </Link>
 
-        {([
-          { panel: "overview", label: t("info"), icon: InformationCircleIcon },
-          { panel: "status", label: statusPanelLabel, iconTestId: "task-status-panel-icon" },
-        ] satisfies Array<{ panel: DetailPanel; label: string; icon?: IconSvgElement; iconTestId?: string }>).map(({ panel, label, icon, iconTestId }) => (
-          <button
-            key={panel}
-            type="button"
-            onClick={() => setActivePanel((current) => current === panel ? null : panel)}
-            className={`mb-1 rounded-md p-2 transition-colors ${
-              activePanel === panel
-                ? "bg-brand-subtle text-text-brand"
-                : "text-text-muted hover:bg-bg-page hover:text-text-primary"
-            }`}
-            title={label}
-            aria-label={label}
-          >
-            {icon ? (
-              <HugeiconsIcon
-                icon={icon}
-                size={17}
-                strokeWidth={1.6}
-                aria-hidden="true"
-                data-testid={iconTestId}
-              />
-            ) : (
-              <AntennaSignalIcon testId={iconTestId} />
-            )}
-          </button>
-        ))}
+        {dockItems.map((item, itemIndex) => {
+          const shortcutIndex = TASK_DETAIL_DOCK_SHORTCUT_INDEXES[itemIndex];
+          const shortcutText = shortcutIndex
+            ? formatShortcutForDisplay(createTaskDetailDockShortcut(shortcutIndex), shortcutPlatform)
+            : null;
+          const title = shortcutText ? `${item.label} (${shortcutText})` : item.label;
 
-        <button
-          type="button"
-          onClick={toggleChatView}
-          className={`mb-1 rounded-md p-2 transition-colors ${
-            mainView === "chat"
-              ? "bg-brand-subtle text-text-brand"
-              : "text-text-muted hover:bg-bg-page hover:text-text-primary"
-          }`}
-          title={t("aiSessions.inlineChat")}
-          aria-label={t("aiSessions.inlineChat")}
-        >
-          <HugeiconsIcon
-            icon={Chatting01Icon}
-            size={17}
-            strokeWidth={1.6}
-            aria-hidden="true"
-          />
-        </button>
+          if (item.href) {
+            return (
+              <a
+                key={item.id}
+                href={item.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mb-1 flex h-8 w-8 items-center justify-center rounded-md border border-tag-pr-text/30 bg-tag-pr-bg text-tag-pr-text transition-opacity hover:opacity-80"
+                title={title}
+                aria-label={item.label}
+              >
+                {item.renderIcon()}
+              </a>
+            );
+          }
 
-        {state.task.prUrl ? (
-          <a
-            href={state.task.prUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mb-1 flex h-8 w-8 items-center justify-center rounded-md border border-tag-pr-text/30 bg-tag-pr-bg text-tag-pr-text transition-opacity hover:opacity-80"
-            title="PR"
-            aria-label="PR"
-          >
-            <PullRequestIcon />
-          </a>
-        ) : null}
+          return (
+            <button
+              key={item.id}
+              type="button"
+              onClick={item.onActivate}
+              className={`mb-1 rounded-md p-2 transition-colors ${
+                item.isActive
+                  ? "bg-brand-subtle text-text-brand"
+                  : "text-text-muted hover:bg-bg-page hover:text-text-primary"
+              }`}
+              title={title}
+              aria-label={item.label}
+            >
+              {item.renderIcon()}
+            </button>
+          );
+        })}
 
         <div className="mt-auto" />
       </aside>

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -512,7 +512,6 @@ describe("TaskDetailRoute", () => {
     const wasNotPrevented = fireEvent.keyDown(terminalInput, {
       key: "1",
       altKey: true,
-      shiftKey: true,
     });
     terminalInput.removeEventListener("keydown", terminalKeyDown);
     window.removeEventListener("keydown", windowBubbleKeyDown);
@@ -550,12 +549,11 @@ describe("TaskDetailRoute", () => {
     );
 
     const prLink = await screen.findByRole("link", { name: "PR" });
-    expect(prLink.getAttribute("title")).toContain("Alt+Shift+4");
+    expect(prLink.getAttribute("title")).toContain("Alt+4");
 
     const wasNotPrevented = fireEvent.keyDown(window, {
       key: "4",
       altKey: true,
-      shiftKey: true,
     });
 
     expect(wasNotPrevented).toBe(false);

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -273,6 +273,8 @@ describe("TaskDetailRoute", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
+    delete window.kanvibeDesktop;
   });
 
   it("캐시가 있으면 stale task detail을 즉시 렌더링하고 이후 최신 데이터로 갱신한다", async () => {
@@ -474,6 +476,134 @@ describe("TaskDetailRoute", () => {
     expect(prLink.getAttribute("href")).toBe(prUrl);
     expect(prLink.getAttribute("target")).toBe("_blank");
     expect(screen.getByTestId("task-detail-pr-icon")).toBeTruthy();
+  });
+
+  it("상세 dock shortcut은 terminal 입력보다 먼저 capture 단계에서 처리한다", async () => {
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(true);
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(
+      <BoardCommandProvider>
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    const terminalInput = await screen.findByLabelText("terminal input");
+    const terminalKeyDown = vi.fn();
+    const windowBubbleKeyDown = vi.fn();
+    terminalInput.addEventListener("keydown", terminalKeyDown);
+    window.addEventListener("keydown", windowBubbleKeyDown);
+
+    const wasNotPrevented = fireEvent.keyDown(terminalInput, {
+      key: "1",
+      altKey: true,
+      shiftKey: true,
+    });
+    terminalInput.removeEventListener("keydown", terminalKeyDown);
+    window.removeEventListener("keydown", windowBubbleKeyDown);
+
+    expect(wasNotPrevented).toBe(false);
+    expect(terminalKeyDown).not.toHaveBeenCalled();
+    expect(windowBubbleKeyDown).not.toHaveBeenCalled();
+    expect(await screen.findByTestId("task-title")).toBeTruthy();
+  });
+
+  it("PR이 있는 task는 dock 4번 shortcut으로 PR을 새 브라우저 창에서 연다", async () => {
+    const prUrl = "https://github.com/kanvibe/kanvibe/pull/236";
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(
+      <BoardCommandProvider>
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    const prLink = await screen.findByRole("link", { name: "PR" });
+    expect(prLink.getAttribute("title")).toContain("Alt+Shift+4");
+
+    const wasNotPrevented = fireEvent.keyDown(window, {
+      key: "4",
+      altKey: true,
+      shiftKey: true,
+    });
+
+    expect(wasNotPrevented).toBe(false);
+    expect(openSpy).toHaveBeenCalledWith(prUrl, "_blank", "noopener,noreferrer");
+  });
+
+  it("Electron main에서 전달된 dock shortcut도 같은 dock action을 실행한다", async () => {
+    let dockShortcutListener: ((index: number) => void) | null = null;
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      onTaskDetailDockShortcut(listener: (index: number) => void) {
+        dockShortcutListener = listener;
+        return () => {
+          dockShortcutListener = null;
+        };
+      },
+    };
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(true);
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(
+      <BoardCommandProvider>
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    await screen.findByLabelText("terminal input");
+
+    act(() => {
+      dockShortcutListener?.(2);
+    });
+
+    expect(await screen.findByTestId("hooks-status-card")).toBeTruthy();
   });
 
   it("채팅 아이콘을 클릭하면 drawer 대신 메인 영역을 AI 채팅 내역으로 전환한다", async () => {

--- a/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
+++ b/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   SHORTCUTS,
+  TASK_DETAIL_DOCK_SHORTCUT_INDEXES,
   captureShortcutFromEvent,
+  createTaskDetailDockShortcut,
   formatShortcutForDisplay,
   getShortcutPlatformFromNavigator,
   isBlockedElectronShortcutInput,
   isBlockedShortcutEvent,
   matchElectronShortcutInput,
+  matchTaskDetailDockShortcutEvent,
   matchShortcutEvent,
 } from "@/desktop/renderer/utils/keyboardShortcut";
 
@@ -187,6 +190,46 @@ describe("keyboardShortcut", () => {
       control: true,
       shift: true,
     }, SHORTCUTS.pageForward, "linux")).toBe(true);
+  });
+
+  it("상세 dock shortcut은 macOS Cmd+Shift+숫자와 Linux Alt+Shift+숫자로 표시하고 매칭한다", () => {
+    expect(TASK_DETAIL_DOCK_SHORTCUT_INDEXES).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "mac")).toBe("Cmd+Shift+1");
+    expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "linux")).toBe("Alt+Shift+1");
+
+    expect(matchShortcutEvent(new KeyboardEvent("keydown", {
+      key: "1",
+      metaKey: true,
+      shiftKey: true,
+    }), createTaskDetailDockShortcut(1), "mac")).toBe(true);
+    expect(matchShortcutEvent(new KeyboardEvent("keydown", {
+      key: "1",
+      altKey: true,
+      shiftKey: true,
+    }), createTaskDetailDockShortcut(1), "linux")).toBe(true);
+    expect(matchShortcutEvent(new KeyboardEvent("keydown", {
+      key: "1",
+      ctrlKey: true,
+      shiftKey: true,
+    }), createTaskDetailDockShortcut(1), "linux")).toBe(false);
+  });
+
+  it("상세 dock shortcut matcher는 일치한 dock 번호를 반환한다", () => {
+    expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
+      key: "4",
+      metaKey: true,
+      shiftKey: true,
+    }), "mac")).toBe(4);
+    expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
+      key: "4",
+      altKey: true,
+      shiftKey: true,
+    }), "linux")).toBe(4);
+    expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
+      key: "4",
+      ctrlKey: true,
+      shiftKey: true,
+    }), "linux")).toBeNull();
   });
 
   it("Cmd/Ctrl+R은 앱에서 차단할 shortcut으로 판별한다", () => {

--- a/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
+++ b/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
@@ -192,25 +192,32 @@ describe("keyboardShortcut", () => {
     }, SHORTCUTS.pageForward, "linux")).toBe(true);
   });
 
-  it("상세 dock shortcut은 macOS Cmd+Shift+숫자와 Linux Alt+Shift+숫자로 표시하고 매칭한다", () => {
+  it("상세 dock shortcut은 macOS Cmd+숫자와 Linux Alt+숫자로 표시하고 매칭한다", () => {
     expect(TASK_DETAIL_DOCK_SHORTCUT_INDEXES).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "mac")).toBe("Cmd+Shift+1");
-    expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "linux")).toBe("Alt+Shift+1");
+    expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "mac")).toBe("Cmd+1");
+    expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "linux")).toBe("Alt+1");
 
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "1",
       metaKey: true,
-      shiftKey: true,
     }), createTaskDetailDockShortcut(1), "mac")).toBe(true);
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "1",
       altKey: true,
-      shiftKey: true,
     }), createTaskDetailDockShortcut(1), "linux")).toBe(true);
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "1",
-      ctrlKey: true,
+      metaKey: true,
       shiftKey: true,
+    }), createTaskDetailDockShortcut(1), "mac")).toBe(false);
+    expect(matchShortcutEvent(new KeyboardEvent("keydown", {
+      key: "1",
+      altKey: true,
+      shiftKey: true,
+    }), createTaskDetailDockShortcut(1), "linux")).toBe(false);
+    expect(matchShortcutEvent(new KeyboardEvent("keydown", {
+      key: "1",
+      ctrlKey: true,
     }), createTaskDetailDockShortcut(1), "linux")).toBe(false);
   });
 
@@ -218,17 +225,14 @@ describe("keyboardShortcut", () => {
     expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
       key: "4",
       metaKey: true,
-      shiftKey: true,
     }), "mac")).toBe(4);
     expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
       key: "4",
       altKey: true,
-      shiftKey: true,
     }), "linux")).toBe(4);
     expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
       key: "4",
       ctrlKey: true,
-      shiftKey: true,
     }), "linux")).toBeNull();
   });
 

--- a/src/desktop/shared/keyboardShortcut.ts
+++ b/src/desktop/shared/keyboardShortcut.ts
@@ -47,6 +47,9 @@ export const BLOCKED_DESKTOP_SHORTCUTS = {
 } as const;
 
 export const DEFAULT_TASK_SEARCH_SHORTCUT = SHORTCUTS.taskSearchDefault;
+export const TASK_DETAIL_DOCK_SHORTCUT_INDEXES = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
+
+export type TaskDetailDockShortcutIndex = typeof TASK_DETAIL_DOCK_SHORTCUT_INDEXES[number];
 
 function normalizeShortcutPlatform(platform: ShortcutPlatformInput): ShortcutPlatform {
   if (typeof platform === "boolean") {
@@ -250,6 +253,39 @@ export function matchElectronShortcutInput(
     altKey: Boolean(input.alt),
     shiftKey: Boolean(input.shift),
   }, shortcut, platform);
+}
+
+export function createTaskDetailDockShortcut(index: TaskDetailDockShortcutIndex): ShortcutDefinition {
+  return {
+    mac: `Meta+Shift+${index}`,
+    linux: `Alt+Shift+${index}`,
+  };
+}
+
+export function matchTaskDetailDockShortcutEvent(
+  event: ShortcutInput,
+  platform: ShortcutPlatformInput,
+): TaskDetailDockShortcutIndex | null {
+  for (const shortcutIndex of TASK_DETAIL_DOCK_SHORTCUT_INDEXES) {
+    if (matchShortcutEvent(event, createTaskDetailDockShortcut(shortcutIndex), platform)) {
+      return shortcutIndex;
+    }
+  }
+
+  return null;
+}
+
+export function matchTaskDetailDockShortcutInput(
+  input: ElectronShortcutInput,
+  platform: ShortcutPlatformInput,
+): TaskDetailDockShortcutIndex | null {
+  for (const shortcutIndex of TASK_DETAIL_DOCK_SHORTCUT_INDEXES) {
+    if (matchElectronShortcutInput(input, createTaskDetailDockShortcut(shortcutIndex), platform)) {
+      return shortcutIndex;
+    }
+  }
+
+  return null;
 }
 
 export function isBlockedShortcutEvent(

--- a/src/desktop/shared/keyboardShortcut.ts
+++ b/src/desktop/shared/keyboardShortcut.ts
@@ -257,8 +257,8 @@ export function matchElectronShortcutInput(
 
 export function createTaskDetailDockShortcut(index: TaskDetailDockShortcutIndex): ShortcutDefinition {
   return {
-    mac: `Meta+Shift+${index}`,
-    linux: `Alt+Shift+${index}`,
+    mac: `Meta+${index}`,
+    linux: `Alt+${index}`,
   };
 }
 

--- a/src/types/kanvibeDesktop.d.ts
+++ b/src/types/kanvibeDesktop.d.ts
@@ -12,6 +12,7 @@ interface KanvibeDesktopApi {
   onNotificationActivated?: (listener: (notification: AppNotification) => void) => () => void;
   onNotificationShortcut?: (listener: () => void) => () => void;
   onCreateTaskShortcut?: (listener: () => void) => () => void;
+  onTaskDetailDockShortcut?: (listener: (shortcutIndex: number) => void) => () => void;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## What changed?
- Add platform-aware numbered shortcuts for task detail dock items: `Cmd+Shift+number` on macOS and `Alt+Shift+number` on Linux.
- Intercept task detail dock shortcuts in Electron before terminal input receives the key event.
- Make dock shortcut numbering derive from visible dock item order, with PR taking slot 4 only when a PR URL exists.
- Document the shortcut behavior in README and add CLAUDE.md conventions for future dock additions.

## How it works
**Shared shortcut handling**
- Add shared task detail dock shortcut factories and matchers so renderer and Electron use the same platform logic.
- Route Electron `before-input-event` matches to the renderer through `kanvibe:task-detail-dock-shortcut`.

**Dynamic task detail dock**
- Render dock entries from a single item array and activate items by 1-based shortcut index.
- Keep PR as a conditional item after the first three dock entries so later entries shift automatically.

Co-Authored-By: OpenAI Codex <codex@openai.com>