### PR TITLE
fix: cap desktop diagnostics log growth

### DIFF
--- a/electron/diagnostics.js
+++ b/electron/diagnostics.js
@@ -4,8 +4,56 @@ const fs = require("node:fs");
 const path = require("node:path");
 const process = require("node:process");
 
+const DEFAULT_DESKTOP_LOG_MAX_BYTES = 10 * 1024 * 1024;
+const DEFAULT_DESKTOP_LOG_TRIM_TO_BYTES = 8 * 1024 * 1024;
+const DEFAULT_DESKTOP_LOG_MAX_ENTRY_BYTES = 256 * 1024;
+
 function resolveDesktopLogPath(userDataPath) {
   return path.join(userDataPath, "logs", "kanvibe-desktop.log");
+}
+
+function toPositiveInteger(value, fallback) {
+  if (Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+
+  return fallback;
+}
+
+function getFileSize(filePath) {
+  try {
+    return fs.statSync(filePath).size;
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return 0;
+    }
+
+    throw error;
+  }
+}
+
+function trimDesktopLogHead(logPath, bytesToRemove) {
+  if (bytesToRemove <= 0 || !fs.existsSync(logPath)) {
+    return;
+  }
+
+  const content = fs.readFileSync(logPath);
+  if (content.length <= bytesToRemove) {
+    fs.writeFileSync(logPath, "", "utf8");
+    return;
+  }
+
+  fs.writeFileSync(logPath, content.subarray(bytesToRemove));
+}
+
+function trimDesktopLogIfNeeded(logPath, incomingBytes, maxFileBytes, trimToBytes) {
+  const currentBytes = getFileSize(logPath);
+  if (currentBytes + incomingBytes <= maxFileBytes) {
+    return;
+  }
+
+  const bytesToKeepBeforeAppend = Math.max(0, trimToBytes - incomingBytes);
+  trimDesktopLogHead(logPath, currentBytes - bytesToKeepBeforeAppend);
 }
 
 function serializeErrorForLog(error) {
@@ -58,10 +106,50 @@ function defaultProcessMeta() {
   };
 }
 
