### PR TITLE
Enable both Codex hook feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ PreToolUse (Bash only)         → PROGRESS
 Stop                           → REVIEW
 ```
 
-KanVibe now uses Codex's current lifecycle hooks model with `.codex/hooks.json` plus `[features].codex_hooks = true` in `.codex/config.toml`, following the latest official docs:
+KanVibe now uses Codex's current lifecycle hooks model with `.codex/hooks.json` plus both `[features].codex_hooks = true` and `[features].hooks = true` in `.codex/config.toml`:
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -217,7 +217,7 @@ PreToolUse (Bash 전용)        → PROGRESS
 Stop                          → REVIEW
 ```
 
-KanVibe는 이제 Codex 최신 lifecycle hooks 방식인 `.codex/hooks.json`과 `.codex/config.toml`의 `[features].codex_hooks = true` 조합을 사용합니다. 기준 문서는 다음 공식 문서입니다.
+KanVibe는 이제 Codex 최신 lifecycle hooks 방식인 `.codex/hooks.json`과 `.codex/config.toml`의 `[features].codex_hooks = true`, `[features].hooks = true` 조합을 사용합니다. 기준 문서는 다음 공식 문서입니다.
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -214,7 +214,7 @@ PreToolUse（仅 Bash）          → PROGRESS
 Stop                           → REVIEW
 ```
 
-KanVibe 现在使用 Codex 当前的 lifecycle hooks 方案：`.codex/hooks.json` 加上 `.codex/config.toml` 中的 `[features].codex_hooks = true`。对应的官方文档如下：
+KanVibe 现在使用 Codex 当前的 lifecycle hooks 方案：`.codex/hooks.json` 加上 `.codex/config.toml` 中的 `[features].codex_hooks = true` 和 `[features].hooks = true`。对应的官方文档如下：
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -21,14 +21,26 @@ describe("codexHooksSetup", () => {
   });
 
   describe("upsertCodexConfigToml", () => {
-    it("should enable codex_hooks under the features table", () => {
+    it("should enable both codex hook feature flags under the features table", () => {
       const content = 'model = "gpt-5"\n[features]\nfast_mode = true\n';
 
       const updated = upsertCodexConfigToml(content);
 
       expect(updated).toContain("[features]");
       expect(updated).toContain("fast_mode = true");
-      expect(updated).toContain("codex_hooks = true");
+      expect(updated).toMatch(/^codex_hooks = true$/m);
+      expect(updated).toMatch(/^hooks = true$/m);
+    });
+
+    it("should keep the legacy codex_hooks flag and add hooks", () => {
+      const content = 'model = "gpt-5"\n[features]\ncodex_hooks = false\nfast_mode = true\n';
+
+      const updated = upsertCodexConfigToml(content);
+
+      expect(updated).toContain("[features]");
+      expect(updated).toContain("fast_mode = true");
+      expect(updated).toMatch(/^codex_hooks = true$/m);
+      expect(updated).toMatch(/^hooks = true$/m);
     });
 
     it("should remove the legacy kanvibe notify entry", () => {
@@ -38,7 +50,8 @@ describe("codexHooksSetup", () => {
 
       expect(updated).not.toContain('notify = [".codex/hooks/kanvibe-notify-hook.sh"]');
       expect(updated).toContain("[features]");
-      expect(updated).toContain("codex_hooks = true");
+      expect(updated).toMatch(/^codex_hooks = true$/m);
+      expect(updated).toMatch(/^hooks = true$/m);
     });
   });
 
@@ -86,7 +99,8 @@ describe("codexHooksSetup", () => {
 
       const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
       expect(configContent).toContain("[features]");
-      expect(configContent).toContain("codex_hooks = true");
+      expect(configContent).toMatch(/^codex_hooks = true$/m);
+      expect(configContent).toMatch(/^hooks = true$/m);
 
       const hooksContent = await readFile(join(repoPath, ".codex", "hooks.json"), "utf-8");
       expect(hooksContent).toContain('"UserPromptSubmit"');
@@ -131,7 +145,8 @@ describe("codexHooksSetup", () => {
       const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
       expect(configContent).not.toContain('notify = [".codex/hooks/kanvibe-notify-hook.sh"]');
       expect(configContent).toContain("[features]");
-      expect(configContent).toContain("codex_hooks = true");
+      expect(configContent).toMatch(/^codex_hooks = true$/m);
+      expect(configContent).toMatch(/^hooks = true$/m);
     });
   });
 

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -34,7 +34,7 @@ vi.mock("@/lib/codexHooksSetup", () => ({
   generatePermissionHookScript: vi.fn(() => "codex permission"),
   generatePreToolHookScript: vi.fn(() => "codex pre tool"),
   generateStopHookScript: vi.fn(() => "codex stop"),
-  upsertCodexConfigToml: vi.fn((content: string) => `${content.trimEnd()}\n[features]\ncodex_hooks = true\n`),
+  upsertCodexConfigToml: vi.fn((content: string) => `${content.trimEnd()}\n[features]\ncodex_hooks = true\nhooks = true\n`),
   upsertCodexHooksJson: vi.fn(() => JSON.stringify({ hooks: { UserPromptSubmit: [{}], PermissionRequest: [{}], PreToolUse: [{}], Stop: [{}] } }, null, 2)),
   PROMPT_HOOK_SCRIPT_NAME: "kanvibe-prompt-hook.sh",
   PERMISSION_HOOK_SCRIPT_NAME: "kanvibe-permission-hook.sh",
@@ -521,7 +521,8 @@ describe("kanvibeHooksInstaller", () => {
     const configContent = extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.codex/config.toml");
     expect(configContent).toContain('model = "gpt-5"');
     expect(configContent).toContain("[features]");
-    expect(configContent).toContain("codex_hooks = true");
+    expect(configContent).toMatch(/^codex_hooks = true$/m);
+    expect(configContent).toMatch(/^hooks = true$/m);
 
     const hooksContent = extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.codex/hooks.json");
     expect(hooksContent).toContain("UserPromptSubmit");

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -6,7 +6,7 @@ import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/li
 import { buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
 
 /**
- * Codex CLI 최신 hooks 설정은 `.codex/config.toml`의 feature flag와
+ * Codex CLI 최신 hooks 설정은 `.codex/config.toml`의 hooks feature flag와
  * `.codex/hooks.json` 조합을 사용한다.
  */
 
@@ -175,22 +175,49 @@ export function upsertCodexConfigToml(configContent: string): string {
 
   if (!featuresSection) {
     const prefix = normalized.length > 0 ? `${normalized}\n\n` : "";
-    return `${prefix}[features]\ncodex_hooks = true\n`;
+    return `${prefix}[features]\ncodex_hooks = true\nhooks = true\n`;
   }
 
-  const flagIndex = lines.findIndex(
-    (line, index) => index > featuresSection.start
-      && index < featuresSection.end
-      && /^\s*codex_hooks\s*=/.test(line),
-  );
+  const beforeFeaturesBody = lines.slice(0, featuresSection.start + 1);
+  const featuresBody = lines.slice(featuresSection.start + 1, featuresSection.end);
+  const afterFeaturesSection = lines.slice(featuresSection.end);
+  const nextFeaturesBody: string[] = [];
+  let hasLegacyHooksFlag = false;
+  let hasHooksFlag = false;
 
-  if (flagIndex !== -1) {
-    lines[flagIndex] = "codex_hooks = true";
-  } else {
-    lines.splice(featuresSection.end, 0, "codex_hooks = true");
+  for (const line of featuresBody) {
+    if (/^\s*codex_hooks\s*=/.test(line)) {
+      if (!hasLegacyHooksFlag) {
+        nextFeaturesBody.push("codex_hooks = true");
+        hasLegacyHooksFlag = true;
+      }
+      continue;
+    }
+
+    if (/^\s*hooks\s*=/.test(line)) {
+      if (!hasHooksFlag) {
+        nextFeaturesBody.push("hooks = true");
+        hasHooksFlag = true;
+      }
+      continue;
+    }
+
+    nextFeaturesBody.push(line);
   }
 
-  return `${lines.join("\n").trimEnd()}\n`;
+  if (!hasLegacyHooksFlag) {
+    nextFeaturesBody.push("codex_hooks = true");
+  }
+
+  if (!hasHooksFlag) {
+    nextFeaturesBody.push("hooks = true");
+  }
+
+  return `${[
+    ...beforeFeaturesBody,
+    ...nextFeaturesBody,
+    ...afterFeaturesSection,
+  ].join("\n").trimEnd()}\n`;
 }
 
 function hasCodexFeatureFlag(configContent: string): boolean {
@@ -201,11 +228,17 @@ function hasCodexFeatureFlag(configContent: string): boolean {
     return false;
   }
 
-  return lines.some(
+  const hasLegacyHooksFlag = lines.some(
     (line, index) => index > featuresSection.start
       && index < featuresSection.end
       && /^\s*codex_hooks\s*=\s*true\s*$/.test(line),
   );
+  const hasHooksFlag = lines.some(
+    (line, index) => index > featuresSection.start
+      && index < featuresSection.end
+      && /^\s*hooks\s*=\s*true\s*$/.test(line),
+  );
+  return hasLegacyHooksFlag && hasHooksFlag;
 }
 
 export function upsertCodexHooksJson(hooksContent: string): string {


### PR DESCRIPTION
## What changed
- Generate both `codex_hooks = true` and `hooks = true` in `.codex/config.toml` for Codex hook setup.
- Keep installation status checks aligned with both feature flags being present.
- Update focused hook setup tests and remote installer mocks to assert both flags.
- Update README translations to document the combined Codex hook feature flag setup.

## Why
Codex now warns that `[features].codex_hooks` is deprecated in favor of `[features].hooks`, but the legacy flag still needs to remain enabled for compatibility. This change keeps the existing flag and adds the new one.

## Validation
- `pnpm test src/lib/__tests__/codexHooksSetup.test.ts src/lib/__tests__/kanvibeHooksInstaller.test.ts`
- `pnpm check`
- `git diff --check`

Co-Authored-By: OpenAI Codex <codex@openai.com>