### PR TITLE
fix(hooks): finish hook setup before returning

### DIFF
--- a/src/desktop/main/services/__tests__/hookService.test.ts
+++ b/src/desktop/main/services/__tests__/hookService.test.ts
@@ -28,10 +28,9 @@ const mocks = vi.hoisted(() => ({
   broadcastBoardUpdate: vi.fn(),
   broadcastHookStatusTargetMissing: vi.fn(),
   broadcastTaskStatusChanged: vi.fn(),
-  scheduleTaskHookInstall: vi.fn(),
+  installTaskHooksImmediately: vi.fn(),
   prepareOptimisticDoneTransition: vi.fn(),
   scheduleDoneCleanupWithRollback: vi.fn(),
-  installKanvibeHooks: vi.fn(),
 }));
 
 vi.mock("@/entities/KanbanTask", () => entityMocks);
@@ -54,14 +53,16 @@ vi.mock("@/lib/boardNotifier", () => ({
 }));
 
 vi.mock("@/desktop/main/services/kanbanService", () => ({
-  scheduleTaskHookInstall: mocks.scheduleTaskHookInstall,
+  installTaskHooksImmediately: mocks.installTaskHooksImmediately,
   prepareOptimisticDoneTransition: mocks.prepareOptimisticDoneTransition,
   scheduleDoneCleanupWithRollback: mocks.scheduleDoneCleanupWithRollback,
 }));
 
