### PR TITLE
feat(hooks): persist shared task status as JSON

### DIFF
--- a/src/desktop/main/services/__tests__/hookService.test.ts
+++ b/src/desktop/main/services/__tests__/hookService.test.ts
@@ -165,8 +165,8 @@ describe("hookService.updateHookTaskStatus", () => {
     await updateHookTaskStatus({ taskId: task.id, status: TaskStatus.REVIEW });
 
     expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/workspace/api__worktrees/feature-sync/.kanvibe/status.md",
-      "review\n",
+      "/workspace/api__worktrees/feature-sync/.kanvibe/status.json",
+      expect.stringContaining('"status": "review"'),
       null,
     );
   });
@@ -312,8 +312,8 @@ describe("hookService.startHookTask", () => {
     const result = await resultPromise;
 
     expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/remote/repo__worktrees/feature-task/.kanvibe/status.md",
-      "todo\n",
+      "/remote/repo__worktrees/feature-task/.kanvibe/status.json",
+      expect.stringContaining('"status": "todo"'),
       "remote-host",
     );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);

--- a/src/desktop/main/services/__tests__/hookService.test.ts
+++ b/src/desktop/main/services/__tests__/hookService.test.ts
@@ -165,13 +165,8 @@ describe("hookService.updateHookTaskStatus", () => {
     await updateHookTaskStatus({ taskId: task.id, status: TaskStatus.REVIEW });
 
     expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/workspace/api__worktrees/feature-sync/.kanvibe/task-state.json",
-      expect.stringContaining('"status": "review"'),
-      null,
-    );
-    expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/workspace/api__worktrees/feature-sync/.kanvibe/task-state.json",
-      expect.stringContaining('"taskId": "task-1"'),
+      "/workspace/api__worktrees/feature-sync/.kanvibe/status.md",
+      "review\n",
       null,
     );
   });
@@ -317,13 +312,8 @@ describe("hookService.startHookTask", () => {
     const result = await resultPromise;
 
     expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/remote/repo__worktrees/feature-task/.kanvibe/task-state.json",
-      expect.stringContaining('"status": "todo"'),
-      "remote-host",
-    );
-    expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/remote/repo__worktrees/feature-task/.kanvibe/task-state.json",
-      expect.stringContaining('"taskId": "task-1"'),
+      "/remote/repo__worktrees/feature-task/.kanvibe/status.md",
+      "todo\n",
       "remote-host",
     );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);

--- a/src/desktop/main/services/__tests__/hookService.test.ts
+++ b/src/desktop/main/services/__tests__/hookService.test.ts
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   installTaskHooksImmediately: vi.fn(),
   prepareOptimisticDoneTransition: vi.fn(),
   scheduleDoneCleanupWithRollback: vi.fn(),
+  writeTextFile: vi.fn(),
 }));
 
 vi.mock("@/entities/KanbanTask", () => entityMocks);
@@ -56,6 +57,10 @@ vi.mock("@/desktop/main/services/kanbanService", () => ({
   installTaskHooksImmediately: mocks.installTaskHooksImmediately,
   prepareOptimisticDoneTransition: mocks.prepareOptimisticDoneTransition,
   scheduleDoneCleanupWithRollback: mocks.scheduleDoneCleanupWithRollback,
+}));
+
+vi.mock("@/lib/hostFileAccess", () => ({
+  writeTextFile: mocks.writeTextFile,
 }));
 
 async function flushMicrotasks(count = 8): Promise<void> {
@@ -139,6 +144,85 @@ describe("hookService.updateHookTaskStatus", () => {
     });
   });
 
+  it("hook 상태 변경은 worktree의 .kanvibe task 상태 파일에도 저장한다", async () => {
+    const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
+    const task = {
+      id: "task-1",
+      title: "Fix sync",
+      description: null,
+      branchName: "feature-sync",
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: TaskStatus.PROGRESS,
+      sessionType: null,
+      sessionName: null,
+      worktreePath: "/workspace/api__worktrees/feature-sync",
+      sshHost: null,
+    };
+    mocks.taskRepo.findOne.mockResolvedValue(task);
+    mocks.taskRepo.save.mockImplementation(async (value) => value);
+
+    await updateHookTaskStatus({ taskId: task.id, status: TaskStatus.REVIEW });
+
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/workspace/api__worktrees/feature-sync/.kanvibe/task-state.json",
+      expect.stringContaining('"status": "review"'),
+      null,
+    );
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/workspace/api__worktrees/feature-sync/.kanvibe/task-state.json",
+      expect.stringContaining('"taskId": "task-1"'),
+      null,
+    );
+  });
+
+  it(".kanvibe task 상태 파일 저장이 실패해도 hook 상태 변경 응답과 broadcast는 계속 진행한다", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
+      const task = {
+        id: "task-1",
+        title: "Fix sync",
+        description: null,
+        branchName: "feature-sync",
+        projectId: "project-1",
+        project: { id: "project-1", name: "kanvibe" },
+        status: TaskStatus.PROGRESS,
+        sessionType: null,
+        sessionName: null,
+        worktreePath: "/workspace/api__worktrees/feature-sync",
+        sshHost: null,
+      };
+      mocks.taskRepo.findOne.mockResolvedValue(task);
+      mocks.taskRepo.save.mockImplementation(async (value) => value);
+      mocks.writeTextFile.mockRejectedValueOnce(new Error("state write failed"));
+
+      const result = await updateHookTaskStatus({ taskId: task.id, status: TaskStatus.REVIEW });
+
+      expect(result).toEqual({
+        success: true,
+        data: {
+          id: task.id,
+          status: TaskStatus.REVIEW,
+          branchName: task.branchName,
+          projectName: "kanvibe",
+        },
+      });
+      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+      expect(mocks.broadcastTaskStatusChanged).toHaveBeenCalledWith(expect.objectContaining({
+        taskId: task.id,
+        newStatus: TaskStatus.REVIEW,
+      }));
+      expect(consoleError).toHaveBeenCalledWith(".kanvibe task 상태 저장 실패:", expect.objectContaining({
+        repoPath: "/workspace/api__worktrees/feature-sync",
+        taskId: task.id,
+        status: TaskStatus.REVIEW,
+      }));
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("task 식별자가 없으면 400을 반환한다", async () => {
     const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
     const result = await updateHookTaskStatus({
@@ -160,6 +244,27 @@ describe("hookService.startHookTask", () => {
     vi.clearAllMocks();
     mocks.taskRepo.create.mockImplementation((value) => value);
     mocks.installTaskHooksImmediately.mockResolvedValue(undefined);
+  });
+
+  it("새 hook task는 기존 .kanvibe 상태가 없으면 todo로 생성한다", async () => {
+    mocks.taskRepo.save.mockImplementation(async (value) => ({ id: "task-1", ...value }));
+
+    const { startHookTask } = await import("@/desktop/main/services/hookService");
+
+    const result = await startHookTask({ title: "new hook task" });
+
+    expect(mocks.taskRepo.create).toHaveBeenCalledWith(expect.objectContaining({
+      title: "new hook task",
+      status: TaskStatus.TODO,
+    }));
+    expect(result).toEqual({
+      success: true,
+      data: {
+        id: "task-1",
+        status: TaskStatus.TODO,
+        sessionName: undefined,
+      },
+    });
   });
 
   it("원격 worktree task를 만들면 hooks 설치와 검증 완료를 기다린 뒤 응답한다", async () => {
@@ -211,13 +316,23 @@ describe("hookService.startHookTask", () => {
     resolveInstall();
     const result = await resultPromise;
 
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/remote/repo__worktrees/feature-task/.kanvibe/task-state.json",
+      expect.stringContaining('"status": "todo"'),
+      "remote-host",
+    );
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/remote/repo__worktrees/feature-task/.kanvibe/task-state.json",
+      expect.stringContaining('"taskId": "task-1"'),
+      "remote-host",
+    );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
     expect(resolved).toBe(true);
     expect(result).toEqual({
       success: true,
       data: {
         id: "task-1",
-        status: TaskStatus.PROGRESS,
+        status: TaskStatus.TODO,
         sessionName: "feature-task",
       },
     });

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -175,8 +175,8 @@ describe("kanbanService.createTask", () => {
       }),
     );
     expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/workspace/repo-worktrees/task-1/.kanvibe/status.md",
-      "todo\n",
+      "/workspace/repo-worktrees/task-1/.kanvibe/status.json",
+      expect.stringContaining('"status": "todo"'),
       null,
     );
     expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
@@ -501,8 +501,8 @@ describe("kanbanService.createTask", () => {
     );
     expect(mocks.scheduleKanvibeHooksInstall).not.toHaveBeenCalled();
     expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/remote/repo__worktrees/feature-remote/.kanvibe/status.md",
-      "progress\n",
+      "/remote/repo__worktrees/feature-remote/.kanvibe/status.json",
+      expect.stringContaining('"status": "progress"'),
       "remote-host",
     );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
@@ -681,8 +681,8 @@ describe("kanbanService.createTask", () => {
     );
     expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
     expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/remote/repo__worktrees/feature-from-task/.kanvibe/status.md",
-      "progress\n",
+      "/remote/repo__worktrees/feature-from-task/.kanvibe/status.json",
+      expect.stringContaining('"status": "progress"'),
       "remote-host",
     );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
@@ -1032,7 +1032,7 @@ describe("kanbanService.createTask", () => {
       status: "review",
     }));
     expect(mocks.writeTextFile).not.toHaveBeenCalledWith(
-      "/workspace/repo/.kanvibe/status.md",
+      "/workspace/repo/.kanvibe/status.json",
       expect.any(String),
       null,
     );

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -175,13 +175,8 @@ describe("kanbanService.createTask", () => {
       }),
     );
     expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/workspace/repo-worktrees/task-1/.kanvibe/task-state.json",
-      expect.stringContaining('"status": "todo"'),
-      null,
-    );
-    expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/workspace/repo-worktrees/task-1/.kanvibe/task-state.json",
-      expect.stringContaining('"taskId": "task-1"'),
+      "/workspace/repo-worktrees/task-1/.kanvibe/status.md",
+      "todo\n",
       null,
     );
     expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
@@ -506,13 +501,8 @@ describe("kanbanService.createTask", () => {
     );
     expect(mocks.scheduleKanvibeHooksInstall).not.toHaveBeenCalled();
     expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/remote/repo__worktrees/feature-remote/.kanvibe/task-state.json",
-      expect.stringContaining('"status": "progress"'),
-      "remote-host",
-    );
-    expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/remote/repo__worktrees/feature-remote/.kanvibe/task-state.json",
-      expect.stringContaining('"taskId": "task-connect"'),
+      "/remote/repo__worktrees/feature-remote/.kanvibe/status.md",
+      "progress\n",
       "remote-host",
     );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
@@ -691,13 +681,8 @@ describe("kanbanService.createTask", () => {
     );
     expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
     expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/remote/repo__worktrees/feature-from-task/.kanvibe/task-state.json",
-      expect.stringContaining('"status": "progress"'),
-      "remote-host",
-    );
-    expect(mocks.writeTextFile).toHaveBeenCalledWith(
-      "/remote/repo__worktrees/feature-from-task/.kanvibe/task-state.json",
-      expect.stringContaining('"taskId": "task-branch"'),
+      "/remote/repo__worktrees/feature-from-task/.kanvibe/status.md",
+      "progress\n",
       "remote-host",
     );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
@@ -1047,7 +1032,7 @@ describe("kanbanService.createTask", () => {
       status: "review",
     }));
     expect(mocks.writeTextFile).not.toHaveBeenCalledWith(
-      "/workspace/repo/.kanvibe/task-state.json",
+      "/workspace/repo/.kanvibe/status.md",
       expect.any(String),
       null,
     );

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   remoteBranchExists: vi.fn(),
   broadcastTaskHookInstallFailed: vi.fn(),
   broadcastTaskPrMergedDetectedBatch: vi.fn(),
+  writeTextFile: vi.fn(),
 }));
 
 vi.mock("child_process", () => ({
@@ -91,6 +92,10 @@ vi.mock("@/lib/gitOperations", () => ({
   execGit: mocks.execGit,
   pullCurrentBranch: mocks.pullCurrentBranch,
   remoteBranchExists: mocks.remoteBranchExists,
+}));
+
+vi.mock("@/lib/hostFileAccess", () => ({
+  writeTextFile: mocks.writeTextFile,
 }));
 
 function nextMacrotask<T>(value: T): Promise<T> {
@@ -168,6 +173,16 @@ describe("kanbanService.createTask", () => {
         onSuccess: expect.any(Function),
         onFailure: expect.any(Function),
       }),
+    );
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/workspace/repo-worktrees/task-1/.kanvibe/task-state.json",
+      expect.stringContaining('"status": "todo"'),
+      null,
+    );
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/workspace/repo-worktrees/task-1/.kanvibe/task-state.json",
+      expect.stringContaining('"taskId": "task-1"'),
+      null,
     );
     expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
   });
@@ -490,6 +505,16 @@ describe("kanbanService.createTask", () => {
       mocks.createSessionWithoutWorktree.mock.invocationCallOrder[0],
     );
     expect(mocks.scheduleKanvibeHooksInstall).not.toHaveBeenCalled();
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/remote/repo__worktrees/feature-remote/.kanvibe/task-state.json",
+      expect.stringContaining('"status": "progress"'),
+      "remote-host",
+    );
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/remote/repo__worktrees/feature-remote/.kanvibe/task-state.json",
+      expect.stringContaining('"taskId": "task-connect"'),
+      "remote-host",
+    );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
   });
 
@@ -665,6 +690,16 @@ describe("kanbanService.createTask", () => {
       mocks.broadcastBoardUpdate.mock.invocationCallOrder[0],
     );
     expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/remote/repo__worktrees/feature-from-task/.kanvibe/task-state.json",
+      expect.stringContaining('"status": "progress"'),
+      "remote-host",
+    );
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/remote/repo__worktrees/feature-from-task/.kanvibe/task-state.json",
+      expect.stringContaining('"taskId": "task-branch"'),
+      "remote-host",
+    );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
   });
 
@@ -979,6 +1014,43 @@ describe("kanbanService.createTask", () => {
 
     // Then
     expect(mocks.taskRepo.update).toHaveBeenCalledWith("task-a", { status: "review" });
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("worktreePath가 없는 비기본 브랜치 task 상태 변경은 프로젝트 루트 task-state를 덮어쓰지 않는다", async () => {
+    // Given
+    const task = {
+      id: "task-feature-no-worktree",
+      status: "todo",
+      projectId: "project-1",
+      branchName: "feature/without-worktree",
+      worktreePath: null,
+      sshHost: null,
+    };
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.taskRepo.save.mockImplementation(async (value) => value);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+
+    const { updateTaskStatus } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await updateTaskStatus("task-feature-no-worktree", "review" as never);
+
+    // Then
+    expect(result).toEqual(expect.objectContaining({
+      id: "task-feature-no-worktree",
+      status: "review",
+    }));
+    expect(mocks.writeTextFile).not.toHaveBeenCalledWith(
+      "/workspace/repo/.kanvibe/task-state.json",
+      expect.any(String),
+      null,
+    );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
   });
 

--- a/src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts
+++ b/src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const entityMocks = vi.hoisted(() => ({
+  TaskStatus: {
+    TODO: "todo",
+    PROGRESS: "progress",
+    PENDING: "pending",
+    REVIEW: "review",
+    DONE: "done",
+  },
+}));
+
+const mocks = vi.hoisted(() => ({
+  projectRepo: {
+    findOneBy: vi.fn(),
+  },
+  getProjectRepository: vi.fn(),
+  readKanvibeTaskState: vi.fn(),
+  writeKanvibeTaskState: vi.fn(),
+}));
+
+vi.mock("@/entities/KanbanTask", () => entityMocks);
+
+vi.mock("@/lib/database", () => ({
+  getProjectRepository: mocks.getProjectRepository,
+}));
+
+vi.mock("@/lib/kanvibeProjectState", () => ({
+  readKanvibeTaskState: mocks.readKanvibeTaskState,
+  writeKanvibeTaskState: mocks.writeKanvibeTaskState,
+}));
+
+const TaskStatus = entityMocks.TaskStatus as unknown as typeof import("@/entities/KanbanTask").TaskStatus;
+
+describe("kanvibeTaskStateService", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.getProjectRepository.mockReset();
+    mocks.projectRepo.findOneBy.mockReset();
+    mocks.readKanvibeTaskState.mockReset();
+    mocks.writeKanvibeTaskState.mockReset();
+    mocks.getProjectRepository.mockResolvedValue(mocks.projectRepo);
+  });
+
+  it("path 기반 task 상태 저장은 누락된 path를 무시한다", async () => {
+    const { persistTaskStateAtPath } = await import("@/desktop/main/services/kanvibeTaskStateService");
+
+    await persistTaskStateAtPath(null, { id: "task-1", status: TaskStatus.PROGRESS }, "ssh-host");
+
+    expect(mocks.writeKanvibeTaskState).not.toHaveBeenCalled();
+  });
+
+  it("path 기반 task 상태 저장은 실패해도 호출자 흐름을 막지 않는다", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.writeKanvibeTaskState.mockRejectedValue(new Error("disk full"));
+    const { persistTaskStateAtPath } = await import("@/desktop/main/services/kanvibeTaskStateService");
+
+    await expect(persistTaskStateAtPath(
+      "/workspace/repo",
+      { id: "task-1", status: TaskStatus.REVIEW },
+      "ssh-host",
+    )).resolves.toBeUndefined();
+
+    expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
+      "/workspace/repo",
+      { taskId: "task-1", status: TaskStatus.REVIEW },
+      "ssh-host",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      ".kanvibe task 상태 저장 실패:",
+      expect.objectContaining({
+        targetPath: "/workspace/repo",
+        taskId: "task-1",
+        status: TaskStatus.REVIEW,
+        sshHost: "ssh-host",
+        error: "disk full",
+      }),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("task worktreePath가 있으면 project 조회 없이 해당 path에 상태를 저장한다", async () => {
+    const { persistTaskStateForTask } = await import("@/desktop/main/services/kanvibeTaskStateService");
+
+    await persistTaskStateForTask({
+      id: "task-1",
+      status: TaskStatus.PENDING,
+      worktreePath: "/workspace/repo__worktrees/task-1",
+      sshHost: "ssh-host",
+      projectId: "project-1",
+      branchName: "feature/sync",
+    });
+
+    expect(mocks.getProjectRepository).not.toHaveBeenCalled();
+    expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
+      "/workspace/repo__worktrees/task-1",
+      { taskId: "task-1", status: TaskStatus.PENDING },
+      "ssh-host",
+    );
+  });
+
+  it("worktreePath가 없는 default branch task는 project root에 상태를 저장한다", async () => {
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: "project-ssh",
+    });
+    const { persistTaskStateForTask } = await import("@/desktop/main/services/kanvibeTaskStateService");
+
+    await persistTaskStateForTask({
+      id: "task-main",
+      status: TaskStatus.TODO,
+      worktreePath: null,
+      sshHost: null,
+      projectId: "project-1",
+      branchName: "main",
+    });
+
+    expect(mocks.projectRepo.findOneBy).toHaveBeenCalledWith({ id: "project-1" });
+    expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
+      "/workspace/repo",
+      { taskId: "task-main", status: TaskStatus.TODO },
+      "project-ssh",
+    );
+  });
+
+  it("worktreePath 없는 non-default branch task는 상태 파일을 쓰지 않는다", async () => {
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+    const { persistTaskStateForTask } = await import("@/desktop/main/services/kanvibeTaskStateService");
+
+    await persistTaskStateForTask({
+      id: "task-feature",
+      status: TaskStatus.PROGRESS,
+      worktreePath: null,
+      sshHost: null,
+      projectId: "project-1",
+      branchName: "feature/sync",
+    });
+
+    expect(mocks.projectRepo.findOneBy).toHaveBeenCalledWith({ id: "project-1" });
+    expect(mocks.writeKanvibeTaskState).not.toHaveBeenCalled();
+  });
+
+  it("저장된 task 상태만 읽어 반환한다", async () => {
+    mocks.readKanvibeTaskState.mockResolvedValue({
+      version: 1,
+      taskId: "task-1",
+      status: TaskStatus.DONE,
+      updatedAt: "2026-06-03T00:00:00.000Z",
+    });
+    const { readPersistedTaskStatusAtPath } = await import("@/desktop/main/services/kanvibeTaskStateService");
+
+    const status = await readPersistedTaskStatusAtPath("/workspace/repo", "ssh-host");
+
+    expect(status).toBe(TaskStatus.DONE);
+    expect(mocks.readKanvibeTaskState).toHaveBeenCalledWith("/workspace/repo", "ssh-host");
+  });
+});

--- a/src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts
+++ b/src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts
@@ -64,7 +64,7 @@ describe("kanvibeTaskStateService", () => {
 
     expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
       "/workspace/repo",
-      { taskId: "task-1", status: TaskStatus.REVIEW },
+      { status: TaskStatus.REVIEW },
       "ssh-host",
     );
     expect(consoleError).toHaveBeenCalledWith(
@@ -95,7 +95,7 @@ describe("kanvibeTaskStateService", () => {
     expect(mocks.getProjectRepository).not.toHaveBeenCalled();
     expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
       "/workspace/repo__worktrees/task-1",
-      { taskId: "task-1", status: TaskStatus.PENDING },
+      { status: TaskStatus.PENDING },
       "ssh-host",
     );
   });
@@ -121,7 +121,7 @@ describe("kanvibeTaskStateService", () => {
     expect(mocks.projectRepo.findOneBy).toHaveBeenCalledWith({ id: "project-1" });
     expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
       "/workspace/repo",
-      { taskId: "task-main", status: TaskStatus.TODO },
+      { status: TaskStatus.TODO },
       "project-ssh",
     );
   });
