### PR TITLE
perf(git): scale remote ssh concurrency by cpu count

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Each pane can run a custom command (e.g., `vim`, `htop`, `lazygit`, test runner,
 - **tmux** and **zellij** are both supported as terminal multiplexers
 - Browser-based terminal via xterm.js + WebSocket
 - SSH remote terminal support (reads `~/.ssh/config`)
-- Non-interactive remote SSH commands reuse an app-local ControlMaster socket pool under `~/.kanvibe` with bounded per-host concurrency
+- Non-interactive remote SSH commands reuse an app-local ControlMaster socket pool under `~/.kanvibe`, with per-host concurrency capped at 4x available CPU cores
 - Remote terminal attach executes tmux/zellij directly over SSH; trusted X11 forwarding (`ssh -Y`) is requested only when local `DISPLAY`, remote `X11Forwarding`, and `xauth` are available
 - Nerd Font rendering support
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -161,7 +161,7 @@ macOS에서 `better-sqlite3` `NODE_MODULE_VERSION` 불일치가 발생하면, Ka
 - **tmux**와 **zellij** 모두 터미널 멀티플렉서로 지원
 - xterm.js + WebSocket 기반 브라우저 터미널
 - SSH 원격 터미널 지원 (`~/.ssh/config` 읽기)
-- 비대화형 원격 SSH 명령은 `~/.kanvibe` 아래의 앱 전용 ControlMaster 소켓 풀을 재사용하며 host별 동시성을 제한합니다
+- 비대화형 원격 SSH 명령은 `~/.kanvibe` 아래의 앱 전용 ControlMaster 소켓 풀을 재사용하며 host별 동시성을 사용 가능한 CPU 코어 수의 4배까지 제한합니다
 - 원격 터미널 attach는 SSH에서 tmux/zellij를 직접 실행하며, 로컬 `DISPLAY`, 원격 `X11Forwarding`, `xauth`가 준비된 경우에만 trusted X11 forwarding(`ssh -Y`)을 요청합니다
 - Nerd Font 렌더링 지원
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -161,7 +161,7 @@ pnpm dist
 - 同时支持 **tmux** 和 **zellij** 作为终端复用器
 - 基于 xterm.js + WebSocket 的浏览器终端
 - SSH 远程终端支持（读取 `~/.ssh/config`）
-- 非交互式远程 SSH 命令会复用 `~/.kanvibe` 下的应用专用 ControlMaster socket 池，并限制每个 host 的并发数
+- 非交互式远程 SSH 命令会复用 `~/.kanvibe` 下的应用专用 ControlMaster socket 池，并将每个 host 的并发数限制为可用 CPU 核心数的 4 倍
 - 远程终端 attach 会通过 SSH 直接执行 tmux/zellij；仅在本地 `DISPLAY`、远程 `X11Forwarding` 和 `xauth` 可用时请求 trusted X11 forwarding（`ssh -Y`）
 - Nerd Font 渲染支持
 

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -115,6 +115,11 @@ function getSpawnedRemoteCommand(callIndex = 0): string {
   return getSpawnedSSHArgs(callIndex).at(-1) ?? "";
 }
 
+function getSpawnedControlPath(callIndex = 0): string {
+  return ((getSpawnedSSHArgs(callIndex).find((arg) => arg.startsWith("ControlPath=")) ?? "")
+    .replace("ControlPath=", ""));
+}
+
 describe("gitOperations.resolvePathForShell", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -405,6 +410,8 @@ describe("gitOperations.resolvePathForShell", () => {
 
   it("같은 SSH host의 원격 명령은 제한된 동시성으로 실행한다", async () => {
     // Given
+    const originalConcurrency = process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY;
+    process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY = "4";
     const startedCommands: string[] = [];
     const pendingChildren: MockSSHProcess[] = [];
     mocks.spawn.mockImplementation((_file: string, args: string[]) => {
@@ -428,41 +435,49 @@ describe("gitOperations.resolvePathForShell", () => {
       };
     });
 
-    const { execGit } = await import("@/lib/gitOperations");
+    try {
+      const { execGit } = await import("@/lib/gitOperations");
 
-    // When
-    const first = execGit("first", "remote-host");
-    const second = execGit("second", "remote-host");
-    const third = execGit("third", "remote-host");
-    const fourth = execGit("fourth", "remote-host");
-    const fifth = execGit("fifth", "remote-host");
-    await new Promise((resolve) => setTimeout(resolve, 0));
+      // When
+      const first = execGit("first", "remote-host");
+      const second = execGit("second", "remote-host");
+      const third = execGit("third", "remote-host");
+      const fourth = execGit("fourth", "remote-host");
+      const fifth = execGit("fifth", "remote-host");
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
-    // Then
-    expect(startedCommands).toHaveLength(4);
-    expect(startedCommands[0]).toContain("first");
-    expect(startedCommands[1]).toContain("second");
-    expect(startedCommands[2]).toContain("third");
-    expect(startedCommands[3]).toContain("fourth");
+      // Then
+      expect(startedCommands).toHaveLength(4);
+      expect(startedCommands[0]).toContain("first");
+      expect(startedCommands[1]).toContain("second");
+      expect(startedCommands[2]).toContain("third");
+      expect(startedCommands[3]).toContain("fourth");
 
-    completeRemoteCommand(pendingChildren.shift()!, "one");
-    await expect(first).resolves.toBe("one");
-    await new Promise((resolve) => setTimeout(resolve, 0));
+      completeRemoteCommand(pendingChildren.shift()!, "one");
+      await expect(first).resolves.toBe("one");
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(startedCommands).toHaveLength(5);
-    expect(startedCommands[4]).toContain("fifth");
+      expect(startedCommands).toHaveLength(5);
+      expect(startedCommands[4]).toContain("fifth");
 
-    completeRemoteCommand(pendingChildren.shift()!, "two");
-    await expect(second).resolves.toBe("two");
-    completeRemoteCommand(pendingChildren.shift()!, "three");
-    completeRemoteCommand(pendingChildren.shift()!, "four");
-    completeRemoteCommand(pendingChildren.shift()!, "five");
-    await expect(third).resolves.toBe("three");
-    await expect(fourth).resolves.toBe("four");
-    await expect(fifth).resolves.toBe("five");
+      completeRemoteCommand(pendingChildren.shift()!, "two");
+      await expect(second).resolves.toBe("two");
+      completeRemoteCommand(pendingChildren.shift()!, "three");
+      completeRemoteCommand(pendingChildren.shift()!, "four");
+      completeRemoteCommand(pendingChildren.shift()!, "five");
+      await expect(third).resolves.toBe("three");
+      await expect(fourth).resolves.toBe("four");
+      await expect(fifth).resolves.toBe("five");
+    } finally {
+      if (originalConcurrency === undefined) {
+        delete process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY;
+      } else {
+        process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY = originalConcurrency;
+      }
+    }
   });
 
-  it("기본 SSH host 동시성은 available CPU의 두 배로 제한한다", async () => {
+  it("기본 SSH host 동시성은 available CPU의 네 배로 제한한다", async () => {
     // Given
     const originalConcurrency = process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY;
     delete process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY;
@@ -494,12 +509,12 @@ describe("gitOperations.resolvePathForShell", () => {
       const { execGit } = await import("@/lib/gitOperations");
 
       // When
-      const commands = Array.from({ length: 7 }, (_, index) => execGit(`command-${index}`, "remote-host"));
+      const commands = Array.from({ length: 13 }, (_, index) => execGit(`command-${index}`, "remote-host"));
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       // Then
-      expect(startedCommands).toHaveLength(6);
-      for (let index = 0; index < 6; index += 1) {
+      expect(startedCommands).toHaveLength(12);
+      for (let index = 0; index < 12; index += 1) {
         expect(startedCommands[index]).toContain(`command-${index}`);
       }
 
@@ -507,8 +522,8 @@ describe("gitOperations.resolvePathForShell", () => {
       await expect(commands[0]).resolves.toBe("done");
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(startedCommands).toHaveLength(7);
-      expect(startedCommands[6]).toContain("command-6");
+      expect(startedCommands).toHaveLength(13);
+      expect(startedCommands[12]).toContain("command-12");
       for (const [index, command] of commands.slice(1).entries()) {
         completeRemoteCommand(pendingChildren.shift()!, String(index));
         await expect(command).resolves.toBe(String(index));
@@ -581,6 +596,66 @@ describe("gitOperations.resolvePathForShell", () => {
     }
   });
 
+  it("환경변수 동시성도 available CPU의 네 배를 넘지 않는다", async () => {
+    // Given
+    const originalConcurrency = process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY;
+    process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY = "12";
+    mocks.availableParallelism.mockReturnValue(2);
+    const startedCommands: string[] = [];
+    const pendingChildren: MockSSHProcess[] = [];
+    mocks.spawn.mockImplementation((_file: string, args: string[]) => {
+      const child = createMockSSHProcess();
+      startedCommands.push(args.at(-1) ?? "");
+      pendingChildren.push(child);
+      return child;
+    });
+
+    vi.doMock("@/lib/sshConfig", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/sshConfig")>();
+      return {
+        ...actual,
+        parseSSHConfig: vi.fn(async () => [{
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        }]),
+      };
+    });
+
+    try {
+      const { execGit } = await import("@/lib/gitOperations");
+
+      // When
+      const commands = Array.from({ length: 9 }, (_, index) => execGit(`command-${index}`, "remote-host"));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Then
+      expect(startedCommands).toHaveLength(8);
+      for (let index = 0; index < 8; index += 1) {
+        expect(startedCommands[index]).toContain(`command-${index}`);
+      }
+
+      completeRemoteCommand(pendingChildren.shift()!, "done");
+      await expect(commands[0]).resolves.toBe("done");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(startedCommands).toHaveLength(9);
+      expect(startedCommands[8]).toContain("command-8");
+      for (const [index, command] of commands.slice(1).entries()) {
+        completeRemoteCommand(pendingChildren.shift()!, String(index));
+        await expect(command).resolves.toBe(String(index));
+      }
+    } finally {
+      if (originalConcurrency === undefined) {
+        delete process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY;
+      } else {
+        process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY = originalConcurrency;
+      }
+    }
+  });
+
   it("동시 원격 명령을 여러 ControlMaster shard로 분산한다", async () => {
     if (process.platform === "win32") {
       return;
@@ -618,10 +693,7 @@ describe("gitOperations.resolvePathForShell", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       // Then
-      const controlPaths = mocks.spawn.mock.calls.map((call) =>
-        ((call[1] as string[]).find((arg) => arg.startsWith("ControlPath=")) ?? "")
-          .replace("ControlPath=", "")
-      );
+      const controlPaths = mocks.spawn.mock.calls.map((_, index) => getSpawnedControlPath(index));
       expect(new Set(controlPaths).size).toBeGreaterThan(1);
       expect(controlPaths).toContain("/home/local-user/.kanvibe/ssh-%C-0");
       expect(controlPaths).toContain("/home/local-user/.kanvibe/ssh-%C-1");
@@ -630,6 +702,70 @@ describe("gitOperations.resolvePathForShell", () => {
         completeRemoteCommand(pendingChildren.shift()!, String(index));
         await expect(command).resolves.toBe(String(index));
       }
+    } finally {
+      if (originalConcurrency === undefined) {
+        delete process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY;
+      } else {
+        process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY = originalConcurrency;
+      }
+    }
+  });
+
+  it("완료된 SSH connection pool shard를 후속 명령에 재사용한다", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    // Given
+    const originalConcurrency = process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY;
+    process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY = "2";
+    const pendingChildren: MockSSHProcess[] = [];
+    mocks.spawn.mockImplementation(() => {
+      const child = createMockSSHProcess();
+      pendingChildren.push(child);
+      return child;
+    });
+
+    vi.doMock("@/lib/sshConfig", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/sshConfig")>();
+      return {
+        ...actual,
+        parseSSHConfig: vi.fn(async () => [{
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        }]),
+      };
+    });
+
+    try {
+      const { execGit } = await import("@/lib/gitOperations");
+
+      // When
+      const first = execGit("first", "remote-host");
+      const second = execGit("second", "remote-host");
+      const third = execGit("third", "remote-host");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Then
+      expect(mocks.spawn).toHaveBeenCalledTimes(2);
+      const firstControlPath = getSpawnedControlPath(0);
+      expect(firstControlPath).toBe("/home/local-user/.kanvibe/ssh-%C-0");
+      expect(getSpawnedControlPath(1)).toBe("/home/local-user/.kanvibe/ssh-%C-1");
+
+      completeRemoteCommand(pendingChildren.shift()!, "one");
+      await expect(first).resolves.toBe("one");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mocks.spawn).toHaveBeenCalledTimes(3);
+      expect(getSpawnedControlPath(2)).toBe(firstControlPath);
+
+      completeRemoteCommand(pendingChildren.shift()!, "two");
+      completeRemoteCommand(pendingChildren.shift()!, "three");
+      await expect(second).resolves.toBe("two");
+      await expect(third).resolves.toBe("three");
     } finally {
       if (originalConcurrency === undefined) {
         delete process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY;

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -41,18 +41,26 @@ const SSH_TRANSPORT_ERROR_PATTERNS = [
 const DEFAULT_REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS = 5_000;
 const MAX_REMOTE_SSH_TRANSPORT_FAILURE_COOLDOWN_MS = 60_000;
 const FALLBACK_REMOTE_SSH_HOST_MAX_CONCURRENCY = 4;
-const MAX_REMOTE_SSH_HOST_MAX_CONCURRENCY = 16;
+const REMOTE_SSH_HOST_CONCURRENCY_PER_CORE = 4;
 const DEFAULT_REMOTE_SSH_COMMAND_TIMEOUT_MS = 45_000;
 const REMOTE_SSH_COMMAND_MAX_ATTEMPTS = 3;
 const REMOTE_SSH_CONTROLMASTER_SHUTDOWN_TIMEOUT_MS = 3_000;
 const REMOTE_COMMAND_EXIT_MARKER = "__KANVIBE_REMOTE_COMMAND_EXIT_7b3f6e5d__";
 const REMOTE_COMMAND_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 const remoteSSHTransportFailures = new Map<string, { until: number; error: Error }>();
-const remoteSSHHostLimiters = new Map<string, {
-  active: number;
+// 실제 SSH 연결은 OpenSSH ControlMaster가 유지하고, 앱은 host별 shard lease와 대기열을 관리한다.
+const remoteSSHConnectionPools = new Map<string, RemoteSSHConnectionPool>();
+
+interface RemoteSSHConnectionPool {
+  activeConnections: number;
   queue: Array<() => void>;
-  availableShards: number[];
-}>();
+  availableShardIndexes: number[];
+}
+
+interface RemoteSSHConnectionLease {
+  controlMasterShardIndex: number;
+  release: () => void;
+}
 
 export interface ExecGitOptions {
   timeoutMs?: number;
@@ -119,23 +127,24 @@ function readPositiveInteger(value: string | undefined, fallback: number): numbe
 }
 
 function getRemoteSSHHostMaxConcurrency(): number {
+  const concurrencyLimit = getRemoteSSHHostConcurrencyLimit();
   return Math.min(
     readPositiveInteger(
       process.env.KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY,
-      getDefaultRemoteSSHHostMaxConcurrency(),
+      concurrencyLimit,
     ),
-    MAX_REMOTE_SSH_HOST_MAX_CONCURRENCY,
+    concurrencyLimit,
   );
 }
 
-function getDefaultRemoteSSHHostMaxConcurrency(): number {
+function getRemoteSSHHostConcurrencyLimit(): number {
   try {
-    const defaultConcurrency = availableParallelism() * 2;
-    if (!Number.isFinite(defaultConcurrency) || defaultConcurrency < 1) {
+    const availableCpuCount = availableParallelism();
+    if (!Number.isFinite(availableCpuCount) || availableCpuCount < 1) {
       return FALLBACK_REMOTE_SSH_HOST_MAX_CONCURRENCY;
     }
 
-    return Math.min(defaultConcurrency, MAX_REMOTE_SSH_HOST_MAX_CONCURRENCY);
+    return Math.floor(availableCpuCount) * REMOTE_SSH_HOST_CONCURRENCY_PER_CORE;
   } catch {
     return FALLBACK_REMOTE_SSH_HOST_MAX_CONCURRENCY;
   }
@@ -416,76 +425,79 @@ async function runLimitedRemoteCommand<T>(
   sshHost: string,
   operation: (controlMasterShardIndex: number) => Promise<T>,
 ): Promise<T> {
-  const slot = await acquireRemoteSSHSlot(sshHost);
+  const lease = await acquireRemoteSSHConnection(sshHost);
 
   try {
-    return await operation(slot.controlMasterShardIndex);
+    return await operation(lease.controlMasterShardIndex);
   } finally {
-    slot.release();
+    lease.release();
   }
 }
 
-function acquireRemoteSSHSlot(sshHost: string): Promise<{
-  controlMasterShardIndex: number;
-  release: () => void;
-}> {
-  let limiter = remoteSSHHostLimiters.get(sshHost);
-  if (!limiter) {
-    limiter = { active: 0, queue: [], availableShards: [] };
-    remoteSSHHostLimiters.set(sshHost, limiter);
-  }
+function acquireRemoteSSHConnection(sshHost: string): Promise<RemoteSSHConnectionLease> {
+  const connectionPool = getOrCreateRemoteSSHConnectionPool(sshHost);
 
   return new Promise((resolve) => {
     const start = () => {
-      const controlMasterShardIndex = acquireRemoteSSHControlMasterShard(limiter);
-      limiter.active += 1;
+      const controlMasterShardIndex = acquireRemoteSSHControlMasterShard(connectionPool);
+      connectionPool.activeConnections += 1;
       resolve({
         controlMasterShardIndex,
-        release: () => releaseRemoteSSHSlot(sshHost, limiter, controlMasterShardIndex),
+        release: () => releaseRemoteSSHConnection(sshHost, connectionPool, controlMasterShardIndex),
       });
     };
 
-    if (limiter.active < getRemoteSSHHostMaxConcurrency()) {
+    if (connectionPool.activeConnections < getRemoteSSHHostMaxConcurrency()) {
       start();
       return;
     }
 
-    limiter.queue.push(start);
+    connectionPool.queue.push(start);
   });
 }
 
+function getOrCreateRemoteSSHConnectionPool(sshHost: string): RemoteSSHConnectionPool {
+  let connectionPool = remoteSSHConnectionPools.get(sshHost);
+  if (!connectionPool) {
+    connectionPool = {
+      activeConnections: 0,
+      queue: [],
+      availableShardIndexes: [],
+    };
+    remoteSSHConnectionPools.set(sshHost, connectionPool);
+  }
+
+  return connectionPool;
+}
+
 function acquireRemoteSSHControlMasterShard(
-  limiter: { active: number; availableShards: number[] },
+  connectionPool: RemoteSSHConnectionPool,
 ): number {
-  const reusableShard = limiter.availableShards.shift();
+  const reusableShard = connectionPool.availableShardIndexes.shift();
   if (reusableShard !== undefined) {
     return reusableShard;
   }
 
-  return limiter.active;
+  return connectionPool.activeConnections;
 }
 
-function releaseRemoteSSHSlot(
+function releaseRemoteSSHConnection(
   sshHost: string,
-  limiter: {
-    active: number;
-    queue: Array<() => void>;
-    availableShards: number[];
-  },
+  connectionPool: RemoteSSHConnectionPool,
   controlMasterShardIndex: number,
 ): void {
-  limiter.active -= 1;
-  limiter.availableShards.push(controlMasterShardIndex);
-  limiter.availableShards.sort((left, right) => left - right);
+  connectionPool.activeConnections -= 1;
+  connectionPool.availableShardIndexes.push(controlMasterShardIndex);
+  connectionPool.availableShardIndexes.sort((left, right) => left - right);
 
-  const next = limiter.queue.shift();
+  const next = connectionPool.queue.shift();
   if (next) {
     next();
     return;
   }
 
-  if (limiter.active === 0) {
-    remoteSSHHostLimiters.delete(sshHost);
+  if (connectionPool.activeConnections === 0) {
+    remoteSSHConnectionPools.delete(sshHost);
   }
 }
 


### PR DESCRIPTION
## What changed
- Scale the default per-host remote SSH command concurrency to four times the available CPU count.
- Clamp `KANVIBE_REMOTE_SSH_HOST_MAX_CONCURRENCY` to the same CPU-based limit so manual overrides cannot exceed the safe cap.
- Replace the remote SSH limiter state with a connection pool that leases and reuses ControlMaster shard indexes after commands finish.
- Update the English, Korean, and Chinese README files with the new concurrency behavior.

## How it was solved
**Remote SSH concurrency**
- Calculate the host concurrency ceiling from `availableParallelism() * 4`.
- Keep the existing fallback value when CPU detection fails.
- Apply the computed ceiling to both default behavior and environment override handling.

**ControlMaster shard reuse**
- Track active SSH connections, pending queue entries, and released shard indexes in a per-host pool.
- Return completed shard indexes to the pool and prefer reusable shards for later commands.

**Coverage and docs**
- Update existing concurrency tests from the previous fixed cap behavior.
- Add tests for environment override clamping and released shard reuse.
- Keep README translations aligned with the implementation.

Co-Authored-By: OpenAI Codex <codex@openai.com>
