### PR TITLE
Fix background sync interval input and reduce sync CPU spikes

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -50,6 +50,7 @@
       "pullFailed": "Pull failed",
       "failureSection": "Sync failures",
       "pullRequestFailure": "Pull Request check failed",
+      "taskPullFailure": "Task pull failed",
       "worktreeFailure": "Worktree sync failed",
       "emptyMerged": "There are no merged PR tasks to move to Done in this review.",
       "emptyRegistered": "There are no newly registered worktrees in this review."

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -50,6 +50,7 @@
       "pullFailed": "Pull 실패",
       "failureSection": "Sync 실패",
       "pullRequestFailure": "Pull Request 조회 실패",
+      "taskPullFailure": "Task pull 실패",
       "worktreeFailure": "Worktree sync 실패",
       "emptyMerged": "이번 검토에서 Done으로 옮길 merge PR이 없습니다.",
       "emptyRegistered": "이번 검토에서 새로 등록된 worktree가 없습니다."

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -49,6 +49,7 @@
       "pullFailed": "Pull 失败",
       "failureSection": "同步失败",
       "pullRequestFailure": "Pull Request 检查失败",
+      "taskPullFailure": "Task pull 失败",
       "worktreeFailure": "Worktree 同步失败",
       "emptyMerged": "本次检查中没有需要移动到 Done 的已合并 PR 任务。",
       "emptyRegistered": "本次检查中没有新注册的 worktree。"

--- a/src/components/ProjectSettings.tsx
+++ b/src/components/ProjectSettings.tsx
@@ -58,6 +58,31 @@ function areNotificationSettingsEqual(
     && left.enabledStatuses.every((status, index) => status === right.enabledStatuses[index]);
 }
 
