### PR TITLE
Make app find and refresh shortcuts global

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -53,19 +53,19 @@
       "worktreeFailure": "Worktree sync failed",
       "emptyMerged": "There are no merged PR tasks to move to Done in this review.",
       "emptyRegistered": "There are no newly registered worktrees in this review."
+    },
+    "pageFind": {
+      "label": "Find on page",
+      "placeholder": "Find text on this page...",
+      "previous": "Prev",
+      "next": "Next",
+      "noMatch": "No matches found on this page."
     }
   },
   "board": {
     "title": "",
     "newTask": "+ New Task",
     "allProjects": "All Projects",
-    "pageFind": {
-      "label": "Find on board",
-      "placeholder": "Find visible text on this board...",
-      "previous": "Prev",
-      "next": "Next",
-      "noMatch": "No matches found on this board."
-    },
     "columns": {
       "todo": "Todo",
       "progress": "Progress",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -53,19 +53,19 @@
       "worktreeFailure": "Worktree sync 실패",
       "emptyMerged": "이번 검토에서 Done으로 옮길 merge PR이 없습니다.",
       "emptyRegistered": "이번 검토에서 새로 등록된 worktree가 없습니다."
+    },
+    "pageFind": {
+      "label": "페이지에서 찾기",
+      "placeholder": "현재 화면에서 텍스트 찾기...",
+      "previous": "이전",
+      "next": "다음",
+      "noMatch": "현재 화면에서 일치하는 텍스트를 찾지 못했습니다."
     }
   },
   "board": {
     "title": "",
     "newTask": "+ 새 작업",
     "allProjects": "전체 프로젝트",
-    "pageFind": {
-      "label": "보드에서 찾기",
-      "placeholder": "이 보드에서 보이는 텍스트 찾기...",
-      "previous": "이전",
-      "next": "다음",
-      "noMatch": "이 보드에서 일치하는 텍스트를 찾지 못했습니다."
-    },
     "columns": {
       "todo": "Todo",
       "progress": "Progress",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -52,19 +52,19 @@
       "worktreeFailure": "Worktree 同步失败",
       "emptyMerged": "本次检查中没有需要移动到 Done 的已合并 PR 任务。",
       "emptyRegistered": "本次检查中没有新注册的 worktree。"
+    },
+    "pageFind": {
+      "label": "在页面中查找",
+      "placeholder": "查找当前页面中的文本...",
+      "previous": "上一个",
+      "next": "下一个",
+      "noMatch": "当前页面中没有找到匹配文本。"
     }
   },
   "board": {
     "title": "",
     "newTask": "+ 新任务",
     "allProjects": "所有项目",
-    "pageFind": {
-      "label": "在看板中查找",
-      "placeholder": "查找当前看板中可见的文本...",
-      "previous": "上一个",
-      "next": "下一个",
-      "noMatch": "当前看板中没有找到匹配文本。"
-    },
     "columns": {
       "todo": "待办",
       "progress": "进行中",

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -3,7 +3,6 @@
 import { useState, useCallback, useEffect, useMemo, useRef, useTransition } from "react";
 import { useTranslations } from "next-intl";
 import { DragDropContext, type DropResult } from "@hello-pangea/dnd";
-import BoardPageFindBar from "./BoardPageFindBar";
 import Column from "./Column";
 import CreateTaskModal from "./CreateTaskModal";
 import NotificationCenterButton from "./NotificationCenterButton";
@@ -702,7 +701,6 @@ export default function Board({
 
   return (
     <div className="min-h-screen bg-bg-page">
-      <BoardPageFindBar />
       <header className={headerClassName}>
         <div className="flex items-center gap-3 [-webkit-app-region:no-drag]">
           <div className="w-64">

--- a/src/components/PageFindBar.tsx
+++ b/src/components/PageFindBar.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent }
 import { useTranslations } from "next-intl";
 import { SHORTCUTS, getCurrentShortcutPlatform, matchShortcutEvent } from "@/desktop/renderer/utils/keyboardShortcut";
 
-const BOARD_PAGE_FIND_SHORTCUT = SHORTCUTS.boardPageFind;
+const PAGE_FIND_SHORTCUT = SHORTCUTS.pageFind;
 
 function findPageText(query: string, backwards = false) {
   const trimmedQuery = query.trim();
@@ -15,8 +15,8 @@ function findPageText(query: string, backwards = false) {
   return window.find(trimmedQuery, false, backwards, true, false, false, false);
 }
 
-export default function BoardPageFindBar() {
-  const t = useTranslations("board");
+export default function PageFindBar() {
+  const t = useTranslations("common.pageFind");
   const tc = useTranslations("common");
   const inputRef = useRef<HTMLInputElement>(null);
   const [isOpen, setIsOpen] = useState(false);
@@ -37,7 +37,7 @@ export default function BoardPageFindBar() {
 
   useEffect(() => {
     function handleGlobalKeyDown(event: KeyboardEvent) {
-      if (!matchShortcutEvent(event, BOARD_PAGE_FIND_SHORTCUT, shortcutPlatform)) {
+      if (!matchShortcutEvent(event, PAGE_FIND_SHORTCUT, shortcutPlatform)) {
         return;
       }
 
@@ -95,8 +95,8 @@ export default function BoardPageFindBar() {
             setHasMatch(null);
           }}
           onKeyDown={handleInputKeyDown}
-          placeholder={t("pageFind.placeholder")}
-          aria-label={t("pageFind.label")}
+          placeholder={t("placeholder")}
+          aria-label={t("label")}
           className="min-w-0 flex-1 rounded-md border border-border-default bg-bg-page px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-brand-primary"
         />
         <button
@@ -104,14 +104,14 @@ export default function BoardPageFindBar() {
           onClick={() => runSearch(true)}
           className="rounded-md border border-border-default bg-bg-page px-2.5 py-2 text-xs text-text-secondary transition-colors hover:border-brand-primary hover:text-text-primary"
         >
-          {t("pageFind.previous")}
+          {t("previous")}
         </button>
         <button
           type="button"
           onClick={() => runSearch(false)}
           className="rounded-md border border-border-default bg-bg-page px-2.5 py-2 text-xs text-text-secondary transition-colors hover:border-brand-primary hover:text-text-primary"
         >
-          {t("pageFind.next")}
+          {t("next")}
         </button>
         <button
           type="button"
@@ -123,7 +123,7 @@ export default function BoardPageFindBar() {
         </button>
       </div>
       {hasMatch === false ? (
-        <p className="mt-2 text-xs text-text-muted">{t("pageFind.noMatch")}</p>
+        <p className="mt-2 text-xs text-text-muted">{t("noMatch")}</p>
       ) : null}
     </div>
   );

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -16,16 +16,6 @@ function mockNavigatorPlatform(platform: string) {
   });
 }
 
-function mockWindowFind(implementation?: (query: string, ...args: unknown[]) => boolean) {
-  const findMock = vi.fn(implementation ?? (() => true));
-  Object.defineProperty(window, "find", {
-    configurable: true,
-    value: findMock,
-  });
-
-  return findMock;
-}
-
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
 }));
@@ -276,7 +266,6 @@ describe("Board defaultSessionType sync", () => {
     vi.clearAllMocks();
     delete window.kanvibeDesktop;
     mockNavigatorPlatform("Linux x86_64");
-    mockWindowFind();
   });
 
   it("defaultSessionType prop이 변경되면 내부 상태와 하위 컴포넌트가 동기화된다", async () => {
@@ -401,7 +390,7 @@ describe("Board defaultSessionType sync", () => {
     expect(screen.queryByRole("button", { name: "logout" })).toBeNull();
   });
 
-  it("리눅스 보드에서 Ctrl+F를 누르면 페이지 검색 바를 연다", async () => {
+  it("보드는 앱 공통 페이지 검색 바를 직접 렌더링하지 않는다", async () => {
     render(
       <Board
         initialTasks={createEmptyTasks()}
@@ -422,9 +411,7 @@ describe("Board defaultSessionType sync", () => {
       ctrlKey: true,
     });
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText("pageFind.placeholder")).toBeTruthy();
-    });
+    expect(screen.queryByPlaceholderText("pageFind.placeholder")).toBeNull();
   });
 
   it("task focus가 없을 때 방향키를 누르면 페이지 스크롤 대신 첫 task로 focus를 진입시킨다", async () => {
@@ -575,69 +562,6 @@ describe("Board defaultSessionType sync", () => {
 
     await waitFor(() => {
       expect(moveTaskToColumn).toHaveBeenCalledWith("task-1", TaskStatus.REVIEW, ["task-1"]);
-    });
-  });
-
-  it("보드 검색 바에서 Enter와 Shift+Enter로 순방향/역방향 찾기를 호출한다", async () => {
-    const findMock = mockWindowFind();
-
-    render(
-      <Board
-        initialTasks={createEmptyTasks()}
-        initialDoneTotal={0}
-        initialDoneLimit={20}
-        sshHosts={[]}
-        projects={[createProject()]}
-        sidebarDefaultCollapsed={false}
-        doneAlertDismissed={false}
-        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
-        defaultSessionType={SessionType.TMUX}
-        taskSearchShortcut="Mod+Shift+O"
-      />,
-    );
-
-    fireEvent.keyDown(window, {
-      key: "f",
-      ctrlKey: true,
-    });
-
-    const input = await screen.findByPlaceholderText("pageFind.placeholder");
-    fireEvent.change(input, {
-      target: { value: "kanvibe" },
-    });
-    fireEvent.keyDown(input, { key: "Enter" });
-    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
-
-    expect(findMock).toHaveBeenNthCalledWith(1, "kanvibe", false, false, true, false, false, false);
-    expect(findMock).toHaveBeenNthCalledWith(2, "kanvibe", false, true, true, false, false, false);
-  });
-
-  it("보드 검색 바에서 Escape를 누르면 검색 UI를 닫는다", async () => {
-    render(
-      <Board
-        initialTasks={createEmptyTasks()}
-        initialDoneTotal={0}
-        initialDoneLimit={20}
-        sshHosts={[]}
-        projects={[createProject()]}
-        sidebarDefaultCollapsed={false}
-        doneAlertDismissed={false}
-        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
-        defaultSessionType={SessionType.TMUX}
-        taskSearchShortcut="Mod+Shift+O"
-      />,
-    );
-
-    fireEvent.keyDown(window, {
-      key: "f",
-      ctrlKey: true,
-    });
-
-    const input = await screen.findByPlaceholderText("pageFind.placeholder");
-    fireEvent.keyDown(input, { key: "Escape" });
-
-    await waitFor(() => {
-      expect(screen.queryByPlaceholderText("pageFind.placeholder")).toBeNull();
     });
   });
 

--- a/src/desktop/main/__tests__/desktopShortcutRouting.test.ts
+++ b/src/desktop/main/__tests__/desktopShortcutRouting.test.ts
@@ -19,11 +19,11 @@ describe("desktop shortcut routing", () => {
     expect(source).toContain("void createAppWindow(currentUrl)");
   });
 
-  it("blocks Cmd/Ctrl+R without registering a Kanvibe refresh shortcut", () => {
+  it("does not reserve Cmd/Ctrl+R in Electron main so renderer can refresh app data", () => {
     const source = readMainSource();
 
     expect(source).toContain("isBlockedElectronShortcutInput");
+    expect(source).not.toContain("BLOCKED_DESKTOP_SHORTCUTS.reload");
     expect(source).not.toContain("kanvibe:refresh-shortcut");
-    expect(source).not.toContain("isRefreshShortcut");
   });
 });

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -12,6 +12,7 @@ import BoardRoute from "@/desktop/renderer/routes/BoardRoute";
 import { getThemePreference, type ThemePreference } from "@/desktop/renderer/actions/appSettings";
 import { applyThemePreference, THEME_PREFERENCE_CHANGED_EVENT } from "@/desktop/renderer/utils/theme";
 import type { BoardEventPayload } from "@/lib/boardNotifier";
+import PageFindBar from "@/components/PageFindBar";
 
 const BOARD_REFRESH_DEBOUNCE_MS = 250;
 
@@ -85,6 +86,7 @@ function LocaleShell() {
     <IntlProvider locale={safeLocale} messages={messages}>
       <ThemeController />
       <BoardCommandProvider>
+        <PageFindBar />
         <TaskQuickSearchDialog />
         <NotificationListener />
         <BoardEventAlert />

--- a/src/desktop/renderer/__tests__/App.test.tsx
+++ b/src/desktop/renderer/__tests__/App.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "@/desktop/renderer/App";
 import type { AppNotification } from "@/desktop/shared/notifications";
@@ -88,6 +88,23 @@ describe("App", () => {
     await waitFor(() => {
       expect(screen.getByText("settings route")).toBeTruthy();
     });
+  });
+
+  it("opens page find from Cmd/Ctrl+F on non-board routes", async () => {
+    window.location.hash = "#/en/settings";
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("settings route")).toBeTruthy();
+    });
+
+    fireEvent.keyDown(window, {
+      key: "f",
+      ctrlKey: true,
+    });
+
+    expect(await screen.findByPlaceholderText("Find text on this page...")).toBeTruthy();
   });
 
   it("debounces board update events and refreshes all visible data", async () => {

--- a/src/desktop/renderer/components/BoardCommandProvider.tsx
+++ b/src/desktop/renderer/components/BoardCommandProvider.tsx
@@ -11,6 +11,7 @@ import {
   type PropsWithChildren,
 } from "react";
 import { useRouter } from "@/desktop/renderer/navigation";
+import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
 import {
   SHORTCUTS,
   getCurrentShortcutPlatform,
@@ -23,6 +24,7 @@ export const BOARD_PROJECT_FILTER_SHORTCUT = SHORTCUTS.boardProjectFilter;
 export const CREATE_BRANCH_TODO_SHORTCUT = SHORTCUTS.createTask;
 export const PAGE_BACK_SHORTCUT = SHORTCUTS.pageBack;
 export const PAGE_FORWARD_SHORTCUT = SHORTCUTS.pageForward;
+export const REFRESH_SHORTCUT = SHORTCUTS.refresh;
 
 export interface BranchTodoDefaults {
   projectId: string;
@@ -74,6 +76,10 @@ function shouldIgnoreGlobalShortcut(eventTarget: EventTarget | null) {
   return eventTarget.closest('[contenteditable="true"]') !== null;
 }
 
+function isShortcutCaptureTarget(eventTarget: EventTarget | null) {
+  return eventTarget instanceof Element && eventTarget.closest('[data-shortcut-capture="true"]') !== null;
+}
+
 export function BoardCommandProvider({ children }: PropsWithChildren) {
   const router = useRouter();
   const handlersRef = useRef<BoardCommandHandlers | null>(null);
@@ -121,6 +127,16 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
     function handleGlobalKeyDown(event: KeyboardEvent) {
       if (isBlockedShortcutEvent(event, shortcutPlatform)) {
         event.preventDefault();
+        return;
+      }
+
+      if (matchShortcutEvent(event, REFRESH_SHORTCUT, shortcutPlatform)) {
+        if (isShortcutCaptureTarget(event.target)) {
+          return;
+        }
+
+        event.preventDefault();
+        triggerDesktopRefresh("all");
         return;
       }
 

--- a/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
+++ b/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
@@ -16,6 +16,7 @@ import {
   formatShortcutForDisplay,
   getCurrentShortcutPlatform,
   isBlockedShortcutEvent,
+  isReservedShortcutEvent,
   matchShortcutEvent,
 } from "@/desktop/renderer/utils/keyboardShortcut";
 import { requestActiveTerminalFocusAfterUiSettles } from "@/desktop/renderer/utils/terminalFocus";
@@ -261,6 +262,11 @@ export default function TaskQuickSearchDialog({
   useEffect(() => {
     function handleGlobalKeyDown(event: KeyboardEvent) {
       if (isBlockedShortcutEvent(event, shortcutPlatform)) {
+        event.preventDefault();
+        return;
+      }
+
+      if (isReservedShortcutEvent(event, shortcutPlatform)) {
         event.preventDefault();
         return;
       }

--- a/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
+++ b/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
@@ -267,7 +267,7 @@ describe("BoardCommandProvider", () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it("blocks Cmd/Ctrl+R so native reload shortcuts cannot run", () => {
+  it("triggers KanVibe refresh from Cmd/Ctrl+R", () => {
     renderWithRouter(
       <BoardCommandProvider>
         <div />
@@ -280,6 +280,6 @@ describe("BoardCommandProvider", () => {
     });
 
     expect(wasNotPrevented).toBe(false);
-    expect(mocks.triggerDesktopRefresh).not.toHaveBeenCalled();
+    expect(mocks.triggerDesktopRefresh).toHaveBeenCalledWith("all");
   });
 });

--- a/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
+++ b/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
@@ -8,6 +8,7 @@ import {
   getShortcutPlatformFromNavigator,
   isBlockedElectronShortcutInput,
   isBlockedShortcutEvent,
+  isReservedShortcutEvent,
   matchElectronShortcutInput,
   matchTaskDetailDockShortcutEvent,
   matchShortcutEvent,
@@ -236,13 +237,23 @@ describe("keyboardShortcut", () => {
     }), "linux")).toBeNull();
   });
 
-  it("Cmd/Ctrl+R은 앱에서 차단할 shortcut으로 판별한다", () => {
+  it("Cmd/Ctrl+R은 앱에서 차단하지 않고 refresh shortcut으로 매칭한다", () => {
     expect(isBlockedShortcutEvent(new KeyboardEvent("keydown", {
       key: "r",
       metaKey: true,
-    }), "mac")).toBe(true);
+    }), "mac")).toBe(false);
 
     expect(isBlockedShortcutEvent(new KeyboardEvent("keydown", {
+      key: "r",
+      ctrlKey: true,
+    }), "linux")).toBe(false);
+
+    expect(matchShortcutEvent(new KeyboardEvent("keydown", {
+      key: "r",
+      ctrlKey: true,
+    }), SHORTCUTS.refresh, "linux")).toBe(true);
+
+    expect(isReservedShortcutEvent(new KeyboardEvent("keydown", {
       key: "r",
       ctrlKey: true,
     }), "linux")).toBe(true);
@@ -254,16 +265,16 @@ describe("keyboardShortcut", () => {
     }), "linux")).toBe(false);
   });
 
-  it("Electron Cmd/Ctrl+R input도 앱에서 차단할 shortcut으로 판별한다", () => {
+  it("Electron Cmd/Ctrl+R input도 앱에서 차단하지 않는다", () => {
     expect(isBlockedElectronShortcutInput({
       type: "keyDown",
       isAutoRepeat: false,
       key: "r",
       control: true,
-    }, "linux")).toBe(true);
+    }, "linux")).toBe(false);
   });
 
-  it("Cmd/Ctrl+R은 사용자 지정 shortcut으로 캡처하지 않는다", () => {
+  it("Cmd/Ctrl+R은 앱 refresh shortcut이므로 사용자 지정 shortcut으로 캡처하지 않는다", () => {
     expect(captureShortcutFromEvent(new KeyboardEvent("keydown", {
       key: "r",
       ctrlKey: true,

--- a/src/desktop/shared/keyboardShortcut.ts
+++ b/src/desktop/shared/keyboardShortcut.ts
@@ -33,7 +33,8 @@ export const SHORTCUTS = {
   newWindow: "Mod+Shift+N",
   pageBack: "Mod+Shift+[",
   pageForward: "Mod+Shift+]",
-  boardPageFind: "Mod+F",
+  pageFind: "Mod+F",
+  refresh: "Mod+R",
 } as const;
 
 export const DESKTOP_SHORTCUTS = {
@@ -43,8 +44,14 @@ export const DESKTOP_SHORTCUTS = {
 } as const;
 
 export const BLOCKED_DESKTOP_SHORTCUTS = {
-  reload: "Mod+R",
 } as const;
+
+export const RESERVED_DESKTOP_SHORTCUTS = {
+  refresh: SHORTCUTS.refresh,
+} as const;
+
+const BLOCKED_DESKTOP_SHORTCUT_VALUES = Object.values(BLOCKED_DESKTOP_SHORTCUTS) as ShortcutDefinition[];
+const RESERVED_DESKTOP_SHORTCUT_VALUES = Object.values(RESERVED_DESKTOP_SHORTCUTS) as ShortcutDefinition[];
 
 export const DEFAULT_TASK_SEARCH_SHORTCUT = SHORTCUTS.taskSearchDefault;
 export const TASK_DETAIL_DOCK_SHORTCUT_INDEXES = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
@@ -292,7 +299,7 @@ export function isBlockedShortcutEvent(
   event: ShortcutInput,
   platform: ShortcutPlatformInput,
 ): boolean {
-  return Object.values(BLOCKED_DESKTOP_SHORTCUTS).some((shortcut) => (
+  return BLOCKED_DESKTOP_SHORTCUT_VALUES.some((shortcut) => (
     matchShortcutEvent(event, shortcut, platform)
   ));
 }
@@ -301,8 +308,17 @@ export function isBlockedElectronShortcutInput(
   input: ElectronShortcutInput,
   platform: ShortcutPlatformInput,
 ): boolean {
-  return Object.values(BLOCKED_DESKTOP_SHORTCUTS).some((shortcut) => (
+  return BLOCKED_DESKTOP_SHORTCUT_VALUES.some((shortcut) => (
     matchElectronShortcutInput(input, shortcut, platform)
+  ));
+}
+
+export function isReservedShortcutEvent(
+  event: ShortcutInput,
+  platform: ShortcutPlatformInput,
+): boolean {
+  return RESERVED_DESKTOP_SHORTCUT_VALUES.some((shortcut) => (
+    matchShortcutEvent(event, shortcut, platform)
   ));
 }
 
@@ -357,9 +373,8 @@ export function captureShortcutFromEvent(
   }
 
   const shortcut = [...MODIFIER_ORDER.filter((modifier) => modifiers.has(modifier)), key].join("+");
-  if (platform !== undefined && Object.values(BLOCKED_DESKTOP_SHORTCUTS).some((blockedShortcut) => (
-    normalizeShortcutParts(blockedShortcut).key === key
-    && matchShortcutEvent(event, blockedShortcut, platform)
+  if (platform !== undefined && RESERVED_DESKTOP_SHORTCUT_VALUES.some((reservedShortcut) => (
+    matchShortcutEvent(event, reservedShortcut, platform)
   ))) {
     return null;
   }


### PR DESCRIPTION
## What changed?
- Make `Cmd/Ctrl+F` open the page find UI across KanVibe routes instead of only on the board.
- Make `Cmd/Ctrl+R` trigger KanVibe's internal refresh signal instead of being blocked.

## How was it solved?
**Global page find**
- Move the find bar from the board component into the app shell.
- Rename the component to `PageFindBar` and update translations from board-specific copy to page-level copy.

**Refresh shortcut routing**
- Add a shared `refresh` shortcut definition for `Mod+R`.
- Remove `Mod+R` from blocked shortcuts and handle it in the renderer by dispatching `triggerDesktopRefresh("all")`.
- Keep `Mod+R` reserved so it cannot be captured as the task quick search shortcut.

## Important changes
### App-wide find

**Current route text search**
- **Why**: Users expect `Cmd/Ctrl+F` to behave like browser page find throughout the desktop app.
- **Files**: `src/components/PageFindBar.tsx`, `src/desktop/renderer/App.tsx`, `src/components/Board.tsx`

### App refresh shortcut

**Refresh through KanVibe data flow**
- **Why**: `Cmd/Ctrl+R` should refresh app data without hard reloading the Electron renderer.
- **Files**: `src/desktop/shared/keyboardShortcut.ts`, `src/desktop/renderer/components/BoardCommandProvider.tsx`, `src/desktop/renderer/components/TaskQuickSearchDialog.tsx`

Co-authored-by: OpenAI Codex <codex@openai.com>
