### PR TITLE
fix(codex): enable lifecycle hooks with hooks flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ PreToolUse (Bash only)         → PROGRESS
 Stop                           → REVIEW
 ```
 
-KanVibe now uses Codex's current lifecycle hooks model with `.codex/hooks.json` plus `[features].codex_hooks = true` in `.codex/config.toml`:
+KanVibe now uses Codex's current lifecycle hooks model with `.codex/hooks.json` plus `[features].hooks = true` in `.codex/config.toml`:
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ PreToolUse (Bash only)         → PROGRESS
 Stop                           → REVIEW
 ```
 
-KanVibe now uses Codex's current lifecycle hooks model with `.codex/hooks.json` plus both `[features].codex_hooks = true` and `[features].hooks = true` in `.codex/config.toml`:
+KanVibe now uses Codex's current lifecycle hooks model with `.codex/hooks.json` plus `[features].hooks = true` in `.codex/config.toml`:
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference

--- a/README.md
+++ b/README.md
@@ -229,10 +229,12 @@ PreToolUse (Bash only)         → PROGRESS
 Stop                           → REVIEW
 ```
 
-KanVibe now uses Codex's current lifecycle hooks model with `.codex/hooks.json` plus `[features].hooks = true` in `.codex/config.toml`:
+KanVibe now uses Codex's current lifecycle hooks model with `.codex/hooks.json` plus `[features].codex_hooks = true` in `.codex/config.toml`:
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference
+
+Codex loads project-local `.codex/` hooks only for trusted project/worktree paths. If a task runs in a generated worktree, trust that worktree in Codex before expecting the local hook file to fire.
 
 > Codex's current `PermissionRequest` and `PreToolUse` matchers are Bash-scoped, so `PENDING` represents approval waits rather than every kind of conversational follow-up question.
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -217,7 +217,7 @@ PreToolUse (Bash 전용)        → PROGRESS
 Stop                          → REVIEW
 ```
 
-KanVibe는 이제 Codex 최신 lifecycle hooks 방식인 `.codex/hooks.json`과 `.codex/config.toml`의 `[features].codex_hooks = true` 조합을 사용합니다. 기준 문서는 다음 공식 문서입니다.
+KanVibe는 이제 Codex 최신 lifecycle hooks 방식인 `.codex/hooks.json`과 `.codex/config.toml`의 `[features].hooks = true` 조합을 사용합니다. 기준 문서는 다음 공식 문서입니다.
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -217,7 +217,7 @@ PreToolUse (Bash 전용)        → PROGRESS
 Stop                          → REVIEW
 ```
 
-KanVibe는 이제 Codex 최신 lifecycle hooks 방식인 `.codex/hooks.json`과 `.codex/config.toml`의 `[features].codex_hooks = true`, `[features].hooks = true` 조합을 사용합니다. 기준 문서는 다음 공식 문서입니다.
+KanVibe는 이제 Codex 최신 lifecycle hooks 방식인 `.codex/hooks.json`과 `.codex/config.toml`의 `[features].hooks = true` 조합을 사용합니다. 기준 문서는 다음 공식 문서입니다.
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -217,10 +217,12 @@ PreToolUse (Bash 전용)        → PROGRESS
 Stop                          → REVIEW
 ```
 
