### PR TITLE
fix(terminal): sanitize task shell environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,13 @@
 
 - Avoid writing code that mutates generic process or server environment variables, because Electron main, hook servers, shells, tmux, zellij, and spawned child processes can inherit those values.
 - Do not set generic environment variables such as `PORT`, `NODE_ENV`, `HOST`, `PATH`, `HOME`, or similar process-wide defaults to express KanVibe runtime state.
+- Treat `PORT`, `HOST`, `NODE_ENV`, `PATH`, `HOME`, and `KANVIBE_*` as examples, not the full boundary. Do not introduce behavior that can affect the overall process-wide, user-wide, shell-wide, tmux-wide, zellij-wide, or agent-wide environment.
+- Avoid global environment side effects such as mutating `process.env` for runtime wiring, writing shell startup files, exporting variables into interactive sessions, changing global package-manager or OS environment config, or forwarding server/runtime environments wholesale.
 - Prefer explicit function arguments, typed configuration objects, or module-local state for runtime wiring such as server ports, hosts, feature flags, and mode selection.
 - If an environment variable is truly required, use a KanVibe-scoped name such as `KANVIBE_*`, document why it must be process-wide, and keep it out of user shell environments unless shell inheritance is the intended behavior.
 - When constructing child process, PTY, shell, tmux, or zellij environments, start from the narrowest required environment and avoid blindly leaking server-only runtime values into interactive sessions.
+- Route local child process and terminal environment creation through `createLocalShellEnvironment()` so `PORT`, `HOST`, `NODE_ENV`, and KanVibe internal `KANVIBE_*` values are stripped before user-visible shells run.
+- When changing terminal or child process environment handling, add focused tests that assert server/runtime variables do not appear in task terminal environments.
 
 ## App-Wide UI Settings
 

--- a/src/lib/__tests__/shellEnvironment.test.ts
+++ b/src/lib/__tests__/shellEnvironment.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createLocalShellEnvironment } from "../shellEnvironment";
+
+const ENV_KEYS_TO_RESTORE = [
+  "PORT",
+  "HOST",
+  "NODE_ENV",
+  "KANVIBE_HOST",
+  "KANVIBE_APP_DATA_DIR",
+  "KANVIBE_DESKTOP",
+  "KANVIBE_REMOTE_SSH_COMMAND_TIMEOUT_MS",
+  "PATH",
+  "HOME",
+  "LANG",
+  "LC_ALL",
+];
+
+const originalEnv = new Map<string, string | undefined>(
+  ENV_KEYS_TO_RESTORE.map((key) => [key, process.env[key]]),
+);
+
+function restoreProcessEnv(): void {
+  for (const [key, value] of originalEnv) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+describe("createLocalShellEnvironment", () => {
+  afterEach(() => {
+    restoreProcessEnv();
+  });
+
+  it("does not leak KanVibe or generic runtime variables into local shells", () => {
+    process.env.PORT = "9736";
+    process.env.HOST = "0.0.0.0";
+    process.env.NODE_ENV = "production";
+    process.env.KANVIBE_HOST = "0.0.0.0";
+    process.env.KANVIBE_APP_DATA_DIR = "/tmp/kanvibe-app-data";
+    process.env.KANVIBE_DESKTOP = "true";
+    process.env.KANVIBE_REMOTE_SSH_COMMAND_TIMEOUT_MS = "1000";
+    process.env.PATH = "/usr/bin";
+    process.env.HOME = "/home/terminal-user";
+    delete process.env.LANG;
+    delete process.env.LC_ALL;
+
+    const environment = createLocalShellEnvironment();
+
+    expect(environment.PORT).toBeUndefined();
+    expect(environment.HOST).toBeUndefined();
+    expect(environment.NODE_ENV).toBeUndefined();
+    expect(environment.KANVIBE_HOST).toBeUndefined();
+    expect(environment.KANVIBE_APP_DATA_DIR).toBeUndefined();
+    expect(environment.KANVIBE_DESKTOP).toBeUndefined();
+    expect(environment.KANVIBE_REMOTE_SSH_COMMAND_TIMEOUT_MS).toBeUndefined();
+    expect(environment.PATH).toContain("/usr/bin");
+    expect(environment.HOME).toBe("/home/terminal-user");
+    expect(environment.LANG).toBe("en_US.UTF-8");
+    expect(environment.LC_ALL).toBe("en_US.UTF-8");
+  });
+});

--- a/src/lib/shellEnvironment.ts
+++ b/src/lib/shellEnvironment.ts
@@ -20,6 +20,30 @@ function getUserLocalCommandPaths(homeDirectory: string): string[] {
   ];
 }
 
+const BLOCKED_LOCAL_SHELL_ENV_KEYS = new Set([
+  "PORT",
+  "HOST",
+  "NODE_ENV",
+]);
+
+function shouldIncludeLocalShellEnvironmentKey(key: string): boolean {
+  return !BLOCKED_LOCAL_SHELL_ENV_KEYS.has(key) && !key.startsWith("KANVIBE_");
+}
+
+function createSanitizedProcessEnvironment(): Record<string, string> {
+  const environment: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined || !shouldIncludeLocalShellEnvironmentKey(key)) {
+      continue;
+    }
+
+    environment[key] = value;
+  }
+
+  return environment;
+}
+
 export function mergeShellPathEntries(pathValues: Array<string | undefined>): string {
   const pathEntries = pathValues
     .flatMap((pathValue) => (pathValue ?? "").split(path.delimiter))
@@ -36,9 +60,10 @@ export function createLocalShellEnvironment(): Record<string, string> {
     : "";
 
   return {
-    ...process.env,
+    ...createSanitizedProcessEnvironment(),
+    HOME: homeDirectory,
     PATH: mergeShellPathEntries([process.env.PATH, extraPath]),
     LANG: process.env.LANG || "en_US.UTF-8",
     LC_ALL: process.env.LC_ALL || "en_US.UTF-8",
-  } as Record<string, string>;
+  };
 }


### PR DESCRIPTION
## Related Materials
- Base branch: `dev`

## What Changed?
- Prevent task terminal sessions from inheriting KanVibe runtime environment variables such as hook server ports and production mode.

## How Was It Solved?
**Sanitize local shell environments**
- Added a central sanitizer in `createLocalShellEnvironment()` that strips generic runtime keys and `KANVIBE_*` values before spawning local child processes, PTYs, tmux, or zellij sessions.
- Preserved required shell basics such as `HOME`, `PATH`, `LANG`, and `LC_ALL` so terminal tooling continues to work.

**Lock the behavior with tests**
- Added a focused Vitest regression test that verifies runtime variables are not exposed through local shell environments.

**Document the convention**
- Updated `CLAUDE.md` to clarify that `PORT`, `HOST`, and `NODE_ENV` are only examples and that KanVibe code must avoid broader process-wide, user-wide, shell-wide, tmux-wide, zellij-wide, or agent-wide environment side effects.

## Important Details
### Runtime Environment Safety

**Block runtime leakage at the environment factory**
- **Why**: task terminals are user-visible interactive sessions and should not inherit KanVibe server/runtime state.
- **Files**: `src/lib/shellEnvironment.ts`, `src/lib/__tests__/shellEnvironment.test.ts`

**Broaden the repository convention**
- **Why**: future changes should avoid all global environment side effects, not just the specific `PORT`, `HOST`, and `NODE_ENV` variables observed in this bug.
- **Files**: `CLAUDE.md`

Co-Authored-By: OpenAI Codex <codex@openai.com>