+function areBackgroundSyncSettingsEqual(
+  left: { isEnabled: boolean; intervalMs: number },
+  right: { isEnabled: boolean; intervalMs: number },
+) {
+  return left.isEnabled === right.isEnabled && left.intervalMs === right.intervalMs;
+}
+
+function formatSyncIntervalMinutes(intervalMs: number) {
+  return String(Math.round(intervalMs / 60_000));
+}
+
+function parseSyncIntervalMinutes(value: string): number | null {
+  const normalizedValue = value.trim();
+  if (!/^\d+$/.test(normalizedValue)) {
+    return null;
+  }
+
+  const minutes = Number(normalizedValue);
+  if (!Number.isSafeInteger(minutes) || minutes < MIN_SYNC_INTERVAL_MINUTES || minutes > MAX_SYNC_INTERVAL_MINUTES) {
+    return null;
+  }
+
+  return minutes;
+}
+
 export default function ProjectSettings({
   isOpen,
   onClose,
@@ -87,6 +112,10 @@ export default function ProjectSettings({
   const [localThemePreference, setLocalThemePreference] = useState<ThemePreference>(themePreference);
   const [localSidebarDefaultCollapsed, setLocalSidebarDefaultCollapsed] = useState(sidebarDefaultCollapsed);
   const [localBackgroundSyncSettings, setLocalBackgroundSyncSettings] = useState(backgroundSyncSettings);
+  const [pendingBackgroundSyncSettings, setPendingBackgroundSyncSettings] = useState<typeof backgroundSyncSettings | null>(null);
+  const [backgroundSyncIntervalInputValue, setBackgroundSyncIntervalInputValue] = useState(
+    () => formatSyncIntervalMinutes(backgroundSyncSettings.intervalMs),
+  );
   const [shouldUseMacTitlebarLayout, setShouldUseMacTitlebarLayout] = useState(false);
   const isPage = variant === "page";
 
@@ -99,8 +128,14 @@ export default function ProjectSettings({
   }, [sidebarDefaultCollapsed]);
 
   useEffect(() => {
+    if (pendingBackgroundSyncSettings && !areBackgroundSyncSettingsEqual(backgroundSyncSettings, pendingBackgroundSyncSettings)) {
+      return;
+    }
+
     setLocalBackgroundSyncSettings(backgroundSyncSettings);
-  }, [backgroundSyncSettings]);
+    setPendingBackgroundSyncSettings(null);
+    setBackgroundSyncIntervalInputValue(formatSyncIntervalMinutes(backgroundSyncSettings.intervalMs));
+  }, [backgroundSyncSettings, pendingBackgroundSyncSettings]);
 
   useEffect(() => {
     setLocalThemePreference(themePreference);
@@ -435,7 +470,9 @@ export default function ProjectSettings({
               aria-checked={localBackgroundSyncSettings.isEnabled}
               onClick={() => {
                 const nextEnabled = !localBackgroundSyncSettings.isEnabled;
-                setLocalBackgroundSyncSettings((prev) => ({ ...prev, isEnabled: nextEnabled }));
+                const nextSettings = { ...localBackgroundSyncSettings, isEnabled: nextEnabled };
+                setLocalBackgroundSyncSettings(nextSettings);
+                setPendingBackgroundSyncSettings(nextSettings);
                 startTransition(async () => {
                   await setBackgroundSyncEnabled(nextEnabled);
                 });
@@ -464,16 +501,31 @@ export default function ProjectSettings({
                 type="number"
                 min={MIN_SYNC_INTERVAL_MINUTES}
                 max={MAX_SYNC_INTERVAL_MINUTES}
-                value={Math.round(localBackgroundSyncSettings.intervalMs / 60_000)}
-                disabled={isPending || !localBackgroundSyncSettings.isEnabled}
+                step={1}
+                inputMode="numeric"
+                value={backgroundSyncIntervalInputValue}
+                disabled={!localBackgroundSyncSettings.isEnabled}
                 onChange={(e) => {
-                  const minutes = Number(e.target.value);
-                  if (!Number.isInteger(minutes) || minutes < MIN_SYNC_INTERVAL_MINUTES || minutes > MAX_SYNC_INTERVAL_MINUTES) return;
+                  const nextInputValue = e.target.value;
+                  setBackgroundSyncIntervalInputValue(nextInputValue);
+
+                  const minutes = parseSyncIntervalMinutes(nextInputValue);
+                  if (minutes === null) return;
+
                   const nextIntervalMs = minutes * 60_000;
-                  setLocalBackgroundSyncSettings((prev) => ({ ...prev, intervalMs: nextIntervalMs }));
+                  if (nextIntervalMs === localBackgroundSyncSettings.intervalMs) return;
+
+                  const nextSettings = { ...localBackgroundSyncSettings, intervalMs: nextIntervalMs };
+                  setLocalBackgroundSyncSettings(nextSettings);
+                  setPendingBackgroundSyncSettings(nextSettings);
                   startTransition(async () => {
                     await setBackgroundSyncIntervalMs(nextIntervalMs);
                   });
+                }}
+                onBlur={() => {
+                  if (parseSyncIntervalMinutes(backgroundSyncIntervalInputValue) === null) {
+                    setBackgroundSyncIntervalInputValue(formatSyncIntervalMinutes(localBackgroundSyncSettings.intervalMs));
+                  }
                 }}
                 className="w-20 px-2 py-1 text-sm bg-bg-page border border-border-default rounded-md text-text-primary text-right focus:outline-none focus:border-brand-primary transition-colors disabled:opacity-50"
               />

--- a/src/components/ProjectSettings.tsx
+++ b/src/components/ProjectSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { useTranslations } from "next-intl";
 import {
   deleteProject,
@@ -116,8 +116,18 @@ export default function ProjectSettings({
   const [backgroundSyncIntervalInputValue, setBackgroundSyncIntervalInputValue] = useState(
     () => formatSyncIntervalMinutes(backgroundSyncSettings.intervalMs),
   );
+  const backgroundSyncIntervalSaveQueueRef = useRef<Promise<void>>(Promise.resolve());
   const [shouldUseMacTitlebarLayout, setShouldUseMacTitlebarLayout] = useState(false);
   const isPage = variant === "page";
+
+  function saveBackgroundSyncIntervalMs(nextIntervalMs: number) {
+    const nextSave = backgroundSyncIntervalSaveQueueRef.current
+      .catch(() => undefined)
+      .then(() => setBackgroundSyncIntervalMs(nextIntervalMs));
+
+    backgroundSyncIntervalSaveQueueRef.current = nextSave;
+    return nextSave;
+  }
 
   useEffect(() => {
     setSelectedDefaultSessionType(defaultSessionType);
@@ -519,7 +529,7 @@ export default function ProjectSettings({
                   setLocalBackgroundSyncSettings(nextSettings);
                   setPendingBackgroundSyncSettings(nextSettings);
                   startTransition(async () => {
-                    await setBackgroundSyncIntervalMs(nextIntervalMs);
+                    await saveBackgroundSyncIntervalMs(nextIntervalMs);
                   });
                 }}
                 onBlur={() => {

--- a/src/components/__tests__/ProjectSettings.test.tsx
+++ b/src/components/__tests__/ProjectSettings.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import ProjectSettings from "../ProjectSettings";
 import { SessionType } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
@@ -10,6 +11,8 @@ const mockSetDefaultSessionType = vi.fn().mockResolvedValue(undefined);
 const mockSetNotificationEnabled = vi.fn().mockResolvedValue(undefined);
 const mockSetNotificationStatuses = vi.fn().mockResolvedValue(undefined);
 const mockSetThemePreference = vi.fn().mockResolvedValue(undefined);
+const mockSetBackgroundSyncEnabled = vi.fn().mockResolvedValue(undefined);
+const mockSetBackgroundSyncIntervalMs = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("next-intl", () => ({
   useTranslations: (namespace?: string) => (key: string, values?: Record<string, string>) => {
@@ -57,8 +60,8 @@ vi.mock("@/desktop/renderer/actions/appSettings", () => ({
   setNotificationStatuses: (...args: unknown[]) => mockSetNotificationStatuses(...args),
   setDefaultSessionType: (...args: unknown[]) => mockSetDefaultSessionType(...args),
   setThemePreference: (...args: unknown[]) => mockSetThemePreference(...args),
-  setBackgroundSyncEnabled: vi.fn().mockResolvedValue(undefined),
-  setBackgroundSyncIntervalMs: vi.fn().mockResolvedValue(undefined),
+  setBackgroundSyncEnabled: (...args: unknown[]) => mockSetBackgroundSyncEnabled(...args),
+  setBackgroundSyncIntervalMs: (...args: unknown[]) => mockSetBackgroundSyncIntervalMs(...args),
 }));
 
 function createProject(): Project {
@@ -318,6 +321,36 @@ describe("ProjectSettings", () => {
       expect(mockSetNotificationStatuses).toHaveBeenCalledWith(["progress", "review"]);
     });
     expect(screen.getByText("pending").className).toContain("bg-bg-page");
+  });
+
+  it("background sync 주기 입력은 기존 한 자리 값을 지운 뒤 두 자리 분 값을 입력할 수 있다", async () => {
+    // Given
+    const user = userEvent.setup();
+
+    render(
+      <ProjectSettings
+        isOpen
+        onClose={vi.fn()}
+        projects={[createProject()]}
+        sshHosts={[]}
+        sidebarDefaultCollapsed={false}
+        defaultSessionType={SessionType.TMUX}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        backgroundSyncSettings={{ isEnabled: true, intervalMs: 1 * 60_000 }}
+      />,
+    );
+
+    const intervalInput = screen.getByRole("spinbutton") as HTMLInputElement;
+
+    // When
+    await user.clear(intervalInput);
+    await user.type(intervalInput, "10");
+
+    // Then
+    expect(intervalInput.value).toBe("10");
+    await waitFor(() => {
+      expect(mockSetBackgroundSyncIntervalMs).toHaveBeenLastCalledWith(10 * 60_000);
+    });
   });
 
 });

--- a/src/components/__tests__/ProjectSettings.test.tsx
+++ b/src/components/__tests__/ProjectSettings.test.tsx
@@ -80,6 +80,8 @@ function createProject(): Project {
 describe("ProjectSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSetBackgroundSyncEnabled.mockResolvedValue(undefined);
+    mockSetBackgroundSyncIntervalMs.mockResolvedValue(undefined);
     delete window.kanvibeDesktop;
     document.documentElement.removeAttribute("data-theme");
     document.documentElement.removeAttribute("data-theme-preference");
@@ -351,6 +353,48 @@ describe("ProjectSettings", () => {
     await waitFor(() => {
       expect(mockSetBackgroundSyncIntervalMs).toHaveBeenLastCalledWith(10 * 60_000);
     });
+  });
+
+  it("background sync 주기 저장은 이전 저장이 끝난 뒤 최신 값을 저장한다", async () => {
+    // Given
+    const user = userEvent.setup();
+    let resolveFirstSave: () => void = () => {};
+    mockSetBackgroundSyncIntervalMs
+      .mockImplementationOnce(() => new Promise<void>((resolve) => {
+        resolveFirstSave = resolve;
+      }))
+      .mockResolvedValue(undefined);
+
+    render(
+      <ProjectSettings
+        isOpen
+        onClose={vi.fn()}
+        projects={[createProject()]}
+        sshHosts={[]}
+        sidebarDefaultCollapsed={false}
+        defaultSessionType={SessionType.TMUX}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        backgroundSyncSettings={{ isEnabled: true, intervalMs: 1 * 60_000 }}
+      />,
+    );
+
+    const intervalInput = screen.getByRole("spinbutton") as HTMLInputElement;
+
+    // When
+    await user.clear(intervalInput);
+    await user.type(intervalInput, "20");
+
+    // Then
+    expect(intervalInput.value).toBe("20");
+    expect(mockSetBackgroundSyncIntervalMs).toHaveBeenCalledTimes(1);
+    expect(mockSetBackgroundSyncIntervalMs).toHaveBeenCalledWith(2 * 60_000);
+
+    resolveFirstSave();
+
+    await waitFor(() => {
+      expect(mockSetBackgroundSyncIntervalMs).toHaveBeenCalledTimes(2);
+    });
+    expect(mockSetBackgroundSyncIntervalMs).toHaveBeenLastCalledWith(20 * 60_000);
   });
 
 });

--- a/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
+++ b/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
@@ -31,6 +31,12 @@ vi.mock("@/desktop/main/services/appSettingsService", () => ({
   registerBackgroundSyncEnabledChangedCallback: vi.fn(),
 }));
 
+async function flushBackgroundSyncCycle() {
+  for (let i = 0; i < 5; i += 1) {
+    await vi.advanceTimersByTimeAsync(0);
+  }
+}
+
 describe("backgroundTaskSyncService", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -150,14 +156,82 @@ describe("backgroundTaskSyncService", () => {
     await vi.advanceTimersByTimeAsync(20_000);
 
     expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
-    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
-    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).not.toHaveBeenCalled();
+    expect(mocks.syncActiveTaskPulls).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(10 * 60_000);
 
     expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).not.toHaveBeenCalled();
+    expect(mocks.syncActiveTaskPulls).not.toHaveBeenCalled();
+
+    resolveWorktreeSync({
+      worktreeTasks: [],
+      registeredWorktrees: [],
+      hooksSetup: [],
+      errors: [],
+      changed: false,
+    });
+    await flushBackgroundSyncCycle();
+
     expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
     expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    await flushBackgroundSyncCycle();
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(2);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(2);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(2);
+
+    stop();
+  });
+
+  it("background task sync cycle은 고비용 sync 작업을 직렬로 실행한다", async () => {
+    const calls: string[] = [];
+    let resolveWorktreeSync: (result: {
+      worktreeTasks: string[];
+      registeredWorktrees: never[];
+      hooksSetup: never[];
+      errors: never[];
+      changed: boolean;
+    }) => void = () => {};
+    let resolvePrSync: (result: {
+      updatedTaskIds: string[];
+      mergeEventKeys: string[];
+      mergedPullRequests: never[];
+    }) => void = () => {};
+
+    mocks.syncRegisteredProjectWorktrees.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        calls.push("worktree:start");
+        resolveWorktreeSync = (result) => {
+          calls.push("worktree:end");
+          resolve(result);
+        };
+      }),
+    );
+    mocks.syncActiveTaskPullRequests.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        calls.push("pr:start");
+        resolvePrSync = (result) => {
+          calls.push("pr:end");
+          resolve(result);
+        };
+      }),
+    );
+    mocks.syncActiveTaskPulls.mockImplementationOnce(async () => {
+      calls.push("pull:start");
+      return { pulledTasks: [] };
+    });
+
+    const { startBackgroundTaskSync } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    const stop = startBackgroundTaskSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+    await flushBackgroundSyncCycle();
+
+    expect(calls).toEqual(["worktree:start"]);
 
     resolveWorktreeSync({
       worktreeTasks: [],
@@ -167,11 +241,17 @@ describe("backgroundTaskSyncService", () => {
       changed: false,
     });
     await vi.advanceTimersByTimeAsync(0);
-    await vi.advanceTimersByTimeAsync(10 * 60_000);
 
-    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(2);
-    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(2);
-    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual(["worktree:start", "worktree:end", "pr:start"]);
+
+    resolvePrSync({
+      updatedTaskIds: [],
+      mergeEventKeys: [],
+      mergedPullRequests: [],
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(calls).toEqual(["worktree:start", "worktree:end", "pr:start", "pr:end", "pull:start"]);
 
     stop();
   });
@@ -181,6 +261,7 @@ describe("backgroundTaskSyncService", () => {
 
     const stop = startBackgroundTaskSync();
     await vi.advanceTimersByTimeAsync(20_000);
+    await flushBackgroundSyncCycle();
 
     expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
     expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
@@ -193,6 +274,7 @@ describe("backgroundTaskSyncService", () => {
     expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(1);
+    await flushBackgroundSyncCycle();
 
     expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(2);
     expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(2);
@@ -220,6 +302,7 @@ describe("backgroundTaskSyncService", () => {
 
     const stop = startBackgroundTaskSync();
     await vi.advanceTimersByTimeAsync(20_000);
+    await flushBackgroundSyncCycle();
 
     expect(mocks.broadcastBackgroundSyncReviewNeeded).toHaveBeenCalledWith({
       registeredWorktrees: [],

--- a/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
+++ b/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
@@ -256,6 +256,62 @@ describe("backgroundTaskSyncService", () => {
     stop();
   });
 
+  it("worktree sync 단계가 예외로 실패해도 PR sync와 pull sync를 계속 실행한다", async () => {
+    mocks.syncRegisteredProjectWorktrees.mockRejectedValue(new Error("project repository unavailable"));
+    mocks.syncActiveTaskPullRequests.mockResolvedValue({
+      updatedTaskIds: ["task-pr"],
+      mergeEventKeys: [],
+      mergedPullRequests: [],
+    });
+    mocks.syncActiveTaskPulls.mockResolvedValue({
+      pulledTasks: [
+        {
+          taskId: "task-pull",
+          taskTitle: "Pull target",
+          branchName: "feature/pull",
+          worktreePath: "/workspace/repo__worktrees/feature-pull",
+          sshHost: null,
+          status: "updated",
+          summary: "Fast-forward",
+        },
+      ],
+    });
+
+    const { startBackgroundTaskSync } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    const stop = startBackgroundTaskSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+    await flushBackgroundSyncCycle();
+
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
+    expect(mocks.broadcastBackgroundSyncReviewNeeded).toHaveBeenCalledWith({
+      registeredWorktrees: [],
+      mergedPullRequests: [],
+      pulledTasks: [
+        {
+          taskId: "task-pull",
+          taskTitle: "Pull target",
+          branchName: "feature/pull",
+          worktreePath: "/workspace/repo__worktrees/feature-pull",
+          sshHost: null,
+          status: "updated",
+          summary: "Fast-forward",
+        },
+      ],
+      failures: [
+        {
+          operation: "worktree-sync",
+          target: "등록 프로젝트 worktree sync",
+          reason: "project repository unavailable",
+        },
+      ],
+    });
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
   it("background task sync 갱신 주기는 최초 실행 후 10분이다", async () => {
     const { startBackgroundTaskSync } = await import("@/desktop/main/services/backgroundTaskSyncService");
 

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -1555,13 +1555,23 @@ describe("kanbanService.createTask", () => {
 
     // Then
     expect(mocks.pullCurrentBranch).toHaveBeenCalledTimes(1);
-    expect(mocks.pullCurrentBranch).toHaveBeenNthCalledWith(1, "/workspace/repo__worktrees/pull-a", null);
+    expect(mocks.pullCurrentBranch).toHaveBeenNthCalledWith(
+      1,
+      "/workspace/repo__worktrees/pull-a",
+      null,
+      expect.objectContaining({ timeoutMs: 45_000 }),
+    );
 
     resolvers[0]("Fast-forward\n src/file.ts | 1 +");
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(mocks.pullCurrentBranch).toHaveBeenCalledTimes(2);
-    expect(mocks.pullCurrentBranch).toHaveBeenNthCalledWith(2, "/workspace/repo__worktrees/pull-b", null);
+    expect(mocks.pullCurrentBranch).toHaveBeenNthCalledWith(
+      2,
+      "/workspace/repo__worktrees/pull-b",
+      null,
+      expect.objectContaining({ timeoutMs: 45_000 }),
+    );
 
     rejecters[1](new Error("Not possible to fast-forward"));
 
@@ -1587,6 +1597,87 @@ describe("kanbanService.createTask", () => {
         },
       ],
     });
+  });
+
+  it("active task pull sync는 한 task의 remote branch 확인이 멈춰도 다음 task를 계속 처리한다", async () => {
+    vi.useFakeTimers();
+    try {
+      // Given
+      mocks.taskRepo.find.mockResolvedValue([
+        {
+          id: "task-main",
+          title: "Main task",
+          projectId: "project-1",
+          branchName: "main",
+          worktreePath: "/workspace/repo",
+          sshHost: null,
+          status: "progress",
+        },
+        {
+          id: "task-stuck",
+          title: "Stuck pull",
+          projectId: "project-1",
+          branchName: "feature/stuck",
+          worktreePath: "/workspace/repo__worktrees/stuck",
+          sshHost: null,
+          status: "progress",
+        },
+        {
+          id: "task-next",
+          title: "Next pull",
+          projectId: "project-1",
+          branchName: "feature/next",
+          worktreePath: "/workspace/repo__worktrees/next",
+          sshHost: null,
+          status: "review",
+        },
+      ]);
+      mocks.projectRepo.findOneBy.mockResolvedValue({
+        id: "project-1",
+        repoPath: "/workspace/repo",
+        defaultBranch: "main",
+        sshHost: null,
+      });
+      mocks.remoteBranchExists.mockImplementation((worktreePath: string) => {
+        if (worktreePath.includes("stuck")) {
+          return new Promise<boolean>(() => {});
+        }
+
+        return Promise.resolve(true);
+      });
+      mocks.pullCurrentBranch.mockResolvedValue("Already up to date.");
+
+      const { syncActiveTaskPulls } = await import("@/desktop/main/services/kanbanService");
+
+      // When
+      const syncPromise = syncActiveTaskPulls();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Then
+      expect(mocks.remoteBranchExists).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(45_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mocks.remoteBranchExists).toHaveBeenCalledTimes(2);
+      expect(mocks.pullCurrentBranch).toHaveBeenCalledWith(
+        "/workspace/repo__worktrees/next",
+        null,
+        expect.objectContaining({ timeoutMs: 45_000 }),
+      );
+      await expect(syncPromise).resolves.toEqual({
+        pulledTasks: [
+          expect.objectContaining({
+            taskId: "task-stuck",
+            branchName: "feature/stuck",
+            status: "failed",
+            summary: expect.stringContaining("timed out"),
+          }),
+        ],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("active task pull sync는 done task를 pull하지 않는다", async () => {
@@ -1634,7 +1725,11 @@ describe("kanbanService.createTask", () => {
       }),
     }));
     expect(mocks.pullCurrentBranch).toHaveBeenCalledTimes(1);
-    expect(mocks.pullCurrentBranch).toHaveBeenCalledWith("/workspace/repo__worktrees/progress", null);
+    expect(mocks.pullCurrentBranch).toHaveBeenCalledWith(
+      "/workspace/repo__worktrees/progress",
+      null,
+      expect.objectContaining({ timeoutMs: 45_000 }),
+    );
     expect(result).toEqual({ pulledTasks: [] });
   });
 
@@ -1669,6 +1764,7 @@ describe("kanbanService.createTask", () => {
       "/workspace/repo__worktrees/missing-remote",
       "feature/missing-remote",
       null,
+      expect.objectContaining({ timeoutMs: 45_000 }),
     );
     expect(mocks.pullCurrentBranch).not.toHaveBeenCalled();
     expect(result).toEqual({ pulledTasks: [] });

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -1112,7 +1112,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execFile).toHaveBeenCalledWith(
       "gh",
       ["pr", "list", "--head", "main", "--json", "url", "-q", ".[0].url"],
-      { cwd: "/workspace/repo" },
+      expect.objectContaining({ cwd: "/workspace/repo", timeout: 45_000 }),
       expect.any(Function),
     );
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
@@ -1182,6 +1182,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execGit).toHaveBeenCalledWith(
       "cd '/remote/repo' && gh pr list --head 'feature/remote-pr' --json url -q '.[0].url'",
       "remote-host",
+      expect.objectContaining({ timeoutMs: 45_000 }),
     );
     expect(mocks.execFile).not.toHaveBeenCalled();
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
@@ -1212,6 +1213,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execGit).toHaveBeenCalledWith(
       "cd '/remote/repo__worktrees/feature-fallback-path' && gh pr list --head 'feature/fallback-path' --json url -q '.[0].url'",
       "remote-host",
+      expect.objectContaining({ timeoutMs: 45_000 }),
     );
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
       id: "task-7",
@@ -1246,6 +1248,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execGit).toHaveBeenCalledWith(
       "cd '/remote/repo' && gh pr list --head 'feature/no-gh' --json url -q '.[0].url'",
       "remote-host",
+      expect.objectContaining({ timeoutMs: 45_000 }),
     );
     expect(mocks.taskRepo.save).not.toHaveBeenCalled();
     expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
@@ -1503,6 +1506,97 @@ describe("kanbanService.createTask", () => {
     await syncPromise;
   });
 
+  it("active task PR sync는 local gh 조회 timeout 후 다음 task를 계속 처리한다", async () => {
+    vi.useFakeTimers();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // Given
+      mocks.taskRepo.find.mockResolvedValue([
+        {
+          id: "task-pr-stuck",
+          title: "Stuck PR",
+          projectId: "project-1",
+          branchName: "feature/pr-stuck",
+          worktreePath: "/workspace/repo__worktrees/pr-stuck",
+          sshHost: null,
+          prUrl: null,
+          status: "review",
+        },
+        {
+          id: "task-pr-next",
+          title: "Next PR",
+          projectId: "project-1",
+          branchName: "feature/pr-next",
+          worktreePath: "/workspace/repo__worktrees/pr-next",
+          sshHost: null,
+          prUrl: null,
+          status: "review",
+        },
+      ]);
+      mocks.projectRepo.findOneBy.mockResolvedValue({
+        id: "project-1",
+        repoPath: "/workspace/repo",
+        defaultBranch: "main",
+        sshHost: null,
+      });
+      const execFileOptions: Array<{ cwd?: string; timeout?: number }> = [];
+      mocks.execFile.mockImplementation((file, args: string[], options, callback) => {
+        execFileOptions.push(options);
+        if (args.includes("feature/pr-stuck")) {
+          if (typeof options.timeout === "number") {
+            setTimeout(() => {
+              callback(Object.assign(new Error("gh pr list timed out"), { killed: true, signal: "SIGTERM" }), "", "");
+            }, options.timeout);
+          }
+          return {} as never;
+        }
+
+        callback(null, JSON.stringify([{
+          url: null,
+          state: null,
+          mergedAt: null,
+          updatedAt: "2026-05-02T01:00:00Z",
+        }]), "");
+        return {} as never;
+      });
+
+      const { syncActiveTaskPullRequests } = await import("@/desktop/main/services/kanbanService");
+
+      // When
+      const syncPromise = syncActiveTaskPullRequests(new Set());
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Then
+      expect(execFileOptions).toEqual([
+        expect.objectContaining({ cwd: "/workspace/repo", timeout: 45_000 }),
+      ]);
+
+      await vi.advanceTimersByTimeAsync(45_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(execFileOptions).toEqual([
+        expect.objectContaining({ cwd: "/workspace/repo", timeout: 45_000 }),
+        expect.objectContaining({ cwd: "/workspace/repo", timeout: 45_000 }),
+      ]);
+      await expect(syncPromise).resolves.toEqual({
+        updatedTaskIds: [],
+        mergeEventKeys: [],
+        mergedPullRequests: [],
+        failures: [
+          expect.objectContaining({
+            operation: "pull-request-sync",
+            taskId: "task-pr-stuck",
+            branchName: "feature/pr-stuck",
+            reason: "gh pr list timed out",
+          }),
+        ],
+      });
+    } finally {
+      consoleErrorSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("active task pull sync는 default branch task를 제외하고 task별 pull을 직렬로 실행한다", async () => {
     // Given
     mocks.taskRepo.find.mockResolvedValue([
@@ -1638,9 +1732,14 @@ describe("kanbanService.createTask", () => {
         defaultBranch: "main",
         sshHost: null,
       });
-      mocks.remoteBranchExists.mockImplementation((worktreePath: string) => {
+      mocks.remoteBranchExists.mockImplementation((worktreePath: string, branchName: string, sshHost: string | null, options?: { timeoutMs?: number }) => {
         if (worktreePath.includes("stuck")) {
-          return new Promise<boolean>(() => {});
+          return new Promise<boolean>((resolve, reject) => {
+            void resolve;
+            setTimeout(() => {
+              reject(new Error(`Remote branch check timed out after ${(options?.timeoutMs ?? 0) / 1000}s`));
+            }, options?.timeoutMs ?? 0);
+          });
         }
 
         return Promise.resolve(true);
@@ -1673,6 +1772,94 @@ describe("kanbanService.createTask", () => {
             status: "failed",
             summary: expect.stringContaining("timed out"),
           }),
+        ],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("remote task pull sync는 외부 timer로 원격 git 결과를 버리지 않는다", async () => {
+    vi.useFakeTimers();
+    try {
+      // Given
+      mocks.taskRepo.find.mockResolvedValue([
+        {
+          id: "task-remote",
+          title: "Remote pull",
+          projectId: "project-remote",
+          branchName: "feature/remote-pull",
+          worktreePath: "/remote/repo__worktrees/remote-pull",
+          sshHost: "remote-host",
+          status: "review",
+        },
+      ]);
+      mocks.projectRepo.findOneBy.mockResolvedValue({
+        id: "project-remote",
+        repoPath: "/remote/repo",
+        defaultBranch: "main",
+        sshHost: "remote-host",
+      });
+      let resolveRemoteBranchExists: (value: boolean) => void = () => {};
+      let resolveRemotePull: (value: string) => void = () => {};
+      mocks.remoteBranchExists.mockImplementation(() => new Promise<boolean>((resolve) => {
+        resolveRemoteBranchExists = resolve;
+      }));
+      mocks.pullCurrentBranch.mockImplementation(() => new Promise<string>((resolve) => {
+        resolveRemotePull = resolve;
+      }));
+
+      const { syncActiveTaskPulls } = await import("@/desktop/main/services/kanbanService");
+
+      // When
+      let isSyncComplete = false;
+      const syncPromise = syncActiveTaskPulls().then((result) => {
+        isSyncComplete = true;
+        return result;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Then
+      expect(mocks.remoteBranchExists).toHaveBeenCalledWith(
+        "/remote/repo__worktrees/remote-pull",
+        "feature/remote-pull",
+        "remote-host",
+        expect.objectContaining({ timeoutMs: 45_000 }),
+      );
+
+      await vi.advanceTimersByTimeAsync(45_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(isSyncComplete).toBe(false);
+      expect(mocks.pullCurrentBranch).not.toHaveBeenCalled();
+
+      resolveRemoteBranchExists(true);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mocks.pullCurrentBranch).toHaveBeenCalledWith(
+        "/remote/repo__worktrees/remote-pull",
+        "remote-host",
+        expect.objectContaining({ timeoutMs: 45_000 }),
+      );
+
+      await vi.advanceTimersByTimeAsync(45_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(isSyncComplete).toBe(false);
+
+      resolveRemotePull("Fast-forward\n src/file.ts | 1 +");
+
+      await expect(syncPromise).resolves.toEqual({
+        pulledTasks: [
+          {
+            taskId: "task-remote",
+            taskTitle: "Remote pull",
+            branchName: "feature/remote-pull",
+            worktreePath: "/remote/repo__worktrees/remote-pull",
+            sshHost: "remote-host",
+            status: "updated",
+            summary: "Fast-forward",
+          },
         ],
       });
     } finally {

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -1112,7 +1112,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execFile).toHaveBeenCalledWith(
       "gh",
       ["pr", "list", "--head", "main", "--json", "url", "-q", ".[0].url"],
-      expect.objectContaining({ cwd: "/workspace/repo", timeout: 2_000 }),
+      expect.objectContaining({ cwd: "/workspace/repo", timeout: 10_000 }),
       expect.any(Function),
     );
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
@@ -1565,15 +1565,15 @@ describe("kanbanService.createTask", () => {
 
       // Then
       expect(execFileOptions).toEqual([
-        expect.objectContaining({ cwd: "/workspace/repo", timeout: 2_000 }),
+        expect.objectContaining({ cwd: "/workspace/repo", timeout: 10_000 }),
       ]);
 
-      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(10_000);
       await vi.advanceTimersByTimeAsync(0);
 
       expect(execFileOptions).toEqual([
-        expect.objectContaining({ cwd: "/workspace/repo", timeout: 2_000 }),
-        expect.objectContaining({ cwd: "/workspace/repo", timeout: 2_000 }),
+        expect.objectContaining({ cwd: "/workspace/repo", timeout: 10_000 }),
+        expect.objectContaining({ cwd: "/workspace/repo", timeout: 10_000 }),
       ]);
       await expect(syncPromise).resolves.toEqual({
         updatedTaskIds: [],
@@ -1650,7 +1650,7 @@ describe("kanbanService.createTask", () => {
       1,
       "/workspace/repo__worktrees/pull-a",
       null,
-      expect.objectContaining({ timeoutMs: 2_000 }),
+      expect.objectContaining({ timeoutMs: 10_000 }),
     );
 
     resolvers[0]("Fast-forward\n src/file.ts | 1 +");
@@ -1661,7 +1661,7 @@ describe("kanbanService.createTask", () => {
       2,
       "/workspace/repo__worktrees/pull-b",
       null,
-      expect.objectContaining({ timeoutMs: 2_000 }),
+      expect.objectContaining({ timeoutMs: 10_000 }),
     );
 
     rejecters[1](new Error("Not possible to fast-forward"));
@@ -1752,14 +1752,14 @@ describe("kanbanService.createTask", () => {
       // Then
       expect(mocks.remoteBranchExists).toHaveBeenCalledTimes(1);
 
-      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(10_000);
       await vi.advanceTimersByTimeAsync(0);
 
       expect(mocks.remoteBranchExists).toHaveBeenCalledTimes(2);
       expect(mocks.pullCurrentBranch).toHaveBeenCalledWith(
         "/workspace/repo__worktrees/next",
         null,
-        expect.objectContaining({ timeoutMs: 2_000 }),
+        expect.objectContaining({ timeoutMs: 10_000 }),
       );
       await expect(syncPromise).resolves.toEqual({
         pulledTasks: [
@@ -1823,7 +1823,7 @@ describe("kanbanService.createTask", () => {
         "remote-host",
       );
 
-      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(10_000);
       await vi.advanceTimersByTimeAsync(0);
 
       expect(isSyncComplete).toBe(false);
@@ -1837,7 +1837,7 @@ describe("kanbanService.createTask", () => {
         "remote-host",
       );
 
-      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(10_000);
       await vi.advanceTimersByTimeAsync(0);
 
       expect(isSyncComplete).toBe(false);
@@ -1910,7 +1910,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.pullCurrentBranch).toHaveBeenCalledWith(
       "/workspace/repo__worktrees/progress",
       null,
-      expect.objectContaining({ timeoutMs: 2_000 }),
+      expect.objectContaining({ timeoutMs: 10_000 }),
     );
     expect(result).toEqual({ pulledTasks: [] });
   });
@@ -1946,7 +1946,7 @@ describe("kanbanService.createTask", () => {
       "/workspace/repo__worktrees/missing-remote",
       "feature/missing-remote",
       null,
-      expect.objectContaining({ timeoutMs: 2_000 }),
+      expect.objectContaining({ timeoutMs: 10_000 }),
     );
     expect(mocks.pullCurrentBranch).not.toHaveBeenCalled();
     expect(result).toEqual({ pulledTasks: [] });

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -1112,7 +1112,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execFile).toHaveBeenCalledWith(
       "gh",
       ["pr", "list", "--head", "main", "--json", "url", "-q", ".[0].url"],
-      expect.objectContaining({ cwd: "/workspace/repo", timeout: 45_000 }),
+      expect.objectContaining({ cwd: "/workspace/repo", timeout: 2_000 }),
       expect.any(Function),
     );
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
@@ -1182,7 +1182,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execGit).toHaveBeenCalledWith(
       "cd '/remote/repo' && gh pr list --head 'feature/remote-pr' --json url -q '.[0].url'",
       "remote-host",
-      expect.objectContaining({ timeoutMs: 45_000 }),
+      expect.objectContaining({ timeoutMs: 2_000 }),
     );
     expect(mocks.execFile).not.toHaveBeenCalled();
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
@@ -1213,7 +1213,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execGit).toHaveBeenCalledWith(
       "cd '/remote/repo__worktrees/feature-fallback-path' && gh pr list --head 'feature/fallback-path' --json url -q '.[0].url'",
       "remote-host",
-      expect.objectContaining({ timeoutMs: 45_000 }),
+      expect.objectContaining({ timeoutMs: 2_000 }),
     );
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
       id: "task-7",
@@ -1248,7 +1248,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execGit).toHaveBeenCalledWith(
       "cd '/remote/repo' && gh pr list --head 'feature/no-gh' --json url -q '.[0].url'",
       "remote-host",
-      expect.objectContaining({ timeoutMs: 45_000 }),
+      expect.objectContaining({ timeoutMs: 2_000 }),
     );
     expect(mocks.taskRepo.save).not.toHaveBeenCalled();
     expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
@@ -1568,15 +1568,15 @@ describe("kanbanService.createTask", () => {
 
       // Then
       expect(execFileOptions).toEqual([
-        expect.objectContaining({ cwd: "/workspace/repo", timeout: 45_000 }),
+        expect.objectContaining({ cwd: "/workspace/repo", timeout: 2_000 }),
       ]);
 
-      await vi.advanceTimersByTimeAsync(45_000);
+      await vi.advanceTimersByTimeAsync(2_000);
       await vi.advanceTimersByTimeAsync(0);
 
       expect(execFileOptions).toEqual([
-        expect.objectContaining({ cwd: "/workspace/repo", timeout: 45_000 }),
-        expect.objectContaining({ cwd: "/workspace/repo", timeout: 45_000 }),
+        expect.objectContaining({ cwd: "/workspace/repo", timeout: 2_000 }),
+        expect.objectContaining({ cwd: "/workspace/repo", timeout: 2_000 }),
       ]);
       await expect(syncPromise).resolves.toEqual({
         updatedTaskIds: [],
@@ -1653,7 +1653,7 @@ describe("kanbanService.createTask", () => {
       1,
       "/workspace/repo__worktrees/pull-a",
       null,
-      expect.objectContaining({ timeoutMs: 45_000 }),
+      expect.objectContaining({ timeoutMs: 2_000 }),
     );
 
     resolvers[0]("Fast-forward\n src/file.ts | 1 +");
@@ -1664,7 +1664,7 @@ describe("kanbanService.createTask", () => {
       2,
       "/workspace/repo__worktrees/pull-b",
       null,
-      expect.objectContaining({ timeoutMs: 45_000 }),
+      expect.objectContaining({ timeoutMs: 2_000 }),
     );
 
     rejecters[1](new Error("Not possible to fast-forward"));
@@ -1755,14 +1755,14 @@ describe("kanbanService.createTask", () => {
       // Then
       expect(mocks.remoteBranchExists).toHaveBeenCalledTimes(1);
 
-      await vi.advanceTimersByTimeAsync(45_000);
+      await vi.advanceTimersByTimeAsync(2_000);
       await vi.advanceTimersByTimeAsync(0);
 
       expect(mocks.remoteBranchExists).toHaveBeenCalledTimes(2);
       expect(mocks.pullCurrentBranch).toHaveBeenCalledWith(
         "/workspace/repo__worktrees/next",
         null,
-        expect.objectContaining({ timeoutMs: 45_000 }),
+        expect.objectContaining({ timeoutMs: 2_000 }),
       );
       await expect(syncPromise).resolves.toEqual({
         pulledTasks: [
@@ -1824,10 +1824,10 @@ describe("kanbanService.createTask", () => {
         "/remote/repo__worktrees/remote-pull",
         "feature/remote-pull",
         "remote-host",
-        expect.objectContaining({ timeoutMs: 45_000 }),
+        expect.objectContaining({ timeoutMs: 2_000 }),
       );
 
-      await vi.advanceTimersByTimeAsync(45_000);
+      await vi.advanceTimersByTimeAsync(2_000);
       await vi.advanceTimersByTimeAsync(0);
 
       expect(isSyncComplete).toBe(false);
@@ -1839,10 +1839,10 @@ describe("kanbanService.createTask", () => {
       expect(mocks.pullCurrentBranch).toHaveBeenCalledWith(
         "/remote/repo__worktrees/remote-pull",
         "remote-host",
-        expect.objectContaining({ timeoutMs: 45_000 }),
+        expect.objectContaining({ timeoutMs: 2_000 }),
       );
 
-      await vi.advanceTimersByTimeAsync(45_000);
+      await vi.advanceTimersByTimeAsync(2_000);
       await vi.advanceTimersByTimeAsync(0);
 
       expect(isSyncComplete).toBe(false);
@@ -1915,7 +1915,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.pullCurrentBranch).toHaveBeenCalledWith(
       "/workspace/repo__worktrees/progress",
       null,
-      expect.objectContaining({ timeoutMs: 45_000 }),
+      expect.objectContaining({ timeoutMs: 2_000 }),
     );
     expect(result).toEqual({ pulledTasks: [] });
   });
@@ -1951,7 +1951,7 @@ describe("kanbanService.createTask", () => {
       "/workspace/repo__worktrees/missing-remote",
       "feature/missing-remote",
       null,
-      expect.objectContaining({ timeoutMs: 45_000 }),
+      expect.objectContaining({ timeoutMs: 2_000 }),
     );
     expect(mocks.pullCurrentBranch).not.toHaveBeenCalled();
     expect(result).toEqual({ pulledTasks: [] });

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -1182,7 +1182,6 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execGit).toHaveBeenCalledWith(
       "cd '/remote/repo' && gh pr list --head 'feature/remote-pr' --json url -q '.[0].url'",
       "remote-host",
-      expect.objectContaining({ timeoutMs: 2_000 }),
     );
     expect(mocks.execFile).not.toHaveBeenCalled();
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
@@ -1213,7 +1212,6 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execGit).toHaveBeenCalledWith(
       "cd '/remote/repo__worktrees/feature-fallback-path' && gh pr list --head 'feature/fallback-path' --json url -q '.[0].url'",
       "remote-host",
-      expect.objectContaining({ timeoutMs: 2_000 }),
     );
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
       id: "task-7",
@@ -1248,7 +1246,6 @@ describe("kanbanService.createTask", () => {
     expect(mocks.execGit).toHaveBeenCalledWith(
       "cd '/remote/repo' && gh pr list --head 'feature/no-gh' --json url -q '.[0].url'",
       "remote-host",
-      expect.objectContaining({ timeoutMs: 2_000 }),
     );
     expect(mocks.taskRepo.save).not.toHaveBeenCalled();
     expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
@@ -1824,7 +1821,6 @@ describe("kanbanService.createTask", () => {
         "/remote/repo__worktrees/remote-pull",
         "feature/remote-pull",
         "remote-host",
-        expect.objectContaining({ timeoutMs: 2_000 }),
       );
 
       await vi.advanceTimersByTimeAsync(2_000);
@@ -1839,7 +1835,6 @@ describe("kanbanService.createTask", () => {
       expect(mocks.pullCurrentBranch).toHaveBeenCalledWith(
         "/remote/repo__worktrees/remote-pull",
         "remote-host",
-        expect.objectContaining({ timeoutMs: 2_000 }),
       );
 
       await vi.advanceTimersByTimeAsync(2_000);

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -1439,25 +1439,25 @@ describe("kanbanService.createTask", () => {
     });
   });
 
-  it("active task PR sync는 task별 GitHub CLI 조회를 병렬로 시작한다", async () => {
+  it("active task PR sync는 task별 GitHub CLI 조회를 직렬로 실행한다", async () => {
     // Given
     mocks.taskRepo.find.mockResolvedValue([
       {
-        id: "task-parallel-a",
-        title: "Parallel PR A",
+        id: "task-serial-a",
+        title: "Serial PR A",
         projectId: "project-1",
-        branchName: "feature/parallel-a",
-        worktreePath: "/workspace/repo__worktrees/parallel-a",
+        branchName: "feature/serial-a",
+        worktreePath: "/workspace/repo__worktrees/serial-a",
         sshHost: null,
         prUrl: null,
         status: "review",
       },
       {
-        id: "task-parallel-b",
-        title: "Parallel PR B",
+        id: "task-serial-b",
+        title: "Serial PR B",
         projectId: "project-1",
-        branchName: "feature/parallel-b",
-        worktreePath: "/workspace/repo__worktrees/parallel-b",
+        branchName: "feature/serial-b",
+        worktreePath: "/workspace/repo__worktrees/serial-b",
         sshHost: null,
         prUrl: null,
         status: "review",
@@ -1482,20 +1482,28 @@ describe("kanbanService.createTask", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     // Then
+    expect(callbacks).toHaveLength(1);
+
+    callbacks[0](null, JSON.stringify([{
+      url: null,
+      state: null,
+      mergedAt: null,
+      updatedAt: "2026-05-02T01:00:00Z",
+    }]), "");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     expect(callbacks).toHaveLength(2);
 
-    callbacks.forEach((callback) => {
-      callback(null, JSON.stringify([{
-        url: null,
-        state: null,
-        mergedAt: null,
-        updatedAt: "2026-05-02T01:00:00Z",
-      }]), "");
-    });
+    callbacks[1](null, JSON.stringify([{
+      url: null,
+      state: null,
+      mergedAt: null,
+      updatedAt: "2026-05-02T01:00:00Z",
+    }]), "");
     await syncPromise;
   });
 
-  it("active task pull sync는 default branch task를 제외하고 task별 pull을 병렬로 실행한다", async () => {
+  it("active task pull sync는 default branch task를 제외하고 task별 pull을 직렬로 실행한다", async () => {
     // Given
     mocks.taskRepo.find.mockResolvedValue([
       {
@@ -1546,11 +1554,15 @@ describe("kanbanService.createTask", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     // Then
-    expect(mocks.pullCurrentBranch).toHaveBeenCalledTimes(2);
+    expect(mocks.pullCurrentBranch).toHaveBeenCalledTimes(1);
     expect(mocks.pullCurrentBranch).toHaveBeenNthCalledWith(1, "/workspace/repo__worktrees/pull-a", null);
-    expect(mocks.pullCurrentBranch).toHaveBeenNthCalledWith(2, "/workspace/repo__worktrees/pull-b", null);
 
     resolvers[0]("Fast-forward\n src/file.ts | 1 +");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.pullCurrentBranch).toHaveBeenCalledTimes(2);
+    expect(mocks.pullCurrentBranch).toHaveBeenNthCalledWith(2, "/workspace/repo__worktrees/pull-b", null);
+
     rejecters[1](new Error("Not possible to fast-forward"));
 
     await expect(syncPromise).resolves.toEqual({

--- a/src/desktop/main/services/backgroundTaskSyncService.ts
+++ b/src/desktop/main/services/backgroundTaskSyncService.ts
@@ -51,15 +51,9 @@ export function startBackgroundTaskSync() {
     try {
       const isEnabled = await getBackgroundSyncEnabled();
       if (isEnabled) {
-        const [
-          worktreeSyncResult,
-          prSyncResult,
-          pullSyncResult,
-        ] = await Promise.all([
-          syncRegisteredProjectWorktrees(),
-          syncActiveTaskPullRequests(emittedMergeEventKeys),
-          syncActiveTaskPulls(),
-        ]);
+        const worktreeSyncResult = await syncRegisteredProjectWorktrees();
+        const prSyncResult = await syncActiveTaskPullRequests(emittedMergeEventKeys);
+        const pullSyncResult = await syncActiveTaskPulls();
         const failures: BackgroundSyncFailurePayload[] = [
           ...worktreeSyncResult.errors.map((reason) => ({
             operation: "worktree-sync" as const,

--- a/src/desktop/main/services/backgroundTaskSyncService.ts
+++ b/src/desktop/main/services/backgroundTaskSyncService.ts
@@ -1,5 +1,10 @@
-import { syncRegisteredProjectWorktrees } from "@/desktop/main/services/projectService";
-import { syncActiveTaskPullRequests, syncActiveTaskPulls } from "@/desktop/main/services/kanbanService";
+import { syncRegisteredProjectWorktrees, type RegisteredProjectWorktreeSyncResult } from "@/desktop/main/services/projectService";
+import {
+  syncActiveTaskPullRequests,
+  syncActiveTaskPulls,
+  type ActiveTaskPullRequestSyncResult,
+  type ActiveTaskPullSyncResult,
+} from "@/desktop/main/services/kanbanService";
 import {
   broadcastBackgroundSyncReviewNeeded,
   broadcastBoardUpdate,
@@ -16,6 +21,68 @@ const INITIAL_SYNC_DELAY_MS = 20_000;
 const FALLBACK_SYNC_INTERVAL_MS = 10 * 60_000;
 
 let activeBackgroundTaskSyncStop: (() => void) | null = null;
+
+interface BackgroundSyncStageResult<T> {
+  result: T;
+  failure: BackgroundSyncFailurePayload | null;
+}
+
+function createEmptyWorktreeSyncResult(): RegisteredProjectWorktreeSyncResult {
+  return {
+    worktreeTasks: [],
+    registeredWorktrees: [],
+    hooksSetup: [],
+    errors: [],
+    changed: false,
+  };
+}
+
+function createEmptyPullRequestSyncResult(): ActiveTaskPullRequestSyncResult {
+  return {
+    updatedTaskIds: [],
+    mergeEventKeys: [],
+    mergedPullRequests: [],
+  };
+}
+
+function createEmptyTaskPullSyncResult(): ActiveTaskPullSyncResult {
+  return {
+    pulledTasks: [],
+  };
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return String(error);
+}
+
+async function runBackgroundSyncStage<T>(
+  stageName: string,
+  operation: () => Promise<T>,
+  createFallbackResult: () => T,
+  createFailure: (reason: string) => BackgroundSyncFailurePayload,
+): Promise<BackgroundSyncStageResult<T>> {
+  try {
+    return {
+      result: await operation(),
+      failure: null,
+    };
+  } catch (error) {
+    console.error(`[background-task-sync] ${stageName} failed:`, error);
+
+    return {
+      result: createFallbackResult(),
+      failure: createFailure(getErrorMessage(error)),
+    };
+  }
+}
 
 export function startBackgroundTaskSync() {
   if (activeBackgroundTaskSyncStop) {
@@ -51,16 +118,49 @@ export function startBackgroundTaskSync() {
     try {
       const isEnabled = await getBackgroundSyncEnabled();
       if (isEnabled) {
-        const worktreeSyncResult = await syncRegisteredProjectWorktrees();
-        const prSyncResult = await syncActiveTaskPullRequests(emittedMergeEventKeys);
-        const pullSyncResult = await syncActiveTaskPulls();
+        const worktreeSync = await runBackgroundSyncStage(
+          "worktree sync",
+          syncRegisteredProjectWorktrees,
+          createEmptyWorktreeSyncResult,
+          (reason) => ({
+            operation: "worktree-sync",
+            target: "등록 프로젝트 worktree sync",
+            reason,
+          }),
+        );
+        const prSync = await runBackgroundSyncStage(
+          "pull request sync",
+          () => syncActiveTaskPullRequests(emittedMergeEventKeys),
+          createEmptyPullRequestSyncResult,
+          (reason) => ({
+            operation: "pull-request-sync",
+            target: "PR 상태 sync",
+            reason,
+          }),
+        );
+        const pullSync = await runBackgroundSyncStage(
+          "task pull sync",
+          syncActiveTaskPulls,
+          createEmptyTaskPullSyncResult,
+          (reason) => ({
+            operation: "task-pull-sync",
+            target: "active task pull sync",
+            reason,
+          }),
+        );
+        const worktreeSyncResult = worktreeSync.result;
+        const prSyncResult = prSync.result;
+        const pullSyncResult = pullSync.result;
         const failures: BackgroundSyncFailurePayload[] = [
+          ...(worktreeSync.failure ? [worktreeSync.failure] : []),
           ...worktreeSyncResult.errors.map((reason) => ({
             operation: "worktree-sync" as const,
             target: "등록 프로젝트 worktree sync",
             reason,
           })),
+          ...(prSync.failure ? [prSync.failure] : []),
           ...(prSyncResult.failures ?? []),
+          ...(pullSync.failure ? [pullSync.failure] : []),
         ];
 
         if (

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -306,7 +306,6 @@ async function getPrUrlFromGitHubCli(branchName: string, cwd: string, sshHost?: 
       const output = await execGit(
         `cd ${quoteForShell(cwd)} && gh pr list --head ${quoteForShell(branchName)} --json url -q '.[0].url'`,
         sshHost,
-        { timeoutMs: ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS },
       );
       return output.trim() || null;
     } catch (error) {
@@ -376,7 +375,6 @@ async function getPrInfoFromGitHubCli(
       const output = await execGit(
         `cd ${quoteForShell(cwd)} && gh pr list --head ${quoteForShell(branchName)} --state all --json url,state,mergedAt,updatedAt`,
         sshHost,
-        { timeoutMs: ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS },
       );
       if (!output.trim()) {
         return null;
@@ -1143,14 +1141,22 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
     const pullFailureKey = buildPullFailureKey(task.id, task.branchName, task.worktreePath, sshHost);
 
     try {
-      const gitOptions = { timeoutMs: ACTIVE_TASK_PULL_GIT_TIMEOUT_MS };
-      const hasRemoteBranch = await remoteBranchExists(task.worktreePath, task.branchName, sshHost, gitOptions);
+      const hasRemoteBranch = sshHost
+        ? await remoteBranchExists(task.worktreePath, task.branchName, sshHost)
+        : await remoteBranchExists(
+          task.worktreePath,
+          task.branchName,
+          sshHost,
+          { timeoutMs: ACTIVE_TASK_PULL_GIT_TIMEOUT_MS },
+        );
       if (!hasRemoteBranch) {
         notifiedPullFailureKeys.delete(pullFailureKey);
         continue;
       }
 
-      const output = await pullCurrentBranch(task.worktreePath, sshHost, gitOptions);
+      const output = sshHost
+        ? await pullCurrentBranch(task.worktreePath, sshHost)
+        : await pullCurrentBranch(task.worktreePath, sshHost, { timeoutMs: ACTIVE_TASK_PULL_GIT_TIMEOUT_MS });
       notifiedPullFailureKeys.delete(pullFailureKey);
       if (isPullNoop(output)) {
         continue;

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -52,8 +52,8 @@ const ACTIVE_PULL_TASK_STATUSES = [
   TaskStatus.PENDING,
   TaskStatus.REVIEW,
 ];
-const ACTIVE_TASK_PULL_GIT_TIMEOUT_MS = 45_000;
-const ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS = 45_000;
+const ACTIVE_TASK_PULL_GIT_TIMEOUT_MS = 2_000;
+const ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS = 2_000;
 const notifiedPullFailureKeys = new Set<string>();
 
 interface CleanupTaskResourcesOptions {

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -53,6 +53,7 @@ const ACTIVE_PULL_TASK_STATUSES = [
   TaskStatus.REVIEW,
 ];
 const ACTIVE_TASK_PULL_GIT_TIMEOUT_MS = 45_000;
+const ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS = 45_000;
 const notifiedPullFailureKeys = new Set<string>();
 
 interface CleanupTaskResourcesOptions {
@@ -305,6 +306,7 @@ async function getPrUrlFromGitHubCli(branchName: string, cwd: string, sshHost?: 
       const output = await execGit(
         `cd ${quoteForShell(cwd)} && gh pr list --head ${quoteForShell(branchName)} --json url -q '.[0].url'`,
         sshHost,
+        { timeoutMs: ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS },
       );
       return output.trim() || null;
     } catch (error) {
@@ -320,7 +322,7 @@ async function getPrUrlFromGitHubCli(branchName: string, cwd: string, sshHost?: 
     execFile(
       "gh",
       ["pr", "list", "--head", branchName, "--json", "url", "-q", ".[0].url"],
-      { cwd },
+      { cwd, timeout: ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS },
       (error, stdout) => {
         if (error) {
           if (isMissingGitHubCli(error)) {
@@ -374,6 +376,7 @@ async function getPrInfoFromGitHubCli(
       const output = await execGit(
         `cd ${quoteForShell(cwd)} && gh pr list --head ${quoteForShell(branchName)} --state all --json url,state,mergedAt,updatedAt`,
         sshHost,
+        { timeoutMs: ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS },
       );
       if (!output.trim()) {
         return null;
@@ -392,7 +395,7 @@ async function getPrInfoFromGitHubCli(
     execFile(
       "gh",
       ["pr", "list", "--head", branchName, "--state", "all", "--json", "url,state,mergedAt,updatedAt"],
-      { cwd },
+      { cwd, timeout: ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS },
       (error, stdout) => {
         if (error) {
           if (isMissingGitHubCli(error)) {
@@ -474,29 +477,6 @@ function isPullNoop(output: string): boolean {
 
 function buildPullFailureKey(taskId: string, branchName: string, worktreePath: string, sshHost: string | null): string {
   return [taskId, branchName, worktreePath, sshHost ?? ""].join("::");
-}
-
-function runWithTimeout<T>(
-  operation: Promise<T>,
-  timeoutMs: number,
-  timeoutMessage: string,
-): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const timeoutHandle = setTimeout(() => {
-      reject(new Error(timeoutMessage));
-    }, timeoutMs);
-
-    operation.then(
-      (value) => {
-        clearTimeout(timeoutHandle);
-        resolve(value);
-      },
-      (error: unknown) => {
-        clearTimeout(timeoutHandle);
-        reject(error);
-      },
-    );
-  });
 }
 
 function isMissingRemoteBranchPullError(error: unknown): boolean {
@@ -1164,22 +1144,13 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
 
     try {
       const gitOptions = { timeoutMs: ACTIVE_TASK_PULL_GIT_TIMEOUT_MS };
-      const timeoutSeconds = ACTIVE_TASK_PULL_GIT_TIMEOUT_MS / 1000;
-      const hasRemoteBranch = await runWithTimeout(
-        remoteBranchExists(task.worktreePath, task.branchName, sshHost, gitOptions),
-        ACTIVE_TASK_PULL_GIT_TIMEOUT_MS,
-        `Remote branch check timed out after ${timeoutSeconds}s: ${task.title} (${task.branchName})`,
-      );
+      const hasRemoteBranch = await remoteBranchExists(task.worktreePath, task.branchName, sshHost, gitOptions);
       if (!hasRemoteBranch) {
         notifiedPullFailureKeys.delete(pullFailureKey);
         continue;
       }
 
-      const output = await runWithTimeout(
-        pullCurrentBranch(task.worktreePath, sshHost, gitOptions),
-        ACTIVE_TASK_PULL_GIT_TIMEOUT_MS,
-        `Pull timed out after ${timeoutSeconds}s: ${task.title} (${task.branchName})`,
-      );
+      const output = await pullCurrentBranch(task.worktreePath, sshHost, gitOptions);
       notifiedPullFailureKeys.delete(pullFailureKey);
       if (isPullNoop(output)) {
         continue;

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -1036,9 +1036,9 @@ export async function syncActiveTaskPullRequests(
   };
   const failures: BackgroundSyncFailurePayload[] = [];
 
-  const taskResults = await Promise.all(tasks.map(async (task) => {
+  for (const task of tasks) {
     if (!task.branchName) {
-      return null;
+      continue;
     }
 
     try {
@@ -1047,14 +1047,14 @@ export async function syncActiveTaskPullRequests(
         : null;
 
       if (isDefaultBranchTask(task, project)) {
-        return null;
+        continue;
       }
 
       const { cwd, sshHost } = await resolveTaskGitContext(task, project);
       const prInfo = await getPrInfoFromGitHubCli(task.branchName, cwd, sshHost);
 
       if (!prInfo?.url) {
-        return null;
+        continue;
       }
 
       const updatedTaskIds: string[] = [];
@@ -1069,22 +1069,22 @@ export async function syncActiveTaskPullRequests(
 
       if (prInfo.state === "MERGED" && prInfo.mergedAt) {
         const mergeEventKey = buildMergedPullRequestEventKey(task.id, prInfo.url, prInfo.mergedAt);
-        if (emittedMergeEventKeys.has(mergeEventKey)) {
-          return { updatedTaskIds, mergeEventKeys, mergedPullRequests };
+        if (!emittedMergeEventKeys.has(mergeEventKey)) {
+          emittedMergeEventKeys.add(mergeEventKey);
+          mergeEventKeys.push(mergeEventKey);
+          mergedPullRequests.push({
+            taskId: task.id,
+            taskTitle: task.title,
+            branchName: task.branchName,
+            prUrl: prInfo.url,
+            mergedAt: prInfo.mergedAt,
+          });
         }
-
-        emittedMergeEventKeys.add(mergeEventKey);
-        mergeEventKeys.push(mergeEventKey);
-        mergedPullRequests.push({
-          taskId: task.id,
-          taskTitle: task.title,
-          branchName: task.branchName,
-          prUrl: prInfo.url,
-          mergedAt: prInfo.mergedAt,
-        });
       }
 
-      return { updatedTaskIds, mergeEventKeys, mergedPullRequests };
+      result.updatedTaskIds.push(...updatedTaskIds);
+      result.mergeEventKeys.push(...mergeEventKeys);
+      result.mergedPullRequests.push(...mergedPullRequests);
     } catch (error) {
       failures.push(buildPullRequestSyncFailure(task, error));
       console.error("PR 상태 동기화 실패:", {
@@ -1092,18 +1092,7 @@ export async function syncActiveTaskPullRequests(
         branchName: task.branchName,
         error: getErrorMessage(error),
       });
-      return null;
     }
-  }));
-
-  for (const taskResult of taskResults) {
-    if (!taskResult) {
-      continue;
-    }
-
-    result.updatedTaskIds.push(...taskResult.updatedTaskIds);
-    result.mergeEventKeys.push(...taskResult.mergeEventKeys);
-    result.mergedPullRequests.push(...taskResult.mergedPullRequests);
   }
 
   if (result.mergedPullRequests.length > 0) {
@@ -1127,13 +1116,15 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
     order: { updatedAt: "ASC" },
   });
 
-  const pulledTasks = await Promise.all(tasks.map(async (task): Promise<TaskPullSyncPayload | null> => {
+  const pulledTasks: TaskPullSyncPayload[] = [];
+
+  for (const task of tasks) {
     if (task.status === TaskStatus.DONE) {
-      return null;
+      continue;
     }
 
     if (!task.branchName || !task.worktreePath) {
-      return null;
+      continue;
     }
 
     const project = task.projectId
@@ -1141,7 +1132,7 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
       : null;
 
     if (isDefaultBranchTask(task, project)) {
-      return null;
+      continue;
     }
 
     const sshHost = task.sshHost || project?.sshHost || null;
@@ -1151,16 +1142,16 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
       const hasRemoteBranch = await remoteBranchExists(task.worktreePath, task.branchName, sshHost);
       if (!hasRemoteBranch) {
         notifiedPullFailureKeys.delete(pullFailureKey);
-        return null;
+        continue;
       }
 
       const output = await pullCurrentBranch(task.worktreePath, sshHost);
       notifiedPullFailureKeys.delete(pullFailureKey);
       if (isPullNoop(output)) {
-        return null;
+        continue;
       }
 
-      return {
+      pulledTasks.push({
         taskId: task.id,
         taskTitle: task.title,
         branchName: task.branchName,
@@ -1168,19 +1159,19 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
         sshHost,
         status: "updated",
         summary: summarizePullOutput(output),
-      };
+      });
     } catch (error) {
       if (isMissingRemoteBranchPullError(error)) {
         notifiedPullFailureKeys.delete(pullFailureKey);
-        return null;
+        continue;
       }
 
       if (notifiedPullFailureKeys.has(pullFailureKey)) {
-        return null;
+        continue;
       }
 
       notifiedPullFailureKeys.add(pullFailureKey);
-      return {
+      pulledTasks.push({
         taskId: task.id,
         taskTitle: task.title,
         branchName: task.branchName,
@@ -1188,11 +1179,11 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
         sshHost,
         status: "failed",
         summary: getErrorMessage(error),
-      };
+      });
     }
-  }));
+  }
 
   return {
-    pulledTasks: pulledTasks.filter((task): task is TaskPullSyncPayload => task !== null),
+    pulledTasks,
   };
 }

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -52,6 +52,7 @@ const ACTIVE_PULL_TASK_STATUSES = [
   TaskStatus.PENDING,
   TaskStatus.REVIEW,
 ];
+const ACTIVE_TASK_PULL_GIT_TIMEOUT_MS = 45_000;
 const notifiedPullFailureKeys = new Set<string>();
 
 interface CleanupTaskResourcesOptions {
@@ -473,6 +474,29 @@ function isPullNoop(output: string): boolean {
 
 function buildPullFailureKey(taskId: string, branchName: string, worktreePath: string, sshHost: string | null): string {
   return [taskId, branchName, worktreePath, sshHost ?? ""].join("::");
+}
+
+function runWithTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeoutHandle = setTimeout(() => {
+      reject(new Error(timeoutMessage));
+    }, timeoutMs);
+
+    operation.then(
+      (value) => {
+        clearTimeout(timeoutHandle);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timeoutHandle);
+        reject(error);
+      },
+    );
+  });
 }
 
 function isMissingRemoteBranchPullError(error: unknown): boolean {
@@ -1139,13 +1163,23 @@ export async function syncActiveTaskPulls(): Promise<ActiveTaskPullSyncResult> {
     const pullFailureKey = buildPullFailureKey(task.id, task.branchName, task.worktreePath, sshHost);
 
     try {
-      const hasRemoteBranch = await remoteBranchExists(task.worktreePath, task.branchName, sshHost);
+      const gitOptions = { timeoutMs: ACTIVE_TASK_PULL_GIT_TIMEOUT_MS };
+      const timeoutSeconds = ACTIVE_TASK_PULL_GIT_TIMEOUT_MS / 1000;
+      const hasRemoteBranch = await runWithTimeout(
+        remoteBranchExists(task.worktreePath, task.branchName, sshHost, gitOptions),
+        ACTIVE_TASK_PULL_GIT_TIMEOUT_MS,
+        `Remote branch check timed out after ${timeoutSeconds}s: ${task.title} (${task.branchName})`,
+      );
       if (!hasRemoteBranch) {
         notifiedPullFailureKeys.delete(pullFailureKey);
         continue;
       }
 
-      const output = await pullCurrentBranch(task.worktreePath, sshHost);
+      const output = await runWithTimeout(
+        pullCurrentBranch(task.worktreePath, sshHost, gitOptions),
+        ACTIVE_TASK_PULL_GIT_TIMEOUT_MS,
+        `Pull timed out after ${timeoutSeconds}s: ${task.title} (${task.branchName})`,
+      );
       notifiedPullFailureKeys.delete(pullFailureKey);
       if (isPullNoop(output)) {
         continue;

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -52,8 +52,8 @@ const ACTIVE_PULL_TASK_STATUSES = [
   TaskStatus.PENDING,
   TaskStatus.REVIEW,
 ];
-const ACTIVE_TASK_PULL_GIT_TIMEOUT_MS = 2_000;
-const ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS = 2_000;
+const ACTIVE_TASK_PULL_GIT_TIMEOUT_MS = 10_000;
+const ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS = 10_000;
 const notifiedPullFailureKeys = new Set<string>();
 
 interface CleanupTaskResourcesOptions {

--- a/src/desktop/renderer/components/BackgroundSyncReviewDialog.tsx
+++ b/src/desktop/renderer/components/BackgroundSyncReviewDialog.tsx
@@ -30,6 +30,18 @@ function getBackgroundSyncReviewPayload(notification: AppNotification | null | u
   return notification.action.payload;
 }
 
+function getBackgroundSyncFailureLabelKey(operation: BackgroundSyncFailurePayload["operation"]) {
+  if (operation === "pull-request-sync") {
+    return "pullRequestFailure";
+  }
+
+  if (operation === "task-pull-sync") {
+    return "taskPullFailure";
+  }
+
+  return "worktreeFailure";
+}
+
 export default function BackgroundSyncReviewDialog() {
   const tc = useTranslations("common");
   const tr = useTranslations("common.backgroundSyncReview");
@@ -267,7 +279,7 @@ export default function BackgroundSyncReviewDialog() {
                           </span>
                         ) : null}
                         <span className="rounded-full bg-red-50 px-2 py-0.5 text-[11px] text-status-error">
-                          {tr(failure.operation === "pull-request-sync" ? "pullRequestFailure" : "worktreeFailure")}
+                          {tr(getBackgroundSyncFailureLabelKey(failure.operation))}
                         </span>
                       </div>
                     </div>

--- a/src/lib/boardNotifier.ts
+++ b/src/lib/boardNotifier.ts
@@ -56,7 +56,7 @@ export interface BackgroundSyncPulledTaskPayload {
 }
 
 export interface BackgroundSyncFailurePayload {
-  operation: "worktree-sync" | "pull-request-sync";
+  operation: "worktree-sync" | "pull-request-sync" | "task-pull-sync";
   target: string;
   reason: string;
   taskId?: string;

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -185,9 +185,10 @@ function isSSHCommandTimeoutError(error: unknown): boolean {
 }
 
 /** 로컬에서 셸 명령을 실행하고 stdout을 반환한다 */
-async function execLocal(command: string): Promise<string> {
+async function execLocal(command: string, options?: ExecGitOptions): Promise<string> {
   const { stdout } = await execAsync(command, {
     env: createLocalShellEnvironment(),
+    ...(options?.timeoutMs ? { timeout: options.timeoutMs } : {}),
   });
   return stdout.trim();
 }
@@ -640,7 +641,7 @@ export async function execGit(
   if (sshHost) {
     return execRemote(sshHost, command, options);
   }
-  return execLocal(command);
+  return execLocal(command, options);
 }
 
 /** remote origin의 최신 브랜치 정보를 가져온다. 네트워크 실패 시 silent fail */
@@ -658,9 +659,10 @@ export async function fetchOrigin(
 /** 현재 checkout된 브랜치를 fast-forward 가능한 경우에만 pull한다 */
 export async function pullCurrentBranch(
   repoPath: string,
-  sshHost?: string | null
+  sshHost?: string | null,
+  options?: ExecGitOptions,
 ): Promise<string> {
-  return execGit(`git -C "${repoPath}" pull --ff-only`, sshHost);
+  return execGit(`git -C "${repoPath}" pull --ff-only`, sshHost, options);
 }
 
 /** origin에 현재 task 브랜치가 존재하는지 확인한다 */
@@ -668,6 +670,7 @@ export async function remoteBranchExists(
   repoPath: string,
   branchName: string,
   sshHost?: string | null,
+  options?: ExecGitOptions,
 ): Promise<boolean> {
   const resolvedRepoPath = resolvePathForShell(repoPath, sshHost);
   const remoteRef = quoteForPosixShell(`refs/heads/${branchName}`);
@@ -677,7 +680,7 @@ export async function remoteBranchExists(
     `if [ "$status" -eq 0 ]; then printf exists; elif [ "$status" -eq 2 ]; then printf missing; else exit "$status"; fi`,
   ].join("; ");
 
-  const output = await execGit(command, sshHost);
+  const output = await execGit(command, sshHost, options);
   return output.trim() === "exists";
 }
 


### PR DESCRIPTION
## Summary
- Allow background sync interval edits to keep a draft value so multi-digit minute values like 10 and 20 can be entered after clearing a one-digit value.
- Preserve the existing 1-1440 minute validation policy and restore invalid drafts on blur.
- Serialize expensive background sync stages and task-level git/GitHub CLI work to reduce CPU spikes while keeping single-flight sync behavior.
- Add regression coverage for multi-digit interval input and serial sync execution.

## Testing
- `pnpm check` passed.
- `pnpm test` passed: 82 test files, 653 tests.
- `pnpm lint` currently fails on pre-existing repo-wide lint errors outside this changeset, including `.opencode/plugins/kanvibe-plugin.ts`, `electron/hookServer.js`, `scripts/*.cjs`, `CollapsibleSidebar.tsx`, `DiffPageClient.tsx`, `NotificationListener.tsx`, and `TaskDetailRoute.tsx`.

Co-Authored-By: Codex <codex@openai.com>