### PR TITLE
fix: allow app windows to resize freely

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -359,8 +359,6 @@ function createBrowserWindowOptions() {
   return {
     width: 1600,
     height: 1000,
-    minWidth: 1200,
-    minHeight: 800,
     backgroundColor: "#ffffff",
     autoHideMenuBar: true,
     ...getTitleBarOptions(),

--- a/src/lib/__tests__/mainWindowOptions.test.ts
+++ b/src/lib/__tests__/mainWindowOptions.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("main window options", () => {
+  it("does not set app-level minimum window dimensions", () => {
+    const source = readFileSync(path.join(process.cwd(), "electron", "main.js"), "utf8");
+    const options = source.match(
+      /function createBrowserWindowOptions\(\) \{\n\s+return \{([\s\S]*?)\n\s+\};\n\}/,
+    )?.[1];
+
+    expect(options).toBeDefined();
+    expect(options).not.toMatch(/\bmin(?:Width|Height)\s*:/);
+  });
+});


### PR DESCRIPTION
## Summary
- Remove Electron BrowserWindow app-level minimum width and height so KanVibe can be resized below the previous 1200x800 floor.
- Add a regression test that guards against reintroducing minimum window dimensions.

## Test Plan
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js exec vitest run src/lib/__tests__/mainWindowOptions.test.ts`
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js check`
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js lint` (passes with existing warnings)
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js build`
- Ad-hoc Electron resize QA under Xvfb with an isolated app data dir: `getMinimumSize()` returned `[0,0]`, and resizing to `640x420` succeeded.
