### PR TITLE
feat(settings): add background sync settings

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -186,7 +186,17 @@
     "notificationStatusFilterDescription": "Only receive notifications when tasks change to selected statuses.",
     "taskCreationSection": "Task Creation",
     "defaultSessionType": "Default session type",
-    "defaultSessionTypeDescription": "The default session type selected when creating a new task."
+    "defaultSessionTypeDescription": "The default session type selected when creating a new task.",
+    "backgroundSyncSection": "Background Sync",
+    "backgroundSyncEnabled": "Background Sync",
+    "backgroundSyncEnabledDescription": "Periodically sync project worktrees and PR status in the background.",
+    "backgroundSyncInterval": "Sync interval",
+    "backgroundSyncIntervalDescription": "How often to run background sync.",
+    "backgroundSyncInterval1min": "1 min",
+    "backgroundSyncInterval5min": "5 min",
+    "backgroundSyncInterval10min": "10 min",
+    "backgroundSyncInterval30min": "30 min",
+    "backgroundSyncInterval60min": "60 min"
   },
   "taskSearch": {
     "title": "Quick Task Search",

--- a/messages/en.json
+++ b/messages/en.json
@@ -191,12 +191,8 @@
     "backgroundSyncEnabled": "Background Sync",
     "backgroundSyncEnabledDescription": "Periodically sync project worktrees and PR status in the background.",
     "backgroundSyncInterval": "Sync interval",
-    "backgroundSyncIntervalDescription": "How often to run background sync.",
-    "backgroundSyncInterval1min": "1 min",
-    "backgroundSyncInterval5min": "5 min",
-    "backgroundSyncInterval10min": "10 min",
-    "backgroundSyncInterval30min": "30 min",
-    "backgroundSyncInterval60min": "60 min"
+    "backgroundSyncIntervalDescription": "How often to run background sync. (1–1440 min)",
+    "backgroundSyncIntervalUnit": "min"
   },
   "taskSearch": {
     "title": "Quick Task Search",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -186,7 +186,17 @@
     "notificationStatusFilterDescription": "선택한 상태로 변경될 때만 알림을 받습니다.",
     "taskCreationSection": "작업 생성",
     "defaultSessionType": "기본 세션 타입",
-    "defaultSessionTypeDescription": "새 작업 생성 시 기본으로 선택되는 세션 타입입니다."
+    "defaultSessionTypeDescription": "새 작업 생성 시 기본으로 선택되는 세션 타입입니다.",
+    "backgroundSyncSection": "백그라운드 Sync",
+    "backgroundSyncEnabled": "백그라운드 Sync",
+    "backgroundSyncEnabledDescription": "주기적으로 프로젝트 worktree와 PR 상태를 백그라운드에서 동기화합니다.",
+    "backgroundSyncInterval": "Sync 주기",
+    "backgroundSyncIntervalDescription": "백그라운드 sync를 실행하는 간격입니다.",
+    "backgroundSyncInterval1min": "1분",
+    "backgroundSyncInterval5min": "5분",
+    "backgroundSyncInterval10min": "10분",
+    "backgroundSyncInterval30min": "30분",
+    "backgroundSyncInterval60min": "60분"
   },
   "taskSearch": {
     "title": "태스크 빠른 검색",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -191,12 +191,8 @@
     "backgroundSyncEnabled": "백그라운드 Sync",
     "backgroundSyncEnabledDescription": "주기적으로 프로젝트 worktree와 PR 상태를 백그라운드에서 동기화합니다.",
     "backgroundSyncInterval": "Sync 주기",
-    "backgroundSyncIntervalDescription": "백그라운드 sync를 실행하는 간격입니다.",
-    "backgroundSyncInterval1min": "1분",
-    "backgroundSyncInterval5min": "5분",
-    "backgroundSyncInterval10min": "10분",
-    "backgroundSyncInterval30min": "30분",
-    "backgroundSyncInterval60min": "60분"
+    "backgroundSyncIntervalDescription": "백그라운드 sync를 실행하는 간격입니다. (1~1440분)",
+    "backgroundSyncIntervalUnit": "분"
   },
   "taskSearch": {
     "title": "태스크 빠른 검색",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -190,12 +190,8 @@
     "backgroundSyncEnabled": "后台同步",
     "backgroundSyncEnabledDescription": "定期在后台同步项目 worktree 和 PR 状态。",
     "backgroundSyncInterval": "同步间隔",
-    "backgroundSyncIntervalDescription": "后台同步的执行间隔。",
-    "backgroundSyncInterval1min": "1 分钟",
-    "backgroundSyncInterval5min": "5 分钟",
-    "backgroundSyncInterval10min": "10 分钟",
-    "backgroundSyncInterval30min": "30 分钟",
-    "backgroundSyncInterval60min": "60 分钟"
+    "backgroundSyncIntervalDescription": "后台同步的执行间隔。（1–1440 分钟）",
+    "backgroundSyncIntervalUnit": "分钟"
   },
   "taskSearch": {
     "title": "快速任务搜索",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -185,7 +185,17 @@
     "notificationStatusFilterDescription": "仅在任务变更为所选状态时接收通知。",
     "taskCreationSection": "任务创建",
     "defaultSessionType": "默认会话类型",
-    "defaultSessionTypeDescription": "创建新任务时默认选择的会话类型。"
+    "defaultSessionTypeDescription": "创建新任务时默认选择的会话类型。",
+    "backgroundSyncSection": "后台同步",
+    "backgroundSyncEnabled": "后台同步",
+    "backgroundSyncEnabledDescription": "定期在后台同步项目 worktree 和 PR 状态。",
+    "backgroundSyncInterval": "同步间隔",
+    "backgroundSyncIntervalDescription": "后台同步的执行间隔。",
+    "backgroundSyncInterval1min": "1 分钟",
+    "backgroundSyncInterval5min": "5 分钟",
+    "backgroundSyncInterval10min": "10 分钟",
+    "backgroundSyncInterval30min": "30 分钟",
+    "backgroundSyncInterval60min": "60 分钟"
   },
   "taskSearch": {
     "title": "快速任务搜索",

--- a/src/components/ProjectSettings.tsx
+++ b/src/components/ProjectSettings.tsx
@@ -13,6 +13,8 @@ import {
   setNotificationStatuses,
   setDefaultSessionType,
   setThemePreference,
+  setBackgroundSyncEnabled,
+  setBackgroundSyncIntervalMs,
   type ThemePreference,
 } from "@/desktop/renderer/actions/appSettings";
 import { SessionType } from "@/entities/KanbanTask";
@@ -21,6 +23,14 @@ import type { Project } from "@/entities/Project";
 import FolderSearchInput from "@/components/FolderSearchInput";
 import { applyThemePreference, notifyThemePreferenceChanged } from "@/desktop/renderer/utils/theme";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
+
+const BACKGROUND_SYNC_INTERVAL_OPTIONS = [
+  { value: 60_000, labelKey: "backgroundSyncInterval1min" },
+  { value: 5 * 60_000, labelKey: "backgroundSyncInterval5min" },
+  { value: 10 * 60_000, labelKey: "backgroundSyncInterval10min" },
+  { value: 30 * 60_000, labelKey: "backgroundSyncInterval30min" },
+  { value: 60 * 60_000, labelKey: "backgroundSyncInterval60min" },
+] as const;
 
 /** 알림 대상 상태 목록 (사용자가 직접 설정하는 todo/done은 제외) */
 const STATUS_OPTIONS = [
@@ -41,6 +51,7 @@ interface ProjectSettingsProps {
   onDefaultSessionTypeChange?: (sessionType: SessionType) => void;
   onThemePreferenceChange?: (themePreference: ThemePreference) => void;
   notificationSettings: { isEnabled: boolean; enabledStatuses: string[] };
+  backgroundSyncSettings: { isEnabled: boolean; intervalMs: number };
 }
 
 function areNotificationSettingsEqual(
@@ -64,6 +75,7 @@ export default function ProjectSettings({
   onDefaultSessionTypeChange,
   onThemePreferenceChange,
   notificationSettings,
+  backgroundSyncSettings,
 }: ProjectSettingsProps) {
   const t = useTranslations("settings");
   const tc = useTranslations("common");
@@ -79,6 +91,7 @@ export default function ProjectSettings({
   const [pendingNotificationSettings, setPendingNotificationSettings] = useState<typeof notificationSettings | null>(null);
   const [localThemePreference, setLocalThemePreference] = useState<ThemePreference>(themePreference);
   const [localSidebarDefaultCollapsed, setLocalSidebarDefaultCollapsed] = useState(sidebarDefaultCollapsed);
+  const [localBackgroundSyncSettings, setLocalBackgroundSyncSettings] = useState(backgroundSyncSettings);
   const [shouldUseMacTitlebarLayout, setShouldUseMacTitlebarLayout] = useState(false);
   const isPage = variant === "page";
 
@@ -89,6 +102,10 @@ export default function ProjectSettings({
   useEffect(() => {
     setLocalSidebarDefaultCollapsed(sidebarDefaultCollapsed);
   }, [sidebarDefaultCollapsed]);
+
+  useEffect(() => {
+    setLocalBackgroundSyncSettings(backgroundSyncSettings);
+  }, [backgroundSyncSettings]);
 
   useEffect(() => {
     setLocalThemePreference(themePreference);
@@ -189,6 +206,7 @@ export default function ProjectSettings({
                 ["detail", t("detailPageSection")],
                 ["creation", t("taskCreationSection")],
                 ["notifications", t("notificationSection")],
+                ["background-sync", t("backgroundSyncSection")],
                 ["projects", t("projectList")],
               ].map(([id, label]) => (
                 <button
@@ -401,6 +419,69 @@ export default function ProjectSettings({
                 );
               })}
             </div>
+          </div>
+        </div>
+
+        {/* 백그라운드 Sync 설정 */}
+        <div id="background-sync" className="p-4 border-b border-border-default">
+          <h3 className="text-xs text-text-muted uppercase tracking-wide mb-3">
+            {t("backgroundSyncSection")}
+          </h3>
+
+          {/* 활성화 토글 */}
+          <label className="flex items-center justify-between cursor-pointer">
+            <div>
+              <span className="text-sm text-text-primary">{t("backgroundSyncEnabled")}</span>
+              <p className="text-xs text-text-muted mt-0.5">{t("backgroundSyncEnabledDescription")}</p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={localBackgroundSyncSettings.isEnabled}
+              onClick={() => {
+                const nextEnabled = !localBackgroundSyncSettings.isEnabled;
+                setLocalBackgroundSyncSettings((prev) => ({ ...prev, isEnabled: nextEnabled }));
+                startTransition(async () => {
+                  await setBackgroundSyncEnabled(nextEnabled);
+                });
+              }}
+              disabled={isPending}
+              className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors ${
+                localBackgroundSyncSettings.isEnabled ? "bg-brand-primary" : "bg-border-default"
+              }`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                  localBackgroundSyncSettings.isEnabled ? "translate-x-4" : "translate-x-0"
+                }`}
+              />
+            </button>
+          </label>
+
+          {/* 주기 선택 */}
+          <div className={`mt-4 flex items-center justify-between ${!localBackgroundSyncSettings.isEnabled ? "opacity-40 pointer-events-none" : ""}`}>
+            <div>
+              <span className="text-sm text-text-primary">{t("backgroundSyncInterval")}</span>
+              <p className="text-xs text-text-muted mt-0.5">{t("backgroundSyncIntervalDescription")}</p>
+            </div>
+            <select
+              value={localBackgroundSyncSettings.intervalMs}
+              onChange={(e) => {
+                const nextIntervalMs = Number(e.target.value);
+                setLocalBackgroundSyncSettings((prev) => ({ ...prev, intervalMs: nextIntervalMs }));
+                startTransition(async () => {
+                  await setBackgroundSyncIntervalMs(nextIntervalMs);
+                });
+              }}
+              disabled={isPending || !localBackgroundSyncSettings.isEnabled}
+              className="px-2 py-1 text-sm bg-bg-page border border-border-default rounded-md text-text-primary focus:outline-none focus:border-brand-primary transition-colors"
+            >
+              {BACKGROUND_SYNC_INTERVAL_OPTIONS.map(({ value, labelKey }) => (
+                <option key={value} value={value}>
+                  {t(labelKey)}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
 

--- a/src/components/ProjectSettings.tsx
+++ b/src/components/ProjectSettings.tsx
@@ -24,13 +24,8 @@ import FolderSearchInput from "@/components/FolderSearchInput";
 import { applyThemePreference, notifyThemePreferenceChanged } from "@/desktop/renderer/utils/theme";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 
-const BACKGROUND_SYNC_INTERVAL_OPTIONS = [
-  { value: 60_000, labelKey: "backgroundSyncInterval1min" },
-  { value: 5 * 60_000, labelKey: "backgroundSyncInterval5min" },
-  { value: 10 * 60_000, labelKey: "backgroundSyncInterval10min" },
-  { value: 30 * 60_000, labelKey: "backgroundSyncInterval30min" },
-  { value: 60 * 60_000, labelKey: "backgroundSyncInterval60min" },
-] as const;
+const MIN_SYNC_INTERVAL_MINUTES = 1;
+const MAX_SYNC_INTERVAL_MINUTES = 1440;
 
 /** 알림 대상 상태 목록 (사용자가 직접 설정하는 todo/done은 제외) */
 const STATUS_OPTIONS = [
@@ -458,30 +453,32 @@ export default function ProjectSettings({
             </button>
           </label>
 
-          {/* 주기 선택 */}
+          {/* 주기 입력 */}
           <div className={`mt-4 flex items-center justify-between ${!localBackgroundSyncSettings.isEnabled ? "opacity-40 pointer-events-none" : ""}`}>
             <div>
               <span className="text-sm text-text-primary">{t("backgroundSyncInterval")}</span>
               <p className="text-xs text-text-muted mt-0.5">{t("backgroundSyncIntervalDescription")}</p>
             </div>
-            <select
-              value={localBackgroundSyncSettings.intervalMs}
-              onChange={(e) => {
-                const nextIntervalMs = Number(e.target.value);
-                setLocalBackgroundSyncSettings((prev) => ({ ...prev, intervalMs: nextIntervalMs }));
-                startTransition(async () => {
-                  await setBackgroundSyncIntervalMs(nextIntervalMs);
-                });
-              }}
-              disabled={isPending || !localBackgroundSyncSettings.isEnabled}
-              className="px-2 py-1 text-sm bg-bg-page border border-border-default rounded-md text-text-primary focus:outline-none focus:border-brand-primary transition-colors"
-            >
-              {BACKGROUND_SYNC_INTERVAL_OPTIONS.map(({ value, labelKey }) => (
-                <option key={value} value={value}>
-                  {t(labelKey)}
-                </option>
-              ))}
-            </select>
+            <div className="flex items-center gap-1.5">
+              <input
+                type="number"
+                min={MIN_SYNC_INTERVAL_MINUTES}
+                max={MAX_SYNC_INTERVAL_MINUTES}
+                value={Math.round(localBackgroundSyncSettings.intervalMs / 60_000)}
+                disabled={isPending || !localBackgroundSyncSettings.isEnabled}
+                onChange={(e) => {
+                  const minutes = Number(e.target.value);
+                  if (!Number.isInteger(minutes) || minutes < MIN_SYNC_INTERVAL_MINUTES || minutes > MAX_SYNC_INTERVAL_MINUTES) return;
+                  const nextIntervalMs = minutes * 60_000;
+                  setLocalBackgroundSyncSettings((prev) => ({ ...prev, intervalMs: nextIntervalMs }));
+                  startTransition(async () => {
+                    await setBackgroundSyncIntervalMs(nextIntervalMs);
+                  });
+                }}
+                className="w-20 px-2 py-1 text-sm bg-bg-page border border-border-default rounded-md text-text-primary text-right focus:outline-none focus:border-brand-primary transition-colors disabled:opacity-50"
+              />
+              <span className="text-sm text-text-muted">{t("backgroundSyncIntervalUnit")}</span>
+            </div>
           </div>
         </div>
 

--- a/src/components/__tests__/ProjectSettings.test.tsx
+++ b/src/components/__tests__/ProjectSettings.test.tsx
@@ -57,6 +57,8 @@ vi.mock("@/desktop/renderer/actions/appSettings", () => ({
   setNotificationStatuses: (...args: unknown[]) => mockSetNotificationStatuses(...args),
   setDefaultSessionType: (...args: unknown[]) => mockSetDefaultSessionType(...args),
   setThemePreference: (...args: unknown[]) => mockSetThemePreference(...args),
+  setBackgroundSyncEnabled: vi.fn().mockResolvedValue(undefined),
+  setBackgroundSyncIntervalMs: vi.fn().mockResolvedValue(undefined),
 }));
 
 function createProject(): Project {
@@ -98,6 +100,7 @@ describe("ProjectSettings", () => {
         defaultSessionType={SessionType.TMUX}
         onDefaultSessionTypeChange={onDefaultSessionTypeChange}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        backgroundSyncSettings={{ isEnabled: true, intervalMs: 10 * 60_000 }}
       />,
     );
 
@@ -126,6 +129,7 @@ describe("ProjectSettings", () => {
         themePreference="system"
         onThemePreferenceChange={onThemePreferenceChange}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        backgroundSyncSettings={{ isEnabled: true, intervalMs: 10 * 60_000 }}
       />,
     );
 
@@ -154,6 +158,7 @@ describe("ProjectSettings", () => {
         sidebarDefaultCollapsed={false}
         defaultSessionType={SessionType.TMUX}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        backgroundSyncSettings={{ isEnabled: true, intervalMs: 10 * 60_000 }}
       />,
     );
 
@@ -176,6 +181,7 @@ describe("ProjectSettings", () => {
         sidebarDefaultCollapsed={false}
         defaultSessionType={SessionType.TMUX}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        backgroundSyncSettings={{ isEnabled: true, intervalMs: 10 * 60_000 }}
       />,
     );
 
@@ -199,6 +205,7 @@ describe("ProjectSettings", () => {
         sidebarDefaultCollapsed={false}
         defaultSessionType={SessionType.TMUX}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        backgroundSyncSettings={{ isEnabled: true, intervalMs: 10 * 60_000 }}
       />,
     );
 
@@ -228,6 +235,7 @@ describe("ProjectSettings", () => {
         sidebarDefaultCollapsed={false}
         defaultSessionType={SessionType.TMUX}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        backgroundSyncSettings={{ isEnabled: true, intervalMs: 10 * 60_000 }}
       />,
     );
 
@@ -254,6 +262,7 @@ describe("ProjectSettings", () => {
         sidebarDefaultCollapsed={false}
         defaultSessionType={SessionType.TMUX}
         notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        backgroundSyncSettings={{ isEnabled: true, intervalMs: 10 * 60_000 }}
       />,
     );
 
@@ -282,6 +291,7 @@ describe("ProjectSettings", () => {
         sidebarDefaultCollapsed={false}
         defaultSessionType={SessionType.TMUX}
         notificationSettings={initialSettings}
+        backgroundSyncSettings={{ isEnabled: true, intervalMs: 10 * 60_000 }}
       />,
     );
 
@@ -299,6 +309,7 @@ describe("ProjectSettings", () => {
           isEnabled: true,
           enabledStatuses: ["progress", "pending", "review"],
         }}
+        backgroundSyncSettings={{ isEnabled: true, intervalMs: 10 * 60_000 }}
       />,
     );
 

--- a/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
+++ b/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/desktop/main/services/appSettingsService", () => ({
   getBackgroundSyncEnabled: mocks.getBackgroundSyncEnabled,
   getBackgroundSyncIntervalMs: mocks.getBackgroundSyncIntervalMs,
   registerBackgroundSyncIntervalChangedCallback: vi.fn(),
+  registerBackgroundSyncEnabledChangedCallback: vi.fn(),
 }));
 
 describe("backgroundTaskSyncService", () => {

--- a/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
+++ b/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
@@ -6,6 +6,8 @@ const mocks = vi.hoisted(() => ({
   syncActiveTaskPulls: vi.fn(),
   broadcastBoardUpdate: vi.fn(),
   broadcastBackgroundSyncReviewNeeded: vi.fn(),
+  getBackgroundSyncEnabled: vi.fn().mockResolvedValue(true),
+  getBackgroundSyncIntervalMs: vi.fn().mockResolvedValue(10 * 60_000),
 }));
 
 vi.mock("@/desktop/main/services/projectService", () => ({
@@ -22,11 +24,18 @@ vi.mock("@/lib/boardNotifier", () => ({
   broadcastBackgroundSyncReviewNeeded: mocks.broadcastBackgroundSyncReviewNeeded,
 }));
 
+vi.mock("@/desktop/main/services/appSettingsService", () => ({
+  getBackgroundSyncEnabled: mocks.getBackgroundSyncEnabled,
+  getBackgroundSyncIntervalMs: mocks.getBackgroundSyncIntervalMs,
+}));
+
 describe("backgroundTaskSyncService", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
     vi.useFakeTimers();
+    mocks.getBackgroundSyncEnabled.mockResolvedValue(true);
+    mocks.getBackgroundSyncIntervalMs.mockResolvedValue(10 * 60_000);
     mocks.syncRegisteredProjectWorktrees.mockResolvedValue({
       worktreeTasks: [],
       registeredWorktrees: [],

--- a/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
+++ b/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
@@ -27,6 +27,7 @@ vi.mock("@/lib/boardNotifier", () => ({
 vi.mock("@/desktop/main/services/appSettingsService", () => ({
   getBackgroundSyncEnabled: mocks.getBackgroundSyncEnabled,
   getBackgroundSyncIntervalMs: mocks.getBackgroundSyncIntervalMs,
+  registerBackgroundSyncIntervalChangedCallback: vi.fn(),
 }));
 
 describe("backgroundTaskSyncService", () => {

--- a/src/desktop/main/services/appSettingsService.ts
+++ b/src/desktop/main/services/appSettingsService.ts
@@ -159,10 +159,16 @@ const BACKGROUND_SYNC_INTERVAL_MS_KEY = "background_sync_interval_ms";
 const DEFAULT_BACKGROUND_SYNC_INTERVAL_MS = 10 * 60_000;
 
 let backgroundSyncIntervalChangedCallback: ((intervalMs: number) => void) | null = null;
+let backgroundSyncEnabledChangedCallback: ((enabled: boolean) => void) | null = null;
 
 /** 백그라운드 sync 주기 변경 시 호출될 콜백을 등록한다. 순환 의존성 없이 서비스 간 협력을 위해 사용한다 */
 export function registerBackgroundSyncIntervalChangedCallback(callback: (intervalMs: number) => void): void {
   backgroundSyncIntervalChangedCallback = callback;
+}
+
+/** 백그라운드 sync 활성화 상태 변경 시 호출될 콜백을 등록한다 */
+export function registerBackgroundSyncEnabledChangedCallback(callback: (enabled: boolean) => void): void {
+  backgroundSyncEnabledChangedCallback = callback;
 }
 
 /** 백그라운드 sync 활성화 여부를 조회한다. 미설정 시 기본값(활성화)을 반환한다 */
@@ -171,9 +177,10 @@ export async function getBackgroundSyncEnabled(): Promise<boolean> {
   return value !== "false";
 }
 
-/** 백그라운드 sync 활성화 여부를 저장한다 */
+/** 백그라운드 sync 활성화 여부를 저장하고, 실행 중인 루프에 즉시 반영한다 */
 export async function setBackgroundSyncEnabled(enabled: boolean): Promise<void> {
   await setAppSetting(BACKGROUND_SYNC_ENABLED_KEY, String(enabled));
+  backgroundSyncEnabledChangedCallback?.(enabled);
 }
 
 /** 백그라운드 sync 실행 주기(ms)를 조회한다. 미설정 시 기본값(10분)을 반환한다 */

--- a/src/desktop/main/services/appSettingsService.ts
+++ b/src/desktop/main/services/appSettingsService.ts
@@ -154,6 +154,34 @@ export async function setNotificationStatuses(statuses: string[]): Promise<void>
   await setAppSetting(NOTIFICATION_STATUSES_KEY, JSON.stringify(statuses));
 }
 
+const BACKGROUND_SYNC_ENABLED_KEY = "background_sync_enabled";
+const BACKGROUND_SYNC_INTERVAL_MS_KEY = "background_sync_interval_ms";
+const DEFAULT_BACKGROUND_SYNC_INTERVAL_MS = 10 * 60_000;
+
+/** 백그라운드 sync 활성화 여부를 조회한다. 미설정 시 기본값(활성화)을 반환한다 */
+export async function getBackgroundSyncEnabled(): Promise<boolean> {
+  const value = await getAppSetting(BACKGROUND_SYNC_ENABLED_KEY);
+  return value !== "false";
+}
+
+/** 백그라운드 sync 활성화 여부를 저장한다 */
+export async function setBackgroundSyncEnabled(enabled: boolean): Promise<void> {
+  await setAppSetting(BACKGROUND_SYNC_ENABLED_KEY, String(enabled));
+}
+
+/** 백그라운드 sync 실행 주기(ms)를 조회한다. 미설정 시 기본값(10분)을 반환한다 */
+export async function getBackgroundSyncIntervalMs(): Promise<number> {
+  const value = await getAppSetting(BACKGROUND_SYNC_INTERVAL_MS_KEY);
+  if (!value) return DEFAULT_BACKGROUND_SYNC_INTERVAL_MS;
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_BACKGROUND_SYNC_INTERVAL_MS;
+}
+
+/** 백그라운드 sync 실행 주기(ms)를 저장한다 */
+export async function setBackgroundSyncIntervalMs(intervalMs: number): Promise<void> {
+  await setAppSetting(BACKGROUND_SYNC_INTERVAL_MS_KEY, String(intervalMs));
+}
+
 const DEFAULT_SESSION_TYPE_KEY = "default_session_type";
 const TASK_SEARCH_SHORTCUT_KEY = "task_search_shortcut";
 

--- a/src/desktop/main/services/appSettingsService.ts
+++ b/src/desktop/main/services/appSettingsService.ts
@@ -158,6 +158,13 @@ const BACKGROUND_SYNC_ENABLED_KEY = "background_sync_enabled";
 const BACKGROUND_SYNC_INTERVAL_MS_KEY = "background_sync_interval_ms";
 const DEFAULT_BACKGROUND_SYNC_INTERVAL_MS = 10 * 60_000;
 
+let backgroundSyncIntervalChangedCallback: ((intervalMs: number) => void) | null = null;
+
+/** 백그라운드 sync 주기 변경 시 호출될 콜백을 등록한다. 순환 의존성 없이 서비스 간 협력을 위해 사용한다 */
+export function registerBackgroundSyncIntervalChangedCallback(callback: (intervalMs: number) => void): void {
+  backgroundSyncIntervalChangedCallback = callback;
+}
+
 /** 백그라운드 sync 활성화 여부를 조회한다. 미설정 시 기본값(활성화)을 반환한다 */
 export async function getBackgroundSyncEnabled(): Promise<boolean> {
   const value = await getAppSetting(BACKGROUND_SYNC_ENABLED_KEY);
@@ -177,9 +184,10 @@ export async function getBackgroundSyncIntervalMs(): Promise<number> {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_BACKGROUND_SYNC_INTERVAL_MS;
 }
 
-/** 백그라운드 sync 실행 주기(ms)를 저장한다 */
+/** 백그라운드 sync 실행 주기(ms)를 저장하고, 실행 중인 루프에 즉시 반영한다 */
 export async function setBackgroundSyncIntervalMs(intervalMs: number): Promise<void> {
   await setAppSetting(BACKGROUND_SYNC_INTERVAL_MS_KEY, String(intervalMs));
+  backgroundSyncIntervalChangedCallback?.(intervalMs);
 }
 
 const DEFAULT_SESSION_TYPE_KEY = "default_session_type";

--- a/src/desktop/main/services/backgroundTaskSyncService.ts
+++ b/src/desktop/main/services/backgroundTaskSyncService.ts
@@ -5,9 +5,14 @@ import {
   broadcastBoardUpdate,
   type BackgroundSyncFailurePayload,
 } from "@/lib/boardNotifier";
-import { getBackgroundSyncEnabled, getBackgroundSyncIntervalMs } from "@/desktop/main/services/appSettingsService";
+import {
+  getBackgroundSyncEnabled,
+  getBackgroundSyncIntervalMs,
+  registerBackgroundSyncIntervalChangedCallback,
+} from "@/desktop/main/services/appSettingsService";
 
 const INITIAL_SYNC_DELAY_MS = 20_000;
+const FALLBACK_SYNC_INTERVAL_MS = 10 * 60_000;
 
 let activeBackgroundTaskSyncStop: (() => void) | null = null;
 
@@ -86,11 +91,21 @@ export function startBackgroundTaskSync() {
       console.error("[background-task-sync] sync failed:", error);
     } finally {
       running = false;
-      const intervalMs = await getBackgroundSyncIntervalMs();
+      const intervalMs = await getBackgroundSyncIntervalMs().catch(() => FALLBACK_SYNC_INTERVAL_MS);
       scheduleNext(intervalMs);
     }
   }
 
+  function reschedule(newIntervalMs: number) {
+    if (disposed) return;
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+      timeoutHandle = null;
+    }
+    scheduleNext(newIntervalMs);
+  }
+
+  registerBackgroundSyncIntervalChangedCallback(reschedule);
   scheduleNext(INITIAL_SYNC_DELAY_MS);
 
   function stopBackgroundTaskSync() {

--- a/src/desktop/main/services/backgroundTaskSyncService.ts
+++ b/src/desktop/main/services/backgroundTaskSyncService.ts
@@ -9,6 +9,7 @@ import {
   getBackgroundSyncEnabled,
   getBackgroundSyncIntervalMs,
   registerBackgroundSyncIntervalChangedCallback,
+  registerBackgroundSyncEnabledChangedCallback,
 } from "@/desktop/main/services/appSettingsService";
 
 const INITIAL_SYNC_DELAY_MS = 20_000;
@@ -98,6 +99,8 @@ export function startBackgroundTaskSync() {
 
   function reschedule(newIntervalMs: number) {
     if (disposed) return;
+    // 사이클 실행 중이면 건너뜀 — finally 블록이 최신 주기를 읽어 스케줄링함
+    if (running) return;
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
       timeoutHandle = null;
@@ -105,7 +108,19 @@ export function startBackgroundTaskSync() {
     scheduleNext(newIntervalMs);
   }
 
+  function rescheduleOnEnable(enabled: boolean) {
+    if (!enabled) return; // 비활성화 시: 루프는 다음 웨이크업에서 작업을 건너뜀
+    if (disposed) return;
+    if (running) return; // 사이클 진행 중: finally 블록이 이어서 스케줄링함
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+      timeoutHandle = null;
+    }
+    scheduleNext(INITIAL_SYNC_DELAY_MS);
+  }
+
   registerBackgroundSyncIntervalChangedCallback(reschedule);
+  registerBackgroundSyncEnabledChangedCallback(rescheduleOnEnable);
   scheduleNext(INITIAL_SYNC_DELAY_MS);
 
   function stopBackgroundTaskSync() {

--- a/src/desktop/main/services/backgroundTaskSyncService.ts
+++ b/src/desktop/main/services/backgroundTaskSyncService.ts
@@ -5,9 +5,9 @@ import {
   broadcastBoardUpdate,
   type BackgroundSyncFailurePayload,
 } from "@/lib/boardNotifier";
+import { getBackgroundSyncEnabled, getBackgroundSyncIntervalMs } from "@/desktop/main/services/appSettingsService";
 
 const INITIAL_SYNC_DELAY_MS = 20_000;
-const SYNC_INTERVAL_MS = 10 * 60_000;
 
 let activeBackgroundTaskSyncStop: (() => void) | null = null;
 
@@ -43,47 +43,51 @@ export function startBackgroundTaskSync() {
     running = true;
 
     try {
-      const [
-        worktreeSyncResult,
-        prSyncResult,
-        pullSyncResult,
-      ] = await Promise.all([
-        syncRegisteredProjectWorktrees(),
-        syncActiveTaskPullRequests(emittedMergeEventKeys),
-        syncActiveTaskPulls(),
-      ]);
-      const failures: BackgroundSyncFailurePayload[] = [
-        ...worktreeSyncResult.errors.map((reason) => ({
-          operation: "worktree-sync" as const,
-          target: "등록 프로젝트 worktree sync",
-          reason,
-        })),
-        ...(prSyncResult.failures ?? []),
-      ];
+      const isEnabled = await getBackgroundSyncEnabled();
+      if (isEnabled) {
+        const [
+          worktreeSyncResult,
+          prSyncResult,
+          pullSyncResult,
+        ] = await Promise.all([
+          syncRegisteredProjectWorktrees(),
+          syncActiveTaskPullRequests(emittedMergeEventKeys),
+          syncActiveTaskPulls(),
+        ]);
+        const failures: BackgroundSyncFailurePayload[] = [
+          ...worktreeSyncResult.errors.map((reason) => ({
+            operation: "worktree-sync" as const,
+            target: "등록 프로젝트 worktree sync",
+            reason,
+          })),
+          ...(prSyncResult.failures ?? []),
+        ];
 
-      if (
-        worktreeSyncResult.registeredWorktrees.length > 0
-        || prSyncResult.mergedPullRequests.length > 0
-        || pullSyncResult.pulledTasks.length > 0
-        || failures.length > 0
-      ) {
-        broadcastBackgroundSyncReviewNeeded({
-          registeredWorktrees: worktreeSyncResult.registeredWorktrees,
-          mergedPullRequests: prSyncResult.mergedPullRequests,
-          pulledTasks: pullSyncResult.pulledTasks,
-          ...(failures.length > 0 ? { failures } : {}),
-        });
-      }
+        if (
+          worktreeSyncResult.registeredWorktrees.length > 0
+          || prSyncResult.mergedPullRequests.length > 0
+          || pullSyncResult.pulledTasks.length > 0
+          || failures.length > 0
+        ) {
+          broadcastBackgroundSyncReviewNeeded({
+            registeredWorktrees: worktreeSyncResult.registeredWorktrees,
+            mergedPullRequests: prSyncResult.mergedPullRequests,
+            pulledTasks: pullSyncResult.pulledTasks,
+            ...(failures.length > 0 ? { failures } : {}),
+          });
+        }
 
-      const hasUpdatedPulledTasks = pullSyncResult.pulledTasks.some((task) => task.status === "updated");
-      if (worktreeSyncResult.changed || prSyncResult.updatedTaskIds.length > 0 || hasUpdatedPulledTasks) {
-        broadcastBoardUpdate();
+        const hasUpdatedPulledTasks = pullSyncResult.pulledTasks.some((task) => task.status === "updated");
+        if (worktreeSyncResult.changed || prSyncResult.updatedTaskIds.length > 0 || hasUpdatedPulledTasks) {
+          broadcastBoardUpdate();
+        }
       }
     } catch (error) {
       console.error("[background-task-sync] sync failed:", error);
     } finally {
       running = false;
-      scheduleNext(SYNC_INTERVAL_MS);
+      const intervalMs = await getBackgroundSyncIntervalMs();
+      scheduleNext(intervalMs);
     }
   }
 

--- a/src/desktop/renderer/actions/appSettings.ts
+++ b/src/desktop/renderer/actions/appSettings.ts
@@ -81,6 +81,22 @@ export function setTaskSearchShortcut(shortcut: string): Promise<void> {
   return invokeAndRefresh("setTaskSearchShortcut", shortcut);
 }
 
+export async function getBackgroundSyncSettings(): Promise<{ isEnabled: boolean; intervalMs: number }> {
+  const [isEnabled, intervalMs] = await Promise.all([
+    invokeDesktop<boolean>("appSettings", "getBackgroundSyncEnabled"),
+    invokeDesktop<number>("appSettings", "getBackgroundSyncIntervalMs"),
+  ]);
+  return { isEnabled, intervalMs };
+}
+
+export function setBackgroundSyncEnabled(enabled: boolean): Promise<void> {
+  return invokeAndRefresh("setBackgroundSyncEnabled", enabled);
+}
+
+export function setBackgroundSyncIntervalMs(intervalMs: number): Promise<void> {
+  return invokeAndRefresh("setBackgroundSyncIntervalMs", intervalMs);
+}
+
 export async function getThemePreference(): Promise<ThemePreference> {
   const value = await getAppSetting(THEME_PREFERENCE_KEY);
   return THEME_PREFERENCES.has(value as ThemePreference) ? value as ThemePreference : "system";

--- a/src/desktop/renderer/routes/SettingsRoute.tsx
+++ b/src/desktop/renderer/routes/SettingsRoute.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import ProjectSettings from "@/components/ProjectSettings";
 import {
+  getBackgroundSyncSettings,
   getDefaultSessionType,
   getNotificationSettings,
   getSidebarDefaultCollapsed,
@@ -20,6 +21,7 @@ interface SettingsData {
   notificationSettings: Awaited<ReturnType<typeof getNotificationSettings>>;
   defaultSessionType: Awaited<ReturnType<typeof getDefaultSessionType>>;
   themePreference: ThemePreference;
+  backgroundSyncSettings: Awaited<ReturnType<typeof getBackgroundSyncSettings>>;
 }
 
 function createEmptySettingsData(): SettingsData {
@@ -30,6 +32,7 @@ function createEmptySettingsData(): SettingsData {
     notificationSettings: { isEnabled: true, enabledStatuses: ["progress", "pending", "review"] },
     defaultSessionType: SessionType.TMUX,
     themePreference: "system",
+    backgroundSyncSettings: { isEnabled: true, intervalMs: 10 * 60_000 },
   };
 }
 
@@ -58,7 +61,8 @@ export default function SettingsRoute() {
       getNotificationSettings(),
       getDefaultSessionType(),
       getThemePreference(),
-    ]).then(([projects, sshHosts, sidebarDefaultCollapsed, notificationSettings, defaultSessionType, themePreference]) => {
+      getBackgroundSyncSettings(),
+    ]).then(([projects, sshHosts, sidebarDefaultCollapsed, notificationSettings, defaultSessionType, themePreference, backgroundSyncSettings]) => {
       window.clearTimeout(loadingTimeout);
       if (!cancelled) {
         setData({
@@ -68,6 +72,7 @@ export default function SettingsRoute() {
           notificationSettings,
           defaultSessionType,
           themePreference,
+          backgroundSyncSettings,
         });
       }
     }).catch((error) => {
@@ -105,6 +110,7 @@ export default function SettingsRoute() {
         setData((currentData) => currentData ? { ...currentData, themePreference } : currentData);
       }}
       notificationSettings={data.notificationSettings}
+      backgroundSyncSettings={data.backgroundSyncSettings}
     />
   );
 }


### PR DESCRIPTION
## Summary

- Add a **Background Sync** section to the settings page (between Notifications and Projects)
- Toggle to enable/disable background sync
- Interval selector (1 / 5 / 10 / 30 / 60 min) that becomes disabled when sync is off
- Sync service now reads `background_sync_enabled` and `background_sync_interval_ms` from the DB on each cycle — changes take effect without restarting

## Changed Files

| File | Change |
|------|--------|
| `appSettingsService.ts` | Added `getBackgroundSyncEnabled/setBackgroundSyncEnabled`, `getBackgroundSyncIntervalMs/setBackgroundSyncIntervalMs` |
| `backgroundTaskSyncService.ts` | Reads enabled flag and interval from DB each cycle; skips sync work when disabled |
| `actions/appSettings.ts` | Added renderer-side IPC wrappers for the new settings |
| `SettingsRoute.tsx` | Loads background sync settings and passes them to `ProjectSettings` |
| `ProjectSettings.tsx` | New "Background Sync" section with toggle + interval select |
| `messages/{en,ko,zh}.json` | Added translation keys for the new section |

## Test plan

- [ ] Open Settings page → verify "Background Sync" section appears between Notifications and Projects
- [ ] Toggle off background sync → interval dropdown becomes visually disabled and unclickable
- [ ] Toggle back on → interval dropdown is interactive again
- [ ] Change interval → restart app → confirm selected interval is persisted
- [ ] Toggle sync off → wait 10 min (or use fake timers) → confirm no sync calls are made
- [ ] All 651 existing tests pass (`pnpm test`)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>