### PR TITLE
fix(project-selector): keep keyboard-highlighted options in view

### DIFF
--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -78,6 +78,7 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
   const isComposingRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const optionItemRefs = useRef<Array<HTMLLIElement | null>>([]);
 
   const filteredProjects = searchQuery
     ? projects.filter((project) => matchesProjectSearch(project, searchQuery))
@@ -213,6 +214,17 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
     ? Math.min(Math.max(highlightedIndex, 0), maxHighlightedIndex)
     : -1;
 
+  /** 키보드로 하이라이트된 항목이 드롭다운 안에 보이도록 스크롤한다 */
+  useEffect(() => {
+    if (!isOpen || normalizedHighlightedIndex < 0) {
+      return;
+    }
+
+    optionItemRefs.current[normalizedHighlightedIndex]?.scrollIntoView({
+      block: "nearest",
+    });
+  }, [isOpen, normalizedHighlightedIndex, searchQuery]);
+
   // ===== 멀티 선택 모드 =====
   if (isMultiple) {
     const handleMultiKeyDown = (e: React.KeyboardEvent) => {
@@ -338,6 +350,9 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
                   return (
                     <li
                       key={project.id}
+                      ref={(element) => {
+                        optionItemRefs.current[index] = element;
+                      }}
                       onMouseDown={(e) => {
                         e.preventDefault();
                         handleToggle(project.id);
@@ -496,6 +511,9 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
           <ul className="max-h-48 overflow-y-auto">
             {showAllOption && (
               <li
+                ref={(element) => {
+                  optionItemRefs.current[0] = element;
+                }}
                 onMouseDown={(e) => {
                   e.preventDefault();
                   handleSelectAll();
@@ -520,6 +538,9 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
                 return (
                   <li
                     key={project.id}
+                    ref={(element) => {
+                      optionItemRefs.current[itemIndex] = element;
+                    }}
                     onMouseDown={(e) => {
                       e.preventDefault();
                       handleToggle(project.id);

--- a/src/components/__tests__/ProjectSelector.test.tsx
+++ b/src/components/__tests__/ProjectSelector.test.tsx
@@ -1,5 +1,5 @@
 import { createRef } from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render, screen, cleanup, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Project } from "@/entities/Project";
@@ -9,6 +9,11 @@ vi.mock("next-intl", () => ({
 }));
 
 import ProjectSelector, { type ProjectSelectorHandle } from "../ProjectSelector";
+
+const scrolledElements: HTMLElement[] = [];
+const scrollIntoViewMock = vi.fn(function (this: HTMLElement) {
+  scrolledElements.push(this);
+});
 
 function createProject(id: string, name: string): Project {
   return {
@@ -50,6 +55,15 @@ const projects = [
 ];
 
 describe("ProjectSelector chip truncation", () => {
+  beforeEach(() => {
+    scrolledElements.length = 0;
+    scrollIntoViewMock.mockClear();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
+  });
+
   afterEach(() => {
     cleanup();
   });
@@ -180,5 +194,49 @@ describe("ProjectSelector chip truncation", () => {
 
     await user.tab();
     expect(screen.getByRole("button", { name: "Select project" })).toBe(document.activeElement);
+  });
+
+  it("should scroll the highlighted single-select option into view after keyboard navigation", () => {
+    render(
+      <ProjectSelector
+        projects={projects}
+        selectedProjectId=""
+        onSelect={vi.fn()}
+        placeholder="Select project"
+        searchPlaceholder="Search project..."
+        allOption={{ label: "All projects" }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "All projects" }));
+    scrolledElements.length = 0;
+    scrollIntoViewMock.mockClear();
+
+    fireEvent.keyDown(screen.getByPlaceholderText("Search project..."), { key: "ArrowDown" });
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+    expect(scrolledElements.at(-1)?.textContent).toContain("Alpha");
+  });
+
+  it("should scroll the highlighted multi-select option into view after keyboard navigation", () => {
+    render(
+      <ProjectSelector
+        multiple
+        projects={projects}
+        selectedProjectIds={[]}
+        onSelectionChange={vi.fn()}
+        placeholder="All projects"
+        searchPlaceholder="Search project..."
+      />,
+    );
+
+    fireEvent.click(screen.getByText("All projects"));
+    scrolledElements.length = 0;
+    scrollIntoViewMock.mockClear();
+
+    fireEvent.keyDown(screen.getByPlaceholderText("Search project..."), { key: "ArrowDown" });
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+    expect(scrolledElements.at(-1)?.textContent).toContain("Beta");
   });
 });


### PR DESCRIPTION
## What changed
- Keep the highlighted project option visible while navigating the project dropdown with the keyboard.
- Apply the scroll sync to both single-select and multi-select `ProjectSelector` modes.
- Add regression coverage for keyboard navigation triggering `scrollIntoView` on the highlighted option.

## Why
When search results overflowed the dropdown, ArrowDown/ArrowUp changed the highlighted project but the list did not scroll with it, making the active selection hard to identify.

## Important details
- Uses item refs to map the normalized highlighted index to the actual rendered `<li>`, including the single-select all-projects option.
- Preserves existing search, selection, and ordering behavior.

Co-Authored-By: OpenAI Codex <codex@openai.com>