-KanVibe는 이제 Codex 최신 lifecycle hooks 방식인 `.codex/hooks.json`과 `.codex/config.toml`의 `[features].hooks = true` 조합을 사용합니다. 기준 문서는 다음 공식 문서입니다.
+KanVibe는 이제 Codex 최신 lifecycle hooks 방식인 `.codex/hooks.json`과 `.codex/config.toml`의 `[features].codex_hooks = true` 조합을 사용합니다. 기준 문서는 다음 공식 문서입니다.
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference
+
+Codex는 신뢰된 프로젝트/worktree 경로에서만 project-local `.codex/` hooks를 로드합니다. 태스크가 생성된 worktree에서 실행된다면 local hook 파일이 실행되기 전에 해당 worktree를 Codex에서 신뢰 상태로 설정해야 합니다.
 
 > 현재 Codex의 `PermissionRequest`와 `PreToolUse` 매처는 Bash 범위에 한정되므로, `PENDING`은 모든 대화형 재질문이 아니라 승인 대기 상태를 의미합니다.
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -214,10 +214,12 @@ PreToolUse（仅 Bash）          → PROGRESS
 Stop                           → REVIEW
 ```
 
-KanVibe 现在使用 Codex 当前的 lifecycle hooks 方案：`.codex/hooks.json` 加上 `.codex/config.toml` 中的 `[features].hooks = true`。对应的官方文档如下：
+KanVibe 现在使用 Codex 当前的 lifecycle hooks 方案：`.codex/hooks.json` 加上 `.codex/config.toml` 中的 `[features].codex_hooks = true`。对应的官方文档如下：
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference
+
+Codex 只会在受信任的项目/worktree 路径中加载 project-local `.codex/` hooks。如果任务运行在生成的 worktree 中，需要先在 Codex 中信任该 worktree，local hook 文件才会触发。
 
 > 当前 Codex 的 `PermissionRequest` 和 `PreToolUse` matcher 仍然限定在 Bash 场景，因此这里的 `PENDING` 表示等待审批，而不是所有类型的对话追问。
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -214,7 +214,7 @@ PreToolUse（仅 Bash）          → PROGRESS
 Stop                           → REVIEW
 ```
 
