### PR TITLE
fix: task 삭제 리소스 정리 정책 공통화

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -669,19 +669,10 @@ describe("kanbanService.createTask", () => {
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it("원격 stale task는 안전하지 않은 worktree/브랜치 삭제를 건너뛴다", async () => {
+  it("원격 stale task 삭제는 안전하지 않은 worktree/브랜치 정리 상태에서 task 레코드를 삭제하지 않는다", async () => {
     // Given
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    mocks.projectRepo.findOneBy.mockResolvedValue({
-      id: "project-1",
-      repoPath: "/remote/repo",
-      sshHost: "remote-host",
-    });
-
-    const { cleanupTaskResources } = await import("@/desktop/main/services/kanbanService");
-
-    // When
-    await cleanupTaskResources({
+    const task = {
       id: "task-1",
       projectId: "project-1",
       branchName: "dev",
@@ -689,22 +680,27 @@ describe("kanbanService.createTask", () => {
       sshHost: "remote-host",
       sessionType: null,
       sessionName: null,
-    } as never);
+    };
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/remote/repo",
+      sshHost: "remote-host",
+    });
 
-    // Then
+    const { deleteTask } = await import("@/desktop/main/services/kanbanService");
+
+    // When & Then
+    await expect(deleteTask("task-1")).rejects.toThrow("task 경로와 project 경로가 일치하지 않아");
     expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
+    expect(mocks.taskRepo.remove).not.toHaveBeenCalled();
     expect(consoleWarnSpy).toHaveBeenCalled();
   });
 
-  it("연결된 프로젝트를 찾을 수 없는 원격 stale task는 세션만 정리한다", async () => {
+  it("연결된 프로젝트를 찾을 수 없는 원격 stale task 삭제는 세션 정리 후 task 레코드를 삭제하지 않는다", async () => {
     // Given
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    mocks.projectRepo.findOneBy.mockResolvedValue(null);
-
-    const { cleanupTaskResources } = await import("@/desktop/main/services/kanbanService");
-
-    // When
-    await cleanupTaskResources({
+    const task = {
       id: "task-2",
       projectId: "missing-project",
       branchName: "main",
@@ -712,27 +708,30 @@ describe("kanbanService.createTask", () => {
       sshHost: "roky-home",
       sessionType: "tmux" as never,
       sessionName: "prompt-main",
-    } as never);
+    };
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.projectRepo.findOneBy.mockResolvedValue(null);
 
-    // Then
+    const { deleteTask } = await import("@/desktop/main/services/kanbanService");
+
+    // When & Then
+    await expect(deleteTask("task-2")).rejects.toThrow("연결된 프로젝트를 찾을 수 없어");
     expect(mocks.detachSession).toHaveBeenCalledWith("task-2", "cleanup-task-resources");
     expect(mocks.removeSessionOnly).toHaveBeenCalledWith(
       "tmux",
       "prompt-main",
       "roky-home",
+      { throwOnError: true },
     );
     expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
+    expect(mocks.taskRepo.remove).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
-  it("프로젝트가 삭제되어 orphan 상태가 된 원격 stale task도 세션만 정리한다", async () => {
+  it("프로젝트가 삭제되어 orphan 상태가 된 원격 stale task 삭제도 task 레코드를 삭제하지 않는다", async () => {
     // Given
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-    const { cleanupTaskResources } = await import("@/desktop/main/services/kanbanService");
-
-    // When
-    await cleanupTaskResources({
+    const task = {
       id: "task-3",
       projectId: null,
       branchName: "dev",
@@ -740,27 +739,33 @@ describe("kanbanService.createTask", () => {
       sshHost: "roky-home",
       sessionType: "tmux" as never,
       sessionName: "techtaurant-be-dev",
-    } as never);
+    };
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
 
-    // Then
+    const { deleteTask } = await import("@/desktop/main/services/kanbanService");
+
+    // When & Then
+    await expect(deleteTask("task-3")).rejects.toThrow("연결된 프로젝트를 찾을 수 없어");
     expect(mocks.projectRepo.findOneBy).not.toHaveBeenCalled();
     expect(mocks.detachSession).toHaveBeenCalledWith("task-3", "cleanup-task-resources");
     expect(mocks.removeSessionOnly).toHaveBeenCalledWith(
       "tmux",
       "techtaurant-be-dev",
       "roky-home",
+      { throwOnError: true },
     );
     expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
+    expect(mocks.taskRepo.remove).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
-  it("원격 task 삭제는 프로젝트를 찾지 못해도 연결된 tmux 세션을 정리한다", async () => {
+  it("세션만 연결된 원격 task 삭제는 프로젝트를 찾지 못해도 tmux 세션을 정리한다", async () => {
     // Given
     const task = {
       id: "task-remote",
       projectId: "missing-project",
-      branchName: "main",
-      worktreePath: "/home/rookedsysc/Downloads/prompt",
+      branchName: null,
+      worktreePath: null,
       sshHost: "roky-home",
       sessionType: "tmux" as never,
       sessionName: "prompt-main",
@@ -781,10 +786,41 @@ describe("kanbanService.createTask", () => {
       "tmux",
       "prompt-main",
       "roky-home",
+      { throwOnError: true },
     );
     expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
     expect(mocks.taskRepo.remove).toHaveBeenCalledWith(task);
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("원격 task 삭제 중 세션 정리가 실패하면 task 레코드를 삭제하지 않는다", async () => {
+    // Given
+    const task = {
+      id: "task-remote-fail",
+      projectId: "missing-project",
+      branchName: "main",
+      worktreePath: "/home/rookedsysc/Downloads/prompt",
+      sshHost: "roky-home",
+      sessionType: "tmux" as never,
+      sessionName: "prompt-main",
+    };
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.projectRepo.findOneBy.mockResolvedValue(null);
+    mocks.removeSessionOnly.mockRejectedValueOnce(new Error("ssh failed"));
+
+    const { deleteTask } = await import("@/desktop/main/services/kanbanService");
+
+    // When & Then
+    await expect(deleteTask("task-remote-fail")).rejects.toThrow("ssh failed");
+    expect(mocks.detachSession).toHaveBeenCalledWith("task-remote-fail", "cleanup-task-resources");
+    expect(mocks.removeSessionOnly).toHaveBeenCalledWith(
+      "tmux",
+      "prompt-main",
+      "roky-home",
+      { throwOnError: true },
+    );
+    expect(mocks.taskRepo.remove).not.toHaveBeenCalled();
+    expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
   });
 
   it("tmux 세션 정리 전 앱이 붙잡고 있는 활성 터미널 PTY를 먼저 닫는다", async () => {
@@ -797,10 +833,7 @@ describe("kanbanService.createTask", () => {
       callOrder.push("remove-session");
     });
 
-    const { cleanupTaskResources } = await import("@/desktop/main/services/kanbanService");
-
-    // When
-    await cleanupTaskResources({
+    mocks.taskRepo.findOneBy.mockResolvedValue({
       id: "task-open-terminal",
       projectId: null,
       branchName: null,
@@ -808,7 +841,13 @@ describe("kanbanService.createTask", () => {
       sshHost: null,
       sessionType: "tmux" as never,
       sessionName: "repo-feat-open",
-    } as never);
+    });
+    mocks.taskRepo.remove.mockResolvedValue({});
+
+    const { deleteTask } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    await deleteTask("task-open-terminal");
 
     // Then
     expect(callOrder).toEqual(["detach", "remove-session"]);
@@ -817,6 +856,7 @@ describe("kanbanService.createTask", () => {
       "tmux",
       "repo-feat-open",
       null,
+      { throwOnError: true },
     );
   });
 

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -60,6 +60,8 @@ interface CleanupTaskResourcesOptions {
   throwOnError?: boolean;
 }
 
+const TASK_RESOURCE_DELETE_CLEANUP_OPTIONS = { throwOnError: true } as const;
+
 interface DoneRollbackSnapshot {
   id: string;
   status: TaskStatus;
@@ -266,7 +268,7 @@ export function prepareOptimisticDoneTransition(
 
 export function scheduleDoneCleanupWithRollback(plan: DoneCleanupPlan): void {
   setTimeout(() => {
-    void cleanupTaskResources(plan.cleanupTask, { throwOnError: true })
+    void deleteTaskResources(plan.cleanupTask)
       .catch((error) => rollbackDoneTransition(plan.rollbackSnapshot, error));
   }, 0);
 }
@@ -726,7 +728,7 @@ export async function updateProjectColor(
 }
 
 /** 작업에 연결된 worktree, 세션, 브랜치를 정리한다. task 레코드는 삭제하지 않는다 */
-export async function cleanupTaskResources(
+async function cleanupTaskResources(
   task: KanbanTask,
   options: CleanupTaskResourcesOptions = {},
 ): Promise<void> {
@@ -746,20 +748,12 @@ export async function cleanupTaskResources(
     try {
       detachSession(task.id, "cleanup-task-resources");
 
-      if (cleanupOptions) {
-        await removeSessionOnly(
-          task.sessionType,
-          task.sessionName,
-          sshHost,
-          cleanupOptions,
-        );
-      } else {
-        await removeSessionOnly(
-          task.sessionType,
-          task.sessionName,
-          sshHost,
-        );
-      }
+      await removeSessionOnly(
+        task.sessionType,
+        task.sessionName,
+        sshHost,
+        cleanupOptions,
+      );
     } catch (error) {
       if (options.throwOnError) {
         throw error;
@@ -770,6 +764,9 @@ export async function cleanupTaskResources(
 
   // 프로젝트 없이 브랜치/worktree만 남은 태스크는 stale 상태이므로 worktree/브랜치 정리는 건너뛴다.
   if (!project && task.branchName && task.worktreePath) {
+    if (options.throwOnError) {
+      throw new Error("연결된 프로젝트를 찾을 수 없어 worktree/브랜치 정리를 완료할 수 없습니다.");
+    }
     return;
   }
 
@@ -800,20 +797,12 @@ export async function cleanupTaskResources(
     }
 
     try {
-      if (cleanupOptions) {
-        await removeWorktreeAndBranch(
-          project?.repoPath || process.cwd(),
-          task.branchName,
-          sshHost,
-          cleanupOptions,
-        );
-      } else {
-        await removeWorktreeAndBranch(
-          project?.repoPath || process.cwd(),
-          task.branchName,
-          sshHost,
-        );
-      }
+      await removeWorktreeAndBranch(
+        project?.repoPath || process.cwd(),
+        task.branchName,
+        sshHost,
+        cleanupOptions,
+      );
     } catch (error) {
       if (options.throwOnError) {
         throw error;
@@ -823,13 +812,18 @@ export async function cleanupTaskResources(
   }
 }
 
+/** task 삭제/Done 전환에서 사용하는 공통 리소스 삭제 정책 */
+async function deleteTaskResources(task: KanbanTask): Promise<void> {
+  await cleanupTaskResources(task, TASK_RESOURCE_DELETE_CLEANUP_OPTIONS);
+}
+
 /** 작업을 삭제한다. worktree와 세션이 있으면 함께 정리한다 */
 export async function deleteTask(taskId: string): Promise<boolean> {
   const repo = await getTaskRepository();
   const task = await repo.findOneBy({ id: taskId });
   if (!task) return false;
 
-  await cleanupTaskResources(task);
+  await deleteTaskResources(task);
 
   await repo.remove(task);
   broadcastBoardUpdate();

--- a/src/desktop/renderer/actions/kanban.ts
+++ b/src/desktop/renderer/actions/kanban.ts
@@ -44,10 +44,6 @@ export function updateProjectColor(projectId: string, color: string): Promise<vo
   return invokeDesktop("kanban", "updateProjectColor", projectId, color);
 }
 
-export function cleanupTaskResources(task: KanbanTask): Promise<void> {
-  return invokeDesktop("kanban", "cleanupTaskResources", task);
-}
-
 export function deleteTask(taskId: string): Promise<boolean> {
   return invokeDesktop("kanban", "deleteTask", taskId);
 }

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -410,21 +410,6 @@ function buildZellijSessionCleanupCommand(sessionName: string, verifyCleanup: bo
   ].join("; ");
 }
 
-/**
- * worktree와 브랜치별 독립 세션을 삭제한다.
- * sshHost가 지정되면 원격에서 실행한다.
- */
-export async function removeWorktreeAndSession(
-  projectPath: string,
-  branchName: string,
-  sessionType: SessionType,
-  sessionName: string,
-  sshHost?: string | null,
-): Promise<void> {
-  await removeSessionOnly(sessionType, sessionName, sshHost);
-  await removeWorktreeAndBranch(projectPath, branchName, sshHost);
-}
-
 /** 활성 tmux/zellij 세션 이름 목록을 반환한다 */
 export async function listActiveSessions(
   sessionType: SessionType,


### PR DESCRIPTION
## 어떤 작업인가요?
- task 삭제와 Done 전환에서 세션, worktree, branch 정리 정책이 갈라지지 않도록 공통 삭제 경로로 통합합니다.

## 어떻게 해결했나요?
**task 리소스 삭제 경로 통합**
- 수동 task 삭제와 Done 전환 백그라운드 정리가 동일한 내부 삭제 정책을 사용하도록 정리했습니다.
- 정리 실패 시 task DB 레코드가 먼저 삭제되지 않도록 실패를 전파합니다.

**우회 가능한 삭제 표면 제거**
- renderer action에서 직접 resource cleanup을 호출할 수 있는 공개 함수를 제거했습니다.
- 미사용 `removeWorktreeAndSession` helper를 제거해 삭제 조합을 kanban service 정책으로 모았습니다.

**예외 정책 유지**
- 설정 창의 프로젝트 삭제는 기존처럼 KanVibe DB 레코드만 삭제하고 git branch/worktree/session은 건드리지 않습니다.

## 중요한 변경 사항은 무엇인가요?
### 삭제 정책 공통화

**수동 삭제와 Done 전환의 리소스 정리 경로 통일**
- **변경 이유**: 원격 task 삭제 시 세션 정리 실패가 묻히고 task 레코드만 삭제되는 상태를 막기 위해서입니다.
- **수정 파일**: `src/desktop/main/services/kanbanService.ts`

**공개 cleanup action 제거**
- **변경 이유**: renderer에서 공통 삭제 정책을 우회할 수 있는 표면을 줄이기 위해서입니다.
- **수정 파일**: `src/desktop/renderer/actions/kanban.ts`

**중복 helper 제거**
- **변경 이유**: worktree/session 삭제 조합이 여러 곳에 분산되지 않도록 하기 위해서입니다.
- **수정 파일**: `src/lib/worktree.ts`

**삭제 실패 케이스 검증 강화**
- **변경 이유**: stale/orphan task, 세션 정리 실패, 세션만 연결된 task 삭제 정책을 명시적으로 검증하기 위해서입니다.
- **수정 파일**: `src/desktop/main/services/__tests__/kanbanService.test.ts`

Co-Authored-By: OpenAI Codex <codex@openai.com>