@@ -150,8 +150,7 @@ describe("kanvibeTaskStateService", () => {
 
   it("저장된 task 상태만 읽어 반환한다", async () => {
     mocks.readKanvibeTaskState.mockResolvedValue({
-      version: 1,
-      taskId: "task-1",
+      schemaVersion: 1,
       status: TaskStatus.DONE,
       updatedAt: "2026-06-03T00:00:00.000Z",
     });

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -1590,7 +1590,7 @@ describe("projectService local hook installation", () => {
     ]);
     mocks.formatSessionName.mockReturnValue("api-feature-review");
     mocks.isSessionAlive.mockResolvedValue(false);
-    mocks.readTextFile.mockResolvedValue(JSON.stringify({ version: 1, status: "review", taskId: "other-client-task" }));
+    mocks.readTextFile.mockResolvedValue(JSON.stringify({ schemaVersion: 1, status: "review", updatedAt: "2026-06-03T00:00:00.000Z" }));
 
     mocks.getProjectRepository.mockResolvedValue({
       find: vi.fn().mockResolvedValue([
@@ -1629,7 +1629,7 @@ describe("projectService local hook installation", () => {
     await syncRegisteredProjectWorktrees();
 
     expect(mocks.readTextFile).toHaveBeenCalledWith(
-      "/workspace/api__worktrees/feature-review/.kanvibe/status.md",
+      "/workspace/api__worktrees/feature-review/.kanvibe/status.json",
       null,
     );
     expect(taskSave).toHaveBeenCalledWith(expect.objectContaining({
@@ -1650,7 +1650,7 @@ describe("projectService local hook installation", () => {
         isBare: false,
       },
     ]);
-    mocks.readTextFile.mockResolvedValue(JSON.stringify({ version: 1, status: "pending" }));
+    mocks.readTextFile.mockResolvedValue(JSON.stringify({ schemaVersion: 1, status: "pending" }));
 
     const existingTask = {
       id: "task-worktree",
@@ -1718,7 +1718,7 @@ describe("projectService local hook installation", () => {
         isBare: false,
       },
     ]);
-    mocks.readTextFile.mockResolvedValue(JSON.stringify({ version: 1, status: "review", taskId: "other-client-task" }));
+    mocks.readTextFile.mockResolvedValue(JSON.stringify({ schemaVersion: 1, status: "review", updatedAt: "2026-06-03T00:00:00.000Z" }));
     mocks.createSessionWithoutWorktree.mockResolvedValue({ sessionName: "api-main" });
     mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
     mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
@@ -1769,7 +1769,7 @@ describe("projectService local hook installation", () => {
       },
     ]);
     mocks.readTextFile.mockImplementation(async (filePath: string) => (
-      filePath.includes("feature-orphan") ? JSON.stringify({ version: 1, status: "done" }) : ""
+      filePath.includes("feature-orphan") ? JSON.stringify({ schemaVersion: 1, status: "done" }) : ""
     ));
     mocks.formatSessionName.mockReturnValue("api-feature-orphan");
     mocks.isSessionAlive.mockResolvedValue(false);
@@ -1837,7 +1837,7 @@ describe("projectService local hook installation", () => {
 
   it("등록된 프로젝트 background sync는 메인 브랜치 세션 연결 시 .kanvibe 상태를 보존한다", async () => {
     mocks.listWorktrees.mockResolvedValue([]);
-    mocks.readTextFile.mockResolvedValue(JSON.stringify({ version: 1, status: "progress" }));
+    mocks.readTextFile.mockResolvedValue(JSON.stringify({ schemaVersion: 1, status: "progress" }));
     mocks.formatSessionName.mockReturnValue("api-main");
     mocks.isSessionAlive.mockResolvedValue(true);
 

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -30,6 +30,9 @@ const mocks = vi.hoisted(() => ({
   installKanvibeHookProvider: vi.fn(),
   scheduleKanvibeHooksInstall: vi.fn(),
   broadcastBoardUpdate: vi.fn(),
+  readTextFile: vi.fn(),
+  writeTextFile: vi.fn(),
+  quoteShellArgument: vi.fn((value: string) => `'${value}'`),
 }));
 
 vi.mock("@/lib/database", () => ({
@@ -135,6 +138,12 @@ vi.mock("@/lib/kanvibeHooksInstaller", () => ({
   installKanvibeHooks: mocks.installKanvibeHooks,
   installKanvibeHookProvider: mocks.installKanvibeHookProvider,
   scheduleKanvibeHooksInstall: mocks.scheduleKanvibeHooksInstall,
+}));
+
+vi.mock("@/lib/hostFileAccess", () => ({
+  readTextFile: mocks.readTextFile,
+  writeTextFile: mocks.writeTextFile,
+  quoteShellArgument: mocks.quoteShellArgument,
 }));
 
 describe("projectService.deleteProject", () => {
@@ -1506,6 +1515,376 @@ describe("projectService local hook installation", () => {
       "task-worktree",
       null,
     );
+  });
+
+  it("등록된 프로젝트 background sync는 활성 세션이 있어도 .kanvibe 상태가 없으면 새 worktree를 TODO task로 등록한다", async () => {
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.listWorktrees.mockResolvedValue([
+      {
+        path: "/workspace/api__worktrees/feature-active",
+        branch: "feature-active",
+        isBare: false,
+      },
+    ]);
+    mocks.formatSessionName.mockReturnValue("api-feature-active");
+    mocks.isSessionAlive.mockResolvedValue(true);
+    mocks.readTextFile.mockResolvedValue("");
+
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          id: "project-1",
+          name: "api",
+          repoPath: "/workspace/api",
+          defaultBranch: "main",
+          sshHost: null,
+        },
+      ]),
+    });
+
+    const taskSave = vi.fn(async (value) => ({ id: value.branchName === "main" ? "task-main" : "task-worktree", ...value }));
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => {
+        if (criteria.projectId === "project-1" && criteria.branchName === "main") {
+          return {
+            id: "task-main",
+            branchName: "main",
+            projectId: "project-1",
+            baseBranch: "main",
+            worktreePath: "/workspace/api",
+            sshHost: null,
+          };
+        }
+
+        return null;
+      }),
+      create: vi.fn((value) => value),
+      save: taskSave,
+    });
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+    await syncRegisteredProjectWorktrees();
+
+    expect(taskSave).toHaveBeenCalledWith(expect.objectContaining({
+      branchName: "feature-active",
+      status: "todo",
+      sessionName: "api-feature-active",
+    }));
+  });
+
+  it("등록된 프로젝트 background sync는 .kanvibe task 상태가 있으면 그 상태로 새 worktree를 등록한다", async () => {
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.listWorktrees.mockResolvedValue([
+      {
+        path: "/workspace/api__worktrees/feature-review",
+        branch: "feature-review",
+        isBare: false,
+      },
+    ]);
+    mocks.formatSessionName.mockReturnValue("api-feature-review");
+    mocks.isSessionAlive.mockResolvedValue(false);
+    mocks.readTextFile.mockResolvedValue(JSON.stringify({ version: 1, status: "review", taskId: "other-client-task" }));
+
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          id: "project-1",
+          name: "api",
+          repoPath: "/workspace/api",
+          defaultBranch: "main",
+          sshHost: null,
+        },
+      ]),
+    });
+
+    const taskSave = vi.fn(async (value) => ({ id: value.branchName === "main" ? "task-main" : "task-worktree", ...value }));
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => {
+        if (criteria.projectId === "project-1" && criteria.branchName === "main") {
+          return {
+            id: "task-main",
+            branchName: "main",
+            projectId: "project-1",
+            baseBranch: "main",
+            worktreePath: "/workspace/api",
+            sshHost: null,
+          };
+        }
+
+        return null;
+      }),
+      create: vi.fn((value) => value),
+      save: taskSave,
+    });
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+    await syncRegisteredProjectWorktrees();
+
+    expect(mocks.readTextFile).toHaveBeenCalledWith(
+      "/workspace/api__worktrees/feature-review/.kanvibe/task-state.json",
+      null,
+    );
+    expect(taskSave).toHaveBeenCalledWith(expect.objectContaining({
+      branchName: "feature-review",
+      status: "review",
+    }));
+  });
+
+  it("등록된 프로젝트 background sync는 기존 worktree task도 .kanvibe task 상태대로 갱신한다", async () => {
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.listWorktrees.mockResolvedValue([
+      {
+        path: "/workspace/api__worktrees/feature-pending",
+        branch: "feature-pending",
+        isBare: false,
+      },
+    ]);
+    mocks.readTextFile.mockResolvedValue(JSON.stringify({ version: 1, status: "pending" }));
+
+    const existingTask = {
+      id: "task-worktree",
+      branchName: "feature-pending",
+      projectId: "project-1",
+      baseBranch: "main",
+      worktreePath: "/workspace/api__worktrees/feature-pending",
+      sshHost: null,
+      status: "todo",
+    };
+
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          id: "project-1",
+          name: "api",
+          repoPath: "/workspace/api",
+          defaultBranch: "main",
+          sshHost: null,
+        },
+      ]),
+    });
+
+    const taskSave = vi.fn(async (value) => value);
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => {
+        if (criteria.projectId === "project-1" && criteria.branchName === "main") {
+          return {
+            id: "task-main",
+            branchName: "main",
+            projectId: "project-1",
+            baseBranch: "main",
+            worktreePath: "/workspace/api",
+            sshHost: null,
+          };
+        }
+
+        if (criteria.projectId === "project-1" && criteria.branchName === "feature-pending") {
+          return existingTask;
+        }
+
+        return null;
+      }),
+      create: vi.fn((value) => value),
+      save: taskSave,
+    });
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+    await syncRegisteredProjectWorktrees();
+
+    expect(taskSave).toHaveBeenCalledWith(expect.objectContaining({
+      id: "task-worktree",
+      status: "pending",
+    }));
+  });
+
+  it("프로젝트 등록은 기본 브랜치 worktree의 .kanvibe 상태를 tmux 연결 후에도 유지한다", async () => {
+    mocks.validateGitRepo.mockResolvedValue(true);
+    mocks.getDefaultBranch.mockResolvedValue("main");
+    mocks.listWorktrees.mockResolvedValue([
+      {
+        path: "/workspace/api",
+        branch: "main",
+        isBare: false,
+      },
+    ]);
+    mocks.readTextFile.mockResolvedValue(JSON.stringify({ version: 1, status: "review", taskId: "other-client-task" }));
+    mocks.createSessionWithoutWorktree.mockResolvedValue({ sessionName: "api-main" });
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: true });
+
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([]),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => ({ id: "project-1", ...value })),
+      remove: vi.fn(),
+    });
+    const taskSave = vi.fn(async (value) => ({ id: "task-main", ...value }));
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn().mockResolvedValue(null),
+      create: vi.fn((value) => value),
+      save: taskSave,
+    });
+
+    const { registerProject } = await import("@/desktop/main/services/projectService");
+
+    await expect(registerProject("api", "/workspace/api")).resolves.toMatchObject({ success: true });
+
+    expect(mocks.createSessionWithoutWorktree).toHaveBeenCalledWith(
+      "/workspace/api",
+      "main",
+      "tmux",
+      null,
+      "/workspace/api",
+    );
+    expect(taskSave).toHaveBeenCalledWith(expect.objectContaining({
+      branchName: "main",
+      sessionName: "api-main",
+      status: "review",
+    }));
+  });
+
+  it("등록된 프로젝트 background sync는 orphan worktree task도 .kanvibe 상태대로 연결한다", async () => {
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.listWorktrees.mockResolvedValue([
+      {
+        path: "/workspace/api__worktrees/feature-orphan",
+        branch: "feature-orphan",
+        isBare: false,
+      },
+    ]);
+    mocks.readTextFile.mockImplementation(async (filePath: string) => (
+      filePath.includes("feature-orphan") ? JSON.stringify({ version: 1, status: "done" }) : ""
+    ));
+    mocks.formatSessionName.mockReturnValue("api-feature-orphan");
+    mocks.isSessionAlive.mockResolvedValue(false);
+
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          id: "project-1",
+          name: "api",
+          repoPath: "/workspace/api",
+          defaultBranch: "main",
+          sshHost: null,
+        },
+      ]),
+    });
+
+    const orphanTask = {
+      id: "orphan-task",
+      branchName: "feature-orphan",
+      projectId: null,
+      worktreePath: "/workspace/api__worktrees/feature-orphan",
+      sshHost: null,
+      status: "todo",
+    };
+    const taskSave = vi.fn(async (value) => value);
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => {
+        if (criteria.projectId === "project-1" && criteria.branchName === "main") {
+          return {
+            id: "task-main",
+            branchName: "main",
+            projectId: "project-1",
+            baseBranch: "main",
+            worktreePath: "/workspace/api",
+            sshHost: null,
+          };
+        }
+
+        if (criteria.projectId === "project-1" && criteria.branchName === "feature-orphan") {
+          return null;
+        }
+
+        if ((criteria.projectId === null || criteria.projectId === undefined) && criteria.branchName === "feature-orphan") {
+          return orphanTask;
+        }
+
+        return null;
+      }),
+      create: vi.fn((value) => value),
+      save: taskSave,
+    });
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+    const result = await syncRegisteredProjectWorktrees();
+
+    expect(result.worktreeTasks).toContain("feature-orphan");
+    expect(taskSave).toHaveBeenCalledWith(expect.objectContaining({
+      id: "orphan-task",
+      projectId: "project-1",
+      baseBranch: "main",
+      status: "done",
+    }));
+  });
+
+  it("등록된 프로젝트 background sync는 메인 브랜치 세션 연결 시 .kanvibe 상태를 보존한다", async () => {
+    mocks.listWorktrees.mockResolvedValue([]);
+    mocks.readTextFile.mockResolvedValue(JSON.stringify({ version: 1, status: "progress" }));
+    mocks.formatSessionName.mockReturnValue("api-main");
+    mocks.isSessionAlive.mockResolvedValue(true);
+
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          id: "project-1",
+          name: "api",
+          repoPath: "/workspace/api",
+          defaultBranch: "main",
+          sshHost: null,
+        },
+      ]),
+    });
+
+    const mainBranchTask = {
+      id: "task-main",
+      branchName: "main",
+      projectId: "project-1",
+      baseBranch: "main",
+      worktreePath: null,
+      sshHost: null,
+      status: "todo",
+    };
+    const taskSave = vi.fn(async (value) => value);
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => {
+        if (criteria.projectId === "project-1" && criteria.branchName === "main") {
+          return mainBranchTask;
+        }
+
+        return null;
+      }),
+      create: vi.fn((value) => value),
+      save: taskSave,
+    });
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+    await syncRegisteredProjectWorktrees();
+
+    expect(taskSave).toHaveBeenCalledWith(expect.objectContaining({
+      id: "task-main",
+      sessionType: "tmux",
+      sessionName: "api-main",
+      status: "progress",
+    }));
   });
 
   it("원격 등록 프로젝트의 새 worktree hooks 설치는 백그라운드로 예약한다", async () => {

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -1629,7 +1629,7 @@ describe("projectService local hook installation", () => {
     await syncRegisteredProjectWorktrees();
 
     expect(mocks.readTextFile).toHaveBeenCalledWith(
-      "/workspace/api__worktrees/feature-review/.kanvibe/task-state.json",
+      "/workspace/api__worktrees/feature-review/.kanvibe/status.md",
       null,
     );
     expect(taskSave).toHaveBeenCalledWith(expect.objectContaining({

--- a/src/desktop/main/services/hookService.ts
+++ b/src/desktop/main/services/hookService.ts
@@ -8,6 +8,7 @@ import {
   scheduleDoneCleanupWithRollback,
   type DoneCleanupPlan,
 } from "@/desktop/main/services/kanbanService";
+import { writeKanvibeTaskState } from "@/lib/kanvibeProjectState";
 
 const STATUS_MAP: Record<string, TaskStatus> = {
   todo: TaskStatus.TODO,
@@ -16,6 +17,29 @@ const STATUS_MAP: Record<string, TaskStatus> = {
   review: TaskStatus.REVIEW,
   done: TaskStatus.DONE,
 };
+
+async function persistHookTaskState(
+  repoPath: string | null | undefined,
+  taskId: string,
+  status: TaskStatus,
+  sshHost?: string | null,
+): Promise<void> {
+  if (!repoPath) {
+    return;
+  }
+
+  try {
+    await writeKanvibeTaskState(repoPath, { taskId, status }, sshHost);
+  } catch (error) {
+    console.error(".kanvibe task 상태 저장 실패:", {
+      repoPath,
+      taskId,
+      status,
+      sshHost: sshHost ?? null,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
 
 export interface HookStartInput {
   title: string;
@@ -46,7 +70,7 @@ export async function startHookTask(input: HookStartInput) {
     sshHost: input.sshHost || null,
     projectId: input.projectId || null,
     baseBranch: input.baseBranch || null,
-    status: TaskStatus.PROGRESS,
+    status: TaskStatus.TODO,
   });
 
   if (input.branchName && input.sessionType && input.projectId) {
@@ -86,6 +110,7 @@ export async function startHookTask(input: HookStartInput) {
       },
       "새 태스크 hooks 동기 설치 실패",
     );
+    await persistHookTaskState(saved.worktreePath, saved.id, saved.status, saved.sshHost);
   }
 
   broadcastBoardUpdate();
@@ -139,6 +164,8 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
   }
 
   const projectName = task.project?.name || task.projectId || "Unknown project";
+  const taskStatePath = task.worktreePath || task.project?.repoPath || null;
+  const taskStateSshHost = task.sshHost || task.project?.sshHost || null;
   let doneCleanupPlan: DoneCleanupPlan | null = null;
 
   if (taskStatus === TaskStatus.DONE) {
@@ -148,6 +175,10 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
   }
 
   const saved = await taskRepo.save(task);
+
+  if (taskStatePath) {
+    await persistHookTaskState(taskStatePath, saved.id, taskStatus, taskStateSshHost);
+  }
 
   broadcastBoardUpdate();
   broadcastTaskStatusChanged({

--- a/src/desktop/main/services/hookService.ts
+++ b/src/desktop/main/services/hookService.ts
@@ -8,7 +8,7 @@ import {
   scheduleDoneCleanupWithRollback,
   type DoneCleanupPlan,
 } from "@/desktop/main/services/kanbanService";
-import { writeKanvibeTaskState } from "@/lib/kanvibeProjectState";
+import { persistTaskStateAtPath as persistHookTaskState } from "@/desktop/main/services/kanvibeTaskStateService";
 
 const STATUS_MAP: Record<string, TaskStatus> = {
   todo: TaskStatus.TODO,
@@ -17,29 +17,6 @@ const STATUS_MAP: Record<string, TaskStatus> = {
   review: TaskStatus.REVIEW,
   done: TaskStatus.DONE,
 };
-
-async function persistHookTaskState(
-  repoPath: string | null | undefined,
-  taskId: string,
-  status: TaskStatus,
-  sshHost?: string | null,
-): Promise<void> {
-  if (!repoPath) {
-    return;
-  }
-
-  try {
-    await writeKanvibeTaskState(repoPath, { taskId, status }, sshHost);
-  } catch (error) {
-    console.error(".kanvibe task 상태 저장 실패:", {
-      repoPath,
-      taskId,
-      status,
-      sshHost: sshHost ?? null,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-}
 
 export interface HookStartInput {
   title: string;
@@ -110,7 +87,7 @@ export async function startHookTask(input: HookStartInput) {
       },
       "새 태스크 hooks 동기 설치 실패",
     );
-    await persistHookTaskState(saved.worktreePath, saved.id, saved.status, saved.sshHost);
+    await persistHookTaskState(saved.worktreePath, { id: saved.id, status: saved.status }, saved.sshHost);
   }
 
   broadcastBoardUpdate();
@@ -177,7 +154,7 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
   const saved = await taskRepo.save(task);
 
   if (taskStatePath) {
-    await persistHookTaskState(taskStatePath, saved.id, taskStatus, taskStateSshHost);
+    await persistHookTaskState(taskStatePath, { id: saved.id, status: taskStatus }, taskStateSshHost);
   }
 
   broadcastBoardUpdate();

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -19,7 +19,7 @@ import {
 } from "@/lib/kanvibeHooksInstaller";
 import { execGit, pullCurrentBranch, remoteBranchExists } from "@/lib/gitOperations";
 import { detachSession } from "@/lib/terminal";
-import { writeKanvibeTaskState } from "@/lib/kanvibeProjectState";
+import { persistTaskStateForTask as persistTaskState } from "@/desktop/main/services/kanvibeTaskStateService";
 
 export type TasksByStatus = Record<TaskStatus, KanbanTask[]>;
 
@@ -123,46 +123,6 @@ function isMissingGitHubCli(error: unknown): boolean {
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-async function persistTaskState(
-  task: Pick<KanbanTask, "id" | "status" | "worktreePath" | "sshHost"> & {
-    projectId?: string | null;
-    branchName?: string | null;
-  },
-): Promise<void> {
-  let project: { repoPath: string; defaultBranch: string; sshHost?: string | null } | null = null;
-
-  if (task.projectId && !task.worktreePath) {
-    const projectRepo = await getProjectRepository();
-    project = await projectRepo.findOneBy({ id: task.projectId });
-  }
-
-  const canUseProjectRoot = Boolean(
-    project
-      && task.branchName
-      && task.branchName === project.defaultBranch,
-  );
-  const targetPath = task.worktreePath || (canUseProjectRoot ? project?.repoPath : null);
-  if (!targetPath) {
-    return;
-  }
-
-  try {
-    await writeKanvibeTaskState(
-      targetPath,
-      { taskId: task.id, status: task.status },
-      task.sshHost || (canUseProjectRoot ? project?.sshHost : null) || null,
-    );
-  } catch (error) {
-    console.error(".kanvibe task 상태 저장 실패:", {
-      taskId: task.id,
-      status: task.status,
-      targetPath,
-      sshHost: task.sshHost || (canUseProjectRoot ? project?.sshHost : null) || null,
-      error: getErrorMessage(error),
-    });
-  }
 }
 
 function buildPullRequestSyncFailure(

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/kanvibeHooksInstaller";
 import { execGit, pullCurrentBranch, remoteBranchExists } from "@/lib/gitOperations";
 import { detachSession } from "@/lib/terminal";
+import { writeKanvibeTaskState } from "@/lib/kanvibeProjectState";
 
 export type TasksByStatus = Record<TaskStatus, KanbanTask[]>;
 
@@ -69,6 +70,8 @@ interface DoneRollbackSnapshot {
   sessionName: string | null;
   worktreePath: string | null;
   sshHost: string | null;
+  projectId: string | null;
+  branchName: string | null;
 }
 
 export interface DoneCleanupPlan {
@@ -120,6 +123,46 @@ function isMissingGitHubCli(error: unknown): boolean {
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+async function persistTaskState(
+  task: Pick<KanbanTask, "id" | "status" | "worktreePath" | "sshHost"> & {
+    projectId?: string | null;
+    branchName?: string | null;
+  },
+): Promise<void> {
+  let project: { repoPath: string; defaultBranch: string; sshHost?: string | null } | null = null;
+
+  if (task.projectId && !task.worktreePath) {
+    const projectRepo = await getProjectRepository();
+    project = await projectRepo.findOneBy({ id: task.projectId });
+  }
+
+  const canUseProjectRoot = Boolean(
+    project
+      && task.branchName
+      && task.branchName === project.defaultBranch,
+  );
+  const targetPath = task.worktreePath || (canUseProjectRoot ? project?.repoPath : null);
+  if (!targetPath) {
+    return;
+  }
+
+  try {
+    await writeKanvibeTaskState(
+      targetPath,
+      { taskId: task.id, status: task.status },
+      task.sshHost || (canUseProjectRoot ? project?.sshHost : null) || null,
+    );
+  } catch (error) {
+    console.error(".kanvibe task 상태 저장 실패:", {
+      taskId: task.id,
+      status: task.status,
+      targetPath,
+      sshHost: task.sshHost || (canUseProjectRoot ? project?.sshHost : null) || null,
+      error: getErrorMessage(error),
+    });
+  }
 }
 
 function buildPullRequestSyncFailure(
@@ -252,6 +295,8 @@ export function prepareOptimisticDoneTransition(
     sessionName: task.sessionName,
     worktreePath: task.worktreePath,
     sshHost: task.sshHost,
+    projectId: task.projectId,
+    branchName: task.branchName,
   };
 
   task.status = TaskStatus.DONE;
@@ -296,6 +341,7 @@ async function rollbackDoneTransition(
       worktreePath: snapshot.worktreePath,
       sshHost: snapshot.sshHost,
     });
+    await persistTaskState(snapshot);
     broadcastBoardUpdate();
   } catch (rollbackError) {
     console.error("Done 상태 롤백 실패:", rollbackError);
@@ -651,6 +697,8 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
     );
   }
 
+  await persistTaskState(saved);
+
   broadcastBoardUpdate();
 
   return serialize(saved);
@@ -668,6 +716,7 @@ export async function updateTaskStatus(
   if (newStatus === TaskStatus.DONE) {
     const doneCleanupPlan = prepareOptimisticDoneTransition(task);
     const saved = await repo.save(task);
+    await persistTaskState({ ...doneCleanupPlan.cleanupTask, status: TaskStatus.DONE });
     broadcastBoardUpdate();
     scheduleDoneCleanupWithRollback(doneCleanupPlan);
     return serialize(saved);
@@ -675,6 +724,7 @@ export async function updateTaskStatus(
 
   task.status = newStatus;
   const saved = await repo.save(task);
+  await persistTaskState(saved);
   broadcastBoardUpdate();
   return serialize(saved);
 }
@@ -882,6 +932,7 @@ export async function branchFromTask(
     );
   }
 
+  await persistTaskState(saved);
   broadcastBoardUpdate();
   return serialize(saved);
 }
@@ -929,6 +980,7 @@ export async function connectTerminalSession(
     task.status = TaskStatus.PROGRESS;
 
     const saved = await repo.save(task);
+    await persistTaskState(saved);
     broadcastBoardUpdate();
     return serialize(saved);
   } catch (error) {
@@ -962,8 +1014,8 @@ export async function moveTaskToColumn(
   let doneCleanupPlan: DoneCleanupPlan | null = null;
 
   try {
+    const task = await repo.findOneBy({ id: taskId });
     if (newStatus === TaskStatus.DONE) {
-      const task = await repo.findOneBy({ id: taskId });
       if (task) {
         doneCleanupPlan = prepareOptimisticDoneTransition(task);
         await repo.update(taskId, {
@@ -972,9 +1024,13 @@ export async function moveTaskToColumn(
           sessionName: null,
           worktreePath: null,
         });
+        await persistTaskState({ ...doneCleanupPlan.cleanupTask, status: TaskStatus.DONE });
       }
     } else {
       await repo.update(taskId, { status: newStatus });
+      if (task) {
+        await persistTaskState({ ...task, status: newStatus });
+      }
     }
 
     const reorderUpdates = destOrderedIds.map((id, index) =>

--- a/src/desktop/main/services/kanvibeTaskStateService.ts
+++ b/src/desktop/main/services/kanvibeTaskStateService.ts
@@ -40,7 +40,7 @@ export async function persistTaskStateAtPath(
   }
 
   try {
-    await writeKanvibeTaskState(repoPath, { taskId: task.id, status: task.status }, sshHost);
+    await writeKanvibeTaskState(repoPath, { status: task.status }, sshHost);
   } catch (error) {
     console.error(".kanvibe task 상태 저장 실패:", {
       repoPath,

--- a/src/desktop/main/services/kanvibeTaskStateService.ts
+++ b/src/desktop/main/services/kanvibeTaskStateService.ts
@@ -1,0 +1,88 @@
+import type { KanbanTask, TaskStatus } from "@/entities/KanbanTask";
+import { getProjectRepository } from "@/lib/database";
+import { readKanvibeTaskState, writeKanvibeTaskState } from "@/lib/kanvibeProjectState";
+
+type TaskStateTask = Pick<KanbanTask, "id" | "status">;
+
+type TaskWithOptionalLocation = Pick<KanbanTask, "id" | "status" | "worktreePath" | "sshHost"> & {
+  projectId?: string | null;
+  branchName?: string | null;
+};
+
+type ProjectTaskStateLocation = {
+  repoPath: string;
+  defaultBranch: string;
+  sshHost?: string | null;
+};
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function readPersistedTaskStatusAtPath(
+  repoPath: string | null | undefined,
+  sshHost?: string | null,
+): Promise<TaskStatus | null> {
+  if (!repoPath) {
+    return null;
+  }
+
+  return (await readKanvibeTaskState(repoPath, sshHost))?.status ?? null;
+}
+
+export async function persistTaskStateAtPath(
+  repoPath: string | null | undefined,
+  task: TaskStateTask,
+  sshHost?: string | null,
+): Promise<void> {
+  if (!repoPath) {
+    return;
+  }
+
+  try {
+    await writeKanvibeTaskState(repoPath, { taskId: task.id, status: task.status }, sshHost);
+  } catch (error) {
+    console.error(".kanvibe task 상태 저장 실패:", {
+      repoPath,
+      targetPath: repoPath,
+      taskId: task.id,
+      status: task.status,
+      sshHost: sshHost ?? null,
+      error: getErrorMessage(error),
+    });
+  }
+}
+
+export async function persistTaskStateForTask(task: TaskWithOptionalLocation): Promise<void> {
+  const resolvedLocation = await resolveTaskStateLocation(task);
+  await persistTaskStateAtPath(resolvedLocation?.repoPath, task, resolvedLocation?.sshHost ?? null);
+}
+
+async function resolveTaskStateLocation(
+  task: Pick<TaskWithOptionalLocation, "worktreePath" | "sshHost" | "projectId" | "branchName">,
+): Promise<{ repoPath: string; sshHost: string | null } | null> {
+  if (task.worktreePath) {
+    return { repoPath: task.worktreePath, sshHost: task.sshHost ?? null };
+  }
+
+  const project = await resolveProjectRootTaskStateLocation(task);
+  if (!project || !task.branchName || task.branchName !== project.defaultBranch) {
+    return null;
+  }
+
+  return {
+    repoPath: project.repoPath,
+    sshHost: task.sshHost || project.sshHost || null,
+  };
+}
+
+async function resolveProjectRootTaskStateLocation(
+  task: Pick<TaskWithOptionalLocation, "projectId">,
+): Promise<ProjectTaskStateLocation | null> {
+  if (!task.projectId) {
+    return null;
+  }
+
+  const projectRepo = await getProjectRepository();
+  return projectRepo.findOneBy({ id: task.projectId });
+}

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -17,36 +17,13 @@ import { broadcastBoardUpdate } from "@/lib/boardNotifier";
 import { getAvailableHosts as readAvailableHosts } from "@/lib/sshConfig";
 import { getDefaultSessionType } from "@/desktop/main/services/appSettingsService";
 import { installKanvibeHooks, installKanvibeHookProvider, scheduleKanvibeHooksInstall } from "@/lib/kanvibeHooksInstaller";
-import { readKanvibeTaskState, writeKanvibeTaskState } from "@/lib/kanvibeProjectState";
+import {
+  persistTaskStateAtPath as persistTaskState,
+  readPersistedTaskStatusAtPath as readPersistedTaskStatus,
+} from "@/desktop/main/services/kanvibeTaskStateService";
 
 function matchesTaskLocation(task: { worktreePath?: string | null; sshHost?: string | null }, expectedPath: string, sshHost?: string | null): boolean {
   return task.worktreePath === expectedPath && (task.sshHost || null) === (sshHost || null);
-}
-
-async function readPersistedTaskStatus(repoPath: string, sshHost?: string | null): Promise<TaskStatus | null> {
-  return (await readKanvibeTaskState(repoPath, sshHost))?.status ?? null;
-}
-
-async function persistTaskState(
-  repoPath: string | null | undefined,
-  task: Pick<KanbanTask, "id" | "status">,
-  sshHost?: string | null,
-): Promise<void> {
-  if (!repoPath) {
-    return;
-  }
-
-  try {
-    await writeKanvibeTaskState(repoPath, { taskId: task.id, status: task.status }, sshHost);
-  } catch (error) {
-    console.error(".kanvibe task 상태 저장 실패:", {
-      repoPath,
-      taskId: task.id,
-      status: task.status,
-      sshHost: sshHost ?? null,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
 }
 
 function resolveDirectorySearchPath(targetPath: string, sshHost?: string): string {

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -17,9 +17,36 @@ import { broadcastBoardUpdate } from "@/lib/boardNotifier";
 import { getAvailableHosts as readAvailableHosts } from "@/lib/sshConfig";
 import { getDefaultSessionType } from "@/desktop/main/services/appSettingsService";
 import { installKanvibeHooks, installKanvibeHookProvider, scheduleKanvibeHooksInstall } from "@/lib/kanvibeHooksInstaller";
+import { readKanvibeTaskState, writeKanvibeTaskState } from "@/lib/kanvibeProjectState";
 
 function matchesTaskLocation(task: { worktreePath?: string | null; sshHost?: string | null }, expectedPath: string, sshHost?: string | null): boolean {
   return task.worktreePath === expectedPath && (task.sshHost || null) === (sshHost || null);
+}
+
+async function readPersistedTaskStatus(repoPath: string, sshHost?: string | null): Promise<TaskStatus | null> {
+  return (await readKanvibeTaskState(repoPath, sshHost))?.status ?? null;
+}
+
+async function persistTaskState(
+  repoPath: string | null | undefined,
+  task: Pick<KanbanTask, "id" | "status">,
+  sshHost?: string | null,
+): Promise<void> {
+  if (!repoPath) {
+    return;
+  }
+
+  try {
+    await writeKanvibeTaskState(repoPath, { taskId: task.id, status: task.status }, sshHost);
+  } catch (error) {
+    console.error(".kanvibe task 상태 저장 실패:", {
+      repoPath,
+      taskId: task.id,
+      status: task.status,
+      sshHost: sshHost ?? null,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 function resolveDirectorySearchPath(targetPath: string, sshHost?: string): string {
@@ -258,9 +285,13 @@ async function createDefaultBranchTask(project: Project) {
   const taskRepo = await getTaskRepository();
   const defaultSessionType = await getDefaultSessionType();
   const defaultBranchWorktreePath = await resolveProjectDefaultBranchWorktreePath(project);
+  const persistedStatus = await readPersistedTaskStatus(defaultBranchWorktreePath || project.repoPath, project.sshHost);
 
   const existing = await taskRepo.findOneBy({ branchName: project.defaultBranch, projectId: project.id });
-  if (existing) return existing;
+  if (existing) {
+    await persistTaskState(defaultBranchWorktreePath || project.repoPath, existing, project.sshHost);
+    return existing;
+  }
 
   const orphan = await taskRepo.findOneBy({ branchName: project.defaultBranch, projectId: IsNull() });
   if (orphan && matchesTaskLocation(orphan, project.repoPath, project.sshHost)) {
@@ -269,7 +300,10 @@ async function createDefaultBranchTask(project: Project) {
     orphan.worktreePath = project.repoPath;
     orphan.sshHost = project.sshHost;
     orphan.baseBranch = project.defaultBranch;
-    return taskRepo.save(orphan);
+    orphan.status = persistedStatus ?? TaskStatus.TODO;
+    const savedOrphan = await taskRepo.save(orphan);
+    await persistTaskState(defaultBranchWorktreePath || project.repoPath, savedOrphan, project.sshHost);
+    return savedOrphan;
   }
 
   const task = taskRepo.create({
@@ -277,7 +311,7 @@ async function createDefaultBranchTask(project: Project) {
     branchName: project.defaultBranch,
     worktreePath: defaultBranchWorktreePath,
     sshHost: project.sshHost,
-    status: TaskStatus.TODO,
+    status: persistedStatus ?? TaskStatus.TODO,
     projectId: project.id,
     baseBranch: project.defaultBranch,
   });
@@ -295,13 +329,15 @@ async function createDefaultBranchTask(project: Project) {
       task.sessionName = session.sessionName;
       task.worktreePath = defaultBranchWorktreePath;
       task.sshHost = project.sshHost;
-      task.status = TaskStatus.PROGRESS;
+      task.status = persistedStatus ?? TaskStatus.TODO;
     } catch (error) {
       console.error("메인 브랜치 tmux 세션 생성 실패:", error);
     }
   }
 
-  return taskRepo.save(task);
+  const savedTask = await taskRepo.save(task);
+  await persistTaskState(defaultBranchWorktreePath || project.repoPath, savedTask, project.sshHost);
+  return savedTask;
 }
 
 async function getProjectRootTask(projectId: string, defaultBranch: string) {
@@ -352,6 +388,7 @@ async function ensureProjectRootTask(
   }
 
   const expectedDefaultBranchWorktreePath = await resolveProjectDefaultBranchWorktreePath(project);
+  const persistedStatus = await readPersistedTaskStatus(expectedDefaultBranchWorktreePath || project.repoPath, project.sshHost);
 
   let shouldSaveTask = false;
   if (task.baseBranch !== project.defaultBranch) {
@@ -369,10 +406,17 @@ async function ensureProjectRootTask(
     shouldSaveTask = true;
   }
 
+  if (persistedStatus !== null && task.status !== persistedStatus) {
+    task.status = persistedStatus;
+    shouldSaveTask = true;
+  }
+
   if (shouldSaveTask) {
     task = await taskRepo.save(task);
     repaired = true;
   }
+
+  await persistTaskState(expectedDefaultBranchWorktreePath || project.repoPath, task, project.sshHost);
 
   if (!repairHooks) {
     return { task, repaired };
@@ -636,17 +680,25 @@ async function syncProjectWorktrees(
 
       /** 해당 프로젝트에 이미 동일 브랜치 태스크가 있으면 건너뛴다 */
       const existingTask = await taskRepo.findOneBy({ branchName: wt.branch, projectId: project.id });
+      const persistedStatus = await readPersistedTaskStatus(wt.path, project.sshHost);
       if (existingTask) {
         const shouldRepairTask = !matchesTaskLocation(existingTask, wt.path, project.sshHost)
-          || existingTask.baseBranch !== project.defaultBranch;
+          || existingTask.baseBranch !== project.defaultBranch
+          || (persistedStatus !== null && existingTask.status !== persistedStatus);
+        let taskToPersist = existingTask;
         if (shouldRepairTask) {
           existingTask.worktreePath = wt.path;
           existingTask.sshHost = project.sshHost;
           existingTask.baseBranch = project.defaultBranch;
+          if (persistedStatus !== null) {
+            existingTask.status = persistedStatus;
+          }
           const savedTask = await taskRepo.save(existingTask);
+          taskToPersist = savedTask;
           result.changed = true;
           await installSyncedWorktreeHooks(project, wt.path, savedTask.id, wt.branch, result);
         }
+        await persistTaskState(wt.path, taskToPersist, project.sshHost);
         continue;
       }
 
@@ -658,8 +710,10 @@ async function syncProjectWorktrees(
         orphanTask.worktreePath = wt.path;
         orphanTask.sshHost = project.sshHost;
         orphanTask.baseBranch = orphanTask.baseBranch || project.defaultBranch;
+        orphanTask.status = persistedStatus ?? TaskStatus.TODO;
         const savedTask = await taskRepo.save(orphanTask);
         result.changed = true;
+        await persistTaskState(wt.path, savedTask, project.sshHost);
         await installSyncedWorktreeHooks(project, wt.path, savedTask.id, wt.branch, result);
         result.worktreeTasks.push(wt.branch);
         result.registeredWorktrees.push({
@@ -686,7 +740,7 @@ async function syncProjectWorktrees(
         worktreePath: wt.path,
         projectId: project.id,
         baseBranch: project.defaultBranch,
-        status: hasSession ? TaskStatus.PROGRESS : TaskStatus.TODO,
+        status: persistedStatus ?? TaskStatus.TODO,
         ...(hasSession && {
           sessionType: SessionType.TMUX,
           sessionName,
@@ -695,6 +749,7 @@ async function syncProjectWorktrees(
       });
       const savedTask = await taskRepo.save(task);
       result.changed = true;
+      await persistTaskState(wt.path, savedTask, project.sshHost);
       await installSyncedWorktreeHooks(project, wt.path, savedTask.id, wt.branch, result);
       result.worktreeTasks.push(wt.branch);
       result.registeredWorktrees.push({
@@ -729,12 +784,16 @@ async function syncProjectWorktrees(
 
       if (hasSession) {
         const defaultBranchWorktreePath = await resolveProjectDefaultBranchWorktreePath(project);
+        const persistedStatus = await readPersistedTaskStatus(defaultBranchWorktreePath || project.repoPath, project.sshHost);
         mainBranchTask.sessionType = SessionType.TMUX;
         mainBranchTask.sessionName = sessionName;
         mainBranchTask.worktreePath = defaultBranchWorktreePath;
         mainBranchTask.sshHost = project.sshHost;
-        mainBranchTask.status = TaskStatus.PROGRESS;
-        await taskRepo.save(mainBranchTask);
+        if (persistedStatus !== null) {
+          mainBranchTask.status = persistedStatus;
+        }
+        const savedTask = await taskRepo.save(mainBranchTask);
+        await persistTaskState(defaultBranchWorktreePath || project.repoPath, savedTask, project.sshHost);
         result.changed = true;
       }
     }

--- a/src/lib/__tests__/claudeHooksSetup.test.ts
+++ b/src/lib/__tests__/claudeHooksSetup.test.ts
@@ -28,9 +28,10 @@ describe("claudeHooksSetup", () => {
     expect(stopScript).not.toContain("X-Kanvibe-Token");
     expect(questionScript).not.toContain("X-Kanvibe-Token");
     expect(promptScript).toContain(".kanvibe");
-    expect(promptScript).toContain("hooks-targets.json");
-    expect(promptScript).toContain("task-state.json");
-    expect(promptScript).toContain("while IFS=");
+    expect(promptScript).toContain("status.md");
+    expect(promptScript).not.toContain("hooks-targets.json");
+    expect(promptScript).not.toContain("task-state.json");
+    expect(promptScript).not.toContain("while IFS=");
 
     const status = await getClaudeHooksStatus(repoPath);
     expect(status.installed).toBe(true);

--- a/src/lib/__tests__/claudeHooksSetup.test.ts
+++ b/src/lib/__tests__/claudeHooksSetup.test.ts
@@ -27,6 +27,10 @@ describe("claudeHooksSetup", () => {
     expect(promptScript).not.toContain("X-Kanvibe-Token");
     expect(stopScript).not.toContain("X-Kanvibe-Token");
     expect(questionScript).not.toContain("X-Kanvibe-Token");
+    expect(promptScript).toContain(".kanvibe");
+    expect(promptScript).toContain("hooks-targets.json");
+    expect(promptScript).toContain("task-state.json");
+    expect(promptScript).toContain("while IFS=");
 
     const status = await getClaudeHooksStatus(repoPath);
     expect(status.installed).toBe(true);

--- a/src/lib/__tests__/claudeHooksSetup.test.ts
+++ b/src/lib/__tests__/claudeHooksSetup.test.ts
@@ -28,13 +28,36 @@ describe("claudeHooksSetup", () => {
     expect(stopScript).not.toContain("X-Kanvibe-Token");
     expect(questionScript).not.toContain("X-Kanvibe-Token");
     expect(promptScript).toContain(".kanvibe");
-    expect(promptScript).toContain("status.md");
+    expect(promptScript).toContain("status.json");
     expect(promptScript).not.toContain("hooks-targets.json");
     expect(promptScript).not.toContain("task-state.json");
     expect(promptScript).not.toContain("while IFS=");
 
     const status = await getClaudeHooksStatus(repoPath);
     expect(status.installed).toBe(true);
+    expect(status.hasStatusJsonPersistence).toBe(true);
+  });
+
+  it("legacy status.md Claude hook은 설치된 것으로 보지 않고 재설치로 복구한다", async () => {
+    const repoPath = tempDir;
+
+    await setupClaudeHooks(repoPath, "task-1", "http://localhost:9736");
+    for (const scriptName of ["kanvibe-prompt-hook.sh", "kanvibe-stop-hook.sh", "kanvibe-question-hook.sh"]) {
+      const scriptPath = join(repoPath, ".claude", "hooks", scriptName);
+      const content = await readFile(scriptPath, "utf-8");
+      await writeFile(scriptPath, content.replaceAll("status.json", "status.md"), "utf-8");
+    }
+
+    const legacyStatus = await getClaudeHooksStatus(repoPath, "task-1");
+    expect(legacyStatus.hasTaskIdBinding).toBe(true);
+    expect(legacyStatus.hasStatusMappings).toBe(true);
+    expect(legacyStatus.hasStatusJsonPersistence).toBe(false);
+    expect(legacyStatus.installed).toBe(false);
+
+    await setupClaudeHooks(repoPath, "task-1", "http://localhost:9736");
+    const repairedStatus = await getClaudeHooksStatus(repoPath, "task-1");
+    expect(repairedStatus.hasStatusJsonPersistence).toBe(true);
+    expect(repairedStatus.installed).toBe(true);
   });
 
   it("stale Claude hook command entries are not treated as installed and are repaired on reinstall", async () => {

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -120,6 +120,8 @@ describe("codexHooksSetup", () => {
       const promptHookContent = await readFile(join(repoPath, ".codex", "hooks", "kanvibe-prompt-hook.sh"), "utf-8");
       expect(promptHookContent).toContain('TASK_ID="task-1"');
       expect(promptHookContent).toContain("taskId");
+      expect(promptHookContent).toContain("status.json");
+      expect(promptHookContent).toContain('"schemaVersion":1');
 
       const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
       expect(configContent).toContain("[features]");
@@ -140,6 +142,29 @@ describe("codexHooksSetup", () => {
 
       const status = await getCodexHooksStatus(repoPath);
       expect(status.installed).toBe(true);
+      expect(status.hasStatusJsonPersistence).toBe(true);
+    });
+
+    it("legacy status.md Codex hook은 설치된 것으로 보지 않는다", async () => {
+      const repoPath = tempDir;
+
+      await setupCodexHooks(repoPath, "task-1", "http://localhost:3000");
+      for (const scriptName of [
+        "kanvibe-prompt-hook.sh",
+        "kanvibe-permission-hook.sh",
+        "kanvibe-pre-tool-hook.sh",
+        "kanvibe-stop-hook.sh",
+      ]) {
+        const scriptPath = join(repoPath, ".codex", "hooks", scriptName);
+        const content = await readFile(scriptPath, "utf-8");
+        await writeFile(scriptPath, content.replaceAll("status.json", "status.md"), "utf-8");
+      }
+
+      const status = await getCodexHooksStatus(repoPath, "task-1");
+      expect(status.hasTaskIdBinding).toBe(true);
+      expect(status.hasStatusMappings).toBe(true);
+      expect(status.hasStatusJsonPersistence).toBe(false);
+      expect(status.installed).toBe(false);
     });
 
     it("should not duplicate hook registrations on reinstall", async () => {
@@ -207,6 +232,7 @@ describe("codexHooksSetup", () => {
         hasTaskIdBinding: true,
         hasExpectedTaskId: true,
         hasStatusMappings: true,
+        hasStatusJsonPersistence: true,
         hasExpectedHookServerUrl: true,
         hasReachableHookServer: true,
         boundTaskId: "task-1",

--- a/src/lib/__tests__/geminiHooksSetup.test.ts
+++ b/src/lib/__tests__/geminiHooksSetup.test.ts
@@ -33,6 +33,8 @@ describe("geminiHooksSetup", () => {
       expect(promptScript).toContain(kanvibeUrl);
       expect(promptScript).toContain(taskId);
       expect(promptScript).toContain("taskId");
+      expect(promptScript).toContain("status.json");
+      expect(promptScript).toContain('"schemaVersion":1');
       expect(promptScript).toContain("echo '{}'");
 
       expect(stopScript).toContain("#!/bin/bash");
@@ -137,6 +139,23 @@ describe("geminiHooksSetup", () => {
       expect(status.hasPromptHook).toBe(true);
       expect(status.hasStopHook).toBe(true);
       expect(status.hasSettingsEntry).toBe(true);
+      expect(status.hasStatusJsonPersistence).toBe(true);
+    });
+
+    it("legacy status.md Gemini hook은 설치된 것으로 보지 않는다", async () => {
+      await setupGeminiHooks(tmpDir, "task-1", "http://localhost:9736");
+      for (const scriptName of ["kanvibe-prompt-hook.sh", "kanvibe-stop-hook.sh"]) {
+        const scriptPath = path.join(tmpDir, ".gemini/hooks", scriptName);
+        const content = await readFile(scriptPath, "utf-8");
+        await writeFile(scriptPath, content.replaceAll("status.json", "status.md"), "utf-8");
+      }
+
+      const status = await getGeminiHooksStatus(tmpDir, "task-1");
+
+      expect(status.hasTaskIdBinding).toBe(true);
+      expect(status.hasStatusMappings).toBe(true);
+      expect(status.hasStatusJsonPersistence).toBe(false);
+      expect(status.installed).toBe(false);
     });
 
     it("should return installed: false when no hooks exist", async () => {

--- a/src/lib/__tests__/gitExclude.remote.test.ts
+++ b/src/lib/__tests__/gitExclude.remote.test.ts
@@ -44,7 +44,7 @@ describe("gitExclude remote", () => {
     );
     expect(mockWriteTextFile).toHaveBeenCalledWith(
       "/remote/main/.git/info/exclude",
-      expect.stringContaining(".kanvibe/status.md"),
+      expect.stringContaining(".kanvibe/status.json"),
       "remote-host",
     );
     expect(mockWriteTextFile).not.toHaveBeenCalledWith(

--- a/src/lib/__tests__/gitExclude.remote.test.ts
+++ b/src/lib/__tests__/gitExclude.remote.test.ts
@@ -44,12 +44,12 @@ describe("gitExclude remote", () => {
     );
     expect(mockWriteTextFile).toHaveBeenCalledWith(
       "/remote/main/.git/info/exclude",
-      expect.stringContaining(".kanvibe/hooks-targets.json"),
+      expect.stringContaining(".kanvibe/status.md"),
       "remote-host",
     );
-    expect(mockWriteTextFile).toHaveBeenCalledWith(
+    expect(mockWriteTextFile).not.toHaveBeenCalledWith(
       "/remote/main/.git/info/exclude",
-      expect.stringContaining(".kanvibe/task-state.json"),
+      expect.stringContaining(".kanvibe/hooks-targets.json"),
       "remote-host",
     );
   });

--- a/src/lib/__tests__/gitExclude.remote.test.ts
+++ b/src/lib/__tests__/gitExclude.remote.test.ts
@@ -42,5 +42,15 @@ describe("gitExclude remote", () => {
       expect.stringContaining(".codex/config.toml"),
       "remote-host",
     );
+    expect(mockWriteTextFile).toHaveBeenCalledWith(
+      "/remote/main/.git/info/exclude",
+      expect.stringContaining(".kanvibe/hooks-targets.json"),
+      "remote-host",
+    );
+    expect(mockWriteTextFile).toHaveBeenCalledWith(
+      "/remote/main/.git/info/exclude",
+      expect.stringContaining(".kanvibe/task-state.json"),
+      "remote-host",
+    );
   });
 });

--- a/src/lib/__tests__/gitExclude.test.ts
+++ b/src/lib/__tests__/gitExclude.test.ts
@@ -38,7 +38,7 @@ describe("gitExclude", () => {
       expect(content).toContain(".codex/hooks.json");
       expect(content).toContain(".codex/config.toml");
       expect(content).toContain(".opencode/plugins/");
-      expect(content).toContain(".kanvibe/status.md");
+      expect(content).toContain(".kanvibe/status.json");
     });
 
     it("should not duplicate patterns when called multiple times", async () => {
@@ -88,7 +88,7 @@ describe("gitExclude", () => {
       expect(content).toContain(".claude/hooks/");
       expect(content).toContain(".codex/config.toml");
       expect(content).toContain(".opencode/plugins/");
-      expect(content).toContain(".kanvibe/status.md");
+      expect(content).toContain(".kanvibe/status.json");
     });
 
     it("should prune legacy KanVibe state files from the auto-generated block", async () => {
@@ -103,6 +103,7 @@ describe("gitExclude", () => {
           ".claude/hooks/",
           ".kanvibe/hooks-targets.json",
           ".kanvibe/task-state.json",
+          ".kanvibe/status.md",
           "",
           "# keep me",
           "dist/",
@@ -119,9 +120,10 @@ describe("gitExclude", () => {
       expect(content).toContain("*.log");
       expect(content).toContain("# keep me");
       expect(content).toContain("dist/");
-      expect(content).toContain(".kanvibe/status.md");
+      expect(content).toContain(".kanvibe/status.json");
       expect(content).not.toContain(".kanvibe/hooks-targets.json");
       expect(content).not.toContain(".kanvibe/task-state.json");
+      expect(content).not.toContain(".kanvibe/status.md");
       expect(content.split("# KanVibe AI hooks (auto-generated)")).toHaveLength(2);
     });
 

--- a/src/lib/__tests__/gitExclude.test.ts
+++ b/src/lib/__tests__/gitExclude.test.ts
@@ -38,6 +38,8 @@ describe("gitExclude", () => {
       expect(content).toContain(".codex/hooks.json");
       expect(content).toContain(".codex/config.toml");
       expect(content).toContain(".opencode/plugins/");
+      expect(content).toContain(".kanvibe/hooks-targets.json");
+      expect(content).toContain(".kanvibe/task-state.json");
     });
 
     it("should not duplicate patterns when called multiple times", async () => {
@@ -87,6 +89,8 @@ describe("gitExclude", () => {
       expect(content).toContain(".claude/hooks/");
       expect(content).toContain(".codex/config.toml");
       expect(content).toContain(".opencode/plugins/");
+      expect(content).toContain(".kanvibe/hooks-targets.json");
+      expect(content).toContain(".kanvibe/task-state.json");
     });
 
     it("should update the shared common-dir exclude when called from a linked worktree", async () => {

--- a/src/lib/__tests__/gitExclude.test.ts
+++ b/src/lib/__tests__/gitExclude.test.ts
@@ -38,8 +38,7 @@ describe("gitExclude", () => {
       expect(content).toContain(".codex/hooks.json");
       expect(content).toContain(".codex/config.toml");
       expect(content).toContain(".opencode/plugins/");
-      expect(content).toContain(".kanvibe/hooks-targets.json");
-      expect(content).toContain(".kanvibe/task-state.json");
+      expect(content).toContain(".kanvibe/status.md");
     });
 
     it("should not duplicate patterns when called multiple times", async () => {
@@ -89,8 +88,41 @@ describe("gitExclude", () => {
       expect(content).toContain(".claude/hooks/");
       expect(content).toContain(".codex/config.toml");
       expect(content).toContain(".opencode/plugins/");
-      expect(content).toContain(".kanvibe/hooks-targets.json");
-      expect(content).toContain(".kanvibe/task-state.json");
+      expect(content).toContain(".kanvibe/status.md");
+    });
+
+    it("should prune legacy KanVibe state files from the auto-generated block", async () => {
+      // Given
+      const excludePath = join(tempDir, ".git", "info", "exclude");
+      await writeFile(
+        excludePath,
+        [
+          "# user pattern",
+          "*.log",
+          "# KanVibe AI hooks (auto-generated)",
+          ".claude/hooks/",
+          ".kanvibe/hooks-targets.json",
+          ".kanvibe/task-state.json",
+          "",
+          "# keep me",
+          "dist/",
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      // When
+      await addAiToolPatternsToGitExclude(tempDir);
+
+      // Then
+      const content = await readFile(excludePath, "utf-8");
+      expect(content).toContain("*.log");
+      expect(content).toContain("# keep me");
+      expect(content).toContain("dist/");
+      expect(content).toContain(".kanvibe/status.md");
+      expect(content).not.toContain(".kanvibe/hooks-targets.json");
+      expect(content).not.toContain(".kanvibe/task-state.json");
+      expect(content.split("# KanVibe AI hooks (auto-generated)")).toHaveLength(2);
     });
 
     it("should update the shared common-dir exclude when called from a linked worktree", async () => {

--- a/src/lib/__tests__/hookTaskBinding.test.ts
+++ b/src/lib/__tests__/hookTaskBinding.test.ts
@@ -17,7 +17,7 @@ describe("hookTaskBinding", () => {
     expect(resolver).not.toContain(".kanvibe/task-id");
   });
 
-  it("shell script에서 고정된 task id를 읽는다", () => {
+  it("shell script에서 고정된 task id를 읽고 없으면 null을 반환한다", () => {
     // Given
     const script = [
       "#!/bin/bash",
@@ -30,6 +30,19 @@ describe("hookTaskBinding", () => {
 
     // Then
     expect(taskId).toBe("task-123");
+    expect(extractShellTaskId('#!/bin/bash\necho "$TASK_ID"')).toBeNull();
+  });
+
+  it("shell task id resolver는 double-quoted shell 특수 문자를 escape하고 다시 읽을 수 있다", () => {
+    // Given
+    const taskId = 'task-"quoted"-\\-`cmd`-$HOME';
+
+    // When
+    const resolver = buildShellTaskIdResolver(taskId);
+
+    // Then
+    expect(resolver).toBe('TASK_ID="task-\\"quoted\\"-\\\\-\\`cmd\\`-\\$HOME"');
+    expect(extractShellTaskId(resolver)).toBe(taskId);
   });
 
   it("모든 shell hook이 같은 현재 task id를 가리키는지 판정한다", () => {
@@ -41,9 +54,15 @@ describe("hookTaskBinding", () => {
 
     // When
     const status = getShellTaskIdBindingStatus(scripts, "task-123");
+    const statusWithoutExpectedTask = getShellTaskIdBindingStatus(scripts);
 
     // Then
     expect(status).toEqual({
+      hasTaskIdBinding: true,
+      hasExpectedTaskId: true,
+      boundTaskId: "task-123",
+    });
+    expect(statusWithoutExpectedTask).toEqual({
       hasTaskIdBinding: true,
       hasExpectedTaskId: true,
       boundTaskId: "task-123",
@@ -68,7 +87,7 @@ describe("hookTaskBinding", () => {
     });
   });
 
-  it("shell hook끼리 서로 다른 task id를 가지면 binding 판정을 실패시킨다", () => {
+  it("shell hook끼리 서로 다른 task id를 가지거나 비어 있으면 binding 판정을 실패시킨다", () => {
     // Given
     const scripts = [
       ['TASK_ID="task-123"', 'curl -d "{\\"taskId\\": \\"${TASK_ID}\\"}"'].join("\n"),
@@ -77,9 +96,15 @@ describe("hookTaskBinding", () => {
 
     // When
     const status = getShellTaskIdBindingStatus(scripts, "task-123");
+    const emptyStatus = getShellTaskIdBindingStatus([], "task-123");
 
     // Then
     expect(status).toEqual({
+      hasTaskIdBinding: false,
+      hasExpectedTaskId: false,
+      boundTaskId: null,
+    });
+    expect(emptyStatus).toEqual({
       hasTaskIdBinding: false,
       hasExpectedTaskId: false,
       boundTaskId: null,

--- a/src/lib/__tests__/hookTaskBinding.test.ts
+++ b/src/lib/__tests__/hookTaskBinding.test.ts
@@ -4,6 +4,7 @@ import {
   buildShellTaskIdResolver,
   extractShellTaskId,
   getShellTaskIdBindingStatus,
+  hasShellKanvibeStatusJsonPersistence,
 } from "@/lib/hookTaskBinding";
 
 describe("hookTaskBinding", () => {
@@ -46,17 +47,28 @@ describe("hookTaskBinding", () => {
     expect(extractShellTaskId(resolver)).toBe(taskId);
   });
 
-  it("status updater는 target fan-out 없이 status.md에 상태만 저장한다", () => {
+  it("status updater는 target fan-out 없이 status.json에 상태만 저장한다", () => {
     const updater = buildShellKanvibeStatusUpdater("review");
 
     expect(updater).toContain("KANVIBE_STATUS=\"review\"");
-    expect(updater).toContain("status.md");
+    expect(updater).toContain("status.json");
+    expect(updater).toContain('"schemaVersion":1');
+    expect(updater).toContain('"status":"%s"');
+    expect(updater).toContain('"updatedAt":"%s"');
     expect(updater).toContain("${KANVIBE_TASK_STATE_FILE}");
     expect(updater).not.toContain("hooks-targets.json");
     expect(updater).not.toContain("task-state.json");
     expect(updater).not.toContain("KANVIBE_TARGET_ROWS");
     expect(updater).not.toContain("while IFS=");
     expect(updater).not.toContain("taskId, status");
+  });
+
+  it("status json persistence 판정은 legacy status.md hook을 거부한다", () => {
+    const updater = buildShellKanvibeStatusUpdater("review");
+    const legacyUpdater = updater.replaceAll("status.json", "status.md");
+
+    expect(hasShellKanvibeStatusJsonPersistence(updater)).toBe(true);
+    expect(hasShellKanvibeStatusJsonPersistence(legacyUpdater)).toBe(false);
   });
 
   it("모든 shell hook이 같은 현재 task id를 가리키는지 판정한다", () => {

--- a/src/lib/__tests__/hookTaskBinding.test.ts
+++ b/src/lib/__tests__/hookTaskBinding.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildShellKanvibeStatusUpdater,
   buildShellTaskIdResolver,
   extractShellTaskId,
   getShellTaskIdBindingStatus,
@@ -43,6 +44,19 @@ describe("hookTaskBinding", () => {
     // Then
     expect(resolver).toBe('TASK_ID="task-\\"quoted\\"-\\\\-\\`cmd\\`-\\$HOME"');
     expect(extractShellTaskId(resolver)).toBe(taskId);
+  });
+
+  it("status updater는 target fan-out 없이 status.md에 상태만 저장한다", () => {
+    const updater = buildShellKanvibeStatusUpdater("review");
+
+    expect(updater).toContain("KANVIBE_STATUS=\"review\"");
+    expect(updater).toContain("status.md");
+    expect(updater).toContain("${KANVIBE_TASK_STATE_FILE}");
+    expect(updater).not.toContain("hooks-targets.json");
+    expect(updater).not.toContain("task-state.json");
+    expect(updater).not.toContain("KANVIBE_TARGET_ROWS");
+    expect(updater).not.toContain("while IFS=");
+    expect(updater).not.toContain("taskId, status");
   });
 
   it("모든 shell hook이 같은 현재 task id를 가리키는지 판정한다", () => {

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -438,7 +438,7 @@ describe("kanvibeHooksInstaller", () => {
     );
   });
 
-  it("원격 hook 설치는 .kanvibe/hooks-targets.json에 현재 hook target을 기존 target 뒤에 추가한다", async () => {
+  it("원격 hook 설치는 제거된 .kanvibe/hooks-targets.json을 읽거나 쓰지 않는다", async () => {
     // Given
     mockExecGit.mockImplementation(async (command: string) => {
       if (command.includes("__KANVIBE_FILE_RECORD__")) {
@@ -460,14 +460,8 @@ describe("kanvibeHooksInstaller", () => {
     await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
 
     // Then
-    const targets = JSON.parse(extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.kanvibe/hooks-targets.json"));
-    expect(targets).toEqual({
-      version: 1,
-      targets: [
-        { url: "http://10.0.0.5:9736", taskId: "other-client-task" },
-        { url: "http://192.168.0.8:9736", taskId: "task-2" },
-      ],
-    });
+    const commands = mockExecGit.mock.calls.map(([command]) => String(command));
+    expect(commands.join("\n")).not.toContain("/remote/repo/.kanvibe/hooks-targets.json");
   });
 
   it.each([
@@ -475,39 +469,20 @@ describe("kanvibeHooksInstaller", () => {
     ["gemini", "/remote/repo/.gemini/settings.json", "/remote/repo/.claude/settings.json"],
     ["codex", "/remote/repo/.codex/hooks.json", "/remote/repo/.opencode/plugins/kanvibe-plugin.ts"],
     ["openCode", "/remote/repo/.opencode/plugins/kanvibe-plugin.ts", "/remote/repo/.codex/hooks.json"],
-  ] as const)("원격 %s 단독 hook 설치도 .kanvibe/hooks-targets.json에 현재 hook target을 추가한다", async (provider, expectedProviderFile, unexpectedProviderFile) => {
+  ] as const)("원격 %s 단독 hook 설치도 provider 파일만 쓰고 hook target registry는 쓰지 않는다", async (provider, expectedProviderFile, unexpectedProviderFile) => {
     // Given
-    mockExecGit.mockImplementation(async (command: string) => {
-      if (command.includes("__KANVIBE_FILE_RECORD__")) {
-        return buildRemoteTextFileRecords({
-          "/remote/repo/.kanvibe/hooks-targets.json": JSON.stringify({
-            version: 1,
-            targets: [
-              { url: "http://10.0.0.5:9736", taskId: "other-client-task" },
-            ],
-          }),
-        });
-      }
-
-      return "";
-    });
     const { installKanvibeHookProvider } = await import("@/lib/kanvibeHooksInstaller");
 
     // When
     await installKanvibeHookProvider("/remote/repo", "task-2", provider, "remote-host");
 
     // Then
-    const targets = JSON.parse(extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.kanvibe/hooks-targets.json"));
-    expect(targets.targets).toEqual([
-      { url: "http://10.0.0.5:9736", taskId: "other-client-task" },
-      { url: "http://192.168.0.8:9736", taskId: "task-2" },
-    ]);
-
-    const writeCommand = mockExecGit.mock.calls.find(([command]) => typeof command === "string"
-      && command.includes("printf '%s'")
-      && command.includes("/remote/repo/.kanvibe/hooks-targets.json"))?.[0] as string;
-    expect(writeCommand).toContain(expectedProviderFile);
-    expect(writeCommand).not.toContain(unexpectedProviderFile);
+    const writeCommands = mockExecGit.mock.calls
+      .map(([command]) => String(command))
+      .filter((command) => command.includes("printf '%s'") && command.includes(" > "));
+    expect(writeCommands.join("\n")).toContain(expectedProviderFile);
+    expect(writeCommands.join("\n")).not.toContain(unexpectedProviderFile);
+    expect(writeCommands.join("\n")).not.toContain("/remote/repo/.kanvibe/hooks-targets.json");
   });
 
   it("원격 전체 hook 설치는 기존 설정 파일을 한 번의 SSH 명령으로 읽는다", async () => {
@@ -528,7 +503,7 @@ describe("kanvibeHooksInstaller", () => {
 
     expect(batchReadCommands).toHaveLength(1);
     expect(individualReadCommands).toHaveLength(0);
-    expect(writeCommands).toHaveLength(5);
+    expect(writeCommands).toHaveLength(4);
   });
 
   it("원격 Claude/Gemini stale hook entry도 재설치 시 현재 project 경로로 덮어쓴다", async () => {
@@ -626,7 +601,7 @@ describe("kanvibeHooksInstaller", () => {
       const writeCommands = mockExecGit.mock.calls.filter(([command]) => typeof command === "string"
         && command.includes("printf '%s'")
         && command.includes(" > "));
-      expect(writeCommands).toHaveLength(15);
+      expect(writeCommands).toHaveLength(12);
     } finally {
       vi.useRealTimers();
     }

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -438,6 +438,78 @@ describe("kanvibeHooksInstaller", () => {
     );
   });
 
+  it("원격 hook 설치는 .kanvibe/hooks-targets.json에 현재 hook target을 기존 target 뒤에 추가한다", async () => {
+    // Given
+    mockExecGit.mockImplementation(async (command: string) => {
+      if (command.includes("__KANVIBE_FILE_RECORD__")) {
+        return buildRemoteTextFileRecords({
+          "/remote/repo/.kanvibe/hooks-targets.json": JSON.stringify({
+            version: 1,
+            targets: [
+              { url: "http://10.0.0.5:9736", taskId: "other-client-task" },
+            ],
+          }),
+        });
+      }
+
+      return "";
+    });
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
+
+    // Then
+    const targets = JSON.parse(extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.kanvibe/hooks-targets.json"));
+    expect(targets).toEqual({
+      version: 1,
+      targets: [
+        { url: "http://10.0.0.5:9736", taskId: "other-client-task" },
+        { url: "http://192.168.0.8:9736", taskId: "task-2" },
+      ],
+    });
+  });
+
+  it.each([
+    ["claude", "/remote/repo/.claude/settings.json", "/remote/repo/.gemini/settings.json"],
+    ["gemini", "/remote/repo/.gemini/settings.json", "/remote/repo/.claude/settings.json"],
+    ["codex", "/remote/repo/.codex/hooks.json", "/remote/repo/.opencode/plugins/kanvibe-plugin.ts"],
+    ["openCode", "/remote/repo/.opencode/plugins/kanvibe-plugin.ts", "/remote/repo/.codex/hooks.json"],
+  ] as const)("원격 %s 단독 hook 설치도 .kanvibe/hooks-targets.json에 현재 hook target을 추가한다", async (provider, expectedProviderFile, unexpectedProviderFile) => {
+    // Given
+    mockExecGit.mockImplementation(async (command: string) => {
+      if (command.includes("__KANVIBE_FILE_RECORD__")) {
+        return buildRemoteTextFileRecords({
+          "/remote/repo/.kanvibe/hooks-targets.json": JSON.stringify({
+            version: 1,
+            targets: [
+              { url: "http://10.0.0.5:9736", taskId: "other-client-task" },
+            ],
+          }),
+        });
+      }
+
+      return "";
+    });
+    const { installKanvibeHookProvider } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    await installKanvibeHookProvider("/remote/repo", "task-2", provider, "remote-host");
+
+    // Then
+    const targets = JSON.parse(extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.kanvibe/hooks-targets.json"));
+    expect(targets.targets).toEqual([
+      { url: "http://10.0.0.5:9736", taskId: "other-client-task" },
+      { url: "http://192.168.0.8:9736", taskId: "task-2" },
+    ]);
+
+    const writeCommand = mockExecGit.mock.calls.find(([command]) => typeof command === "string"
+      && command.includes("printf '%s'")
+      && command.includes("/remote/repo/.kanvibe/hooks-targets.json"))?.[0] as string;
+    expect(writeCommand).toContain(expectedProviderFile);
+    expect(writeCommand).not.toContain(unexpectedProviderFile);
+  });
+
   it("원격 전체 hook 설치는 기존 설정 파일을 한 번의 SSH 명령으로 읽는다", async () => {
     // Given
     const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
@@ -456,7 +528,7 @@ describe("kanvibeHooksInstaller", () => {
 
     expect(batchReadCommands).toHaveLength(1);
     expect(individualReadCommands).toHaveLength(0);
-    expect(writeCommands).toHaveLength(4);
+    expect(writeCommands).toHaveLength(5);
   });
 
   it("원격 Claude/Gemini stale hook entry도 재설치 시 현재 project 경로로 덮어쓴다", async () => {
@@ -554,7 +626,7 @@ describe("kanvibeHooksInstaller", () => {
       const writeCommands = mockExecGit.mock.calls.filter(([command]) => typeof command === "string"
         && command.includes("printf '%s'")
         && command.includes(" > "));
-      expect(writeCommands).toHaveLength(12);
+      expect(writeCommands).toHaveLength(15);
     } finally {
       vi.useRealTimers();
     }

--- a/src/lib/__tests__/kanvibeProjectState.test.ts
+++ b/src/lib/__tests__/kanvibeProjectState.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { TaskStatus } from "@/entities/KanbanTask";
+
+const { mockReadTextFile, mockWriteTextFile } = vi.hoisted(() => ({
+  mockReadTextFile: vi.fn(),
+  mockWriteTextFile: vi.fn(),
+}));
+
+vi.mock("@/lib/hostFileAccess", () => ({
+  readTextFile: (...args: unknown[]) => mockReadTextFile(...args),
+  writeTextFile: (...args: unknown[]) => mockWriteTextFile(...args),
+}));
+
+import {
+  buildKanvibeHookTargetsContent,
+  buildKanvibeTaskStateContent,
+  getKanvibeHookTargetsPath,
+  getKanvibeTaskStatePath,
+  parseKanvibeTaskState,
+  parseTaskStatus,
+  readKanvibeTaskState,
+  upsertKanvibeHookTarget,
+  writeKanvibeTaskState,
+} from "@/lib/kanvibeProjectState";
+
+describe("kanvibeProjectState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReadTextFile.mockResolvedValue("");
+    mockWriteTextFile.mockResolvedValue(undefined);
+  });
+
+  it("adds the current hook target after existing valid targets and removes only exact duplicates", () => {
+    const current = JSON.stringify({
+      version: 1,
+      targets: [
+        { url: "http://old-client:9736", taskId: "old-task" },
+        { url: "http://local:9736", taskId: "task-1" },
+        { url: "http://same-url-different-task:9736", taskId: "task-1" },
+        { url: "http://local:9736", taskId: "other-task" },
+      ],
+    });
+
+    const updated = JSON.parse(buildKanvibeHookTargetsContent(current, {
+      url: "http://local:9736",
+      taskId: "task-1",
+    }));
+
+    expect(updated).toEqual({
+      version: 1,
+      targets: [
+        { url: "http://old-client:9736", taskId: "old-task" },
+        { url: "http://same-url-different-task:9736", taskId: "task-1" },
+        { url: "http://local:9736", taskId: "other-task" },
+        { url: "http://local:9736", taskId: "task-1" },
+      ],
+    });
+  });
+
+  it("drops malformed hook target entries instead of writing broken fan-out targets", () => {
+    const updated = JSON.parse(buildKanvibeHookTargetsContent(JSON.stringify({
+      version: 1,
+      targets: [
+        null,
+        "not-object",
+        { url: 42, taskId: "task-1" },
+        { url: "http://missing-task:9736" },
+        { url: "", taskId: "task-1" },
+        { url: "http://empty-task:9736", taskId: "" },
+        { url: "http://valid:9736", taskId: "valid-task" },
+      ],
+    }), {
+      url: "http://local:9736",
+      taskId: "task-1",
+    }));
+
+    expect(updated.targets).toEqual([
+      { url: "http://valid:9736", taskId: "valid-task" },
+      { url: "http://local:9736", taskId: "task-1" },
+    ]);
+  });
+
+  it("falls back to a fresh hook target document when existing content is empty, invalid, or missing the target array", () => {
+    const target = { url: "http://local:9736", taskId: "task-1" };
+
+    expect(JSON.parse(buildKanvibeHookTargetsContent("", target))).toEqual({
+      version: 1,
+      targets: [target],
+    });
+    expect(JSON.parse(buildKanvibeHookTargetsContent("{not-json", target))).toEqual({
+      version: 1,
+      targets: [target],
+    });
+    expect(JSON.parse(buildKanvibeHookTargetsContent(JSON.stringify({ targets: "not-array" }), target))).toEqual({
+      version: 1,
+      targets: [target],
+    });
+  });
+
+  it("builds and parses task state while omitting absent optional fields", () => {
+    const withTask = parseKanvibeTaskState(buildKanvibeTaskStateContent({
+      taskId: "task-1",
+      status: TaskStatus.REVIEW,
+    }));
+    const withoutTask = parseKanvibeTaskState(buildKanvibeTaskStateContent({
+      taskId: null,
+      status: TaskStatus.TODO,
+    }));
+
+    expect(withTask).toEqual(expect.objectContaining({
+      version: 1,
+      taskId: "task-1",
+      status: TaskStatus.REVIEW,
+      updatedAt: expect.any(String),
+    }));
+    expect(withoutTask).toEqual(expect.objectContaining({
+      version: 1,
+      status: TaskStatus.TODO,
+      updatedAt: expect.any(String),
+    }));
+    expect(withoutTask).not.toHaveProperty("taskId");
+  });
+
+  it("normalizes valid persisted task statuses and rejects unusable state files", () => {
+    expect(parseTaskStatus("PROGRESS")).toBe(TaskStatus.PROGRESS);
+    expect(parseTaskStatus(TaskStatus.PENDING)).toBe(TaskStatus.PENDING);
+    expect(parseTaskStatus(42)).toBeNull();
+    expect(parseTaskStatus("blocked")).toBeNull();
+
+    expect(parseKanvibeTaskState("")).toBeNull();
+    expect(parseKanvibeTaskState("not-json")).toBeNull();
+    expect(parseKanvibeTaskState(JSON.stringify({ status: "blocked" }))).toBeNull();
+    expect(parseKanvibeTaskState(JSON.stringify({ status: 42 }))).toBeNull();
+    expect(parseKanvibeTaskState(JSON.stringify({ status: "DONE", taskId: "", updatedAt: "" }))).toEqual({
+      version: 1,
+      status: TaskStatus.DONE,
+    });
+  });
+
+  it("uses host-aware .kanvibe paths when reading and writing project sync files", async () => {
+    mockReadTextFile.mockResolvedValue(JSON.stringify({
+      version: 1,
+      targets: [{ url: "http://old:9736", taskId: "old-task" }],
+    }));
+
+    await upsertKanvibeHookTarget("/remote/repo", { url: "http://local:9736", taskId: "task-1" }, "ssh-host");
+
+    expect(mockReadTextFile).toHaveBeenCalledWith("/remote/repo/.kanvibe/hooks-targets.json", "ssh-host");
+    expect(mockWriteTextFile).toHaveBeenCalledWith(
+      "/remote/repo/.kanvibe/hooks-targets.json",
+      expect.stringContaining("http://local:9736"),
+      "ssh-host",
+    );
+
+    mockReadTextFile.mockResolvedValueOnce(JSON.stringify({ status: "pending", taskId: "task-2" }));
+    await expect(readKanvibeTaskState("/remote/repo", "ssh-host")).resolves.toEqual({
+      version: 1,
+      status: TaskStatus.PENDING,
+      taskId: "task-2",
+    });
+
+    await writeKanvibeTaskState("/remote/repo", { status: TaskStatus.DONE, taskId: "task-2" }, "ssh-host");
+    expect(mockWriteTextFile).toHaveBeenLastCalledWith(
+      "/remote/repo/.kanvibe/task-state.json",
+      expect.stringContaining('"status": "done"'),
+      "ssh-host",
+    );
+
+    expect(getKanvibeHookTargetsPath("/local/repo")).toBe("/local/repo/.kanvibe/hooks-targets.json");
+    expect(getKanvibeTaskStatePath("/local/repo")).toBe("/local/repo/.kanvibe/task-state.json");
+  });
+});

--- a/src/lib/__tests__/kanvibeProjectState.test.ts
+++ b/src/lib/__tests__/kanvibeProjectState.test.ts
@@ -27,16 +27,21 @@ describe("kanvibeProjectState", () => {
     mockWriteTextFile.mockResolvedValue(undefined);
   });
 
-  it("builds status.md content with only the shared task status", () => {
+  it("builds extensible status.json content without task/url mappings", () => {
     const content = buildKanvibeTaskStateContent({
-      taskId: "task-1",
       status: TaskStatus.REVIEW,
     });
+    const parsed = JSON.parse(content) as { schemaVersion?: unknown; status?: unknown; updatedAt?: unknown };
 
-    expect(content).toBe("review\n");
+    expect(parsed).toEqual({
+      schemaVersion: 1,
+      status: TaskStatus.REVIEW,
+      updatedAt: expect.any(String),
+    });
+    expect(Number.isNaN(Date.parse(String(parsed.updatedAt)))).toBe(false);
     expect(content).not.toContain("task-1");
     expect(content).not.toContain("taskId");
-    expect(content).not.toContain("updatedAt");
+    expect(content).not.toContain("url");
   });
 
   it("normalizes valid persisted task statuses and rejects unusable state files", () => {
@@ -47,31 +52,45 @@ describe("kanvibeProjectState", () => {
 
     expect(parseKanvibeTaskState("")).toBeNull();
     expect(parseKanvibeTaskState("not-a-status")).toBeNull();
+    expect(parseKanvibeTaskState(JSON.stringify({ schemaVersion: 1, status: "review", updatedAt: "2026-06-03T00:00:00.000Z" }))).toEqual({
+      schemaVersion: 1,
+      status: TaskStatus.REVIEW,
+      updatedAt: "2026-06-03T00:00:00.000Z",
+    });
     expect(parseKanvibeTaskState("DONE\n")).toEqual({
-      version: 1,
+      schemaVersion: 1,
       status: TaskStatus.DONE,
     });
     expect(parseKanvibeTaskState("  review  \n")).toEqual({
-      version: 1,
+      schemaVersion: 1,
       status: TaskStatus.REVIEW,
     });
   });
 
-  it("uses host-aware .kanvibe/status.md paths when reading and writing project status", async () => {
-    mockReadTextFile.mockResolvedValueOnce("pending\n");
+  it("uses host-aware .kanvibe/status.json paths when reading and writing project status", async () => {
+    mockReadTextFile.mockResolvedValueOnce(JSON.stringify({ schemaVersion: 1, status: "pending" }));
     await expect(readKanvibeTaskState("/remote/repo", "ssh-host")).resolves.toEqual({
-      version: 1,
+      schemaVersion: 1,
       status: TaskStatus.PENDING,
     });
-    expect(mockReadTextFile).toHaveBeenCalledWith("/remote/repo/.kanvibe/status.md", "ssh-host");
+    expect(mockReadTextFile).toHaveBeenCalledWith("/remote/repo/.kanvibe/status.json", "ssh-host");
 
-    await writeKanvibeTaskState("/remote/repo", { status: TaskStatus.DONE, taskId: "task-2" }, "ssh-host");
+    await writeKanvibeTaskState("/remote/repo", { status: TaskStatus.DONE }, "ssh-host");
     expect(mockWriteTextFile).toHaveBeenLastCalledWith(
-      "/remote/repo/.kanvibe/status.md",
-      "done\n",
+      "/remote/repo/.kanvibe/status.json",
+      expect.stringContaining('"status": "done"'),
       "ssh-host",
     );
+    const writtenContent = mockWriteTextFile.mock.calls.at(-1)?.[1] as string;
+    expect(JSON.parse(writtenContent)).toEqual({
+      schemaVersion: 1,
+      status: TaskStatus.DONE,
+      updatedAt: expect.any(String),
+    });
+    expect(writtenContent).not.toContain("task-2");
+    expect(writtenContent).not.toContain("taskId");
+    expect(writtenContent).not.toContain("url");
 
-    expect(getKanvibeTaskStatePath("/local/repo")).toBe("/local/repo/.kanvibe/status.md");
+    expect(getKanvibeTaskStatePath("/local/repo")).toBe("/local/repo/.kanvibe/status.json");
   });
 });

--- a/src/lib/__tests__/kanvibeProjectState.test.ts
+++ b/src/lib/__tests__/kanvibeProjectState.test.ts
@@ -12,14 +12,11 @@ vi.mock("@/lib/hostFileAccess", () => ({
 }));
 
 import {
-  buildKanvibeHookTargetsContent,
   buildKanvibeTaskStateContent,
-  getKanvibeHookTargetsPath,
   getKanvibeTaskStatePath,
   parseKanvibeTaskState,
   parseTaskStatus,
   readKanvibeTaskState,
-  upsertKanvibeHookTarget,
   writeKanvibeTaskState,
 } from "@/lib/kanvibeProjectState";
 
@@ -30,95 +27,16 @@ describe("kanvibeProjectState", () => {
     mockWriteTextFile.mockResolvedValue(undefined);
   });
 
-  it("adds the current hook target after existing valid targets and removes only exact duplicates", () => {
-    const current = JSON.stringify({
-      version: 1,
-      targets: [
-        { url: "http://old-client:9736", taskId: "old-task" },
-        { url: "http://local:9736", taskId: "task-1" },
-        { url: "http://same-url-different-task:9736", taskId: "task-1" },
-        { url: "http://local:9736", taskId: "other-task" },
-      ],
-    });
-
-    const updated = JSON.parse(buildKanvibeHookTargetsContent(current, {
-      url: "http://local:9736",
-      taskId: "task-1",
-    }));
-
-    expect(updated).toEqual({
-      version: 1,
-      targets: [
-        { url: "http://old-client:9736", taskId: "old-task" },
-        { url: "http://same-url-different-task:9736", taskId: "task-1" },
-        { url: "http://local:9736", taskId: "other-task" },
-        { url: "http://local:9736", taskId: "task-1" },
-      ],
-    });
-  });
-
-  it("drops malformed hook target entries instead of writing broken fan-out targets", () => {
-    const updated = JSON.parse(buildKanvibeHookTargetsContent(JSON.stringify({
-      version: 1,
-      targets: [
-        null,
-        "not-object",
-        { url: 42, taskId: "task-1" },
-        { url: "http://missing-task:9736" },
-        { url: "", taskId: "task-1" },
-        { url: "http://empty-task:9736", taskId: "" },
-        { url: "http://valid:9736", taskId: "valid-task" },
-      ],
-    }), {
-      url: "http://local:9736",
-      taskId: "task-1",
-    }));
-
-    expect(updated.targets).toEqual([
-      { url: "http://valid:9736", taskId: "valid-task" },
-      { url: "http://local:9736", taskId: "task-1" },
-    ]);
-  });
-
-  it("falls back to a fresh hook target document when existing content is empty, invalid, or missing the target array", () => {
-    const target = { url: "http://local:9736", taskId: "task-1" };
-
-    expect(JSON.parse(buildKanvibeHookTargetsContent("", target))).toEqual({
-      version: 1,
-      targets: [target],
-    });
-    expect(JSON.parse(buildKanvibeHookTargetsContent("{not-json", target))).toEqual({
-      version: 1,
-      targets: [target],
-    });
-    expect(JSON.parse(buildKanvibeHookTargetsContent(JSON.stringify({ targets: "not-array" }), target))).toEqual({
-      version: 1,
-      targets: [target],
-    });
-  });
-
-  it("builds and parses task state while omitting absent optional fields", () => {
-    const withTask = parseKanvibeTaskState(buildKanvibeTaskStateContent({
+  it("builds status.md content with only the shared task status", () => {
+    const content = buildKanvibeTaskStateContent({
       taskId: "task-1",
       status: TaskStatus.REVIEW,
-    }));
-    const withoutTask = parseKanvibeTaskState(buildKanvibeTaskStateContent({
-      taskId: null,
-      status: TaskStatus.TODO,
-    }));
+    });
 
-    expect(withTask).toEqual(expect.objectContaining({
-      version: 1,
-      taskId: "task-1",
-      status: TaskStatus.REVIEW,
-      updatedAt: expect.any(String),
-    }));
-    expect(withoutTask).toEqual(expect.objectContaining({
-      version: 1,
-      status: TaskStatus.TODO,
-      updatedAt: expect.any(String),
-    }));
-    expect(withoutTask).not.toHaveProperty("taskId");
+    expect(content).toBe("review\n");
+    expect(content).not.toContain("task-1");
+    expect(content).not.toContain("taskId");
+    expect(content).not.toContain("updatedAt");
   });
 
   it("normalizes valid persisted task statuses and rejects unusable state files", () => {
@@ -128,45 +46,32 @@ describe("kanvibeProjectState", () => {
     expect(parseTaskStatus("blocked")).toBeNull();
 
     expect(parseKanvibeTaskState("")).toBeNull();
-    expect(parseKanvibeTaskState("not-json")).toBeNull();
-    expect(parseKanvibeTaskState(JSON.stringify({ status: "blocked" }))).toBeNull();
-    expect(parseKanvibeTaskState(JSON.stringify({ status: 42 }))).toBeNull();
-    expect(parseKanvibeTaskState(JSON.stringify({ status: "DONE", taskId: "", updatedAt: "" }))).toEqual({
+    expect(parseKanvibeTaskState("not-a-status")).toBeNull();
+    expect(parseKanvibeTaskState("DONE\n")).toEqual({
       version: 1,
       status: TaskStatus.DONE,
     });
+    expect(parseKanvibeTaskState("  review  \n")).toEqual({
+      version: 1,
+      status: TaskStatus.REVIEW,
+    });
   });
 
-  it("uses host-aware .kanvibe paths when reading and writing project sync files", async () => {
-    mockReadTextFile.mockResolvedValue(JSON.stringify({
-      version: 1,
-      targets: [{ url: "http://old:9736", taskId: "old-task" }],
-    }));
-
-    await upsertKanvibeHookTarget("/remote/repo", { url: "http://local:9736", taskId: "task-1" }, "ssh-host");
-
-    expect(mockReadTextFile).toHaveBeenCalledWith("/remote/repo/.kanvibe/hooks-targets.json", "ssh-host");
-    expect(mockWriteTextFile).toHaveBeenCalledWith(
-      "/remote/repo/.kanvibe/hooks-targets.json",
-      expect.stringContaining("http://local:9736"),
-      "ssh-host",
-    );
-
-    mockReadTextFile.mockResolvedValueOnce(JSON.stringify({ status: "pending", taskId: "task-2" }));
+  it("uses host-aware .kanvibe/status.md paths when reading and writing project status", async () => {
+    mockReadTextFile.mockResolvedValueOnce("pending\n");
     await expect(readKanvibeTaskState("/remote/repo", "ssh-host")).resolves.toEqual({
       version: 1,
       status: TaskStatus.PENDING,
-      taskId: "task-2",
     });
+    expect(mockReadTextFile).toHaveBeenCalledWith("/remote/repo/.kanvibe/status.md", "ssh-host");
 
     await writeKanvibeTaskState("/remote/repo", { status: TaskStatus.DONE, taskId: "task-2" }, "ssh-host");
     expect(mockWriteTextFile).toHaveBeenLastCalledWith(
-      "/remote/repo/.kanvibe/task-state.json",
-      expect.stringContaining('"status": "done"'),
+      "/remote/repo/.kanvibe/status.md",
+      "done\n",
       "ssh-host",
     );
 
-    expect(getKanvibeHookTargetsPath("/local/repo")).toBe("/local/repo/.kanvibe/hooks-targets.json");
-    expect(getKanvibeTaskStatePath("/local/repo")).toBe("/local/repo/.kanvibe/task-state.json");
+    expect(getKanvibeTaskStatePath("/local/repo")).toBe("/local/repo/.kanvibe/status.md");
   });
 });

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -54,11 +54,12 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toContain("/api/hooks/status");
       expect(pluginContent).toContain('const TASK_ID = "task-1";');
       expect(pluginContent).not.toContain(".kanvibe/task-id");
-      expect(pluginContent).toContain("status.md");
+      expect(pluginContent).toContain("status.json");
       expect(pluginContent).not.toContain("hooks-targets.json");
       expect(pluginContent).not.toContain("task-state.json");
       expect(pluginContent).not.toContain("readFileSync(KANVIBE_TARGETS_FILE");
       expect(pluginContent).toContain("writeFileSync(");
+      expect(pluginContent).toContain("JSON.stringify({ schemaVersion: 1, status, updatedAt: new Date().toISOString() }");
       expect(pluginContent).toContain("taskId: TASK_ID");
     });
 
@@ -139,6 +140,7 @@ describe("openCodeHooksSetup", () => {
       // Then - should still be installed correctly
       const status = await getOpenCodeHooksStatus(repoPath);
       expect(status.installed).toBe(true);
+      expect(status.hasStatusJsonPersistence).toBe(true);
     });
 
     it("should repair stale branch-bound plugin content on reinstall", async () => {
@@ -199,11 +201,30 @@ export const KanvibePlugin: Plugin = async ({ $ }) => {
       expect(status.installed).toBe(true);
       expect(status.hasDuplicateProgressGuard).toBe(true);
       expect(status.hasEventMappings).toBe(true);
+      expect(status.hasStatusJsonPersistence).toBe(true);
       expect(status.targetPath).toBe(repoPath);
       expect(status.pluginPath).toBe(join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts"));
       expect(status.registeredPluginUrls).toEqual([
         `file://${repoPath}/.opencode/plugins/kanvibe-plugin.ts`,
       ]);
+    });
+
+    it("legacy status.md OpenCode plugin은 설치된 것으로 보지 않는다", async () => {
+      // Given
+      const repoPath = tempDir;
+      const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
+      await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:3000");
+      const pluginContent = await readFile(pluginPath, "utf-8");
+      await writeFile(pluginPath, pluginContent.replaceAll("status.json", "status.md"), "utf-8");
+
+      // When
+      const status = await getOpenCodeHooksStatus(repoPath, "task-1");
+
+      // Then
+      expect(status.hasTaskIdBinding).toBe(true);
+      expect(status.hasEventMappings).toBe(true);
+      expect(status.hasStatusJsonPersistence).toBe(false);
+      expect(status.installed).toBe(false);
     });
 
     it("should return installed: false when no plugin exists", async () => {

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -54,9 +54,10 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toContain("/api/hooks/status");
       expect(pluginContent).toContain('const TASK_ID = "task-1";');
       expect(pluginContent).not.toContain(".kanvibe/task-id");
-      expect(pluginContent).toContain("hooks-targets.json");
-      expect(pluginContent).toContain("task-state.json");
-      expect(pluginContent).toContain("readFileSync(KANVIBE_TARGETS_FILE");
+      expect(pluginContent).toContain("status.md");
+      expect(pluginContent).not.toContain("hooks-targets.json");
+      expect(pluginContent).not.toContain("task-state.json");
+      expect(pluginContent).not.toContain("readFileSync(KANVIBE_TARGETS_FILE");
       expect(pluginContent).toContain("writeFileSync(");
       expect(pluginContent).toContain("taskId: TASK_ID");
     });

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -54,7 +54,10 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toContain("/api/hooks/status");
       expect(pluginContent).toContain('const TASK_ID = "task-1";');
       expect(pluginContent).not.toContain(".kanvibe/task-id");
-      expect(pluginContent).not.toContain("readFile");
+      expect(pluginContent).toContain("hooks-targets.json");
+      expect(pluginContent).toContain("task-state.json");
+      expect(pluginContent).toContain("readFileSync(KANVIBE_TARGETS_FILE");
+      expect(pluginContent).toContain("writeFileSync(");
       expect(pluginContent).toContain("taskId: TASK_ID");
     });
 

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -4,7 +4,6 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
 import { buildShellKanvibeStatusUpdater, buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
-import { upsertKanvibeHookTarget } from "@/lib/kanvibeProjectState";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
 export function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
@@ -139,7 +138,6 @@ export async function setupClaudeHooks(
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
   await chmod(questionScriptPath, 0o755);
-  await upsertKanvibeHookTarget(repoPath, { url: kanvibeUrl, taskId });
 
   const settings = await readSettingsJson(settingsPath);
   if (!settings.hooks) {

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -3,7 +3,12 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { buildShellKanvibeStatusUpdater, buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
+import {
+  buildShellKanvibeStatusUpdater,
+  buildShellTaskIdResolver,
+  getShellTaskIdBindingStatus,
+  hasShellKanvibeStatusJsonPersistence,
+} from "@/lib/hookTaskBinding";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
 export function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
@@ -206,6 +211,7 @@ export interface ClaudeHooksStatus {
   hasTaskIdBinding?: boolean;
   hasExpectedTaskId?: boolean;
   hasStatusMappings?: boolean;
+  hasStatusJsonPersistence?: boolean;
   hasExpectedHookServerUrl?: boolean;
   hasReachableHookServer?: boolean;
   boundTaskId?: string | null;
@@ -248,6 +254,7 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
     promptContent.includes('\\\"status\\\": \\\"progress\\\"') &&
     stopContent.includes('\\\"status\\\": \\\"review\\\"') &&
     questionContent.includes('\\\"status\\\": \\\"pending\\\"');
+  const hasStatusJsonPersistence = scriptContents.every(hasShellKanvibeStatusJsonPersistence);
 
   let hasSettingsEntry = false;
   try {
@@ -271,6 +278,7 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
     && hasTaskIdBinding
     && hasExpectedTaskId
     && hasStatusMappings
+    && hasStatusJsonPersistence
     && hookServerValidation.hasExpectedHookServerUrl;
 
   return {
@@ -282,6 +290,7 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
     hasTaskIdBinding,
     hasExpectedTaskId,
     hasStatusMappings,
+    hasStatusJsonPersistence,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
     hasReachableHookServer: hookServerValidation.hasReachableHookServer,
     boundTaskId,

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -3,7 +3,8 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
+import { buildShellKanvibeStatusUpdater, buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
+import { upsertKanvibeHookTarget } from "@/lib/kanvibeProjectState";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
 export function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
@@ -14,11 +15,7 @@ export function generatePromptHookScript(kanvibeUrl: string, taskId: string): st
 
 KANVIBE_URL="${kanvibeUrl}"
 ${buildShellTaskIdResolver(taskId)}
-
-curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
-  -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"progress\\\"}" \\
-  > /dev/null 2>&1
+${buildShellKanvibeStatusUpdater("progress")}
 
 exit 0
 `;
@@ -33,11 +30,7 @@ export function generateStopHookScript(kanvibeUrl: string, taskId: string): stri
 
 KANVIBE_URL="${kanvibeUrl}"
 ${buildShellTaskIdResolver(taskId)}
-
-curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
-  -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
-  > /dev/null 2>&1
+${buildShellKanvibeStatusUpdater("review")}
 
 exit 0
 `;
@@ -52,11 +45,7 @@ export function generateQuestionHookScript(kanvibeUrl: string, taskId: string): 
 
 KANVIBE_URL="${kanvibeUrl}"
 ${buildShellTaskIdResolver(taskId)}
-
-curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
-  -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"pending\\\"}" \\
-  > /dev/null 2>&1
+${buildShellKanvibeStatusUpdater("pending")}
 
 exit 0
 `;
@@ -150,6 +139,7 @@ export async function setupClaudeHooks(
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
   await chmod(questionScriptPath, 0o755);
+  await upsertKanvibeHookTarget(repoPath, { url: kanvibeUrl, taskId });
 
   const settings = await readSettingsJson(settingsPath);
   if (!settings.hooks) {

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -4,7 +4,6 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
 import { buildShellKanvibeStatusUpdater, buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
-import { upsertKanvibeHookTarget } from "@/lib/kanvibeProjectState";
 
 /**
  * Codex CLI 최신 hooks 설정은 `.codex/config.toml`의 hooks feature flag와
@@ -306,7 +305,6 @@ export async function setupCodexHooks(
   await chmod(permissionScriptPath, 0o755);
   await chmod(preToolScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
-  await upsertKanvibeHookTarget(repoPath, { url: kanvibeUrl, taskId });
 
   const configContent = await readTextFile(configPath);
   await writeFile(configPath, upsertCodexConfigToml(configContent), "utf-8");

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -3,7 +3,12 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { buildShellKanvibeStatusUpdater, buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
+import {
+  buildShellKanvibeStatusUpdater,
+  buildShellTaskIdResolver,
+  getShellTaskIdBindingStatus,
+  hasShellKanvibeStatusJsonPersistence,
+} from "@/lib/hookTaskBinding";
 
 /**
  * Codex CLI 최신 hooks 설정은 `.codex/config.toml`의 hooks feature flag와
@@ -331,6 +336,7 @@ export interface CodexHooksStatus {
   hasTaskIdBinding?: boolean;
   hasExpectedTaskId?: boolean;
   hasStatusMappings?: boolean;
+  hasStatusJsonPersistence?: boolean;
   hasExpectedHookServerUrl?: boolean;
   hasReachableHookServer?: boolean;
   boundTaskId?: string | null;
@@ -377,6 +383,7 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
     && permissionContent.includes('\\\"status\\\": \\\"pending\\\"')
     && preToolContent.includes('\\\"status\\\": \\\"progress\\\"')
     && stopContent.includes('\\\"status\\\": \\\"review\\\"');
+  const hasStatusJsonPersistence = hookScripts.every(hasShellKanvibeStatusJsonPersistence);
   const hookServerValidation = await validateHookServerConfiguration(
     hookScripts.map((content) => extractShellHookServerUrl(content)),
     Boolean(taskId),
@@ -401,6 +408,7 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
     && hasTaskIdBinding
     && hasExpectedTaskId
     && hasStatusMappings
+    && hasStatusJsonPersistence
     && hookServerValidation.hasExpectedHookServerUrl;
 
   return {
@@ -415,6 +423,7 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
     hasTaskIdBinding,
     hasExpectedTaskId,
     hasStatusMappings,
+    hasStatusJsonPersistence,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
     hasReachableHookServer: hookServerValidation.hasReachableHookServer,
     boundTaskId,

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -3,7 +3,8 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
+import { buildShellKanvibeStatusUpdater, buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
+import { upsertKanvibeHookTarget } from "@/lib/kanvibeProjectState";
 
 /**
  * Codex CLI 최신 hooks 설정은 `.codex/config.toml`의 hooks feature flag와
@@ -50,11 +51,7 @@ function generateStatusHookScript(
 
 KANVIBE_URL="${kanvibeUrl}"
 ${buildShellTaskIdResolver(taskId)}
-
-curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
-  -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"${status}\\\"}" \\
-  > /dev/null 2>&1
+${buildShellKanvibeStatusUpdater(status)}
 
 exit 0
 `;
@@ -309,6 +306,7 @@ export async function setupCodexHooks(
   await chmod(permissionScriptPath, 0o755);
   await chmod(preToolScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
+  await upsertKanvibeHookTarget(repoPath, { url: kanvibeUrl, taskId });
 
   const configContent = await readTextFile(configPath);
   await writeFile(configPath, upsertCodexConfigToml(configContent), "utf-8");

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -3,7 +3,8 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
+import { buildShellKanvibeStatusUpdater, buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
+import { upsertKanvibeHookTarget } from "@/lib/kanvibeProjectState";
 
 /**
  * Gemini CLI hooks는 stdout에 반드시 JSON만 출력해야 한다.
@@ -20,11 +21,7 @@ export function generatePromptHookScript(kanvibeUrl: string, taskId: string): st
 
 KANVIBE_URL="${kanvibeUrl}"
 ${buildShellTaskIdResolver(taskId)}
-
-curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
-  -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"progress\\\"}" \\
-  > /dev/null 2>&1
+${buildShellKanvibeStatusUpdater("progress")}
 
 echo '{}'
 exit 0
@@ -41,11 +38,7 @@ export function generateStopHookScript(kanvibeUrl: string, taskId: string): stri
 
 KANVIBE_URL="${kanvibeUrl}"
 ${buildShellTaskIdResolver(taskId)}
-
-curl -s -X POST "\${KANVIBE_URL}/api/hooks/status" \\
-  -H "Content-Type: application/json" \\
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"review\\\"}" \\
-  > /dev/null 2>&1
+${buildShellKanvibeStatusUpdater("review")}
 
 echo '{}'
 exit 0
@@ -133,6 +126,7 @@ export async function setupGeminiHooks(
   await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
+  await upsertKanvibeHookTarget(repoPath, { url: kanvibeUrl, taskId });
 
   const settings = await readSettingsJson(settingsPath);
   if (!settings.hooks) {

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -3,7 +3,12 @@ import path from "path";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
-import { buildShellKanvibeStatusUpdater, buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
+import {
+  buildShellKanvibeStatusUpdater,
+  buildShellTaskIdResolver,
+  getShellTaskIdBindingStatus,
+  hasShellKanvibeStatusJsonPersistence,
+} from "@/lib/hookTaskBinding";
 
 /**
  * Gemini CLI hooks는 stdout에 반드시 JSON만 출력해야 한다.
@@ -172,6 +177,7 @@ export interface GeminiHooksStatus {
   hasTaskIdBinding?: boolean;
   hasExpectedTaskId?: boolean;
   hasStatusMappings?: boolean;
+  hasStatusJsonPersistence?: boolean;
   hasExpectedHookServerUrl?: boolean;
   hasReachableHookServer?: boolean;
   boundTaskId?: string | null;
@@ -209,6 +215,7 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
   const hasStatusMappings =
     promptContent.includes('\\\"status\\\": \\\"progress\\\"') &&
     stopContent.includes('\\\"status\\\": \\\"review\\\"');
+  const hasStatusJsonPersistence = scriptContents.every(hasShellKanvibeStatusJsonPersistence);
 
   let hasSettingsEntry = false;
   try {
@@ -229,6 +236,7 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
     && hasTaskIdBinding
     && hasExpectedTaskId
     && hasStatusMappings
+    && hasStatusJsonPersistence
     && hookServerValidation.hasExpectedHookServerUrl;
 
   return {
@@ -239,6 +247,7 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
     hasTaskIdBinding,
     hasExpectedTaskId,
     hasStatusMappings,
+    hasStatusJsonPersistence,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
     hasReachableHookServer: hookServerValidation.hasReachableHookServer,
     boundTaskId,

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -4,7 +4,6 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
 import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
 import { buildShellKanvibeStatusUpdater, buildShellTaskIdResolver, getShellTaskIdBindingStatus } from "@/lib/hookTaskBinding";
-import { upsertKanvibeHookTarget } from "@/lib/kanvibeProjectState";
 
 /**
  * Gemini CLI hooks는 stdout에 반드시 JSON만 출력해야 한다.
@@ -126,7 +125,6 @@ export async function setupGeminiHooks(
   await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId), "utf-8");
   await chmod(promptScriptPath, 0o755);
   await chmod(stopScriptPath, 0o755);
-  await upsertKanvibeHookTarget(repoPath, { url: kanvibeUrl, taskId });
 
   const settings = await readSettingsJson(settingsPath);
   if (!settings.hooks) {

--- a/src/lib/gitExclude.ts
+++ b/src/lib/gitExclude.ts
@@ -13,6 +13,10 @@ const EXCLUDE_PATTERNS = [
   ".codex/hooks.json",
   ".codex/config.toml",
   ".opencode/plugins/",
+  ".kanvibe/status.md",
+];
+
+const LEGACY_EXCLUDE_PATTERNS = [
   ".kanvibe/hooks-targets.json",
   ".kanvibe/task-state.json",
 ];
@@ -29,7 +33,11 @@ function buildExcludeContent(currentContent: string): string {
     }
 
     index += 1;
-    while (index < lines.length && (EXCLUDE_PATTERNS.includes(lines[index]) || lines[index] === "")) {
+    while (index < lines.length && (
+      EXCLUDE_PATTERNS.includes(lines[index])
+      || LEGACY_EXCLUDE_PATTERNS.includes(lines[index])
+      || lines[index] === ""
+    )) {
       index += 1;
     }
     index -= 1;

--- a/src/lib/gitExclude.ts
+++ b/src/lib/gitExclude.ts
@@ -13,6 +13,8 @@ const EXCLUDE_PATTERNS = [
   ".codex/hooks.json",
   ".codex/config.toml",
   ".opencode/plugins/",
+  ".kanvibe/hooks-targets.json",
+  ".kanvibe/task-state.json",
 ];
 
 function buildExcludeContent(currentContent: string): string {

--- a/src/lib/gitExclude.ts
+++ b/src/lib/gitExclude.ts
@@ -13,12 +13,13 @@ const EXCLUDE_PATTERNS = [
   ".codex/hooks.json",
   ".codex/config.toml",
   ".opencode/plugins/",
-  ".kanvibe/status.md",
+  ".kanvibe/status.json",
 ];
 
 const LEGACY_EXCLUDE_PATTERNS = [
   ".kanvibe/hooks-targets.json",
   ".kanvibe/task-state.json",
+  ".kanvibe/status.md",
 ];
 
 function buildExcludeContent(currentContent: string): string {

--- a/src/lib/hookTaskBinding.ts
+++ b/src/lib/hookTaskBinding.ts
@@ -29,60 +29,15 @@ export function buildShellKanvibeStatusUpdater(status: "progress" | "pending" | 
   return `KANVIBE_STATUS="${status}"
 KANVIBE_REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "\${BASH_SOURCE[0]}")/../.." && pwd))"
 KANVIBE_STATE_DIR="\${KANVIBE_REPO_ROOT}/.kanvibe"
-KANVIBE_TARGETS_FILE="\${KANVIBE_STATE_DIR}/hooks-targets.json"
-KANVIBE_TASK_STATE_FILE="\${KANVIBE_STATE_DIR}/task-state.json"
+KANVIBE_TASK_STATE_FILE="\${KANVIBE_STATE_DIR}/status.md"
 
 mkdir -p "\${KANVIBE_STATE_DIR}" 2>/dev/null || true
-if command -v node >/dev/null 2>&1; then
-  node - "\${KANVIBE_TASK_STATE_FILE}" "\${TASK_ID}" "\${KANVIBE_STATUS}" <<'NODE' >/dev/null 2>&1 || true
-const fs = require("fs");
-const [filePath, taskId, status] = process.argv.slice(2);
-fs.mkdirSync(require("path").dirname(filePath), { recursive: true });
-fs.writeFileSync(filePath, JSON.stringify({ version: 1, taskId, status, updatedAt: new Date().toISOString() }, null, 2) + "\\n");
-NODE
-else
-  printf '{"version":1,"taskId":"%s","status":"${status}"}\\n' "\${TASK_ID}" > "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null || true
-fi
+printf '%s\\n' "\${KANVIBE_STATUS}" > "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null || true
 
-KANVIBE_TARGET_ROWS=""
-if [ -f "\${KANVIBE_TARGETS_FILE}" ] && command -v node >/dev/null 2>&1; then
-  KANVIBE_TARGET_ROWS="$(node - "\${KANVIBE_TARGETS_FILE}" <<'NODE' 2>/dev/null || true
-const fs = require("fs");
-const filePath = process.argv[2];
-const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
-for (const target of Array.isArray(parsed.targets) ? parsed.targets : []) {
-  if (target && typeof target.url === "string" && typeof target.taskId === "string" && target.url && target.taskId) {
-    process.stdout.write(target.url + "\\t" + target.taskId + "\\n");
-  }
-}
-NODE
-)"
-elif [ -f "\${KANVIBE_TARGETS_FILE}" ] && command -v python3 >/dev/null 2>&1; then
-  KANVIBE_TARGET_ROWS="$(python3 - "\${KANVIBE_TARGETS_FILE}" <<'PY' 2>/dev/null || true
-import json, sys
-with open(sys.argv[1], "r", encoding="utf-8") as fp:
-    parsed = json.load(fp)
-for target in parsed.get("targets", []):
-    url = target.get("url")
-    task_id = target.get("taskId")
-    if isinstance(url, str) and isinstance(task_id, str) and url and task_id:
-        print(f"{url}\\t{task_id}")
-PY
-)"
-fi
-
-if [ -z "\${KANVIBE_TARGET_ROWS}" ]; then
-  KANVIBE_TARGET_ROWS="$(printf '%s\\t%s\\n' "\${KANVIBE_URL}" "\${TASK_ID}")"
-fi
-
-printf '%s\\n' "\${KANVIBE_TARGET_ROWS}" | while IFS="$(printf '\\t')" read -r KANVIBE_TARGET_URL KANVIBE_TARGET_TASK_ID; do
-  [ -n "\${KANVIBE_TARGET_URL}" ] || continue
-  [ -n "\${KANVIBE_TARGET_TASK_ID}" ] || KANVIBE_TARGET_TASK_ID="\${TASK_ID}"
-  curl -s -X POST "\${KANVIBE_TARGET_URL%/}/api/hooks/status" \\
-    -H "Content-Type: application/json" \\
-    -d "{\\"taskId\\": \\\"\${KANVIBE_TARGET_TASK_ID}\\\", \\\"status\\\": \\\"${status}\\\"}" \\
-    > /dev/null 2>&1 || true
-done`;
+curl -s -X POST "\${KANVIBE_URL%/}/api/hooks/status" \
+  -H "Content-Type: application/json" \
+  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"${status}\\\"}" \
+  > /dev/null 2>&1 || true`;
 }
 
 export function getShellTaskIdBindingStatus(

--- a/src/lib/hookTaskBinding.ts
+++ b/src/lib/hookTaskBinding.ts
@@ -25,6 +25,66 @@ export interface ShellTaskIdBindingStatus {
   boundTaskId: string | null;
 }
 
+export function buildShellKanvibeStatusUpdater(status: "progress" | "pending" | "review" | "done") {
+  return `KANVIBE_STATUS="${status}"
+KANVIBE_REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "\${BASH_SOURCE[0]}")/../.." && pwd))"
+KANVIBE_STATE_DIR="\${KANVIBE_REPO_ROOT}/.kanvibe"
+KANVIBE_TARGETS_FILE="\${KANVIBE_STATE_DIR}/hooks-targets.json"
+KANVIBE_TASK_STATE_FILE="\${KANVIBE_STATE_DIR}/task-state.json"
+
+mkdir -p "\${KANVIBE_STATE_DIR}" 2>/dev/null || true
+if command -v node >/dev/null 2>&1; then
+  node - "\${KANVIBE_TASK_STATE_FILE}" "\${TASK_ID}" "\${KANVIBE_STATUS}" <<'NODE' >/dev/null 2>&1 || true
+const fs = require("fs");
+const [filePath, taskId, status] = process.argv.slice(2);
+fs.mkdirSync(require("path").dirname(filePath), { recursive: true });
+fs.writeFileSync(filePath, JSON.stringify({ version: 1, taskId, status, updatedAt: new Date().toISOString() }, null, 2) + "\\n");
+NODE
+else
+  printf '{"version":1,"taskId":"%s","status":"${status}"}\\n' "\${TASK_ID}" > "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null || true
+fi
+
+KANVIBE_TARGET_ROWS=""
+if [ -f "\${KANVIBE_TARGETS_FILE}" ] && command -v node >/dev/null 2>&1; then
+  KANVIBE_TARGET_ROWS="$(node - "\${KANVIBE_TARGETS_FILE}" <<'NODE' 2>/dev/null || true
+const fs = require("fs");
+const filePath = process.argv[2];
+const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+for (const target of Array.isArray(parsed.targets) ? parsed.targets : []) {
+  if (target && typeof target.url === "string" && typeof target.taskId === "string" && target.url && target.taskId) {
+    process.stdout.write(target.url + "\\t" + target.taskId + "\\n");
+  }
+}
+NODE
+)"
+elif [ -f "\${KANVIBE_TARGETS_FILE}" ] && command -v python3 >/dev/null 2>&1; then
+  KANVIBE_TARGET_ROWS="$(python3 - "\${KANVIBE_TARGETS_FILE}" <<'PY' 2>/dev/null || true
+import json, sys
+with open(sys.argv[1], "r", encoding="utf-8") as fp:
+    parsed = json.load(fp)
+for target in parsed.get("targets", []):
+    url = target.get("url")
+    task_id = target.get("taskId")
+    if isinstance(url, str) and isinstance(task_id, str) and url and task_id:
+        print(f"{url}\\t{task_id}")
+PY
+)"
+fi
+
+if [ -z "\${KANVIBE_TARGET_ROWS}" ]; then
+  KANVIBE_TARGET_ROWS="$(printf '%s\\t%s\\n' "\${KANVIBE_URL}" "\${TASK_ID}")"
+fi
+
+printf '%s\\n' "\${KANVIBE_TARGET_ROWS}" | while IFS="$(printf '\\t')" read -r KANVIBE_TARGET_URL KANVIBE_TARGET_TASK_ID; do
+  [ -n "\${KANVIBE_TARGET_URL}" ] || continue
+  [ -n "\${KANVIBE_TARGET_TASK_ID}" ] || KANVIBE_TARGET_TASK_ID="\${TASK_ID}"
+  curl -s -X POST "\${KANVIBE_TARGET_URL%/}/api/hooks/status" \\
+    -H "Content-Type: application/json" \\
+    -d "{\\"taskId\\": \\\"\${KANVIBE_TARGET_TASK_ID}\\\", \\\"status\\\": \\\"${status}\\\"}" \\
+    > /dev/null 2>&1 || true
+done`;
+}
+
 export function getShellTaskIdBindingStatus(
   contents: string[],
   expectedTaskId?: string,

--- a/src/lib/hookTaskBinding.ts
+++ b/src/lib/hookTaskBinding.ts
@@ -29,15 +29,27 @@ export function buildShellKanvibeStatusUpdater(status: "progress" | "pending" | 
   return `KANVIBE_STATUS="${status}"
 KANVIBE_REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "\${BASH_SOURCE[0]}")/../.." && pwd))"
 KANVIBE_STATE_DIR="\${KANVIBE_REPO_ROOT}/.kanvibe"
-KANVIBE_TASK_STATE_FILE="\${KANVIBE_STATE_DIR}/status.md"
+KANVIBE_TASK_STATE_FILE="\${KANVIBE_STATE_DIR}/status.json"
 
 mkdir -p "\${KANVIBE_STATE_DIR}" 2>/dev/null || true
-printf '%s\\n' "\${KANVIBE_STATUS}" > "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null || true
+KANVIBE_UPDATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || true)"
+if [ -n "\${KANVIBE_UPDATED_AT}" ]; then
+  printf '{"schemaVersion":1,"status":"%s","updatedAt":"%s"}\\n' "\${KANVIBE_STATUS}" "\${KANVIBE_UPDATED_AT}" > "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null || true
+else
+  printf '{"schemaVersion":1,"status":"%s"}\\n' "\${KANVIBE_STATUS}" > "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null || true
+fi
 
 curl -s -X POST "\${KANVIBE_URL%/}/api/hooks/status" \
   -H "Content-Type: application/json" \
   -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"${status}\\\"}" \
   > /dev/null 2>&1 || true`;
+}
+
+export function hasShellKanvibeStatusJsonPersistence(content: string): boolean {
+  return content.includes("status.json")
+    && content.includes("KANVIBE_TASK_STATE_FILE")
+    && content.includes('"schemaVersion":1')
+    && content.includes('"status":"%s"');
 }
 
 export function getShellTaskIdBindingStatus(

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -23,6 +23,7 @@ import { setupOpenCodeHooks, getOpenCodeHooksStatus, generatePluginScript, PLUGI
 import { getHookServerUrl } from "@/lib/hookEndpoint";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { quoteShellArgument, readTextFiles } from "@/lib/hostFileAccess";
+import { buildKanvibeHookTargetsContent, getKanvibeHookTargetsPath } from "@/lib/kanvibeProjectState";
 
 const HOOK_INSTALL_MAX_ATTEMPTS = 3;
 const HOOK_INSTALL_RETRY_DELAY_MS = 500;
@@ -427,9 +428,14 @@ async function installKanvibeHookProviderOnce(
 async function setupRemoteClaudeHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
   const claudeDir = path.posix.join(repoPath, ".claude");
   const settingsPath = path.posix.join(claudeDir, "settings.json");
+  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
+  const files = await readTextFiles([settingsPath, hookTargetsPath], sshHost);
 
   await writeRemoteTextFiles(
-    buildRemoteClaudeHookFiles(repoPath, taskId, hookServerUrl, await readRemoteTextFile(settingsPath, sshHost)),
+    [
+      ...buildRemoteClaudeHookFiles(repoPath, taskId, hookServerUrl, files.get(settingsPath)?.content ?? ""),
+      buildRemoteHookTargetsFile(repoPath, taskId, hookServerUrl, sshHost, files.get(hookTargetsPath)?.content ?? ""),
+    ],
     sshHost,
   );
 }
@@ -437,9 +443,14 @@ async function setupRemoteClaudeHooks(repoPath: string, taskId: string, hookServ
 async function setupRemoteGeminiHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
   const geminiDir = path.posix.join(repoPath, ".gemini");
   const settingsPath = path.posix.join(geminiDir, "settings.json");
+  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
+  const files = await readTextFiles([settingsPath, hookTargetsPath], sshHost);
 
   await writeRemoteTextFiles(
-    buildRemoteGeminiHookFiles(repoPath, taskId, hookServerUrl, await readRemoteTextFile(settingsPath, sshHost)),
+    [
+      ...buildRemoteGeminiHookFiles(repoPath, taskId, hookServerUrl, files.get(settingsPath)?.content ?? ""),
+      buildRemoteHookTargetsFile(repoPath, taskId, hookServerUrl, sshHost, files.get(hookTargetsPath)?.content ?? ""),
+    ],
     sshHost,
   );
 }
@@ -448,22 +459,31 @@ async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServe
   const codexDir = path.posix.join(repoPath, ".codex");
   const configPath = path.posix.join(codexDir, CONFIG_FILE_NAME);
   const hooksPath = path.posix.join(codexDir, HOOKS_FILE_NAME);
-  const files = await readTextFiles([configPath, hooksPath], sshHost);
+  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
+  const files = await readTextFiles([configPath, hooksPath, hookTargetsPath], sshHost);
 
   await writeRemoteTextFiles(
-    buildRemoteCodexHookFiles(
-      repoPath,
-      taskId,
-      hookServerUrl,
-      files.get(configPath)?.content ?? "",
-      files.get(hooksPath)?.content ?? "",
-    ),
+    [
+      ...buildRemoteCodexHookFiles(
+        repoPath,
+        taskId,
+        hookServerUrl,
+        files.get(configPath)?.content ?? "",
+        files.get(hooksPath)?.content ?? "",
+      ),
+      buildRemoteHookTargetsFile(repoPath, taskId, hookServerUrl, sshHost, files.get(hookTargetsPath)?.content ?? ""),
+    ],
     sshHost,
   );
 }
 
 async function setupRemoteOpenCodeHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
-  await writeRemoteTextFiles(buildRemoteOpenCodeHookFiles(repoPath, taskId, hookServerUrl), sshHost);
+  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
+  const files = await readTextFiles([hookTargetsPath], sshHost);
+  await writeRemoteTextFiles([
+    ...buildRemoteOpenCodeHookFiles(repoPath, taskId, hookServerUrl),
+    buildRemoteHookTargetsFile(repoPath, taskId, hookServerUrl, sshHost, files.get(hookTargetsPath)?.content ?? ""),
+  ], sshHost);
 }
 
 async function setupRemoteKanvibeHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
@@ -471,11 +491,13 @@ async function setupRemoteKanvibeHooks(repoPath: string, taskId: string, hookSer
   const geminiSettingsPath = path.posix.join(repoPath, ".gemini", "settings.json");
   const codexConfigPath = path.posix.join(repoPath, ".codex", CONFIG_FILE_NAME);
   const codexHooksPath = path.posix.join(repoPath, ".codex", HOOKS_FILE_NAME);
+  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
   const existingFiles = await readTextFiles([
     claudeSettingsPath,
     geminiSettingsPath,
     codexConfigPath,
     codexHooksPath,
+    hookTargetsPath,
   ], sshHost);
   const plans = [
     {
@@ -499,6 +521,16 @@ async function setupRemoteKanvibeHooks(repoPath: string, taskId: string, hookSer
     {
       label: "OpenCode",
       files: buildRemoteOpenCodeHookFiles(repoPath, taskId, hookServerUrl),
+    },
+    {
+      label: "KanVibe targets",
+      files: [buildRemoteHookTargetsFile(
+        repoPath,
+        taskId,
+        hookServerUrl,
+        sshHost,
+        existingFiles.get(hookTargetsPath)?.content ?? "",
+      )],
     },
   ];
 
@@ -667,15 +699,17 @@ function buildRemoteOpenCodeHookFiles(
   ];
 }
 
-async function readRemoteTextFile(filePath: string, sshHost: string): Promise<string> {
-  try {
-    return await execGit(
-      `test -f ${quoteShellArgument(filePath)} && cat ${quoteShellArgument(filePath)} || true`,
-      sshHost,
-    );
-  } catch {
-    return "";
-  }
+function buildRemoteHookTargetsFile(
+  repoPath: string,
+  taskId: string,
+  hookServerUrl: string,
+  sshHost: string,
+  currentContent: string,
+): RemoteTextFile {
+  return {
+    filePath: getKanvibeHookTargetsPath(repoPath, sshHost),
+    content: buildKanvibeHookTargetsContent(currentContent, { url: hookServerUrl, taskId }),
+  };
 }
 
 function parseRemoteJsonObject(content: string): Record<string, unknown> {

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -428,13 +428,18 @@ async function installKanvibeHookProviderOnce(
 async function setupRemoteClaudeHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
   const claudeDir = path.posix.join(repoPath, ".claude");
   const settingsPath = path.posix.join(claudeDir, "settings.json");
-  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
-  const files = await readTextFiles([settingsPath, hookTargetsPath], sshHost);
+  const { existingFiles, hookTargetsFile } = await readRemoteHookInstallInputs(
+    repoPath,
+    taskId,
+    hookServerUrl,
+    sshHost,
+    [settingsPath],
+  );
 
   await writeRemoteTextFiles(
     [
-      ...buildRemoteClaudeHookFiles(repoPath, taskId, hookServerUrl, files.get(settingsPath)?.content ?? ""),
-      buildRemoteHookTargetsFile(repoPath, taskId, hookServerUrl, sshHost, files.get(hookTargetsPath)?.content ?? ""),
+      ...buildRemoteClaudeHookFiles(repoPath, taskId, hookServerUrl, existingFiles.get(settingsPath)?.content ?? ""),
+      hookTargetsFile,
     ],
     sshHost,
   );
@@ -443,13 +448,18 @@ async function setupRemoteClaudeHooks(repoPath: string, taskId: string, hookServ
 async function setupRemoteGeminiHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
   const geminiDir = path.posix.join(repoPath, ".gemini");
   const settingsPath = path.posix.join(geminiDir, "settings.json");
-  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
-  const files = await readTextFiles([settingsPath, hookTargetsPath], sshHost);
+  const { existingFiles, hookTargetsFile } = await readRemoteHookInstallInputs(
+    repoPath,
+    taskId,
+    hookServerUrl,
+    sshHost,
+    [settingsPath],
+  );
 
   await writeRemoteTextFiles(
     [
-      ...buildRemoteGeminiHookFiles(repoPath, taskId, hookServerUrl, files.get(settingsPath)?.content ?? ""),
-      buildRemoteHookTargetsFile(repoPath, taskId, hookServerUrl, sshHost, files.get(hookTargetsPath)?.content ?? ""),
+      ...buildRemoteGeminiHookFiles(repoPath, taskId, hookServerUrl, existingFiles.get(settingsPath)?.content ?? ""),
+      hookTargetsFile,
     ],
     sshHost,
   );
@@ -459,8 +469,13 @@ async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServe
   const codexDir = path.posix.join(repoPath, ".codex");
   const configPath = path.posix.join(codexDir, CONFIG_FILE_NAME);
   const hooksPath = path.posix.join(codexDir, HOOKS_FILE_NAME);
-  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
-  const files = await readTextFiles([configPath, hooksPath, hookTargetsPath], sshHost);
+  const { existingFiles, hookTargetsFile } = await readRemoteHookInstallInputs(
+    repoPath,
+    taskId,
+    hookServerUrl,
+    sshHost,
+    [configPath, hooksPath],
+  );
 
   await writeRemoteTextFiles(
     [
@@ -468,21 +483,20 @@ async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServe
         repoPath,
         taskId,
         hookServerUrl,
-        files.get(configPath)?.content ?? "",
-        files.get(hooksPath)?.content ?? "",
+        existingFiles.get(configPath)?.content ?? "",
+        existingFiles.get(hooksPath)?.content ?? "",
       ),
-      buildRemoteHookTargetsFile(repoPath, taskId, hookServerUrl, sshHost, files.get(hookTargetsPath)?.content ?? ""),
+      hookTargetsFile,
     ],
     sshHost,
   );
 }
 
 async function setupRemoteOpenCodeHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
-  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
-  const files = await readTextFiles([hookTargetsPath], sshHost);
+  const { hookTargetsFile } = await readRemoteHookInstallInputs(repoPath, taskId, hookServerUrl, sshHost);
   await writeRemoteTextFiles([
     ...buildRemoteOpenCodeHookFiles(repoPath, taskId, hookServerUrl),
-    buildRemoteHookTargetsFile(repoPath, taskId, hookServerUrl, sshHost, files.get(hookTargetsPath)?.content ?? ""),
+    hookTargetsFile,
   ], sshHost);
 }
 
@@ -491,14 +505,13 @@ async function setupRemoteKanvibeHooks(repoPath: string, taskId: string, hookSer
   const geminiSettingsPath = path.posix.join(repoPath, ".gemini", "settings.json");
   const codexConfigPath = path.posix.join(repoPath, ".codex", CONFIG_FILE_NAME);
   const codexHooksPath = path.posix.join(repoPath, ".codex", HOOKS_FILE_NAME);
-  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
-  const existingFiles = await readTextFiles([
-    claudeSettingsPath,
-    geminiSettingsPath,
-    codexConfigPath,
-    codexHooksPath,
-    hookTargetsPath,
-  ], sshHost);
+  const { existingFiles, hookTargetsFile } = await readRemoteHookInstallInputs(
+    repoPath,
+    taskId,
+    hookServerUrl,
+    sshHost,
+    [claudeSettingsPath, geminiSettingsPath, codexConfigPath, codexHooksPath],
+  );
   const plans = [
     {
       label: "Claude",
@@ -524,13 +537,7 @@ async function setupRemoteKanvibeHooks(repoPath: string, taskId: string, hookSer
     },
     {
       label: "KanVibe targets",
-      files: [buildRemoteHookTargetsFile(
-        repoPath,
-        taskId,
-        hookServerUrl,
-        sshHost,
-        existingFiles.get(hookTargetsPath)?.content ?? "",
-      )],
+      files: [hookTargetsFile],
     },
   ];
 
@@ -548,6 +555,28 @@ async function setupRemoteKanvibeHooks(repoPath: string, taskId: string, hookSer
     }
   }));
   assertHookInstallResults(results, plans.map(({ label }) => label));
+}
+
+async function readRemoteHookInstallInputs(
+  repoPath: string,
+  taskId: string,
+  hookServerUrl: string,
+  sshHost: string,
+  filePaths: string[] = [],
+): Promise<{ existingFiles: Awaited<ReturnType<typeof readTextFiles>>; hookTargetsFile: RemoteTextFile }> {
+  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
+  const existingFiles = await readTextFiles([...filePaths, hookTargetsPath], sshHost);
+
+  return {
+    existingFiles,
+    hookTargetsFile: buildRemoteHookTargetsFile(
+      repoPath,
+      taskId,
+      hookServerUrl,
+      sshHost,
+      existingFiles.get(hookTargetsPath)?.content ?? "",
+    ),
+  };
 }
 
 function buildRemoteClaudeHookFiles(

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -23,7 +23,6 @@ import { setupOpenCodeHooks, getOpenCodeHooksStatus, generatePluginScript, PLUGI
 import { getHookServerUrl } from "@/lib/hookEndpoint";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { quoteShellArgument, readTextFiles } from "@/lib/hostFileAccess";
-import { buildKanvibeHookTargetsContent, getKanvibeHookTargetsPath } from "@/lib/kanvibeProjectState";
 
 const HOOK_INSTALL_MAX_ATTEMPTS = 3;
 const HOOK_INSTALL_RETRY_DELAY_MS = 500;
@@ -428,18 +427,11 @@ async function installKanvibeHookProviderOnce(
 async function setupRemoteClaudeHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
   const claudeDir = path.posix.join(repoPath, ".claude");
   const settingsPath = path.posix.join(claudeDir, "settings.json");
-  const { existingFiles, hookTargetsFile } = await readRemoteHookInstallInputs(
-    repoPath,
-    taskId,
-    hookServerUrl,
-    sshHost,
-    [settingsPath],
-  );
+  const existingFiles = await readRemoteHookInstallInputs(sshHost, [settingsPath]);
 
   await writeRemoteTextFiles(
     [
       ...buildRemoteClaudeHookFiles(repoPath, taskId, hookServerUrl, existingFiles.get(settingsPath)?.content ?? ""),
-      hookTargetsFile,
     ],
     sshHost,
   );
@@ -448,18 +440,11 @@ async function setupRemoteClaudeHooks(repoPath: string, taskId: string, hookServ
 async function setupRemoteGeminiHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
   const geminiDir = path.posix.join(repoPath, ".gemini");
   const settingsPath = path.posix.join(geminiDir, "settings.json");
-  const { existingFiles, hookTargetsFile } = await readRemoteHookInstallInputs(
-    repoPath,
-    taskId,
-    hookServerUrl,
-    sshHost,
-    [settingsPath],
-  );
+  const existingFiles = await readRemoteHookInstallInputs(sshHost, [settingsPath]);
 
   await writeRemoteTextFiles(
     [
       ...buildRemoteGeminiHookFiles(repoPath, taskId, hookServerUrl, existingFiles.get(settingsPath)?.content ?? ""),
-      hookTargetsFile,
     ],
     sshHost,
   );
@@ -469,13 +454,7 @@ async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServe
   const codexDir = path.posix.join(repoPath, ".codex");
   const configPath = path.posix.join(codexDir, CONFIG_FILE_NAME);
   const hooksPath = path.posix.join(codexDir, HOOKS_FILE_NAME);
-  const { existingFiles, hookTargetsFile } = await readRemoteHookInstallInputs(
-    repoPath,
-    taskId,
-    hookServerUrl,
-    sshHost,
-    [configPath, hooksPath],
-  );
+  const existingFiles = await readRemoteHookInstallInputs(sshHost, [configPath, hooksPath]);
 
   await writeRemoteTextFiles(
     [
@@ -486,18 +465,13 @@ async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServe
         existingFiles.get(configPath)?.content ?? "",
         existingFiles.get(hooksPath)?.content ?? "",
       ),
-      hookTargetsFile,
     ],
     sshHost,
   );
 }
 
 async function setupRemoteOpenCodeHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
-  const { hookTargetsFile } = await readRemoteHookInstallInputs(repoPath, taskId, hookServerUrl, sshHost);
-  await writeRemoteTextFiles([
-    ...buildRemoteOpenCodeHookFiles(repoPath, taskId, hookServerUrl),
-    hookTargetsFile,
-  ], sshHost);
+  await writeRemoteTextFiles(buildRemoteOpenCodeHookFiles(repoPath, taskId, hookServerUrl), sshHost);
 }
 
 async function setupRemoteKanvibeHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
@@ -505,10 +479,7 @@ async function setupRemoteKanvibeHooks(repoPath: string, taskId: string, hookSer
   const geminiSettingsPath = path.posix.join(repoPath, ".gemini", "settings.json");
   const codexConfigPath = path.posix.join(repoPath, ".codex", CONFIG_FILE_NAME);
   const codexHooksPath = path.posix.join(repoPath, ".codex", HOOKS_FILE_NAME);
-  const { existingFiles, hookTargetsFile } = await readRemoteHookInstallInputs(
-    repoPath,
-    taskId,
-    hookServerUrl,
+  const existingFiles = await readRemoteHookInstallInputs(
     sshHost,
     [claudeSettingsPath, geminiSettingsPath, codexConfigPath, codexHooksPath],
   );
@@ -535,10 +506,6 @@ async function setupRemoteKanvibeHooks(repoPath: string, taskId: string, hookSer
       label: "OpenCode",
       files: buildRemoteOpenCodeHookFiles(repoPath, taskId, hookServerUrl),
     },
-    {
-      label: "KanVibe targets",
-      files: [hookTargetsFile],
-    },
   ];
 
   const results = await Promise.allSettled(plans.map(async ({ label, files }) => {
@@ -558,25 +525,10 @@ async function setupRemoteKanvibeHooks(repoPath: string, taskId: string, hookSer
 }
 
 async function readRemoteHookInstallInputs(
-  repoPath: string,
-  taskId: string,
-  hookServerUrl: string,
   sshHost: string,
   filePaths: string[] = [],
-): Promise<{ existingFiles: Awaited<ReturnType<typeof readTextFiles>>; hookTargetsFile: RemoteTextFile }> {
-  const hookTargetsPath = getKanvibeHookTargetsPath(repoPath, sshHost);
-  const existingFiles = await readTextFiles([...filePaths, hookTargetsPath], sshHost);
-
-  return {
-    existingFiles,
-    hookTargetsFile: buildRemoteHookTargetsFile(
-      repoPath,
-      taskId,
-      hookServerUrl,
-      sshHost,
-      existingFiles.get(hookTargetsPath)?.content ?? "",
-    ),
-  };
+): Promise<Awaited<ReturnType<typeof readTextFiles>>> {
+  return readTextFiles(filePaths, sshHost);
 }
 
 function buildRemoteClaudeHookFiles(
@@ -726,19 +678,6 @@ function buildRemoteOpenCodeHookFiles(
       content: generatePluginScript(hookServerUrl, taskId),
     },
   ];
-}
-
-function buildRemoteHookTargetsFile(
-  repoPath: string,
-  taskId: string,
-  hookServerUrl: string,
-  sshHost: string,
-  currentContent: string,
-): RemoteTextFile {
-  return {
-    filePath: getKanvibeHookTargetsPath(repoPath, sshHost),
-    content: buildKanvibeHookTargetsContent(currentContent, { url: hookServerUrl, taskId }),
-  };
 }
 
 function parseRemoteJsonObject(content: string): Record<string, unknown> {

--- a/src/lib/kanvibeProjectState.ts
+++ b/src/lib/kanvibeProjectState.ts
@@ -3,42 +3,15 @@ import { TaskStatus } from "@/entities/KanbanTask";
 import { readTextFile, writeTextFile } from "@/lib/hostFileAccess";
 
 export const KANVIBE_DIR_NAME = ".kanvibe";
-export const HOOK_TARGETS_FILE_NAME = "hooks-targets.json";
-export const TASK_STATE_FILE_NAME = "task-state.json";
-
-export interface KanvibeHookTarget {
-  url: string;
-  taskId: string;
-}
-
-export interface KanvibeHookTargetsDocument {
-  version: 1;
-  targets: KanvibeHookTarget[];
-}
+export const TASK_STATE_FILE_NAME = "status.md";
 
 export interface KanvibeTaskState {
   version: 1;
-  taskId?: string;
   status: TaskStatus;
-  updatedAt?: string;
-}
-
-export function getKanvibeHookTargetsPath(repoPath: string, sshHost?: string | null): string {
-  return getPathModule(sshHost).join(repoPath, KANVIBE_DIR_NAME, HOOK_TARGETS_FILE_NAME);
 }
 
 export function getKanvibeTaskStatePath(repoPath: string, sshHost?: string | null): string {
   return getPathModule(sshHost).join(repoPath, KANVIBE_DIR_NAME, TASK_STATE_FILE_NAME);
-}
-
-export async function upsertKanvibeHookTarget(
-  repoPath: string,
-  target: KanvibeHookTarget,
-  sshHost?: string | null,
-): Promise<void> {
-  const filePath = getKanvibeHookTargetsPath(repoPath, sshHost);
-  const currentContent = await readTextFile(filePath, sshHost);
-  await writeTextFile(filePath, buildKanvibeHookTargetsContent(currentContent, target), sshHost);
 }
 
 export async function readKanvibeTaskState(
@@ -61,30 +34,10 @@ export async function writeKanvibeTaskState(
   );
 }
 
-export function buildKanvibeHookTargetsContent(
-  currentContent: string,
-  target: KanvibeHookTarget,
-): string {
-  const parsed = parseKanvibeHookTargets(currentContent);
-  const nextTargets = parsed.targets.filter((value) => !(
-    value.url === target.url && value.taskId === target.taskId
-  ));
-  nextTargets.push(target);
-
-  return JSON.stringify({ version: 1, targets: nextTargets } satisfies KanvibeHookTargetsDocument, null, 2) + "\n";
-}
-
 export function buildKanvibeTaskStateContent(
   taskState: Pick<KanvibeTaskState, "status"> & { taskId?: string | null },
 ): string {
-  const payload: KanvibeTaskState = {
-    version: 1,
-    ...(taskState.taskId ? { taskId: taskState.taskId } : {}),
-    status: taskState.status,
-    updatedAt: new Date().toISOString(),
-  };
-
-  return JSON.stringify(payload, null, 2) + "\n";
+  return `${taskState.status}\n`;
 }
 
 export function parseKanvibeTaskState(content: string): KanvibeTaskState | null {
@@ -92,8 +45,16 @@ export function parseKanvibeTaskState(content: string): KanvibeTaskState | null 
     return null;
   }
 
+  const statusFromMarkdown = parseTaskStatus(content.trim());
+  if (statusFromMarkdown) {
+    return {
+      version: 1,
+      status: statusFromMarkdown,
+    };
+  }
+
   try {
-    const parsed = JSON.parse(content) as { taskId?: unknown; status?: unknown; updatedAt?: unknown };
+    const parsed = JSON.parse(content) as { status?: unknown };
     const status = parseTaskStatus(parsed.status);
     if (!status) {
       return null;
@@ -101,9 +62,7 @@ export function parseKanvibeTaskState(content: string): KanvibeTaskState | null 
 
     return {
       version: 1,
-      ...(typeof parsed.taskId === "string" && parsed.taskId.length > 0 ? { taskId: parsed.taskId } : {}),
       status,
-      ...(typeof parsed.updatedAt === "string" && parsed.updatedAt.length > 0 ? { updatedAt: parsed.updatedAt } : {}),
     };
   } catch {
     return null;
@@ -118,38 +77,6 @@ export function parseTaskStatus(value: unknown): TaskStatus | null {
   const normalized = value.toLowerCase();
   const statuses = new Set<string>(Object.values(TaskStatus));
   return statuses.has(normalized) ? normalized as TaskStatus : null;
-}
-
-function parseKanvibeHookTargets(content: string): KanvibeHookTargetsDocument {
-  if (!content.trim()) {
-    return { version: 1, targets: [] };
-  }
-
-  try {
-    const parsed = JSON.parse(content) as { targets?: unknown };
-    const targets = Array.isArray(parsed.targets)
-      ? parsed.targets.flatMap((value): KanvibeHookTarget[] => {
-        if (!value || typeof value !== "object") {
-          return [];
-        }
-
-        const candidate = value as { url?: unknown; taskId?: unknown };
-        if (typeof candidate.url !== "string" || typeof candidate.taskId !== "string") {
-          return [];
-        }
-
-        if (!candidate.url || !candidate.taskId) {
-          return [];
-        }
-
-        return [{ url: candidate.url, taskId: candidate.taskId }];
-      })
-      : [];
-
-    return { version: 1, targets };
-  } catch {
-    return { version: 1, targets: [] };
-  }
 }
 
 function getPathModule(sshHost?: string | null): typeof path.posix | typeof path {

--- a/src/lib/kanvibeProjectState.ts
+++ b/src/lib/kanvibeProjectState.ts
@@ -3,11 +3,12 @@ import { TaskStatus } from "@/entities/KanbanTask";
 import { readTextFile, writeTextFile } from "@/lib/hostFileAccess";
 
 export const KANVIBE_DIR_NAME = ".kanvibe";
-export const TASK_STATE_FILE_NAME = "status.md";
+export const TASK_STATE_FILE_NAME = "status.json";
 
 export interface KanvibeTaskState {
-  version: 1;
+  schemaVersion: 1;
   status: TaskStatus;
+  updatedAt?: string;
 }
 
 export function getKanvibeTaskStatePath(repoPath: string, sshHost?: string | null): string {
@@ -24,7 +25,7 @@ export async function readKanvibeTaskState(
 
 export async function writeKanvibeTaskState(
   repoPath: string,
-  taskState: Pick<KanvibeTaskState, "status"> & { taskId?: string | null },
+  taskState: Pick<KanvibeTaskState, "status">,
   sshHost?: string | null,
 ): Promise<void> {
   await writeTextFile(
@@ -35,9 +36,15 @@ export async function writeKanvibeTaskState(
 }
 
 export function buildKanvibeTaskStateContent(
-  taskState: Pick<KanvibeTaskState, "status"> & { taskId?: string | null },
+  taskState: Pick<KanvibeTaskState, "status">,
 ): string {
-  return `${taskState.status}\n`;
+  const payload: KanvibeTaskState = {
+    schemaVersion: 1,
+    status: taskState.status,
+    updatedAt: new Date().toISOString(),
+  };
+
+  return JSON.stringify(payload, null, 2) + "\n";
 }
 
 export function parseKanvibeTaskState(content: string): KanvibeTaskState | null {
@@ -48,21 +55,22 @@ export function parseKanvibeTaskState(content: string): KanvibeTaskState | null 
   const statusFromMarkdown = parseTaskStatus(content.trim());
   if (statusFromMarkdown) {
     return {
-      version: 1,
+      schemaVersion: 1,
       status: statusFromMarkdown,
     };
   }
 
   try {
-    const parsed = JSON.parse(content) as { status?: unknown };
+    const parsed = JSON.parse(content) as { status?: unknown; updatedAt?: unknown };
     const status = parseTaskStatus(parsed.status);
     if (!status) {
       return null;
     }
 
     return {
-      version: 1,
+      schemaVersion: 1,
       status,
+      ...(typeof parsed.updatedAt === "string" && parsed.updatedAt.length > 0 ? { updatedAt: parsed.updatedAt } : {}),
     };
   } catch {
     return null;

--- a/src/lib/kanvibeProjectState.ts
+++ b/src/lib/kanvibeProjectState.ts
@@ -1,0 +1,157 @@
+import path from "path";
+import { TaskStatus } from "@/entities/KanbanTask";
+import { readTextFile, writeTextFile } from "@/lib/hostFileAccess";
+
+export const KANVIBE_DIR_NAME = ".kanvibe";
+export const HOOK_TARGETS_FILE_NAME = "hooks-targets.json";
+export const TASK_STATE_FILE_NAME = "task-state.json";
+
+export interface KanvibeHookTarget {
+  url: string;
+  taskId: string;
+}
+
+export interface KanvibeHookTargetsDocument {
+  version: 1;
+  targets: KanvibeHookTarget[];
+}
+
+export interface KanvibeTaskState {
+  version: 1;
+  taskId?: string;
+  status: TaskStatus;
+  updatedAt?: string;
+}
+
+export function getKanvibeHookTargetsPath(repoPath: string, sshHost?: string | null): string {
+  return getPathModule(sshHost).join(repoPath, KANVIBE_DIR_NAME, HOOK_TARGETS_FILE_NAME);
+}
+
+export function getKanvibeTaskStatePath(repoPath: string, sshHost?: string | null): string {
+  return getPathModule(sshHost).join(repoPath, KANVIBE_DIR_NAME, TASK_STATE_FILE_NAME);
+}
+
+export async function upsertKanvibeHookTarget(
+  repoPath: string,
+  target: KanvibeHookTarget,
+  sshHost?: string | null,
+): Promise<void> {
+  const filePath = getKanvibeHookTargetsPath(repoPath, sshHost);
+  const currentContent = await readTextFile(filePath, sshHost);
+  await writeTextFile(filePath, buildKanvibeHookTargetsContent(currentContent, target), sshHost);
+}
+
+export async function readKanvibeTaskState(
+  repoPath: string,
+  sshHost?: string | null,
+): Promise<KanvibeTaskState | null> {
+  const content = await readTextFile(getKanvibeTaskStatePath(repoPath, sshHost), sshHost);
+  return parseKanvibeTaskState(content);
+}
+
+export async function writeKanvibeTaskState(
+  repoPath: string,
+  taskState: Pick<KanvibeTaskState, "status"> & { taskId?: string | null },
+  sshHost?: string | null,
+): Promise<void> {
+  await writeTextFile(
+    getKanvibeTaskStatePath(repoPath, sshHost),
+    buildKanvibeTaskStateContent(taskState),
+    sshHost,
+  );
+}
+
+export function buildKanvibeHookTargetsContent(
+  currentContent: string,
+  target: KanvibeHookTarget,
+): string {
+  const parsed = parseKanvibeHookTargets(currentContent);
+  const nextTargets = parsed.targets.filter((value) => !(
+    value.url === target.url && value.taskId === target.taskId
+  ));
+  nextTargets.push(target);
+
+  return JSON.stringify({ version: 1, targets: nextTargets } satisfies KanvibeHookTargetsDocument, null, 2) + "\n";
+}
+
+export function buildKanvibeTaskStateContent(
+  taskState: Pick<KanvibeTaskState, "status"> & { taskId?: string | null },
+): string {
+  const payload: KanvibeTaskState = {
+    version: 1,
+    ...(taskState.taskId ? { taskId: taskState.taskId } : {}),
+    status: taskState.status,
+    updatedAt: new Date().toISOString(),
+  };
+
+  return JSON.stringify(payload, null, 2) + "\n";
+}
+
+export function parseKanvibeTaskState(content: string): KanvibeTaskState | null {
+  if (typeof content !== "string" || !content.trim()) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(content) as { taskId?: unknown; status?: unknown; updatedAt?: unknown };
+    const status = parseTaskStatus(parsed.status);
+    if (!status) {
+      return null;
+    }
+
+    return {
+      version: 1,
+      ...(typeof parsed.taskId === "string" && parsed.taskId.length > 0 ? { taskId: parsed.taskId } : {}),
+      status,
+      ...(typeof parsed.updatedAt === "string" && parsed.updatedAt.length > 0 ? { updatedAt: parsed.updatedAt } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function parseTaskStatus(value: unknown): TaskStatus | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.toLowerCase();
+  const statuses = new Set<string>(Object.values(TaskStatus));
+  return statuses.has(normalized) ? normalized as TaskStatus : null;
+}
+
+function parseKanvibeHookTargets(content: string): KanvibeHookTargetsDocument {
+  if (!content.trim()) {
+    return { version: 1, targets: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(content) as { targets?: unknown };
+    const targets = Array.isArray(parsed.targets)
+      ? parsed.targets.flatMap((value): KanvibeHookTarget[] => {
+        if (!value || typeof value !== "object") {
+          return [];
+        }
+
+        const candidate = value as { url?: unknown; taskId?: unknown };
+        if (typeof candidate.url !== "string" || typeof candidate.taskId !== "string") {
+          return [];
+        }
+
+        if (!candidate.url || !candidate.taskId) {
+          return [];
+        }
+
+        return [{ url: candidate.url, taskId: candidate.taskId }];
+      })
+      : [];
+
+    return { version: 1, targets };
+  } catch {
+    return { version: 1, targets: [] };
+  }
+}
+
+function getPathModule(sshHost?: string | null): typeof path.posix | typeof path {
+  return sshHost ? path.posix : path;
+}

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -32,14 +32,18 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
   const TASK_ID = ${JSON.stringify(taskId)};
   const KANVIBE_REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
   const KANVIBE_STATE_DIR = resolve(KANVIBE_REPO_ROOT, ".kanvibe");
-  const KANVIBE_STATUS_FILE = resolve(KANVIBE_STATE_DIR, "status.md");
+  const KANVIBE_STATUS_FILE = resolve(KANVIBE_STATE_DIR, "status.json");
   const lastStatusBySession = new Map<string, string>();
   const lastUserMessageBySession = new Map<string, string>();
 
   function writeKanvibeTaskState(status: string): void {
     try {
       mkdirSync(KANVIBE_STATE_DIR, { recursive: true });
-      writeFileSync(KANVIBE_STATUS_FILE, status + "\\n", "utf8");
+      writeFileSync(
+        KANVIBE_STATUS_FILE,
+        JSON.stringify({ schemaVersion: 1, status, updatedAt: new Date().toISOString() }, null, 2) + "\\n",
+        "utf8",
+      );
     } catch {
       /* 파일 쓰기 에러 무시 */
     }
@@ -199,6 +203,11 @@ function hasKanvibePlugin(pluginContent: string): boolean {
   return pluginContent.includes("KanvibePlugin") && pluginContent.includes("/api/hooks/status");
 }
 
+function hasOpenCodeStatusJsonPersistence(pluginContent: string): boolean {
+  return pluginContent.includes("status.json")
+    && pluginContent.includes("JSON.stringify({ schemaVersion: 1, status, updatedAt: new Date().toISOString() }");
+}
+
 function extractPluginTaskId(pluginContent: string): string | null {
   const match = pluginContent.match(/const TASK_ID = ("(?:\\.|[^"\\])*");/);
   if (!match) return null;
@@ -243,6 +252,7 @@ export interface OpenCodeHooksStatus {
   hasExpectedTaskId?: boolean;
   hasStatusEndpoint?: boolean;
   hasEventMappings?: boolean;
+  hasStatusJsonPersistence?: boolean;
   hasMainSessionGuard?: boolean;
   hasDuplicateProgressGuard?: boolean;
   hasExpectedHookServerUrl?: boolean;
@@ -270,6 +280,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
   let hasTaskIdBinding = false;
   let hasStatusEndpoint = false;
   let hasEventMappings = false;
+  let hasStatusJsonPersistence = false;
   let hasMainSessionGuard = false;
   let hasDuplicateProgressGuard = false;
   let hasRegisteredPlugin = sshHost ? true : false;
@@ -289,6 +300,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
       hasExpectedTaskId = hasTaskIdBinding && (!taskId || boundTaskId === taskId);
       hasStatusEndpoint = content.includes("/api/hooks/status");
       hasEventMappings = ["progress", "pending", "review", "done", "message.updated", "question.asked", "question.replied", "session.idle", "session.deleted"].every((fragment) => content.includes(fragment));
+      hasStatusJsonPersistence = hasOpenCodeStatusJsonPersistence(content);
       hasMainSessionGuard = content.includes("isMainSession(message)") && content.includes("isMainSession(event.properties)");
       hasDuplicateProgressGuard = content.includes("lastUserMessageBySession") && content.includes("buildMessageSignature") && content.includes("dedupeMessage: true");
     } catch {
@@ -315,6 +327,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
     && hasExpectedTaskId
     && hasStatusEndpoint
     && hasEventMappings
+    && hasStatusJsonPersistence
     && hasMainSessionGuard
     && hasDuplicateProgressGuard
     && hasRegisteredPlugin
@@ -329,6 +342,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
     hasExpectedTaskId,
     hasStatusEndpoint,
     hasEventMappings,
+    hasStatusJsonPersistence,
     hasMainSessionGuard,
     hasDuplicateProgressGuard,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -5,7 +5,6 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFiles } from "@/lib/hostFileAccess";
 import { extractPluginHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
 import { getOpenCodeRegisteredKanvibePluginUrls } from "@/lib/openCodePluginRegistry";
-import { upsertKanvibeHookTarget } from "@/lib/kanvibeProjectState";
 
 /**
  * OpenCode는 `.opencode/plugins/` 디렉토리에 TypeScript 플러그인을 배치하여 hooks를 등록한다.
@@ -19,7 +18,7 @@ export const PLUGIN_DIR_NAME = "plugins";
 /** OpenCode plugin TypeScript 파일 내용을 생성한다 */
 export function generatePluginScript(kanvibeUrl: string, taskId: string): string {
   return `import type { Plugin } from "@opencode-ai/plugin";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { mkdirSync, writeFileSync } from "fs";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 
@@ -33,38 +32,14 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
   const TASK_ID = ${JSON.stringify(taskId)};
   const KANVIBE_REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
   const KANVIBE_STATE_DIR = resolve(KANVIBE_REPO_ROOT, ".kanvibe");
-  const KANVIBE_TARGETS_FILE = resolve(KANVIBE_STATE_DIR, "hooks-targets.json");
-  const KANVIBE_TASK_STATE_FILE = resolve(KANVIBE_STATE_DIR, "task-state.json");
+  const KANVIBE_STATUS_FILE = resolve(KANVIBE_STATE_DIR, "status.md");
   const lastStatusBySession = new Map<string, string>();
   const lastUserMessageBySession = new Map<string, string>();
-
-  function readKanvibeTargets(): Array<{ url: string; taskId: string }> {
-    try {
-      if (!existsSync(KANVIBE_TARGETS_FILE)) {
-        return [{ url: KANVIBE_URL, taskId: TASK_ID }];
-      }
-
-      const parsed = JSON.parse(readFileSync(KANVIBE_TARGETS_FILE, "utf8"));
-      const targets = Array.isArray(parsed.targets)
-        ? parsed.targets.filter((target: any) => (
-          target && typeof target.url === "string" && target.url && typeof target.taskId === "string" && target.taskId
-        ))
-        : [];
-
-      return targets.length > 0 ? targets : [{ url: KANVIBE_URL, taskId: TASK_ID }];
-    } catch {
-      return [{ url: KANVIBE_URL, taskId: TASK_ID }];
-    }
-  }
 
   function writeKanvibeTaskState(status: string): void {
     try {
       mkdirSync(KANVIBE_STATE_DIR, { recursive: true });
-      writeFileSync(
-        KANVIBE_TASK_STATE_FILE,
-        JSON.stringify({ version: 1, taskId: TASK_ID, status, updatedAt: new Date().toISOString() }, null, 2) + "\\n",
-        "utf8",
-      );
+      writeFileSync(KANVIBE_STATUS_FILE, status + "\\n", "utf8");
     } catch {
       /* 파일 쓰기 에러 무시 */
     }
@@ -118,16 +93,14 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
 
     writeKanvibeTaskState(status);
 
-    for (const target of readKanvibeTargets()) {
-      try {
-        await fetch(\`\${target.url.replace(/\/$/, "")}/api/hooks/status\`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ taskId: target.taskId, status }),
-        });
-      } catch {
-        /* 네트워크 에러 무시 */
-      }
+    try {
+      await fetch(\`\${KANVIBE_URL.replace(/\/$/, "")}/api/hooks/status\`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ taskId: TASK_ID, status }),
+      });
+    } catch {
+      /* 네트워크 에러 무시 */
     }
 
     if (sessionID) {
@@ -253,7 +226,6 @@ export async function setupOpenCodeHooks(
 
   const pluginPath = path.join(pluginsDir, PLUGIN_FILE_NAME);
   await writeFile(pluginPath, generatePluginScript(kanvibeUrl, taskId), "utf-8");
-  await upsertKanvibeHookTarget(repoPath, { url: kanvibeUrl, taskId });
 
   try {
     await addAiToolPatternsToGitExclude(repoPath);

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -5,6 +5,7 @@ import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readTextFiles } from "@/lib/hostFileAccess";
 import { extractPluginHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
 import { getOpenCodeRegisteredKanvibePluginUrls } from "@/lib/openCodePluginRegistry";
+import { upsertKanvibeHookTarget } from "@/lib/kanvibeProjectState";
 
 /**
  * OpenCode는 `.opencode/plugins/` 디렉토리에 TypeScript 플러그인을 배치하여 hooks를 등록한다.
@@ -18,6 +19,9 @@ export const PLUGIN_DIR_NAME = "plugins";
 /** OpenCode plugin TypeScript 파일 내용을 생성한다 */
 export function generatePluginScript(kanvibeUrl: string, taskId: string): string {
   return `import type { Plugin } from "@opencode-ai/plugin";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 
 /**
  * KanVibe OpenCode Plugin
@@ -27,8 +31,44 @@ export function generatePluginScript(kanvibeUrl: string, taskId: string): string
 export const KanvibePlugin: Plugin = async ({ client }) => {
   const KANVIBE_URL = "${kanvibeUrl}";
   const TASK_ID = ${JSON.stringify(taskId)};
+  const KANVIBE_REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+  const KANVIBE_STATE_DIR = resolve(KANVIBE_REPO_ROOT, ".kanvibe");
+  const KANVIBE_TARGETS_FILE = resolve(KANVIBE_STATE_DIR, "hooks-targets.json");
+  const KANVIBE_TASK_STATE_FILE = resolve(KANVIBE_STATE_DIR, "task-state.json");
   const lastStatusBySession = new Map<string, string>();
   const lastUserMessageBySession = new Map<string, string>();
+
+  function readKanvibeTargets(): Array<{ url: string; taskId: string }> {
+    try {
+      if (!existsSync(KANVIBE_TARGETS_FILE)) {
+        return [{ url: KANVIBE_URL, taskId: TASK_ID }];
+      }
+
+      const parsed = JSON.parse(readFileSync(KANVIBE_TARGETS_FILE, "utf8"));
+      const targets = Array.isArray(parsed.targets)
+        ? parsed.targets.filter((target: any) => (
+          target && typeof target.url === "string" && target.url && typeof target.taskId === "string" && target.taskId
+        ))
+        : [];
+
+      return targets.length > 0 ? targets : [{ url: KANVIBE_URL, taskId: TASK_ID }];
+    } catch {
+      return [{ url: KANVIBE_URL, taskId: TASK_ID }];
+    }
+  }
+
+  function writeKanvibeTaskState(status: string): void {
+    try {
+      mkdirSync(KANVIBE_STATE_DIR, { recursive: true });
+      writeFileSync(
+        KANVIBE_TASK_STATE_FILE,
+        JSON.stringify({ version: 1, taskId: TASK_ID, status, updatedAt: new Date().toISOString() }, null, 2) + "\\n",
+        "utf8",
+      );
+    } catch {
+      /* 파일 쓰기 에러 무시 */
+    }
+  }
 
   function getSessionID(source: any): string | undefined {
     return (
@@ -76,17 +116,22 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
       return;
     }
 
-    try {
-      await fetch(\`\${KANVIBE_URL}/api/hooks/status\`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ taskId: TASK_ID, status }),
-      });
-      if (sessionID) {
-        lastStatusBySession.set(sessionID, status);
+    writeKanvibeTaskState(status);
+
+    for (const target of readKanvibeTargets()) {
+      try {
+        await fetch(\`\${target.url.replace(/\/$/, "")}/api/hooks/status\`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ taskId: target.taskId, status }),
+        });
+      } catch {
+        /* 네트워크 에러 무시 */
       }
-    } catch {
-      /* 네트워크 에러 무시 */
+    }
+
+    if (sessionID) {
+      lastStatusBySession.set(sessionID, status);
     }
   }
 
@@ -208,6 +253,7 @@ export async function setupOpenCodeHooks(
 
   const pluginPath = path.join(pluginsDir, PLUGIN_FILE_NAME);
   await writeFile(pluginPath, generatePluginScript(kanvibeUrl, taskId), "utf-8");
+  await upsertKanvibeHookTarget(repoPath, { url: kanvibeUrl, taskId });
 
   try {
     await addAiToolPatternsToGitExclude(repoPath);


### PR DESCRIPTION
## Summary
- Persist the shared project task status in `.kanvibe/status.json` as an extensible JSON object (`schemaVersion`, `status`, `updatedAt`).
- Keep the state file status-only: no `taskId`, hook URL, or task/url mapping is written to the project state.
- Update Claude, Gemini, Codex, and OpenCode hooks/plugins to write the JSON state and treat legacy `status.md` hooks as stale so reinstall upgrades them.
- Keep `.kanvibe/status.json` ignored by git and prune legacy `.kanvibe/hooks-targets.json`, `.kanvibe/task-state.json`, and `.kanvibe/status.md` exclude entries.

## Verification
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js check` — passed
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js exec vitest run src/lib/__tests__/hookTaskBinding.test.ts src/lib/__tests__/kanvibeProjectState.test.ts src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts src/desktop/main/services/__tests__/projectService.test.ts src/lib/__tests__/claudeHooksSetup.test.ts src/lib/__tests__/geminiHooksSetup.test.ts src/lib/__tests__/codexHooksSetup.test.ts src/lib/__tests__/openCodeHooksSetup.test.ts` — 8 files / 102 tests passed
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js lint` — passed with 0 errors and existing 11 warnings
- `git diff --check` — passed

Earlier full PR validation before the schema field rename:
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js test` — 89 files / 731 tests passed
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js build` — passed