-KanVibe 现在使用 Codex 当前的 lifecycle hooks 方案：`.codex/hooks.json` 加上 `.codex/config.toml` 中的 `[features].codex_hooks = true` 和 `[features].hooks = true`。对应的官方文档如下：
+KanVibe 现在使用 Codex 当前的 lifecycle hooks 方案：`.codex/hooks.json` 加上 `.codex/config.toml` 中的 `[features].hooks = true`。对应的官方文档如下：
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -214,7 +214,7 @@ PreToolUse（仅 Bash）          → PROGRESS
 Stop                           → REVIEW
 ```
 
-KanVibe 现在使用 Codex 当前的 lifecycle hooks 方案：`.codex/hooks.json` 加上 `.codex/config.toml` 中的 `[features].codex_hooks = true`。对应的官方文档如下：
+KanVibe 现在使用 Codex 当前的 lifecycle hooks 方案：`.codex/hooks.json` 加上 `.codex/config.toml` 中的 `[features].hooks = true`。对应的官方文档如下：
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -21,26 +21,39 @@ describe("codexHooksSetup", () => {
   });
 
   describe("upsertCodexConfigToml", () => {
-    it("should enable both codex hook feature flags under the features table", () => {
+    it("should enable the hooks feature flag under the features table", () => {
       const content = 'model = "gpt-5"\n[features]\nfast_mode = true\n';
 
       const updated = upsertCodexConfigToml(content);
 
       expect(updated).toContain("[features]");
       expect(updated).toContain("fast_mode = true");
-      expect(updated).toMatch(/^codex_hooks = true$/m);
       expect(updated).toMatch(/^hooks = true$/m);
+      expect(updated).not.toMatch(/^codex_hooks\s*=/m);
+      expect(updated).not.toMatch(/^codex_hook\s*=/m);
     });
 
-    it("should keep the legacy codex_hooks flag and add hooks", () => {
-      const content = 'model = "gpt-5"\n[features]\ncodex_hooks = false\nfast_mode = true\n';
+    it("should replace hooks and remove obsolete codex hook feature flags", () => {
+      const obsoleteCodexHookFlag = "codex" + "_hook = true";
+      const obsoleteCodexHooksFlag = "codex" + "_hooks = true";
+      const obsoleteHooksFlag = "hooks" + " = true";
+      const content = [
+        'model = "gpt-5"',
+        "[features]",
+        obsoleteCodexHooksFlag,
+        obsoleteCodexHookFlag,
+        obsoleteHooksFlag.replace("true", "false"),
+        "fast_mode = true",
+        "",
+      ].join("\n");
 
       const updated = upsertCodexConfigToml(content);
 
       expect(updated).toContain("[features]");
       expect(updated).toContain("fast_mode = true");
-      expect(updated).toMatch(/^codex_hooks = true$/m);
       expect(updated).toMatch(/^hooks = true$/m);
+      expect(updated).not.toMatch(/^codex_hooks\s*=/m);
+      expect(updated).not.toMatch(/^codex_hook\s*=/m);
     });
 
     it("should remove the legacy kanvibe notify entry", () => {
@@ -50,8 +63,18 @@ describe("codexHooksSetup", () => {
 
       expect(updated).not.toContain('notify = [".codex/hooks/kanvibe-notify-hook.sh"]');
       expect(updated).toContain("[features]");
-      expect(updated).toMatch(/^codex_hooks = true$/m);
       expect(updated).toMatch(/^hooks = true$/m);
+      expect(updated).not.toMatch(/^codex_hooks\s*=/m);
+    });
+
+    it("should keep inline hooks tables outside the features table", () => {
+      const content = 'model = "gpt-5"\n[features]\nfast_mode = true\n\n[[hooks.PreToolUse]]\nmatcher = "^Bash$"\n';
+
+      const updated = upsertCodexConfigToml(content);
+
+      expect(updated).toMatch(/\[features\][\s\S]*hooks = true[\s\S]*\[\[hooks\.PreToolUse\]\]/);
+      expect(updated).toContain('matcher = "^Bash$"');
+      expect(updated).not.toMatch(/^codex_hooks\s*=/m);
     });
   });
 
@@ -99,8 +122,8 @@ describe("codexHooksSetup", () => {
 
       const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
       expect(configContent).toContain("[features]");
-      expect(configContent).toMatch(/^codex_hooks = true$/m);
       expect(configContent).toMatch(/^hooks = true$/m);
+      expect(configContent).not.toMatch(/^codex_hooks\s*=/m);
 
       const hooksContent = await readFile(join(repoPath, ".codex", "hooks.json"), "utf-8");
       expect(hooksContent).toContain('"UserPromptSubmit"');
@@ -145,8 +168,8 @@ describe("codexHooksSetup", () => {
       const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
       expect(configContent).not.toContain('notify = [".codex/hooks/kanvibe-notify-hook.sh"]');
       expect(configContent).toContain("[features]");
-      expect(configContent).toMatch(/^codex_hooks = true$/m);
       expect(configContent).toMatch(/^hooks = true$/m);
+      expect(configContent).not.toMatch(/^codex_hooks\s*=/m);
     });
   });
 

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -21,26 +21,26 @@ describe("codexHooksSetup", () => {
   });
 
   describe("upsertCodexConfigToml", () => {
-    it("should enable the hooks feature flag under the features table", () => {
+    it("should enable the codex hooks feature flag under the features table", () => {
       const content = 'model = "gpt-5"\n[features]\nfast_mode = true\n';
 
       const updated = upsertCodexConfigToml(content);
 
       expect(updated).toContain("[features]");
       expect(updated).toContain("fast_mode = true");
-      expect(updated).toMatch(/^hooks = true$/m);
-      expect(updated).not.toMatch(/^codex_hooks\s*=/m);
+      expect(updated).toMatch(/^codex_hooks = true$/m);
+      expect(updated).not.toMatch(/^hooks\s*=/m);
       expect(updated).not.toMatch(/^codex_hook\s*=/m);
     });
 
-    it("should replace hooks and remove obsolete codex hook feature flags", () => {
+    it("should replace stale hook flags and remove obsolete codex hook feature flags", () => {
       const obsoleteCodexHookFlag = "codex" + "_hook = true";
-      const obsoleteCodexHooksFlag = "codex" + "_hooks = true";
+      const disabledCodexHooksFlag = "codex" + "_hooks = false";
       const obsoleteHooksFlag = "hooks" + " = true";
       const content = [
         'model = "gpt-5"',
         "[features]",
-        obsoleteCodexHooksFlag,
+        disabledCodexHooksFlag,
         obsoleteCodexHookFlag,
         obsoleteHooksFlag.replace("true", "false"),
         "fast_mode = true",
@@ -51,8 +51,9 @@ describe("codexHooksSetup", () => {
 
       expect(updated).toContain("[features]");
       expect(updated).toContain("fast_mode = true");
-      expect(updated).toMatch(/^hooks = true$/m);
-      expect(updated).not.toMatch(/^codex_hooks\s*=/m);
+      expect(updated).toMatch(/^codex_hooks = true$/m);
+      expect(updated.match(/^codex_hooks\s*=/gm)).toHaveLength(1);
+      expect(updated).not.toMatch(/^hooks\s*=/m);
       expect(updated).not.toMatch(/^codex_hook\s*=/m);
     });
 
@@ -63,8 +64,8 @@ describe("codexHooksSetup", () => {
 
       expect(updated).not.toContain('notify = [".codex/hooks/kanvibe-notify-hook.sh"]');
       expect(updated).toContain("[features]");
-      expect(updated).toMatch(/^hooks = true$/m);
-      expect(updated).not.toMatch(/^codex_hooks\s*=/m);
+      expect(updated).toMatch(/^codex_hooks = true$/m);
+      expect(updated).not.toMatch(/^hooks\s*=/m);
     });
 
     it("should keep inline hooks tables outside the features table", () => {
@@ -72,9 +73,9 @@ describe("codexHooksSetup", () => {
 
       const updated = upsertCodexConfigToml(content);
 
-      expect(updated).toMatch(/\[features\][\s\S]*hooks = true[\s\S]*\[\[hooks\.PreToolUse\]\]/);
+      expect(updated).toMatch(/\[features\][\s\S]*codex_hooks = true[\s\S]*\[\[hooks\.PreToolUse\]\]/);
       expect(updated).toContain('matcher = "^Bash$"');
-      expect(updated).not.toMatch(/^codex_hooks\s*=/m);
+      expect(updated).not.toMatch(/^hooks\s*=/m);
     });
   });
 
@@ -122,8 +123,8 @@ describe("codexHooksSetup", () => {
 
       const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
       expect(configContent).toContain("[features]");
-      expect(configContent).toMatch(/^hooks = true$/m);
-      expect(configContent).not.toMatch(/^codex_hooks\s*=/m);
+      expect(configContent).toMatch(/^codex_hooks = true$/m);
+      expect(configContent).not.toMatch(/^hooks\s*=/m);
 
       const hooksContent = await readFile(join(repoPath, ".codex", "hooks.json"), "utf-8");
       expect(hooksContent).toContain('"UserPromptSubmit"');
@@ -168,8 +169,8 @@ describe("codexHooksSetup", () => {
       const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
       expect(configContent).not.toContain('notify = [".codex/hooks/kanvibe-notify-hook.sh"]');
       expect(configContent).toContain("[features]");
-      expect(configContent).toMatch(/^hooks = true$/m);
-      expect(configContent).not.toMatch(/^codex_hooks\s*=/m);
+      expect(configContent).toMatch(/^codex_hooks = true$/m);
+      expect(configContent).not.toMatch(/^hooks\s*=/m);
     });
   });
 

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -21,28 +21,28 @@ describe("codexHooksSetup", () => {
   });
 
   describe("upsertCodexConfigToml", () => {
-    it("should enable the codex hooks feature flag under the features table", () => {
+    it("should enable the hooks feature flag under the features table", () => {
       const content = 'model = "gpt-5"\n[features]\nfast_mode = true\n';
 
       const updated = upsertCodexConfigToml(content);
 
       expect(updated).toContain("[features]");
       expect(updated).toContain("fast_mode = true");
-      expect(updated).toMatch(/^codex_hooks = true$/m);
-      expect(updated).not.toMatch(/^hooks\s*=/m);
+      expect(updated).toMatch(/^hooks = true$/m);
+      expect(updated).not.toMatch(/^codex_hooks\s*=/m);
       expect(updated).not.toMatch(/^codex_hook\s*=/m);
     });
 
     it("should replace stale hook flags and remove obsolete codex hook feature flags", () => {
       const obsoleteCodexHookFlag = "codex" + "_hook = true";
       const disabledCodexHooksFlag = "codex" + "_hooks = false";
-      const obsoleteHooksFlag = "hooks" + " = true";
+      const disabledHooksFlag = "hooks" + " = false";
       const content = [
         'model = "gpt-5"',
         "[features]",
         disabledCodexHooksFlag,
         obsoleteCodexHookFlag,
-        obsoleteHooksFlag.replace("true", "false"),
+        disabledHooksFlag,
         "fast_mode = true",
         "",
       ].join("\n");
@@ -51,9 +51,9 @@ describe("codexHooksSetup", () => {
 
       expect(updated).toContain("[features]");
       expect(updated).toContain("fast_mode = true");
-      expect(updated).toMatch(/^codex_hooks = true$/m);
-      expect(updated.match(/^codex_hooks\s*=/gm)).toHaveLength(1);
-      expect(updated).not.toMatch(/^hooks\s*=/m);
+      expect(updated).toMatch(/^hooks = true$/m);
+      expect(updated.match(/^hooks\s*=/gm)).toHaveLength(1);
+      expect(updated).not.toMatch(/^codex_hooks\s*=/m);
       expect(updated).not.toMatch(/^codex_hook\s*=/m);
     });
 
@@ -64,8 +64,8 @@ describe("codexHooksSetup", () => {
 
       expect(updated).not.toContain('notify = [".codex/hooks/kanvibe-notify-hook.sh"]');
       expect(updated).toContain("[features]");
-      expect(updated).toMatch(/^codex_hooks = true$/m);
-      expect(updated).not.toMatch(/^hooks\s*=/m);
+      expect(updated).toMatch(/^hooks = true$/m);
+      expect(updated).not.toMatch(/^codex_hooks\s*=/m);
     });
 
     it("should keep inline hooks tables outside the features table", () => {
@@ -73,9 +73,9 @@ describe("codexHooksSetup", () => {
 
       const updated = upsertCodexConfigToml(content);
 
-      expect(updated).toMatch(/\[features\][\s\S]*codex_hooks = true[\s\S]*\[\[hooks\.PreToolUse\]\]/);
+      expect(updated).toMatch(/\[features\][\s\S]*hooks = true[\s\S]*\[\[hooks\.PreToolUse\]\]/);
       expect(updated).toContain('matcher = "^Bash$"');
-      expect(updated).not.toMatch(/^hooks\s*=/m);
+      expect(updated.match(/^hooks\s*=/gm)).toHaveLength(1);
     });
   });
 
@@ -123,8 +123,8 @@ describe("codexHooksSetup", () => {
 
       const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
       expect(configContent).toContain("[features]");
-      expect(configContent).toMatch(/^codex_hooks = true$/m);
-      expect(configContent).not.toMatch(/^hooks\s*=/m);
+      expect(configContent).toMatch(/^hooks = true$/m);
+      expect(configContent).not.toMatch(/^codex_hooks\s*=/m);
 
       const hooksContent = await readFile(join(repoPath, ".codex", "hooks.json"), "utf-8");
       expect(hooksContent).toContain('"UserPromptSubmit"');
@@ -169,8 +169,8 @@ describe("codexHooksSetup", () => {
       const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
       expect(configContent).not.toContain('notify = [".codex/hooks/kanvibe-notify-hook.sh"]');
       expect(configContent).toContain("[features]");
-      expect(configContent).toMatch(/^codex_hooks = true$/m);
-      expect(configContent).not.toMatch(/^hooks\s*=/m);
+      expect(configContent).toMatch(/^hooks = true$/m);
+      expect(configContent).not.toMatch(/^codex_hooks\s*=/m);
     });
   });
 

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -34,7 +34,7 @@ vi.mock("@/lib/codexHooksSetup", () => ({
   generatePermissionHookScript: vi.fn(() => "codex permission"),
   generatePreToolHookScript: vi.fn(() => "codex pre tool"),
   generateStopHookScript: vi.fn(() => "codex stop"),
-  upsertCodexConfigToml: vi.fn((content: string) => `${content.trimEnd()}\n[features]\nhooks = true\n`),
+  upsertCodexConfigToml: vi.fn((content: string) => `${content.trimEnd()}\n[features]\ncodex_hooks = true\n`),
   upsertCodexHooksJson: vi.fn(() => JSON.stringify({ hooks: { UserPromptSubmit: [{}], PermissionRequest: [{}], PreToolUse: [{}], Stop: [{}] } }, null, 2)),
   PROMPT_HOOK_SCRIPT_NAME: "kanvibe-prompt-hook.sh",
   PERMISSION_HOOK_SCRIPT_NAME: "kanvibe-permission-hook.sh",
@@ -521,8 +521,8 @@ describe("kanvibeHooksInstaller", () => {
     const configContent = extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.codex/config.toml");
     expect(configContent).toContain('model = "gpt-5"');
     expect(configContent).toContain("[features]");
-    expect(configContent).toMatch(/^hooks = true$/m);
-    expect(configContent).not.toMatch(/^codex_hooks\s*=/m);
+    expect(configContent).toMatch(/^codex_hooks = true$/m);
+    expect(configContent).not.toMatch(/^hooks\s*=/m);
 
     const hooksContent = extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.codex/hooks.json");
     expect(hooksContent).toContain("UserPromptSubmit");

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -34,7 +34,7 @@ vi.mock("@/lib/codexHooksSetup", () => ({
   generatePermissionHookScript: vi.fn(() => "codex permission"),
   generatePreToolHookScript: vi.fn(() => "codex pre tool"),
   generateStopHookScript: vi.fn(() => "codex stop"),
-  upsertCodexConfigToml: vi.fn((content: string) => `${content.trimEnd()}\n[features]\ncodex_hooks = true\nhooks = true\n`),
+  upsertCodexConfigToml: vi.fn((content: string) => `${content.trimEnd()}\n[features]\nhooks = true\n`),
   upsertCodexHooksJson: vi.fn(() => JSON.stringify({ hooks: { UserPromptSubmit: [{}], PermissionRequest: [{}], PreToolUse: [{}], Stop: [{}] } }, null, 2)),
   PROMPT_HOOK_SCRIPT_NAME: "kanvibe-prompt-hook.sh",
   PERMISSION_HOOK_SCRIPT_NAME: "kanvibe-permission-hook.sh",
@@ -521,8 +521,8 @@ describe("kanvibeHooksInstaller", () => {
     const configContent = extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.codex/config.toml");
     expect(configContent).toContain('model = "gpt-5"');
     expect(configContent).toContain("[features]");
-    expect(configContent).toMatch(/^codex_hooks = true$/m);
     expect(configContent).toMatch(/^hooks = true$/m);
+    expect(configContent).not.toMatch(/^codex_hooks\s*=/m);
 
     const hooksContent = extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.codex/hooks.json");
     expect(hooksContent).toContain("UserPromptSubmit");

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -34,7 +34,7 @@ vi.mock("@/lib/codexHooksSetup", () => ({
   generatePermissionHookScript: vi.fn(() => "codex permission"),
   generatePreToolHookScript: vi.fn(() => "codex pre tool"),
   generateStopHookScript: vi.fn(() => "codex stop"),
-  upsertCodexConfigToml: vi.fn((content: string) => `${content.trimEnd()}\n[features]\ncodex_hooks = true\n`),
+  upsertCodexConfigToml: vi.fn((content: string) => `${content.trimEnd()}\n[features]\nhooks = true\n`),
   upsertCodexHooksJson: vi.fn(() => JSON.stringify({ hooks: { UserPromptSubmit: [{}], PermissionRequest: [{}], PreToolUse: [{}], Stop: [{}] } }, null, 2)),
   PROMPT_HOOK_SCRIPT_NAME: "kanvibe-prompt-hook.sh",
   PERMISSION_HOOK_SCRIPT_NAME: "kanvibe-permission-hook.sh",
@@ -521,8 +521,8 @@ describe("kanvibeHooksInstaller", () => {
     const configContent = extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.codex/config.toml");
     expect(configContent).toContain('model = "gpt-5"');
     expect(configContent).toContain("[features]");
-    expect(configContent).toMatch(/^codex_hooks = true$/m);
-    expect(configContent).not.toMatch(/^hooks\s*=/m);
+    expect(configContent).toMatch(/^hooks = true$/m);
+    expect(configContent).not.toMatch(/^codex_hooks\s*=/m);
 
     const hooksContent = extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.codex/hooks.json");
     expect(hooksContent).toContain("UserPromptSubmit");

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -34,7 +34,7 @@ const CODEX_PROMPT_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hook
 const CODEX_PERMISSION_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hooks/${PERMISSION_HOOK_SCRIPT_NAME}"`;
 const CODEX_PRE_TOOL_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hooks/${PRE_TOOL_HOOK_SCRIPT_NAME}"`;
 const CODEX_STOP_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hooks/${STOP_HOOK_SCRIPT_NAME}"`;