+function getByteLength(value) {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function buildLogLine(timestamp, event, entry) {
+  return `[${timestamp}] ${event} ${JSON.stringify(entry)}\n`;
+}
+
+function constrainLogLineBytes(timestamp, event, entry, maxEntryBytes) {
+  const line = buildLogLine(timestamp, event, entry);
+  const originalBytes = getByteLength(line);
+  if (originalBytes <= maxEntryBytes) {
+    return {
+      line,
+      lineBytes: originalBytes,
+    };
+  }
+
+  const truncatedLine = buildLogLine(timestamp, event, {
+    diagnosticPayloadTruncated: true,
+    originalBytes,
+    maxEntryBytes,
+    process: entry.process,
+  });
+
+  return {
+    line: truncatedLine,
+    lineBytes: getByteLength(truncatedLine),
+  };
+}
+
 function createDesktopDiagnostics(options) {
   const logPath = options.logPath;
   const getTimestamp = options.getTimestamp || (() => new Date().toISOString());
   const getProcessMeta = options.getProcessMeta || defaultProcessMeta;
+  const maxFileBytes = toPositiveInteger(options.maxFileBytes, DEFAULT_DESKTOP_LOG_MAX_BYTES);
+  const trimToBytes = Math.min(
+    toPositiveInteger(options.trimToBytes, DEFAULT_DESKTOP_LOG_TRIM_TO_BYTES),
+    maxFileBytes,
+  );
+  const maxEntryBytes = Math.min(
+    toPositiveInteger(options.maxEntryBytes, DEFAULT_DESKTOP_LOG_MAX_ENTRY_BYTES),
+    maxFileBytes,
+  );
 
   function log(event, payload = {}) {
     try {
@@ -70,7 +158,9 @@ function createDesktopDiagnostics(options) {
         ...normalizePayload(payload),
         process: getProcessMeta(),
       };
-      fs.appendFileSync(logPath, `[${getTimestamp()}] ${event} ${JSON.stringify(entry)}\n`, "utf8");
+      const { line, lineBytes } = constrainLogLineBytes(getTimestamp(), event, entry, maxEntryBytes);
+      trimDesktopLogIfNeeded(logPath, lineBytes, maxFileBytes, trimToBytes);
+      fs.appendFileSync(logPath, line, "utf8");
     } catch (error) {
       console.error("[kanvibe] failed to write desktop diagnostics log:", error);
     }
@@ -83,6 +173,9 @@ function createDesktopDiagnostics(options) {
 }
 
 module.exports = {
+  DEFAULT_DESKTOP_LOG_MAX_BYTES,
+  DEFAULT_DESKTOP_LOG_MAX_ENTRY_BYTES,
+  DEFAULT_DESKTOP_LOG_TRIM_TO_BYTES,
   createDesktopDiagnostics,
   resolveDesktopLogPath,
   serializeErrorForLog,

--- a/electron/diagnostics.test.mjs
+++ b/electron/diagnostics.test.mjs
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const tempDirs = [];
+
+function createTempLogPath() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "kanvibe-diagnostics-"));
+  tempDirs.push(tempDir);
+  return path.join(tempDir, "logs", "kanvibe-desktop.log");
+}
+
+function createDiagnostics(logPath, options = {}) {
+  const { createDesktopDiagnostics } = require("./diagnostics");
+  return createDesktopDiagnostics({
+    logPath,
+    getTimestamp: () => "2026-01-01T00:00:00.000Z",
+    getProcessMeta: () => ({ pid: 42, platform: "test" }),
+    ...options,
+  });
+}
+
+function getFileSize(filePath) {
+  return fs.statSync(filePath).size;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("Electron desktop diagnostics", () => {
+  it("keeps one append-only diagnostics file by trimming bytes from the head", () => {
+    const logPath = createTempLogPath();
+    const maxFileBytes = 260;
+    const diagnostics = createDiagnostics(logPath, {
+      maxFileBytes,
+      trimToBytes: 180,
+      maxEntryBytes: 220,
+    });
+
+    for (let index = 0; index < 8; index += 1) {
+      diagnostics.log("renderer:console-message", {
+        index,
+        message: `entry-${index}-${"x".repeat(20)}`,
+      });
+    }
+
+    const content = fs.readFileSync(logPath, "utf8");
+    expect(content).not.toContain("entry-0");
+    expect(content).toContain("entry-7");
+    expect(getFileSize(logPath)).toBeLessThanOrEqual(maxFileBytes);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(false);
+  });
+
+  it("trims an oversized legacy log instead of rotating it into a backup", () => {
+    const logPath = createTempLogPath();
+    const maxFileBytes = 220;
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.writeFileSync(logPath, `legacy-start\n${"legacy-middle".repeat(20)}\nlegacy-tail\n`, "utf8");
+    const diagnostics = createDiagnostics(logPath, {
+      maxFileBytes,
+      trimToBytes: 150,
+      maxEntryBytes: 180,
+    });
+
+    diagnostics.log("main:start", { ok: true });
+
+    const content = fs.readFileSync(logPath, "utf8");
+    expect(content).not.toContain("legacy-start");
+    expect(content).toContain("main:start");
+    expect(getFileSize(logPath)).toBeLessThanOrEqual(maxFileBytes);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(false);
+  });
+
+  it("truncates oversized diagnostic entries before appending them", () => {
+    const logPath = createTempLogPath();
+    const diagnostics = createDiagnostics(logPath, {
+      maxFileBytes: 1024,
+      trimToBytes: 768,
+      maxEntryBytes: 512,
+    });
+
+    diagnostics.log("renderer:console-message", {
+      message: "x".repeat(5000),
+    });
+
+    const content = fs.readFileSync(logPath, "utf8");
+    expect(content).toContain("diagnosticPayloadTruncated");
+    expect(content).toContain("originalBytes");
+    expect(content).not.toContain("x".repeat(1000));
+    expect(getFileSize(logPath)).toBeLessThan(1024);
+  });
+});


### PR DESCRIPTION
## Summary
- Cap `kanvibe-desktop.log` as a single active diagnostics file at 10 MiB
- Remove oldest bytes from the head of the file when the next append would exceed the cap; no backup or rotation files are created
- Trim down to 8 MiB before appending to avoid rewriting the file on every log line near the cap
- Truncate unusually large single diagnostic entries so one append cannot blow past the cap

## Test Plan
- `pnpm exec vitest run electron/diagnostics.test.mjs`
- `pnpm check`
- `pnpm lint` (passes with existing warnings)
- `pnpm build`
