### PR TITLE
fix(runtime): stop exporting generic desktop env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # KanVibe Agent Conventions
 
+## Runtime Environment Safety
+
+- Avoid writing code that mutates generic process or server environment variables, because Electron main, hook servers, shells, tmux, zellij, and spawned child processes can inherit those values.
+- Do not set generic environment variables such as `PORT`, `NODE_ENV`, `HOST`, `PATH`, `HOME`, or similar process-wide defaults to express KanVibe runtime state.
+- Prefer explicit function arguments, typed configuration objects, or module-local state for runtime wiring such as server ports, hosts, feature flags, and mode selection.
+- If an environment variable is truly required, use a KanVibe-scoped name such as `KANVIBE_*`, document why it must be process-wide, and keep it out of user shell environments unless shell inheritance is the intended behavior.
+- When constructing child process, PTY, shell, tmux, or zellij environments, start from the narrowest required environment and avoid blindly leaking server-only runtime values into interactive sessions.
+
 ## App-Wide UI Settings
 
 - Store app-wide UI preferences in the app settings layer (`appSettingsService` / `AppSettings`), not in route-specific state or route cache.

--- a/electron/main.js
+++ b/electron/main.js
@@ -266,15 +266,10 @@ function ensureRuntimeEnvironment() {
   ensureMacLocalCommandPath();
   process.env.KANVIBE_DESKTOP = "true";
   process.env.KANVIBE_HOST = HOOK_SERVER_HOST;
-  process.env.PORT = String(HOOK_SERVER_PORT);
   process.env.KANVIBE_APP_DATA_DIR = app.getPath("userData");
   process.env.KANVIBE_SEED_DB_PATH = app.isPackaged
     ? path.join(process.resourcesPath, "database", "app.seed.db")
     : path.join(appRoot, "resources", "database", "app.seed.db");
-
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = app.isPackaged ? "production" : "development";
-  }
 }
 
 function getRendererEntryPath() {

--- a/src/desktop/main/__tests__/runtimeEnvironment.test.ts
+++ b/src/desktop/main/__tests__/runtimeEnvironment.test.ts
@@ -24,6 +24,20 @@ describe("desktop runtime environment", () => {
     );
   });
 
+  it("does not export the hook server port through the generic PORT environment variable", () => {
+    const source = readFileSync(path.join(process.cwd(), "electron", "main.js"), "utf8");
+
+    expect(source).not.toContain("process.env.PORT");
+    expect(source).toContain("createHookServer({ host: HOOK_SERVER_HOST, port: HOOK_SERVER_PORT })");
+    expect(source).toContain("setHookServerPort(HOOK_SERVER_PORT)");
+  });
+
+  it("does not inject NODE_ENV into the desktop runtime environment", () => {
+    const source = readFileSync(path.join(process.cwd(), "electron", "main.js"), "utf8");
+
+    expect(source).not.toContain("process.env.NODE_ENV");
+  });
+
   it("uses port 19736 for hook server in desktop dev mode", () => {
     const source = readFileSync(path.join(process.cwd(), "electron", "main.js"), "utf8");
 


### PR DESCRIPTION
## What changed
- Remove desktop runtime injection of generic `PORT` and `NODE_ENV` values.
- Keep the hook server port wired through explicit runtime paths instead of process-wide generic environment variables.
- Add runtime environment regression coverage to prevent `PORT` and `NODE_ENV` from being reintroduced.
- Document runtime environment safety rules in `CLAUDE.md` so future changes avoid mutating server or process-wide environment state.

## Why
Shell sessions spawned by the desktop app inherit `process.env`, so generic runtime defaults such as `PORT=9736` and forced `NODE_ENV` values can leak into user shells, tmux, and zellij sessions. The convention update makes that constraint explicit for future implementation work.

## Implementation notes
- `electron/main.js` now only sets KanVibe-specific runtime environment values in `ensureRuntimeEnvironment()`.
- Hook server port selection still uses `HOOK_SERVER_PORT`, `createHookServer({ host, port })`, and `setHookServerPort(HOOK_SERVER_PORT)`.
- `runtimeEnvironment.test.ts` checks that generic env variables are not exported while the hook port wiring remains intact.
- `CLAUDE.md` now directs contributors to prefer explicit arguments, typed configuration, module-local state, or documented `KANVIBE_*` names over generic environment mutation.