### PR TITLE
fix(worktree): 실제 worktree 경로로 task 리소스 정리

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -68,7 +68,6 @@ vi.mock("@/lib/worktree", () => ({
   removeWorktreeAndBranch: mocks.removeWorktreeAndBranch,
   createSessionWithoutWorktree: mocks.createSessionWithoutWorktree,
   removeSessionOnly: mocks.removeSessionOnly,
-  buildManagedWorktreePath: vi.fn((projectPath: string, branchName: string) => `${projectPath}__worktrees/${branchName}`),
 }));
 
 vi.mock("@/lib/terminal", () => ({
@@ -669,7 +668,7 @@ describe("kanbanService.createTask", () => {
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it("원격 stale task는 안전하지 않은 worktree/브랜치 삭제를 건너뛴다", async () => {
+  it("DB worktreePath가 managed 예상 경로와 달라도 프로젝트와 브랜치 기준으로 정리한다", async () => {
     // Given
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     mocks.projectRepo.findOneBy.mockResolvedValue({
@@ -692,8 +691,12 @@ describe("kanbanService.createTask", () => {
     } as never);
 
     // Then
-    expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
-    expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(mocks.removeWorktreeAndBranch).toHaveBeenCalledWith(
+      "/remote/repo",
+      "dev",
+      "remote-host",
+    );
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   it("연결된 프로젝트를 찾을 수 없는 원격 stale task는 세션만 정리한다", async () => {

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -695,6 +695,7 @@ describe("kanbanService.createTask", () => {
       "/remote/repo",
       "dev",
       "remote-host",
+      { worktreePath: "/Users/local/repo__worktrees/dev" },
     );
     expect(consoleWarnSpy).not.toHaveBeenCalled();
   });

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -737,21 +737,22 @@ export async function cleanupTaskResources(
   }
 
   const sshHost = task.sshHost || project?.sshHost || null;
-  const cleanupOptions = options.throwOnError
-    ? { throwOnError: true }
-    : undefined;
+  const cleanupOptions = {
+    ...(options.throwOnError ? { throwOnError: true } : {}),
+    worktreePath: task.worktreePath,
+  };
 
   /** 브랜치별 독립 세션 정리 */
   if (task.sessionType && task.sessionName) {
     try {
       detachSession(task.id, "cleanup-task-resources");
 
-      if (cleanupOptions) {
+      if (options.throwOnError) {
         await removeSessionOnly(
           task.sessionType,
           task.sessionName,
           sshHost,
-          cleanupOptions,
+          { throwOnError: true },
         );
       } else {
         await removeSessionOnly(
@@ -796,7 +797,7 @@ export async function cleanupTaskResources(
     }
 
     try {
-      if (cleanupOptions) {
+      if (options.throwOnError) {
         await removeWorktreeAndBranch(
           project?.repoPath || process.cwd(),
           task.branchName,
@@ -808,6 +809,7 @@ export async function cleanupTaskResources(
           project?.repoPath || process.cwd(),
           task.branchName,
           sshHost,
+          cleanupOptions,
         );
       }
     } catch (error) {

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -3,7 +3,7 @@ import { In, Not, Like } from "typeorm";
 import { getTaskRepository } from "@/lib/database";
 import { KanbanTask, TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
-import { createWorktreeWithSession, removeWorktreeAndBranch, createSessionWithoutWorktree, removeSessionOnly, buildManagedWorktreePath } from "@/lib/worktree";
+import { createWorktreeWithSession, removeWorktreeAndBranch, createSessionWithoutWorktree, removeSessionOnly } from "@/lib/worktree";
 import { getProjectRepository } from "@/lib/database";
 import {
   broadcastBoardUpdate,
@@ -774,15 +774,11 @@ export async function cleanupTaskResources(
   }
 
   const isProjectRoot = project && task.worktreePath === project.repoPath;
-  const expectedWorktreePath = project?.repoPath && task.branchName
-    ? buildManagedWorktreePath(project.repoPath, task.branchName)
-    : null;
 
   /** worktree + 브랜치 정리 (프로젝트 루트 브랜치 제외) */
   if (task.branchName && !isProjectRoot) {
     const canCleanupBranch = Boolean(project?.repoPath)
-      && Boolean(task.worktreePath)
-      && task.worktreePath === expectedWorktreePath;
+      && Boolean(task.worktreePath);
 
     if (!canCleanupBranch) {
       const warningPayload = {
@@ -792,9 +788,9 @@ export async function cleanupTaskResources(
         projectRepoPath: project?.repoPath ?? null,
         sshHost,
       };
-      console.warn("worktree/브랜치 정리 건너뜀: task 경로와 project 경로가 일치하지 않습니다.", warningPayload);
+      console.warn("worktree/브랜치 정리 건너뜀: 정리할 프로젝트 또는 worktree 정보가 부족합니다.", warningPayload);
       if (options.throwOnError) {
-        throw new Error("task 경로와 project 경로가 일치하지 않아 worktree/브랜치 정리를 건너뛰었습니다.");
+        throw new Error("정리할 프로젝트 또는 worktree 정보가 부족해 worktree/브랜치 정리를 건너뛰었습니다.");
       }
       return;
     }

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -249,6 +249,26 @@ describe("removeWorktreeAndBranch", () => {
       undefined,
     );
   });
+
+  it("should not remove or delete a branch checked out in the project root", async () => {
+    // Given
+    mockListWorktrees.mockResolvedValue([
+      {
+        path: "/workspace/repo",
+        branch: "feature/root-checkout",
+        isBare: false,
+      },
+    ]);
+
+    const { removeWorktreeAndBranch } = await import("@/lib/worktree");
+
+    // When
+    await removeWorktreeAndBranch("/workspace/repo/", "feature/root-checkout", null, { throwOnError: true });
+
+    // Then
+    expect(filterCalls("worktree remove")).toHaveLength(0);
+    expect(filterCalls("branch -D")).toHaveLength(0);
+  });
 });
 
 describe("removeSessionOnly", () => {

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -250,7 +250,7 @@ describe("removeWorktreeAndBranch", () => {
     );
   });
 
-  it("should fall back to the task worktree path when the worktree branch changed", async () => {
+  it("should fall back to the managed task worktree path when the worktree branch changed", async () => {
     // Given
     mockListWorktrees.mockResolvedValue([
       {
@@ -280,6 +280,39 @@ describe("removeWorktreeAndBranch", () => {
       'git -C "/workspace/repo" worktree remove "/workspace/repo__worktrees/feature-task" --force',
       "remote-host",
     );
+    expect(mockExecGit).toHaveBeenCalledWith(
+      'git -C "/workspace/repo" branch -D "feature/task"',
+      "remote-host",
+    );
+  });
+
+  it("should not fall back to a stale task path owned by another linked worktree", async () => {
+    // Given
+    mockListWorktrees.mockResolvedValue([
+      {
+        path: "/workspace/repo",
+        branch: "main",
+        isBare: false,
+      },
+      {
+        path: "/workspace/custom-worktrees/other-task",
+        branch: "feature/other-task",
+        isBare: false,
+      },
+    ]);
+
+    const { removeWorktreeAndBranch } = await import("@/lib/worktree");
+
+    // When
+    await removeWorktreeAndBranch(
+      "/workspace/repo",
+      "feature/task",
+      "remote-host",
+      { worktreePath: "/workspace/custom-worktrees/other-task" },
+    );
+
+    // Then
+    expect(filterCalls("worktree remove")).toHaveLength(0);
     expect(mockExecGit).toHaveBeenCalledWith(
       'git -C "/workspace/repo" branch -D "feature/task"',
       "remote-host",

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -250,6 +250,42 @@ describe("removeWorktreeAndBranch", () => {
     );
   });
 
+  it("should fall back to the task worktree path when the worktree branch changed", async () => {
+    // Given
+    mockListWorktrees.mockResolvedValue([
+      {
+        path: "/workspace/repo",
+        branch: "main",
+        isBare: false,
+      },
+      {
+        path: "/workspace/repo__worktrees/feature-task",
+        branch: "debug/other-branch",
+        isBare: false,
+      },
+    ]);
+
+    const { removeWorktreeAndBranch } = await import("@/lib/worktree");
+
+    // When
+    await removeWorktreeAndBranch(
+      "/workspace/repo",
+      "feature/task",
+      "remote-host",
+      { worktreePath: "/workspace/repo__worktrees/feature-task/" },
+    );
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledWith(
+      'git -C "/workspace/repo" worktree remove "/workspace/repo__worktrees/feature-task" --force',
+      "remote-host",
+    );
+    expect(mockExecGit).toHaveBeenCalledWith(
+      'git -C "/workspace/repo" branch -D "feature/task"',
+      "remote-host",
+    );
+  });
+
   it("should not remove or delete a branch checked out in the project root", async () => {
     // Given
     mockListWorktrees.mockResolvedValue([

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -6,9 +6,11 @@ import { SessionType } from "@/entities/KanbanTask";
 // --- Mocks ---
 
 const mockExecGit = vi.fn().mockResolvedValue("");
+const mockListWorktrees = vi.fn().mockResolvedValue([]);
 
 vi.mock("@/lib/gitOperations", () => ({
   execGit: (...args: unknown[]) => mockExecGit(...args),
+  listWorktrees: (...args: unknown[]) => mockListWorktrees(...args),
 }));
 
 const mockGetEffectivePaneLayout = vi.fn();
@@ -187,6 +189,64 @@ describe("isSessionAlive", () => {
     expect(mockExecGit).toHaveBeenCalledWith(
       'tmux has-session -t "feat-branch" 2>/dev/null',
       "remote-host",
+    );
+  });
+});
+
+describe("removeWorktreeAndBranch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecGit.mockResolvedValue("");
+    mockListWorktrees.mockResolvedValue([]);
+  });
+
+  it("should remove the actual worktree path resolved from git worktree list", async () => {
+    // Given
+    mockListWorktrees.mockResolvedValue([
+      {
+        path: "/workspace/custom-worktrees/feature-real-path",
+        branch: "feature/real-path",
+        isBare: false,
+      },
+    ]);
+
+    const { removeWorktreeAndBranch } = await import("@/lib/worktree");
+
+    // When
+    await removeWorktreeAndBranch("/workspace/repo", "feature/real-path", "remote-host");
+
+    // Then
+    expect(mockListWorktrees).toHaveBeenCalledWith("/workspace/repo", "remote-host");
+    expect(mockExecGit).toHaveBeenCalledWith(
+      'git -C "/workspace/repo" worktree remove "/workspace/custom-worktrees/feature-real-path" --force',
+      "remote-host",
+    );
+    expect(mockExecGit).toHaveBeenCalledWith(
+      'git -C "/workspace/repo" branch -D "feature/real-path"',
+      "remote-host",
+    );
+  });
+
+  it("should skip worktree removal when the branch has no registered worktree", async () => {
+    // Given
+    mockListWorktrees.mockResolvedValue([
+      {
+        path: "/workspace/repo",
+        branch: "main",
+        isBare: false,
+      },
+    ]);
+
+    const { removeWorktreeAndBranch } = await import("@/lib/worktree");
+
+    // When
+    await removeWorktreeAndBranch("/workspace/repo", "feature/missing");
+
+    // Then
+    expect(filterCalls("worktree remove")).toHaveLength(0);
+    expect(mockExecGit).toHaveBeenCalledWith(
+      'git -C "/workspace/repo" branch -D "feature/missing"',
+      undefined,
     );
   });
 });

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -338,6 +338,9 @@ async function resolveBranchWorktreePath(
   const normalizedFallbackWorktreePath = fallbackWorktreePath
     ? normalizeGitWorktreePath(fallbackWorktreePath)
     : null;
+  const normalizedManagedWorktreePath = normalizeGitWorktreePath(
+    buildManagedWorktreePath(projectPath, branchName),
+  );
   const matchingWorktrees = worktrees.filter((worktree) => (
     !worktree.isBare && worktree.branch === branchName
   ));
@@ -350,6 +353,7 @@ async function resolveBranchWorktreePath(
     ? worktrees.find((worktree) => (
         !worktree.isBare
         && normalizeGitWorktreePath(worktree.path) === normalizedFallbackWorktreePath
+        && normalizedFallbackWorktreePath === normalizedManagedWorktreePath
         && normalizedFallbackWorktreePath !== normalizedProjectPath
       ))
     : null;

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -315,6 +315,7 @@ export async function createSessionWithoutWorktree(
 
 interface ResourceCleanupOptions {
   throwOnError?: boolean;
+  worktreePath?: string | null;
 }
 
 interface ResolvedBranchWorktree {
@@ -329,10 +330,14 @@ function normalizeGitWorktreePath(worktreePath: string): string {
 async function resolveBranchWorktreePath(
   projectPath: string,
   branchName: string,
+  fallbackWorktreePath?: string | null,
   sshHost?: string | null,
 ): Promise<ResolvedBranchWorktree> {
   const worktrees = await listWorktrees(projectPath, sshHost);
   const normalizedProjectPath = normalizeGitWorktreePath(projectPath);
+  const normalizedFallbackWorktreePath = fallbackWorktreePath
+    ? normalizeGitWorktreePath(fallbackWorktreePath)
+    : null;
   const matchingWorktrees = worktrees.filter((worktree) => (
     !worktree.isBare && worktree.branch === branchName
   ));
@@ -341,8 +346,16 @@ async function resolveBranchWorktreePath(
     normalizeGitWorktreePath(worktree.path) !== normalizedProjectPath
   ));
 
+  const fallbackWorktree = normalizedFallbackWorktreePath
+    ? worktrees.find((worktree) => (
+        !worktree.isBare
+        && normalizeGitWorktreePath(worktree.path) === normalizedFallbackWorktreePath
+        && normalizedFallbackWorktreePath !== normalizedProjectPath
+      ))
+    : null;
+
   return {
-    path: linkedWorktree?.path ?? null,
+    path: linkedWorktree?.path ?? fallbackWorktree?.path ?? null,
     isProjectRootCheckout: matchingWorktrees.some((worktree) => (
       normalizeGitWorktreePath(worktree.path) === normalizedProjectPath
     )),
@@ -356,7 +369,12 @@ export async function removeWorktreeAndBranch(
   sshHost?: string | null,
   options: ResourceCleanupOptions = {},
 ): Promise<void> {
-  const resolvedWorktree = await resolveBranchWorktreePath(projectPath, branchName, sshHost);
+  const resolvedWorktree = await resolveBranchWorktreePath(
+    projectPath,
+    branchName,
+    options.worktreePath,
+    sshHost,
+  );
   const worktreePath = resolvedWorktree.path;
   const branchCommand = options.throwOnError
     ? `if git -C "${projectPath}" show-ref --verify --quiet "refs/heads/${branchName}"; then git -C "${projectPath}" branch -D "${branchName}"; fi`

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -317,15 +317,36 @@ interface ResourceCleanupOptions {
   throwOnError?: boolean;
 }
 
+interface ResolvedBranchWorktree {
+  path: string | null;
+  isProjectRootCheckout: boolean;
+}
+
+function normalizeGitWorktreePath(worktreePath: string): string {
+  return worktreePath.replace(/\/+$/, "") || worktreePath;
+}
+
 async function resolveBranchWorktreePath(
   projectPath: string,
   branchName: string,
   sshHost?: string | null,
-): Promise<string | null> {
+): Promise<ResolvedBranchWorktree> {
   const worktrees = await listWorktrees(projectPath, sshHost);
-  return worktrees.find((worktree) => (
+  const normalizedProjectPath = normalizeGitWorktreePath(projectPath);
+  const matchingWorktrees = worktrees.filter((worktree) => (
     !worktree.isBare && worktree.branch === branchName
-  ))?.path ?? null;
+  ));
+
+  const linkedWorktree = matchingWorktrees.find((worktree) => (
+    normalizeGitWorktreePath(worktree.path) !== normalizedProjectPath
+  ));
+
+  return {
+    path: linkedWorktree?.path ?? null,
+    isProjectRootCheckout: matchingWorktrees.some((worktree) => (
+      normalizeGitWorktreePath(worktree.path) === normalizedProjectPath
+    )),
+  };
 }
 
 /** worktree와 브랜치를 삭제한다. 세션은 건드리지 않는다 */
@@ -335,7 +356,8 @@ export async function removeWorktreeAndBranch(
   sshHost?: string | null,
   options: ResourceCleanupOptions = {},
 ): Promise<void> {
-  const worktreePath = await resolveBranchWorktreePath(projectPath, branchName, sshHost);
+  const resolvedWorktree = await resolveBranchWorktreePath(projectPath, branchName, sshHost);
+  const worktreePath = resolvedWorktree.path;
   const branchCommand = options.throwOnError
     ? `if git -C "${projectPath}" show-ref --verify --quiet "refs/heads/${branchName}"; then git -C "${projectPath}" branch -D "${branchName}"; fi`
     : `git -C "${projectPath}" branch -D "${branchName}"`;
@@ -353,6 +375,10 @@ export async function removeWorktreeAndBranch(
       }
       // worktree가 이미 삭제된 경우 무시
     }
+  }
+
+  if (resolvedWorktree.isProjectRootCheckout) {
+    return;
   }
 
   try {

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { writeFile } from "fs/promises";
 import { SessionType } from "@/entities/KanbanTask";
 import { PaneLayoutType, type PaneCommand } from "@/entities/PaneLayoutConfig";
-import { execGit } from "@/lib/gitOperations";
+import { execGit, listWorktrees } from "@/lib/gitOperations";
 import { getEffectivePaneLayout } from "@/desktop/main/services/paneLayoutService";
 
 interface WorktreeSession {
@@ -317,6 +317,17 @@ interface ResourceCleanupOptions {
   throwOnError?: boolean;
 }
 
+async function resolveBranchWorktreePath(
+  projectPath: string,
+  branchName: string,
+  sshHost?: string | null,
+): Promise<string | null> {
+  const worktrees = await listWorktrees(projectPath, sshHost);
+  return worktrees.find((worktree) => (
+    !worktree.isBare && worktree.branch === branchName
+  ))?.path ?? null;
+}
+
 /** worktree와 브랜치를 삭제한다. 세션은 건드리지 않는다 */
 export async function removeWorktreeAndBranch(
   projectPath: string,
@@ -324,21 +335,24 @@ export async function removeWorktreeAndBranch(
   sshHost?: string | null,
   options: ResourceCleanupOptions = {},
 ): Promise<void> {
-  const worktreePath = buildManagedWorktreePath(projectPath, branchName);
-  const worktreeCommand = options.throwOnError
-    ? `if git -C "${projectPath}" worktree list --porcelain | grep -Fxq "worktree ${worktreePath}"; then git -C "${projectPath}" worktree remove "${worktreePath}" --force; fi`
-    : `git -C "${projectPath}" worktree remove "${worktreePath}" --force`;
+  const worktreePath = await resolveBranchWorktreePath(projectPath, branchName, sshHost);
   const branchCommand = options.throwOnError
     ? `if git -C "${projectPath}" show-ref --verify --quiet "refs/heads/${branchName}"; then git -C "${projectPath}" branch -D "${branchName}"; fi`
     : `git -C "${projectPath}" branch -D "${branchName}"`;
 
-  try {
-    await execGit(worktreeCommand, sshHost);
-  } catch {
-    if (options.throwOnError) {
-      throw new Error(`worktree 정리 실패: ${worktreePath}`);
+  if (worktreePath) {
+    const worktreeCommand = options.throwOnError
+      ? `if git -C "${projectPath}" worktree list --porcelain | grep -Fxq "worktree ${worktreePath}"; then git -C "${projectPath}" worktree remove "${worktreePath}" --force; fi`
+      : `git -C "${projectPath}" worktree remove "${worktreePath}" --force`;
+
+    try {
+      await execGit(worktreeCommand, sshHost);
+    } catch {
+      if (options.throwOnError) {
+        throw new Error(`worktree 정리 실패: ${worktreePath}`);
+      }
+      // worktree가 이미 삭제된 경우 무시
     }
-    // worktree가 이미 삭제된 경우 무시
   }
 
   try {


### PR DESCRIPTION
## 어떤 작업인가요?
- task 삭제와 Done 이동 정리에서 DB에 저장된 worktreePath가 오래된 경우에도 실제 git worktree 경로를 찾아 리소스를 정리하도록 수정합니다.

## 어떻게 해결했나요?
**worktree 삭제 경로 resolve 개선**
- `git worktree list --porcelain` 결과에서 branchName과 매칭되는 non-bare worktree path를 찾아 `git worktree remove`에 사용합니다.
- 매칭되는 worktree가 이미 없으면 worktree 삭제는 스킵하고 브랜치 삭제는 계속 시도하도록 유지했습니다.

**task cleanup 조건 완화**
- `cleanupTaskResources`에서 DB `worktreePath`와 managed 예상 경로를 직접 비교하던 조건을 제거했습니다.
- 프로젝트 repo와 브랜치 정보가 있으면 삭제 유틸에 위임해 실제 worktree 목록 기준으로 정리하게 했습니다.

## 중요한 변경 사항은 무엇인가요?
### 실제 worktree 경로 기반 삭제

**DB 경로 의존 제거**
- **변경 이유**: DB에 저장된 worktreePath가 현재 git worktree 경로와 달라진 경우 삭제가 스킵되는 문제를 막기 위함입니다.
- **수정 파일**: `src/lib/worktree.ts`, `src/desktop/main/services/kanbanService.ts`

**회귀 테스트 추가**
- **변경 이유**: stale DB path 상황에서도 프로젝트와 브랜치 기준으로 정리가 호출되고, 실제 worktree list path로 remove command가 만들어지는지 고정하기 위함입니다.
- **수정 파일**: `src/lib/__tests__/worktree.test.ts`, `src/desktop/main/services/__tests__/kanbanService.test.ts`

Co-Authored-By: Codex <codex@openai.com>