-const CODEX_HOOKS_FEATURE_FLAG = "codex_hooks";
+const CODEX_HOOKS_FEATURE_FLAG = "hooks";
 
 function generateStatusHookScript(
   eventLabel: string,
@@ -223,7 +223,7 @@ function hasCodexFeatureFlag(configContent: string): boolean {
   return lines.some(
     (line, index) => index > featuresSection.start
       && index < featuresSection.end
-      && /^\s*codex_hooks\s*=\s*true\s*$/.test(line),
+      && /^\s*hooks\s*=\s*true\s*$/.test(line),
   );
 }
 

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -144,7 +144,7 @@ function upsertHookEntries<T>(hookEntries: unknown[] | undefined, scriptName: st
 }
 
 function isSectionHeader(line: string): boolean {
-  return /^\s*\[[^\]]+\]\s*$/.test(line);
+  return /^\s*(?:\[[^\[\]]+\]|\[\[[^\[\]]+\]\])\s*$/.test(line);
 }
 
 function findFeaturesSection(lines: string[]) {
@@ -175,25 +175,16 @@ export function upsertCodexConfigToml(configContent: string): string {
 
   if (!featuresSection) {
     const prefix = normalized.length > 0 ? `${normalized}\n\n` : "";
-    return `${prefix}[features]\ncodex_hooks = true\nhooks = true\n`;
+    return `${prefix}[features]\nhooks = true\n`;
   }
 
   const beforeFeaturesBody = lines.slice(0, featuresSection.start + 1);
   const featuresBody = lines.slice(featuresSection.start + 1, featuresSection.end);
   const afterFeaturesSection = lines.slice(featuresSection.end);
   const nextFeaturesBody: string[] = [];
-  let hasLegacyHooksFlag = false;
   let hasHooksFlag = false;
 
   for (const line of featuresBody) {
-    if (/^\s*codex_hooks\s*=/.test(line)) {
-      if (!hasLegacyHooksFlag) {
-        nextFeaturesBody.push("codex_hooks = true");
-        hasLegacyHooksFlag = true;
-      }
-      continue;
-    }
-
     if (/^\s*hooks\s*=/.test(line)) {
       if (!hasHooksFlag) {
         nextFeaturesBody.push("hooks = true");
@@ -202,11 +193,11 @@ export function upsertCodexConfigToml(configContent: string): string {
       continue;
     }
 
-    nextFeaturesBody.push(line);
-  }
+    if (/^\s*(?:codex_hooks|codex_hook)\s*=/.test(line)) {
+      continue;
+    }
 
-  if (!hasLegacyHooksFlag) {
-    nextFeaturesBody.push("codex_hooks = true");
+    nextFeaturesBody.push(line);
   }
 
   if (!hasHooksFlag) {
@@ -228,17 +219,11 @@ function hasCodexFeatureFlag(configContent: string): boolean {
     return false;
   }
 
-  const hasLegacyHooksFlag = lines.some(
-    (line, index) => index > featuresSection.start
-      && index < featuresSection.end
-      && /^\s*codex_hooks\s*=\s*true\s*$/.test(line),
-  );
-  const hasHooksFlag = lines.some(
+  return lines.some(
     (line, index) => index > featuresSection.start
       && index < featuresSection.end
       && /^\s*hooks\s*=\s*true\s*$/.test(line),
   );
-  return hasLegacyHooksFlag && hasHooksFlag;
 }
 
 export function upsertCodexHooksJson(hooksContent: string): string {

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -34,6 +34,7 @@ const CODEX_PROMPT_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hook
 const CODEX_PERMISSION_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hooks/${PERMISSION_HOOK_SCRIPT_NAME}"`;
 const CODEX_PRE_TOOL_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hooks/${PRE_TOOL_HOOK_SCRIPT_NAME}"`;
 const CODEX_STOP_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hooks/${STOP_HOOK_SCRIPT_NAME}"`;
+const CODEX_HOOKS_FEATURE_FLAG = "codex_hooks";
 
 function generateStatusHookScript(
   eventLabel: string,
@@ -175,33 +176,33 @@ export function upsertCodexConfigToml(configContent: string): string {
 
   if (!featuresSection) {
     const prefix = normalized.length > 0 ? `${normalized}\n\n` : "";
-    return `${prefix}[features]\nhooks = true\n`;
+    return `${prefix}[features]\n${CODEX_HOOKS_FEATURE_FLAG} = true\n`;
   }
 
   const beforeFeaturesBody = lines.slice(0, featuresSection.start + 1);
   const featuresBody = lines.slice(featuresSection.start + 1, featuresSection.end);
   const afterFeaturesSection = lines.slice(featuresSection.end);
   const nextFeaturesBody: string[] = [];
-  let hasHooksFlag = false;
+  let hasCodexHooksFlag = false;
 
   for (const line of featuresBody) {
-    if (/^\s*hooks\s*=/.test(line)) {
-      if (!hasHooksFlag) {
-        nextFeaturesBody.push("hooks = true");
-        hasHooksFlag = true;
+    if (/^\s*codex_hooks\s*=/.test(line)) {
+      if (!hasCodexHooksFlag) {
+        nextFeaturesBody.push(`${CODEX_HOOKS_FEATURE_FLAG} = true`);
+        hasCodexHooksFlag = true;
       }
       continue;
     }
 
-    if (/^\s*(?:codex_hooks|codex_hook)\s*=/.test(line)) {
+    if (/^\s*(?:hooks|codex_hook)\s*=/.test(line)) {
       continue;
     }
 
     nextFeaturesBody.push(line);
   }
 
-  if (!hasHooksFlag) {
-    nextFeaturesBody.push("hooks = true");
+  if (!hasCodexHooksFlag) {
+    nextFeaturesBody.push(`${CODEX_HOOKS_FEATURE_FLAG} = true`);
   }
 
   return `${[
@@ -222,7 +223,7 @@ function hasCodexFeatureFlag(configContent: string): boolean {
   return lines.some(
     (line, index) => index > featuresSection.start
       && index < featuresSection.end
-      && /^\s*hooks\s*=\s*true\s*$/.test(line),
+      && /^\s*codex_hooks\s*=\s*true\s*$/.test(line),
   );
 }
 


### PR DESCRIPTION
## What changed?
- Update Codex hook setup to write `[features].hooks = true` as the lifecycle hooks feature flag used by the current Codex CLI.
- Treat stale `[features].codex_hooks` and singular `codex_hook` entries as obsolete when repairing Codex config, while keeping `.codex/hooks.json` lifecycle event registration unchanged.
- Update install verification and README references to match the `hooks` feature flag.

## Why
- On the current local Codex CLI, `codex features list` exposes the hook feature as `hooks`, and `features.codex_hooks=true` does not enable that feature when `features.hooks=false` is supplied.
- Without this, KanVibe can install `.codex/hooks.json` and still fail to have Codex load the lifecycle hooks.

## Important details
- This PR does not auto-trust hooks. As discussed in https://github.com/openai/codex/issues/21639#issuecomment-4407202957, Codex is expected to add an automatic hook trust option later.
- Existing KanVibe hook scripts and status mappings stay unchanged.

Co-Authored-By: Codex <codex@openai.com>