### PR TITLE
modify(project): delete project tasks when removing projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Always run these commands under Node 24.x.
 
 Search for your local git repository using the **fzf-style folder search** in project settings. KanVibe scans the directory and automatically detects existing worktree branches.
 
+To stop managing a project, delete it from project settings. This removes the project and its KanVibe tasks from the embedded SQLite database only; git branches, worktrees, and files on disk are kept.
+
 ### 2. Create Tasks
 
 Add a TODO task from the Kanban board. When creating a task with a branch name, KanVibe automatically:
@@ -158,6 +160,7 @@ Each pane can run a custom command (e.g., `vim`, `htop`, `lazygit`, test runner,
 - Automatic git worktree creation when a branch-based task is created
 - Worktree scanning: existing branches are auto-registered as TODO tasks
 - Automatic cleanup (branch + worktree + session) when task moves to DONE
+- Project deletion from settings only removes KanVibe database records for that project and its tasks; existing branches and worktrees remain untouched
 
 ### Terminal Sessions (tmux / zellij)
 - **tmux** and **zellij** are both supported as terminal multiplexers

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -113,6 +113,8 @@ macOS에서 `better-sqlite3` `NODE_MODULE_VERSION` 불일치가 발생하면, Ka
 
 프로젝트 설정에서 **fzf 스타일 폴더 검색**으로 로컬 git 저장소를 검색하고 등록합니다. KanVibe가 디렉토리를 스캔하여 기존 worktree 브랜치를 자동 감지합니다.
 
+프로젝트 관리를 중단하려면 프로젝트 설정에서 삭제하세요. 이 동작은 내장 SQLite 데이터베이스에서 해당 프로젝트와 KanVibe task만 삭제하며, 디스크의 git branch, worktree, 파일은 보존합니다.
+
 ### 2. 태스크 생성
 
 칸반 보드에서 TODO 태스크를 추가합니다. 브랜치명으로 태스크를 생성하면 KanVibe가 자동으로:
@@ -156,6 +158,7 @@ macOS에서 `better-sqlite3` `NODE_MODULE_VERSION` 불일치가 발생하면, Ka
 - 브랜치 기반 태스크 생성 시 git worktree 자동 생성
 - Worktree 스캔: 기존 브랜치를 TODO 태스크로 자동 등록
 - DONE 상태 전환 시 브랜치 + worktree + 세션 자동 정리
+- 설정에서 프로젝트를 삭제하면 해당 프로젝트와 task의 KanVibe DB 레코드만 삭제되며, 기존 branch와 worktree는 건드리지 않습니다
 
 ### 터미널 세션 (tmux / zellij)
 - **tmux**와 **zellij** 모두 터미널 멀티플렉서로 지원

--- a/messages/en.json
+++ b/messages/en.json
@@ -150,7 +150,7 @@
     "noProjects": "No registered projects.",
     "defaultBranch": "Default branch",
     "deleteProject": "Delete",
-    "deleteConfirm": "Are you sure you want to delete \"{name}\"?",
+    "deleteConfirm": "Delete \"{name}\" from KanVibe? This removes the project's KanVibe tasks from the database, but keeps git branches and worktrees on disk.",
     "hooksInstalled": "Hooks Installed",
     "hooksNotInstalled": "No Hooks",
     "installHooks": "Install Hooks",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -150,7 +150,7 @@
     "noProjects": "등록된 프로젝트가 없습니다.",
     "defaultBranch": "기본 브랜치",
     "deleteProject": "삭제",
-    "deleteConfirm": "\"{name}\" 프로젝트를 삭제하시겠습니까?",
+    "deleteConfirm": "\"{name}\" 프로젝트를 KanVibe에서 삭제하시겠습니까? 이 프로젝트의 KanVibe task DB 레코드는 삭제되지만 git branch와 worktree는 보존됩니다.",
     "hooksInstalled": "Hooks 설치됨",
     "hooksNotInstalled": "Hooks 미설치",
     "installHooks": "Hooks 설치",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -149,7 +149,7 @@
     "noProjects": "没有已注册的项目。",
     "defaultBranch": "默认分支",
     "deleteProject": "删除",
-    "deleteConfirm": "确定要删除 \"{name}\" 吗？",
+    "deleteConfirm": "要从 KanVibe 删除 \"{name}\" 吗？这会从数据库中删除该项目的 KanVibe 任务，但会保留 git 分支和 worktree。",
     "hooksInstalled": "Hooks 已安装",
     "hooksNotInstalled": "未安装 Hooks",
     "installHooks": "安装 Hooks",

--- a/src/components/__tests__/ProjectSettings.test.tsx
+++ b/src/components/__tests__/ProjectSettings.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import ProjectSettings from "../ProjectSettings";
 import { SessionType } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
+import enMessages from "../../../messages/en.json";
+import { deleteProject } from "@/desktop/renderer/actions/project";
 
 const mockSetDefaultSessionType = vi.fn().mockResolvedValue(undefined);
 const mockSetNotificationEnabled = vi.fn().mockResolvedValue(undefined);
@@ -10,7 +12,13 @@ const mockSetNotificationStatuses = vi.fn().mockResolvedValue(undefined);
 const mockSetThemePreference = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("next-intl", () => ({
-  useTranslations: () => (key: string) => key,
+  useTranslations: (namespace?: string) => (key: string, values?: Record<string, string>) => {
+    if (namespace === "settings" && key === "deleteConfirm") {
+      return enMessages.settings.deleteConfirm.replace(/\{(\w+)\}/g, (_, name: string) => values?.[name] ?? `{${name}}`);
+    }
+
+    return key;
+  },
 }));
 
 vi.mock("@/desktop/renderer/navigation", () => ({
@@ -176,6 +184,37 @@ describe("ProjectSettings", () => {
 
     // Then
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("프로젝트 삭제 확인 문구는 task DB 삭제와 branch/worktree 보존을 알린다", async () => {
+    // Given
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(
+      <ProjectSettings
+        isOpen
+        onClose={vi.fn()}
+        projects={[createProject()]}
+        sshHosts={[]}
+        sidebarDefaultCollapsed={false}
+        defaultSessionType={SessionType.TMUX}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+      />,
+    );
+
+    try {
+      // When
+      fireEvent.click(screen.getByRole("button", { name: "deleteProject" }));
+
+      // Then
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining("KanVibe tasks"));
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining("branches and worktrees"));
+      await waitFor(() => {
+        expect(deleteProject).toHaveBeenCalledWith("project-1");
+      });
+    } finally {
+      confirmSpy.mockRestore();
+    }
   });
 
   it("알림 활성화 토글은 로컬 상태를 즉시 반영한다", async () => {

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -134,6 +134,64 @@ vi.mock("@/lib/kanvibeHooksInstaller", () => ({
   scheduleKanvibeHooksInstall: mocks.scheduleKanvibeHooksInstall,
 }));
 
+describe("projectService.deleteProject", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("프로젝트 삭제 시 KanVibe DB의 관련 task 레코드도 삭제한다", async () => {
+    // Given
+    const project = {
+      id: "project-1",
+      name: "api",
+      repoPath: "/workspace/api",
+      defaultBranch: "main",
+      sshHost: null,
+    };
+    const projectRepo = {
+      findOneBy: vi.fn().mockResolvedValue(project),
+      remove: vi.fn().mockResolvedValue(project),
+    };
+    const taskRepo = {
+      delete: vi.fn().mockResolvedValue({ affected: 2 }),
+    };
+    mocks.getProjectRepository.mockResolvedValue(projectRepo);
+    mocks.getTaskRepository.mockResolvedValue(taskRepo);
+
+    const { deleteProject } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const result = await deleteProject("project-1");
+
+    // Then
+    expect(result).toBe(true);
+    expect(taskRepo.delete).toHaveBeenCalledWith({ projectId: "project-1" });
+    expect(projectRepo.remove).toHaveBeenCalledWith(project);
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("프로젝트가 없으면 task 삭제와 보드 갱신을 수행하지 않는다", async () => {
+    // Given
+    const projectRepo = {
+      findOneBy: vi.fn().mockResolvedValue(null),
+      remove: vi.fn(),
+    };
+    mocks.getProjectRepository.mockResolvedValue(projectRepo);
+
+    const { deleteProject } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const result = await deleteProject("missing-project");
+
+    // Then
+    expect(result).toBe(false);
+    expect(mocks.getTaskRepository).not.toHaveBeenCalled();
+    expect(projectRepo.remove).not.toHaveBeenCalled();
+    expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
+  });
+});
+
 describe("projectService.listSubdirectories", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -41,6 +41,7 @@ vi.mock("@/entities/Project", () => ({
 }));
 
 vi.mock("@/entities/KanbanTask", () => ({
+  KanbanTask: class KanbanTask {},
   TaskStatus: {
     TODO: "todo",
     PROGRESS: "progress",
@@ -149,15 +150,17 @@ describe("projectService.deleteProject", () => {
       defaultBranch: "main",
       sshHost: null,
     };
-    const projectRepo = {
+    const manager = {
       findOneBy: vi.fn().mockResolvedValue(project),
+      delete: vi.fn().mockResolvedValue({ affected: 2 }),
       remove: vi.fn().mockResolvedValue(project),
     };
-    const taskRepo = {
-      delete: vi.fn().mockResolvedValue({ affected: 2 }),
+    const projectRepo = {
+      manager: {
+        transaction: vi.fn(async (callback: (transactionManager: typeof manager) => Promise<void>) => callback(manager)),
+      },
     };
     mocks.getProjectRepository.mockResolvedValue(projectRepo);
-    mocks.getTaskRepository.mockResolvedValue(taskRepo);
 
     const { deleteProject } = await import("@/desktop/main/services/projectService");
 
@@ -166,16 +169,25 @@ describe("projectService.deleteProject", () => {
 
     // Then
     expect(result).toBe(true);
-    expect(taskRepo.delete).toHaveBeenCalledWith({ projectId: "project-1" });
-    expect(projectRepo.remove).toHaveBeenCalledWith(project);
+    expect(projectRepo.manager.transaction).toHaveBeenCalledTimes(1);
+    expect(manager.findOneBy).toHaveBeenCalledWith(expect.any(Function), { id: "project-1" });
+    expect(manager.delete).toHaveBeenCalledWith(expect.any(Function), { projectId: "project-1" });
+    expect(manager.remove).toHaveBeenCalledWith(project);
+    expect(mocks.getTaskRepository).not.toHaveBeenCalled();
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
   });
 
   it("프로젝트가 없으면 task 삭제와 보드 갱신을 수행하지 않는다", async () => {
     // Given
-    const projectRepo = {
+    const manager = {
       findOneBy: vi.fn().mockResolvedValue(null),
+      delete: vi.fn(),
       remove: vi.fn(),
+    };
+    const projectRepo = {
+      manager: {
+        transaction: vi.fn(async (callback: (transactionManager: typeof manager) => Promise<void>) => callback(manager)),
+      },
     };
     mocks.getProjectRepository.mockResolvedValue(projectRepo);
 
@@ -187,8 +199,69 @@ describe("projectService.deleteProject", () => {
     // Then
     expect(result).toBe(false);
     expect(mocks.getTaskRepository).not.toHaveBeenCalled();
-    expect(projectRepo.remove).not.toHaveBeenCalled();
+    expect(manager.delete).not.toHaveBeenCalled();
+    expect(manager.remove).not.toHaveBeenCalled();
     expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
+  });
+
+  it("삭제 중 예약된 root task repair는 기본 브랜치 task를 되살리지 않는다", async () => {
+    // Given
+    vi.useFakeTimers();
+
+    const project = {
+      id: "project-1",
+      name: "api",
+      repoPath: "/workspace/api",
+      defaultBranch: "main",
+      sshHost: null,
+    };
+    let releaseTransaction!: () => void;
+    const transactionStarted = new Promise<void>((resolve) => {
+      const manager = {
+        findOneBy: vi.fn().mockResolvedValue(project),
+        delete: vi.fn().mockResolvedValue({ affected: 1 }),
+        remove: vi.fn(async () => {
+          resolve();
+          await new Promise<void>((release) => {
+            releaseTransaction = release;
+          });
+          return project;
+        }),
+      };
+
+      mocks.getProjectRepository.mockResolvedValue({
+        find: vi.fn().mockResolvedValue([project]),
+        manager: {
+          transaction: vi.fn(async (callback: (transactionManager: typeof manager) => Promise<void>) => callback(manager)),
+        },
+      });
+    });
+    const findOneBy = vi.fn().mockResolvedValue(null);
+    const save = vi.fn(async (value) => ({ id: "task-main", ...value }));
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy,
+      create: vi.fn((value) => value),
+      save,
+    });
+
+    const { getAllProjects, deleteProject } = await import("@/desktop/main/services/projectService");
+
+    try {
+      // When
+      await getAllProjects();
+      const deletePromise = deleteProject(project.id);
+      await transactionStarted;
+      await vi.runAllTimersAsync();
+      releaseTransaction();
+      const result = await deletePromise;
+
+      // Then
+      expect(result).toBe(true);
+      expect(save).not.toHaveBeenCalled();
+      expect(findOneBy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -501,12 +501,14 @@ export async function registerProject(
   return { success: true, project: serialize(saved) };
 }
 
-/** 프로젝트를 삭제한다. 연결된 작업의 projectId는 FK cascade로 null이 된다 */
+/** 프로젝트를 삭제한다. 연결된 task DB 레코드는 삭제하되 git branch/worktree는 건드리지 않는다 */
 export async function deleteProject(projectId: string): Promise<boolean> {
   const repo = await getProjectRepository();
   const project = await repo.findOneBy({ id: projectId });
   if (!project) return false;
 
+  const taskRepo = await getTaskRepository();
+  await taskRepo.delete({ projectId });
   await repo.remove(project);
   broadcastBoardUpdate();
   return true;

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -1,7 +1,7 @@
 import { getProjectRepository, getTaskRepository } from "@/lib/database";
 import { Project } from "@/entities/Project";
 import { validateGitRepo, getDefaultBranch, listBranches, scanGitRepos, listWorktrees, execGit } from "@/lib/gitOperations";
-import { TaskStatus, SessionType } from "@/entities/KanbanTask";
+import { KanbanTask, TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { IsNull } from "typeorm";
 import { isSessionAlive, formatSessionName, createSessionWithoutWorktree } from "@/lib/worktree";
 import { getClaudeHooksStatus, type ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
@@ -97,8 +97,18 @@ const projectRootHookRepairJobs = new Map<string, Promise<void>>();
 const projectRootHookRepairScheduled = new Set<string>();
 const projectRootTaskRepairJobs = new Map<string, Promise<void>>();
 const projectRootTaskRepairScheduled = new Set<string>();
+const projectRootRepairDeletingProjectIds = new Set<string>();
+const projectRootRepairDeletedProjectIds = new Set<string>();
+
+function isProjectRootRepairBlocked(projectId: string): boolean {
+  return projectRootRepairDeletingProjectIds.has(projectId) || projectRootRepairDeletedProjectIds.has(projectId);
+}
 
 function scheduleProjectRootHookRepair(project: Project) {
+  if (isProjectRootRepairBlocked(project.id)) {
+    return;
+  }
+
   const projectPathKey = buildProjectPathKey(project.repoPath, project.sshHost);
   if (projectRootHookRepairScheduled.has(projectPathKey)) {
     return;
@@ -109,6 +119,10 @@ function scheduleProjectRootHookRepair(project: Project) {
   setTimeout(() => {
     const repairJob = (async () => {
       try {
+        if (isProjectRootRepairBlocked(project.id)) {
+          return;
+        }
+
         const { repaired } = await ensureProjectRootTask(project, {
           repairHooks: true,
           throwOnHookRepairFailure: false,
@@ -163,6 +177,10 @@ async function installSyncedWorktreeHooks(
 }
 
 function scheduleProjectRootTaskRepair(project: Project) {
+  if (isProjectRootRepairBlocked(project.id)) {
+    return;
+  }
+
   const projectPathKey = buildProjectPathKey(project.repoPath, project.sshHost);
   if (projectRootTaskRepairScheduled.has(projectPathKey)) {
     return;
@@ -173,6 +191,10 @@ function scheduleProjectRootTaskRepair(project: Project) {
   setTimeout(() => {
     const repairJob = (async () => {
       try {
+        if (isProjectRootRepairBlocked(project.id)) {
+          return;
+        }
+
         const { repaired } = await ensureProjectRootTask(project);
         scheduleProjectRootHookRepair(project);
 
@@ -309,6 +331,10 @@ async function ensureProjectRootTask(
     suppressRemoteConnectionErrorLogging?: boolean;
   },
 ): Promise<{ task: Awaited<ReturnType<typeof getProjectRootTask>>; repaired: boolean }> {
+  if (isProjectRootRepairBlocked(project.id)) {
+    return { task: null, repaired: false };
+  }
+
   const taskRepo = await getTaskRepository();
   const repairHooks = options?.repairHooks === true;
   const throwOnHookRepairFailure = options?.throwOnHookRepairFailure !== false;
@@ -504,12 +530,27 @@ export async function registerProject(
 /** 프로젝트를 삭제한다. 연결된 task DB 레코드는 삭제하되 git branch/worktree는 건드리지 않는다 */
 export async function deleteProject(projectId: string): Promise<boolean> {
   const repo = await getProjectRepository();
-  const project = await repo.findOneBy({ id: projectId });
-  if (!project) return false;
+  let projectDeleted = false;
 
-  const taskRepo = await getTaskRepository();
-  await taskRepo.delete({ projectId });
-  await repo.remove(project);
+  projectRootRepairDeletingProjectIds.add(projectId);
+  try {
+    await repo.manager.transaction(async (manager) => {
+      const project = await manager.findOneBy(Project, { id: projectId });
+      if (!project) {
+        return;
+      }
+
+      await manager.delete(KanbanTask, { projectId });
+      await manager.remove(project);
+      projectDeleted = true;
+    });
+  } finally {
+    projectRootRepairDeletingProjectIds.delete(projectId);
+  }
+
+  if (!projectDeleted) return false;
+
+  projectRootRepairDeletedProjectIds.add(projectId);
   broadcastBoardUpdate();
   return true;
 }


### PR DESCRIPTION
## What changed
- Change project deletion from settings so it also removes project-scoped KanVibe task records from the embedded SQLite database.
- Keep git branches, worktrees, files, and sessions untouched when a project is removed from KanVibe management.
- Prevent pending root repair jobs from recreating default-branch tasks while project deletion is in progress or after it completes.
- Update delete confirmation copy and README documentation to make the behavior explicit.

## How it was implemented
**Project removal behavior**
- Delete project-scoped `kanban_tasks` and the project record inside a single TypeORM transaction.
- Avoid the task deletion cleanup path so branch and worktree resources are not modified.

**Repair job guard**
- Track project ids that are currently being deleted or were already deleted.
- Skip scheduled root task/hook repair work for those projects so stale background jobs cannot resurrect tasks.

**User-facing copy and docs**
- Update English, Korean, and Chinese settings confirmation text.
- Document the settings deletion behavior in the English and Korean READMEs.

**Regression coverage**
- Add service tests for transactional project/task deletion and missing-project behavior.
- Add a race regression test that keeps deletion in progress while pending root repair timers run.
- Add a settings UI test for the updated confirmation message.

Co-authored-by: OpenAI Codex <codex@openai.com>