-vi.mock("@/lib/kanvibeHooksInstaller", () => ({
-  installKanvibeHooks: mocks.installKanvibeHooks,
-}));
+async function flushMicrotasks(count = 8): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
+}
 
 describe("hookService.updateHookTaskStatus", () => {
   beforeEach(() => {
@@ -158,9 +159,10 @@ describe("hookService.startHookTask", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.taskRepo.create.mockImplementation((value) => value);
+    mocks.installTaskHooksImmediately.mockResolvedValue(undefined);
   });
 
-  it("원격 worktree task를 만들면 hooks 설치를 백그라운드 예약한다", async () => {
+  it("원격 worktree task를 만들면 hooks 설치와 검증 완료를 기다린 뒤 응답한다", async () => {
     const project = {
       id: "project-1",
       repoPath: "/remote/repo",
@@ -173,25 +175,89 @@ describe("hookService.startHookTask", () => {
       sessionName: "feature-task",
     });
     mocks.taskRepo.save.mockImplementation(async (value) => ({ id: "task-1", ...value }));
+    let resolveInstall!: () => void;
+    mocks.installTaskHooksImmediately.mockReturnValue(new Promise<void>((resolve) => {
+      resolveInstall = resolve;
+    }));
 
     const { startHookTask } = await import("@/desktop/main/services/hookService");
 
-    await startHookTask({
+    let resolved = false;
+    const resultPromise = startHookTask({
       title: "remote task",
       branchName: "feature-task",
       sessionType: "tmux" as never,
       sshHost: "remote-host",
       projectId: "project-1",
+    }).then((result) => {
+      resolved = true;
+      return result;
     });
 
-    expect(mocks.scheduleTaskHookInstall).toHaveBeenCalledWith(
+    await flushMicrotasks();
+
+    expect(mocks.installTaskHooksImmediately).toHaveBeenCalledWith(
       "/remote/repo__worktrees/feature-task",
       {
         id: "task-1",
         title: "remote task",
         sshHost: "remote-host",
       },
+      "새 태스크 hooks 동기 설치 실패",
     );
-    expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
+    expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
+    expect(resolved).toBe(false);
+
+    resolveInstall();
+    const result = await resultPromise;
+
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+    expect(resolved).toBe(true);
+    expect(result).toEqual({
+      success: true,
+      data: {
+        id: "task-1",
+        status: TaskStatus.PROGRESS,
+        sessionName: "feature-task",
+      },
+    });
+  });
+
+  it("hooks 설치와 검증이 실패하면 성공 응답과 board update를 보내지 않는다", async () => {
+    const project = {
+      id: "project-1",
+      repoPath: "/remote/repo",
+      defaultBranch: "main",
+      sshHost: "remote-host",
+    };
+    const installError = new Error("hooks verification failed");
+    mocks.projectRepo.findOneBy.mockResolvedValue(project);
+    mocks.createWorktreeWithSession.mockResolvedValue({
+      worktreePath: "/remote/repo__worktrees/feature-task",
+      sessionName: "feature-task",
+    });
+    mocks.taskRepo.save.mockImplementation(async (value) => ({ id: "task-1", ...value }));
+    mocks.installTaskHooksImmediately.mockRejectedValue(installError);
+
+    const { startHookTask } = await import("@/desktop/main/services/hookService");
+
+    await expect(startHookTask({
+      title: "remote task",
+      branchName: "feature-task",
+      sessionType: "tmux" as never,
+      sshHost: "remote-host",
+      projectId: "project-1",
+    })).rejects.toThrow("hooks verification failed");
+
+    expect(mocks.installTaskHooksImmediately).toHaveBeenCalledWith(
+      "/remote/repo__worktrees/feature-task",
+      {
+        id: "task-1",
+        title: "remote task",
+        sshHost: "remote-host",
+      },
+      "새 태스크 hooks 동기 설치 실패",
+    );
+    expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -343,6 +343,40 @@ describe("kanbanService.createTask", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it("즉시 hooks 전체 설치는 검증 포함 설치를 사용하고 실패를 전파한다", async () => {
+    // Given
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const installError = new Error("verification unavailable");
+    mocks.installKanvibeHooks.mockRejectedValueOnce(installError);
+
+    const { installTaskHooksImmediately } = await import("@/desktop/main/services/kanbanService");
+
+    // When & Then
+    await expect(installTaskHooksImmediately(
+      "/remote/repo__worktrees/feature-task",
+      {
+        id: "task-1",
+        title: "원격 hooks 보장",
+        sshHost: "remote-host",
+      } as never,
+      "새 태스크 hooks 동기 설치 실패",
+    )).rejects.toBe(installError);
+
+    expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
+      "/remote/repo__worktrees/feature-task",
+      "task-1",
+      "remote-host",
+    );
+    expect(mocks.installKanvibeHookFiles).not.toHaveBeenCalled();
+    expect(mocks.scheduleKanvibeHooksVerification).not.toHaveBeenCalled();
+    expect(mocks.broadcastTaskHookInstallFailed).toHaveBeenCalledWith({
+      taskId: "task-1",
+      taskTitle: "원격 hooks 보장",
+      error: "verification unavailable",
+    });
+    consoleErrorSpy.mockRestore();
+  });
+
   it("동기 hooks 설치가 성공하면 설치 이후 board update를 한 번 브로드캐스트한다", async () => {
     // Given
     mocks.projectRepo.findOneBy.mockResolvedValue({

--- a/src/desktop/main/services/hookService.ts
+++ b/src/desktop/main/services/hookService.ts
@@ -3,9 +3,9 @@ import { getProjectRepository, getTaskRepository } from "@/lib/database";
 import { createWorktreeWithSession } from "@/lib/worktree";
 import { broadcastBoardUpdate, broadcastHookStatusTargetMissing, broadcastTaskStatusChanged } from "@/lib/boardNotifier";
 import {
+  installTaskHooksImmediately,
   prepareOptimisticDoneTransition,
   scheduleDoneCleanupWithRollback,
-  scheduleTaskHookInstall,
   type DoneCleanupPlan,
 } from "@/desktop/main/services/kanbanService";
 
@@ -77,11 +77,15 @@ export async function startHookTask(input: HookStartInput) {
   const saved = await repo.save(task);
 
   if (saved.worktreePath) {
-    scheduleTaskHookInstall(saved.worktreePath, {
-      id: saved.id,
-      title: saved.title,
-      sshHost: saved.sshHost,
-    });
+    await installTaskHooksImmediately(
+      saved.worktreePath,
+      {
+        id: saved.id,
+        title: saved.title,
+        sshHost: saved.sshHost,
+      },
+      "새 태스크 hooks 동기 설치 실패",
+    );
   }
 
   broadcastBoardUpdate();

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -13,8 +13,8 @@ import {
   type TaskPrMergedDetectedPayload,
 } from "@/lib/boardNotifier";
 import {
+  installKanvibeHooks,
   installKanvibeHookFiles,
-  scheduleKanvibeHooksInstall,
   scheduleKanvibeHooksVerification,
 } from "@/lib/kanvibeHooksInstaller";
 import { execGit, pullCurrentBranch, remoteBranchExists } from "@/lib/gitOperations";
@@ -138,20 +138,6 @@ function quoteForShell(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
-export function scheduleTaskHookInstall(
-  targetPath: string,
-  task: Pick<KanbanTask, "id" | "title" | "sshHost">,
-) {
-  scheduleKanvibeHooksInstall(targetPath, task.id, task.sshHost, {
-    onSuccess: () => {
-      broadcastBoardUpdate();
-    },
-    onFailure: (error) => {
-      reportTaskHookInstallFailure(targetPath, task, error, "새 태스크 hooks 백그라운드 설치 실패");
-    },
-  });
-}
-
 function scheduleTaskHookVerification(
   targetPath: string,
   task: Pick<KanbanTask, "id" | "title" | "sshHost">,
@@ -166,7 +152,20 @@ function scheduleTaskHookVerification(
   });
 }
 
-async function installTaskHookFilesSafely(
+export async function installTaskHooksImmediately(
+  targetPath: string,
+  task: Pick<KanbanTask, "id" | "title" | "sshHost">,
+  failureLogMessage: string,
+) {
+  try {
+    await installKanvibeHooks(targetPath, task.id, task.sshHost);
+  } catch (error) {
+    reportTaskHookInstallFailure(targetPath, task, error, failureLogMessage);
+    throw error;
+  }
+}
+
+export async function installTaskHookFilesImmediately(
   targetPath: string,
   task: Pick<KanbanTask, "id" | "title" | "sshHost">,
   failureLogMessage: string,
@@ -183,7 +182,7 @@ async function installTaskHookFilesBeforeTerminalAttach(
   targetPath: string,
   task: Pick<KanbanTask, "id" | "title" | "sshHost">,
 ) {
-  const installJob = installTaskHookFilesSafely(
+  const installJob = installTaskHookFilesImmediately(
     targetPath,
     task,
     "터미널 연결 전 hooks 동기 설치 실패",
@@ -641,7 +640,7 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
   const saved = await repo.save(task);
 
   if (shouldInstallHooks && hookTargetPath) {
-    await installTaskHookFilesSafely(
+    await installTaskHookFilesImmediately(
       hookTargetPath,
       saved,
       "새 태스크 hooks 동기 설치 실패",
@@ -875,7 +874,7 @@ export async function branchFromTask(
   const saved = await repo.save(task);
 
   if (session.worktreePath) {
-    await installTaskHookFilesSafely(
+    await installTaskHookFilesImmediately(
       session.worktreePath,
       saved,
       "Hooks 설정 실패",


### PR DESCRIPTION
## What Changed
- Wait for the full hook install and verification retry flow when starting hook-created tasks before broadcasting the board update and returning success.
- Add a task-hook helper that uses `installKanvibeHooks`, preserving the previous full install+verify retry semantics for hook-created worktrees.
- Propagate hook install or verification failures after logging and broadcasting the failure event, so `/api/hooks/start` does not report success when setup fails.
- Update hook service and kanban service unit coverage for success waiting, failure propagation, and full installer usage.

## Why
- Hook-created tasks should only report success after local hook setup is actually usable.

Co-Authored-By: OpenAI Codex <codex@openai.com>