### PR TITLE
fix: load local and remote AI chat history

### DIFF
--- a/qa/electron/flows/ai-session-history.cjs
+++ b/qa/electron/flows/ai-session-history.cjs
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const fs = require("node:fs");
 const path = require("node:path");
-const { execFileSync } = require("node:child_process");
+const { execFileSync, spawnSync } = require("node:child_process");
 const { createQaRun } = require("../lib/report.cjs");
 const { launchKanVibeElectron } = require("../lib/launchElectron.cjs");
 
@@ -343,6 +343,150 @@ connection.close()
   return { claudeFile, codexFile, geminiChatFile, openCodeDbPath: dbPath };
 }
 
+function commandExists(command) {
+  try {
+    execFileSync("bash", ["-lc", `command -v ${command}`], { stdio: "ignore", timeout: 3000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveCodexHeadlessCommand() {
+  if (process.env.KANVIBE_QA_CODEX_COMMAND) {
+    const parts = process.env.KANVIBE_QA_CODEX_COMMAND.split(" ").filter(Boolean);
+    return parts.length > 0 ? { command: parts[0], baseArgs: parts.slice(1), label: process.env.KANVIBE_QA_CODEX_COMMAND } : null;
+  }
+
+  if (commandExists("codex")) {
+    return { command: "codex", baseArgs: [], label: "codex" };
+  }
+
+  if (commandExists("npx")) {
+    return { command: "npx", baseArgs: ["-y", "@openai/codex"], label: "npx -y @openai/codex" };
+  }
+
+  return null;
+}
+
+function collectJsonlFiles(rootPath) {
+  if (!fs.existsSync(rootPath)) return [];
+  const entries = fs.readdirSync(rootPath, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const entryPath = path.join(rootPath, entry.name);
+    if (entry.isDirectory()) return collectJsonlFiles(entryPath);
+    return entry.isFile() && entry.name.endsWith(".jsonl") ? [entryPath] : [];
+  });
+}
+
+function findCodexHeadlessSessionFile(codexHome, marker, targetPath) {
+  const sessionsRoot = path.join(codexHome, "sessions");
+  return collectJsonlFiles(sessionsRoot)
+    .sort((left, right) => fs.statSync(right).mtimeMs - fs.statSync(left).mtimeMs)
+    .find((filePath) => {
+      const content = fs.readFileSync(filePath, "utf8");
+      return content.includes(marker) && content.includes(targetPath);
+    }) || null;
+}
+
+function classifyCodexHeadlessSkipReason(output) {
+  const normalized = output.toLowerCase();
+  if (/command not found|enoent|not found|could not determine executable|npm error.*eacces/.test(normalized)) {
+    return "Codex CLI is not installed or could not be started";
+  }
+  if (/not logged in|login required|please log in|unauthorized|authentication|auth|api key|401/.test(normalized)) {
+    return "Codex is not logged in or authentication is unavailable";
+  }
+  if (/rate limit|usage limit|limit reached|quota|insufficient_quota|429|too many requests|temporarily unavailable/.test(normalized)) {
+    return "Codex usage/rate limit is currently blocking live requests";
+  }
+  if (/network|enotfound|econn|etimedout|fetch failed|proxy|tls|certificate/.test(normalized)) {
+    return "Network/runtime environment prevented the live Codex request";
+  }
+  return null;
+}
+
+function runActualCodexHeadlessRequest({ run, fakeHome, previousHome, fixture }) {
+  const commandSpec = resolveCodexHeadlessCommand();
+  if (!commandSpec) {
+    return { state: "skipped", reason: "Codex CLI is not installed and npx is unavailable" };
+  }
+
+  const realHome = process.env.KANVIBE_QA_REAL_HOME || previousHome;
+  if (!realHome) {
+    return { state: "skipped", reason: "Real HOME is unavailable, so Codex auth cannot be checked" };
+  }
+
+  const realCodexHome = process.env.KANVIBE_QA_REAL_CODEX_HOME || path.join(realHome, ".codex");
+  const realAuthPath = path.join(realCodexHome, "auth.json");
+  if (!fs.existsSync(realAuthPath)) {
+    return { state: "skipped", reason: "Codex auth.json is missing; agent is not logged in" };
+  }
+
+  const fakeCodexHome = path.join(fakeHome, ".codex");
+  fs.mkdirSync(fakeCodexHome, { recursive: true });
+  const fakeAuthPath = path.join(fakeCodexHome, "auth.json");
+  fs.rmSync(fakeAuthPath, { force: true });
+  fs.symlinkSync(realAuthPath, fakeAuthPath);
+
+  const marker = `KANVIBE_CODEX_HEADLESS_OK_${run.runId.replace(/[^a-zA-Z0-9]/g, "_")}`;
+  const stdoutPath = path.join(run.runDir, "codex-headless.stdout.jsonl");
+  const stderrPath = path.join(run.runDir, "codex-headless.stderr.log");
+  const prompt = `KanVibe QA headless smoke. Do not modify files. Reply exactly: ${marker}.`;
+  const args = [
+    ...commandSpec.baseArgs,
+    "exec",
+    "--json",
+    "--skip-git-repo-check",
+    "--sandbox",
+    "read-only",
+    "-C",
+    fixture.repoDir,
+    prompt,
+  ];
+  const timeout = Number(process.env.KANVIBE_QA_CODEX_HEADLESS_TIMEOUT_MS || 180_000);
+
+  try {
+    const result = spawnSync(commandSpec.command, args, {
+      cwd: fixture.repoDir,
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        CODEX_HOME: fakeCodexHome,
+      },
+      encoding: "utf8",
+      timeout,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+
+    fs.writeFileSync(stdoutPath, result.stdout || "", "utf8");
+    fs.writeFileSync(stderrPath, result.stderr || "", "utf8");
+
+    const combinedOutput = `${result.error ? result.error.message : ""}\n${result.stderr || ""}\n${result.stdout || ""}`;
+    if (result.error) {
+      const reason = classifyCodexHeadlessSkipReason(combinedOutput) || `Codex process error: ${result.error.message}`;
+      return { state: "skipped", reason, stdoutPath, stderrPath, marker, command: commandSpec.label };
+    }
+
+    if (result.status !== 0) {
+      const skipReason = classifyCodexHeadlessSkipReason(combinedOutput);
+      if (skipReason) {
+        return { state: "skipped", reason: skipReason, stdoutPath, stderrPath, marker, command: commandSpec.label };
+      }
+      return { state: "failed", reason: `Codex exited with status ${result.status}`, stdoutPath, stderrPath, marker, command: commandSpec.label };
+    }
+
+    const sessionFile = findCodexHeadlessSessionFile(fakeCodexHome, marker, fixture.repoDir);
+    if (!sessionFile) {
+      return { state: "failed", reason: "Codex succeeded but no persisted session JSONL contained the marker", stdoutPath, stderrPath, marker, command: commandSpec.label };
+    }
+
+    return { state: "passed", marker, sessionFile, stdoutPath, stderrPath, command: commandSpec.label };
+  } finally {
+    fs.rmSync(fakeAuthPath, { force: true });
+  }
+}
+
 async function waitForText(page, text) {
   await page.getByText(text, { exact: false }).first().waitFor({ state: "visible", timeout: 15000 });
 }
@@ -389,6 +533,7 @@ async function main() {
   let traceStarted = false;
   let fixture;
   let seededTask;
+  let headlessCodexResult = null;
 
   const check = async (name, fn) => {
     try {
@@ -417,6 +562,18 @@ async function main() {
   try {
     fixture = createFixtureRepository(run);
     const aiFixtures = createFakeAiSessionHistory(fakeHome, fixture);
+
+    await optionalCheck("Actual Codex headless CLI request persists readable history (non-blocking when unavailable)", async () => {
+      headlessCodexResult = runActualCodexHeadlessRequest({ run, fakeHome, previousHome, fixture });
+      if (headlessCodexResult.state === "failed") {
+        throw new Error(headlessCodexResult.reason);
+      }
+      if (headlessCodexResult.state === "skipped") {
+        return `skipped (non-blocking): ${headlessCodexResult.reason}`;
+      }
+      return `passed: ${headlessCodexResult.command}; marker=${headlessCodexResult.marker}; session=${headlessCodexResult.sessionFile}`;
+    });
+
     process.env.HOME = fakeHome;
 
     const launched = await launchKanVibeElectron({
@@ -501,6 +658,17 @@ async function main() {
       return "all four provider icons and expected session titles/prompts are visible";
     });
     await takeScreenshot(page, run, "provider-session-list-visible", screenshots);
+
+    await check("Actual Codex headless session is visible in the KanVibe history UI when available", async () => {
+      if (!headlessCodexResult || headlessCodexResult.state !== "passed") {
+        return `not required: ${headlessCodexResult?.reason || "headless Codex did not run"}`;
+      }
+      const listText = await getSessionListText(page);
+      if (!listText.includes(headlessCodexResult.marker)) {
+        throw new Error(`live Codex marker was not visible in the loaded session list: ${headlessCodexResult.marker}`);
+      }
+      return `live Codex exec marker visible in session list: ${headlessCodexResult.marker}`;
+    });
 
     await setStepOverlay(page, "3/6 왼쪽 provider 아이콘 rail: Claude+Gemini OR 필터 동작 검증");
     await check("Provider icon rail filters sessions with OR semantics", async () => {
@@ -655,6 +823,11 @@ async function main() {
   else notes.push("No mp4 was present when flow finished; wrapper script is expected to fail if recording is missing.");
   notes.push(`Fake HOME for provider history fixtures: ${fakeHome}`);
   if (fixture) notes.push(`Fixture repo/worktree: ${fixture.repoDir} / ${fixture.worktreePath}`);
+  if (headlessCodexResult?.state === "passed") {
+    notes.push(`Actual Codex headless request persisted to fake HOME and was checked in the UI: ${headlessCodexResult.sessionFile}`);
+  } else if (headlessCodexResult?.state === "skipped") {
+    notes.push(`Actual Codex headless request skipped without failing QA: ${headlessCodexResult.reason}`);
+  }
   notes.push("QA uses isolated KANVIBE_APP_DATA_DIR and fake HOME under the run directory, not the user's app data or real AI history.");
   diagnostics.push(`CDP counters: ${JSON.stringify(cdpCollector.counters)}`);
   diagnostics.push("Playwright trace captures actions, screenshots, DOM snapshots, console, and network timeline.");
@@ -671,6 +844,7 @@ async function main() {
     videoPath: fs.existsSync(run.videoPath) ? run.videoPath : null,
     tracePath: fs.existsSync(run.tracePath) ? run.tracePath : null,
     cdpDiagnosticsPath: fs.existsSync(run.cdpDiagnosticsPath) ? run.cdpDiagnosticsPath : null,
+    headlessCodex: headlessCodexResult,
     notes,
   };
 

--- a/scripts/qa-ai-session-history-video.sh
+++ b/scripts/qa-ai-session-history-video.sh
@@ -7,6 +7,15 @@ RUN_DIR="${KANVIBE_QA_RUN_DIR:-$ROOT_DIR/qa-output/$RUN_ID}"
 VIDEO_PATH="$RUN_DIR/run.mp4"
 LOG_PATH="$RUN_DIR/ffmpeg.log"
 mkdir -p "$RUN_DIR"
+if [[ -z "${HOME:-}" || ! -d "$HOME" ]]; then
+  HOME="$(python3 - <<'PY'
+import os, pwd
+print(pwd.getpwuid(os.getuid()).pw_dir)
+PY
+)"
+  export HOME
+fi
+export KANVIBE_QA_REAL_HOME="${KANVIBE_QA_REAL_HOME:-$HOME}"
 
 run_flow() {
   cd "$ROOT_DIR"

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -67,6 +67,7 @@ const STATUS_TRANSITIONS = [
 ] as const;
 
 const INLINE_CHAT_DETAIL_LIMIT = 40;
+const INLINE_CHAT_INCLUDE_REPO_SESSIONS = true;
 
 const AGENT_TAG_STYLES: Record<string, string> = {
   claude: "bg-tag-claude-bg text-tag-claude-text",
@@ -303,7 +304,7 @@ function InlineAiChatView({ taskId }: { taskId: string }) {
     setIsHistoryLoading(true);
     setHistoryError(null);
     try {
-      const result = await getTaskAiSessions(taskId, false, normalizedQuery);
+      const result = await getTaskAiSessions(taskId, INLINE_CHAT_INCLUDE_REPO_SESSIONS, normalizedQuery);
       setHistory(result);
       setAppliedSearchQuery(normalizedQuery);
       setSelectedSessionKey(null);
@@ -357,7 +358,7 @@ function InlineAiChatView({ taskId }: { taskId: string }) {
       selectedSession.sourceRef ?? null,
       null,
       INLINE_CHAT_DETAIL_LIMIT,
-      false,
+      INLINE_CHAT_INCLUDE_REPO_SESSIONS,
       appliedSearchQuery,
       activeRoles.length > 0 ? activeRoles : undefined,
     ).then((result) => {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -960,9 +960,30 @@ describe("TaskDetailRoute", () => {
 
     expect(await screen.findByTestId("inline-ai-chat")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "aiSessions.loadHistory" }));
+
+    await waitFor(() => {
+      expect(mocks.getTaskAiSessions).toHaveBeenCalledWith("task-1", true, undefined);
+    });
+
     fireEvent.click(await screen.findByRole("button", { name: /Claude chat/ }));
 
-    expect(await screen.findByText("Please fix the UI")).toBeTruthy();
+    await waitFor(() => {
+      expect(mocks.getTaskAiSessionDetail).toHaveBeenCalledWith(
+        "task-1",
+        "claude",
+        "claude-session",
+        null,
+        null,
+        40,
+        true,
+        undefined,
+        undefined,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Please fix the UI").length).toBeGreaterThanOrEqual(1);
+    });
     expect(screen.getByText("Updated the terminal chat view.")).toBeTruthy();
     expect(screen.queryByLabelText("terminal input")).toBeNull();
 
@@ -1416,7 +1437,7 @@ describe("TaskDetailRoute", () => {
 
     await waitFor(() => {
       expect(mocks.getTaskAiSessions).toHaveBeenCalledTimes(1);
-      expect(mocks.getTaskAiSessions).toHaveBeenCalledWith("task-1", false, undefined);
+      expect(mocks.getTaskAiSessions).toHaveBeenCalledWith("task-1", true, undefined);
     });
   });
 
@@ -1558,7 +1579,7 @@ describe("TaskDetailRoute", () => {
     fireEvent.submit(searchInput.closest("form")!);
 
     await waitFor(() => {
-      expect(mocks.getTaskAiSessions).toHaveBeenCalledWith("task-1", false, "database migration");
+      expect(mocks.getTaskAiSessions).toHaveBeenCalledWith("task-1", true, "database migration");
     });
     expect(await screen.findByRole("button", { name: /Gemini architecture answer/ })).toBeTruthy();
   });
@@ -1618,7 +1639,7 @@ describe("TaskDetailRoute", () => {
         "claude.jsonl",
         null,
         expect.any(Number),
-        false,
+        true,
         undefined,
         undefined,
       );
@@ -1634,7 +1655,7 @@ describe("TaskDetailRoute", () => {
         "claude.jsonl",
         null,
         expect.any(Number),
-        false,
+        true,
         undefined,
         ["system"],
       );

--- a/src/lib/aiSessions/__tests__/readAiSessions.test.ts
+++ b/src/lib/aiSessions/__tests__/readAiSessions.test.ts
@@ -1,8 +1,9 @@
+import { execFile } from "child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { readClaudeSessionDetail } from "@/lib/aiSessions/readClaudeSessions";
+import { readClaudeSessionDetail, readClaudeSessions } from "@/lib/aiSessions/readClaudeSessions";
 import { readCodexSessionDetail } from "@/lib/aiSessions/readCodexSessions";
 import { readGeminiSessionDetail, readGeminiSessions } from "@/lib/aiSessions/readGeminiSessions";
 
@@ -277,6 +278,132 @@ describe("AI session history readers", () => {
       "user",
     ]);
     expect(detail?.messages.find((message) => message.role === "tool")?.fullText).toContain("read_file");
+  });
+
+  it("discovers Claude Code sessions by parsing JSONL cwd when the encoded project directory lookup misses", async () => {
+    const worktreePath = path.join(tempHome, "repo__worktrees", "task");
+    const sessionFile = path.join(tempHome, ".claude", "projects", "legacy-or-aliased-project-dir", "claude-session.jsonl");
+
+    await writeJsonLines(sessionFile, [
+      {
+        type: "user",
+        sessionId: "claude-aliased-session",
+        cwd: worktreePath,
+        timestamp: "2026-01-01T00:01:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "load aliased claude history" }] },
+      },
+      {
+        type: "assistant",
+        sessionId: "claude-aliased-session",
+        cwd: worktreePath,
+        timestamp: "2026-01-01T00:02:00.000Z",
+        message: { role: "assistant", content: [{ type: "text", text: "aliased history loaded" }] },
+      },
+    ]);
+
+    const sessions = await readClaudeSessions({ worktreePath, repoPath: worktreePath });
+
+    expect(sessions.sessions).toHaveLength(1);
+    expect(sessions.sessions[0]).toMatchObject({
+      id: "claude-aliased-session",
+      provider: "claude",
+      matchedPath: worktreePath,
+      firstUserPrompt: "load aliased claude history",
+      sourceRef: sessionFile,
+    });
+  });
+
+  it("uses Gemini CLI .project_root metadata when projects.json does not map the chat directory", async () => {
+    const worktreePath = path.join(tempHome, "repo__worktrees", "task");
+    const projectDir = path.join(tempHome, ".gemini", "tmp", "project-with-root-file");
+    const chatFile = path.join(projectDir, "chats", "session-2026-01-01T00-20-gemini.json");
+
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(path.join(projectDir, ".project_root"), worktreePath, "utf-8");
+    await writeJson(chatFile, {
+      sessionId: "gemini-root-file-session",
+      startTime: "2026-01-01T00:20:00.000Z",
+      lastUpdated: "2026-01-01T00:22:00.000Z",
+      messages: [
+        { id: "user-1", timestamp: "2026-01-01T00:21:00.000Z", type: "user", content: [{ text: "load project root gemini history" }] },
+        { id: "assistant-1", timestamp: "2026-01-01T00:22:00.000Z", type: "gemini", content: [{ text: "project root history loaded" }] },
+      ],
+    });
+
+    const sessions = await readGeminiSessions({ worktreePath, repoPath: worktreePath });
+
+    expect(sessions.sessions).toHaveLength(1);
+    expect(sessions.sessions[0]).toMatchObject({
+      id: "gemini-root-file-session",
+      provider: "gemini",
+      matchedPath: worktreePath,
+      firstUserPrompt: "load project root gemini history",
+      sourceRef: chatFile,
+    });
+
+    const detail = await readGeminiSessionDetail({ worktreePath, repoPath: worktreePath }, "gemini-root-file-session", chatFile);
+    expect(detail?.messages.map((message) => [message.role, message.fullText])).toEqual([
+      ["assistant", "project root history loaded"],
+      ["user", "load project root gemini history"],
+    ]);
+  });
+
+  it("falls back to Python sqlite for local OpenCode history when native better-sqlite3 cannot open the DB", async () => {
+    const worktreePath = path.join(tempHome, "repo__worktrees", "task");
+    const dbPath = path.join(tempHome, ".local", "share", "opencode", "opencode.db");
+    const seedScript = `
+import json
+import sqlite3
+import sys
+
+db_path, directory = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(db_path)
+cur = conn.cursor()
+cur.executescript("""
+CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL, title TEXT, time_created INTEGER, time_updated INTEGER);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data TEXT NOT NULL);
+CREATE TABLE part (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, message_id TEXT NOT NULL, data TEXT NOT NULL, time_created INTEGER NOT NULL);
+""")
+cur.execute("INSERT INTO session VALUES (?, ?, ?, ?, ?)", ("local-open", directory, "Local OpenCode", 1700000000000, 1700000010000))
+for message_id, role, text, timestamp in [
+    ("user-message", "user", "load local opencode history", 1700000000000),
+    ("assistant-message", "assistant", "local opencode history loaded", 1700000010000),
+]:
+    cur.execute("INSERT INTO message VALUES (?, ?, ?)", (message_id, "local-open", json.dumps({"role": role})))
+    cur.execute("INSERT INTO part VALUES (?, ?, ?, ?, ?)", (f"{message_id}-part", "local-open", message_id, json.dumps({"type": "text", "text": text}), timestamp))
+conn.commit()
+conn.close()
+`;
+    await mkdir(path.dirname(dbPath), { recursive: true });
+    await new Promise<void>((resolve, reject) => {
+      execFile("python3", ["-c", seedScript, dbPath, worktreePath], (error) => error ? reject(error) : resolve());
+    });
+
+    vi.resetModules();
+    vi.doMock("@/lib/sqliteConnectionPool", () => ({
+      getSqliteConnection: vi.fn(() => {
+        throw new Error("native sqlite unavailable");
+      }),
+      querySqlite: vi.fn(),
+    }));
+    const { readOpenCodeSessionDetail, readOpenCodeSessions } = await import("@/lib/aiSessions/readOpenCodeSessions");
+
+    const sessions = await readOpenCodeSessions({ worktreePath, repoPath: worktreePath });
+    expect(sessions).toMatchObject({ provider: "opencode", available: true, sessionCount: 1 });
+    expect(sessions.sessions[0]).toMatchObject({
+      id: "local-open",
+      provider: "opencode",
+      matchedPath: worktreePath,
+      title: "Local OpenCode",
+      firstUserPrompt: "load local opencode history",
+      sourceRef: "local-open",
+    });
+
+    const detail = await readOpenCodeSessionDetail({ worktreePath, repoPath: worktreePath }, "local-open", "local-open");
+    expect(detail?.messages.map((message) => [message.role, message.fullText])).toEqual([
+      ["assistant", "local opencode history loaded"],
+      ["user", "load local opencode history"],
+    ]);
   });
 
   it("reads remote Claude Code repo sessions and detail over SSH", async () => {

--- a/src/lib/aiSessions/__tests__/readAiSessions.test.ts
+++ b/src/lib/aiSessions/__tests__/readAiSessions.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readClaudeSessionDetail, readClaudeSessions } from "@/lib/aiSessions/readClaudeSessions";
-import { readCodexSessionDetail } from "@/lib/aiSessions/readCodexSessions";
+import { readCodexSessionDetail, readCodexSessions } from "@/lib/aiSessions/readCodexSessions";
 import { readGeminiSessionDetail, readGeminiSessions } from "@/lib/aiSessions/readGeminiSessions";
 
 let tempHome: string;
@@ -222,6 +222,63 @@ describe("AI session history readers", () => {
       "developer",
     ]);
     expect(detail?.messages.find((message) => message.role === "developer")?.fullText).toBe("Follow project rules.");
+  });
+
+  it("uses actual Codex exec prompts and final answers instead of internal environment messages", async () => {
+    const worktreePath = path.join(tempHome, "repo__worktrees", "task");
+    const sessionFile = path.join(tempHome, ".codex", "sessions", "2026", "codex-exec-session.jsonl");
+
+    await writeJsonLines(sessionFile, [
+      {
+        type: "session_meta",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        payload: { id: "codex-exec-session", cwd: worktreePath, timestamp: "2026-01-01T00:00:00.000Z", source: "exec" },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-01-01T00:01:00.000Z",
+        payload: { type: "message", role: "developer", content: [{ type: "input_text", text: "<permissions instructions>\nSandbox metadata\n</permissions instructions>" }] },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-01-01T00:02:00.000Z",
+        payload: { type: "message", role: "user", content: [{ type: "input_text", text: `<environment_context>\n  <cwd>${worktreePath}</cwd>\n</environment_context>` }] },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-01-01T00:03:00.000Z",
+        payload: { type: "message", role: "user", content: [{ type: "input_text", text: "Run the headless smoke check." }] },
+      },
+      {
+        type: "event_msg",
+        timestamp: "2026-01-01T00:04:00.000Z",
+        payload: { type: "agent_message", message: "KANVIBE_CODEX_HEADLESS_OK", phase: "final_answer" },
+      },
+    ]);
+
+    const sessions = await readCodexSessions({ worktreePath, repoPath: worktreePath, query: "KANVIBE_CODEX_HEADLESS_OK" });
+    expect(sessions).toMatchObject({ provider: "codex", available: true, sessionCount: 1 });
+    expect(sessions.sessions[0]).toMatchObject({
+      id: "codex-exec-session",
+      provider: "codex",
+      title: "Run the headless smoke check.",
+      firstUserPrompt: "Run the headless smoke check.",
+      messageCount: 2,
+      sourceRef: sessionFile,
+    });
+
+    const detail = await readCodexSessionDetail(
+      { worktreePath, repoPath: worktreePath },
+      "codex-exec-session",
+      sessionFile,
+      null,
+      20,
+    );
+
+    expect(detail?.messages.map((message) => [message.role, message.fullText])).toEqual([
+      ["assistant", "KANVIBE_CODEX_HEADLESS_OK"],
+      ["user", "Run the headless smoke check."],
+    ]);
   });
 
   it("reads Gemini chat recordings from ~/.gemini/tmp/<project>/chats and classifies responses, thoughts, and tool calls", async () => {

--- a/src/lib/aiSessions/__tests__/readAiSessions.test.ts
+++ b/src/lib/aiSessions/__tests__/readAiSessions.test.ts
@@ -30,6 +30,7 @@ describe("AI session history readers", () => {
 
   afterEach(async () => {
     vi.doUnmock("@/lib/sqliteConnectionPool");
+    vi.doUnmock("@/lib/gitOperations");
     vi.unstubAllEnvs();
     await rm(tempHome, { recursive: true, force: true });
   });
@@ -206,6 +207,98 @@ describe("AI session history readers", () => {
       "user",
     ]);
     expect(detail?.messages.find((message) => message.role === "tool")?.fullText).toContain("read_file");
+  });
+
+  it("reads remote OpenCode sessions and detail over SSH", async () => {
+    const worktreePath = "/remote/repo__worktrees/task";
+    const repoPath = "/remote/repo";
+    const execCalls: Array<{ command: string; sshHost?: string | null }> = [];
+    let remoteSqliteQueryCount = 0;
+
+    vi.resetModules();
+    vi.doMock("@/lib/gitOperations", () => ({
+      execGit: vi.fn(async (command: string, sshHost?: string | null) => {
+        execCalls.push({ command, sshHost });
+        if (command === "printf '%s' \"$HOME\"") {
+          return "/remote/home";
+        }
+        if (command.includes("test -e") && command.includes("opencode.db")) {
+          return "1";
+        }
+        if (command.includes("python3 -c")) {
+          remoteSqliteQueryCount += 1;
+          if (remoteSqliteQueryCount === 1) {
+            return JSON.stringify([
+              {
+                id: "remote-open",
+                directory: worktreePath,
+                title: "Remote OpenCode",
+                time_created: 1_700_000_000_000,
+                time_updated: 1_700_000_010_000,
+                part_count: 2,
+                first_user_part: JSON.stringify({ type: "text", text: "fix remote chat" }),
+                matching_part_count: 0,
+              },
+            ]);
+          }
+
+          return JSON.stringify([
+            {
+              session_id: "remote-open",
+              directory: worktreePath,
+              title: "Remote OpenCode",
+              message_id: "user-message",
+              part_data: JSON.stringify({ type: "text", text: "fix remote chat" }),
+              time_created: 1_700_000_000_000,
+              message_data: JSON.stringify({ role: "user" }),
+            },
+            {
+              session_id: "remote-open",
+              directory: worktreePath,
+              title: "Remote OpenCode",
+              message_id: "assistant-message",
+              part_data: JSON.stringify({ type: "text", text: "remote history loaded" }),
+              time_created: 1_700_000_010_000,
+              message_data: JSON.stringify({ role: "assistant" }),
+            },
+          ]);
+        }
+        throw new Error(`unexpected remote command: ${command}`);
+      }),
+    }));
+
+    const { readOpenCodeSessionDetail, readOpenCodeSessions } = await import("@/lib/aiSessions/readOpenCodeSessions");
+
+    const sessions = await readOpenCodeSessions({ worktreePath, repoPath, sshHost: "remote-host" });
+    expect(sessions).toMatchObject({
+      provider: "opencode",
+      available: true,
+      sessionCount: 1,
+      reason: null,
+    });
+    expect(sessions.sessions[0]).toMatchObject({
+      id: "remote-open",
+      provider: "opencode",
+      matchedPath: worktreePath,
+      title: "Remote OpenCode",
+      firstUserPrompt: "fix remote chat",
+      sourceRef: "remote-open",
+    });
+
+    const detail = await readOpenCodeSessionDetail(
+      { worktreePath, repoPath, sshHost: "remote-host" },
+      "remote-open",
+      "remote-open",
+      null,
+      20,
+    );
+
+    expect(detail?.messages.map((message) => [message.role, message.fullText])).toEqual([
+      ["assistant", "remote history loaded"],
+      ["user", "fix remote chat"],
+    ]);
+    expect(execCalls.every((call) => call.sshHost === "remote-host")).toBe(true);
+    expect(remoteSqliteQueryCount).toBe(2);
   });
 
   it("treats OpenCode body search wildcard characters as literal text", async () => {

--- a/src/lib/aiSessions/__tests__/readAiSessions.test.ts
+++ b/src/lib/aiSessions/__tests__/readAiSessions.test.ts
@@ -15,11 +15,80 @@ async function writeJson(filePath: string, value: unknown) {
 
 async function writeJsonLines(filePath: string, values: unknown[]) {
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, `${values.map((value) => JSON.stringify(value)).join("\n")}\n`, "utf-8");
+  await writeFile(filePath, jsonLines(values), "utf-8");
+}
+
+function jsonLines(values: unknown[]) {
+  return `${values.map((value) => JSON.stringify(value)).join("\n")}\n`;
 }
 
 function claudeProjectDirectoryName(targetPath: string) {
   return path.resolve(targetPath).replaceAll(path.sep, "-").replaceAll("_", "-");
+}
+
+function setupRemoteFileSystem(files: Record<string, string>) {
+  const fileMap = new Map(Object.entries(files));
+  const directorySet = new Set<string>();
+  const execCalls: Array<{ command: string; sshHost?: string | null }> = [];
+
+  for (const filePath of fileMap.keys()) {
+    let current = path.dirname(filePath);
+    while (current && current !== path.dirname(current)) {
+      directorySet.add(current);
+      current = path.dirname(current);
+    }
+  }
+
+  const pathExists = (targetPath: string) => fileMap.has(targetPath) || directorySet.has(targetPath);
+  const listFiles = (rootPath: string, suffix: string, recursive: boolean) => Array.from(fileMap.keys())
+    .filter((filePath) => filePath.endsWith(suffix))
+    .filter((filePath) => recursive
+      ? filePath.startsWith(`${rootPath}/`)
+      : path.dirname(filePath) === rootPath)
+    .sort()
+    .join("\n");
+
+  vi.doMock("@/lib/gitOperations", () => ({
+    execGit: vi.fn(async (command: string, sshHost?: string | null) => {
+      execCalls.push({ command, sshHost });
+      if (command === "printf '%s' \"$HOME\"") {
+        return "/remote/home";
+      }
+
+      const findMatch = command.match(/test -d '([^']+)' && find '([^']+)' (?:-maxdepth 1 )?-type f -name '\*([^']+)'/);
+      if (findMatch) {
+        if (findMatch[1] !== findMatch[2]) {
+          throw new Error(`find command path mismatch: ${command}`);
+        }
+        return listFiles(findMatch[1], findMatch[3], !command.includes(" -maxdepth 1 "));
+      }
+
+      const catMatch = command.match(/test -f '([^']+)' && cat '([^']+)' \|\| true/);
+      if (catMatch) {
+        if (catMatch[1] !== catMatch[2]) {
+          throw new Error(`cat command path mismatch: ${command}`);
+        }
+        return fileMap.get(catMatch[1]) ?? "";
+      }
+
+      const statMatch = command.match(/test -e '([^']+)' && \(stat -c %Y '([^']+)'/);
+      if (statMatch) {
+        if (statMatch[1] !== statMatch[2]) {
+          throw new Error(`stat command path mismatch: ${command}`);
+        }
+        return pathExists(statMatch[1]) ? "1700000000" : "";
+      }
+
+      const existsMatch = command.match(/test -e '([^']+)' && printf '1' \|\| true/);
+      if (existsMatch) {
+        return pathExists(existsMatch[1]) ? "1" : "";
+      }
+
+      throw new Error(`unexpected remote command: ${command}`);
+    }),
+  }));
+
+  return { execCalls };
 }
 
 describe("AI session history readers", () => {
@@ -31,6 +100,7 @@ describe("AI session history readers", () => {
   afterEach(async () => {
     vi.doUnmock("@/lib/sqliteConnectionPool");
     vi.doUnmock("@/lib/gitOperations");
+    vi.resetModules();
     vi.unstubAllEnvs();
     await rm(tempHome, { recursive: true, force: true });
   });
@@ -207,6 +277,161 @@ describe("AI session history readers", () => {
       "user",
     ]);
     expect(detail?.messages.find((message) => message.role === "tool")?.fullText).toContain("read_file");
+  });
+
+  it("reads remote Claude Code repo sessions and detail over SSH", async () => {
+    const worktreePath = "/remote/repo__worktrees/task";
+    const repoPath = "/remote/repo";
+    const sessionFile = `/remote/home/.claude/projects/${claudeProjectDirectoryName(repoPath)}/remote-claude.jsonl`;
+
+    vi.resetModules();
+    const { execCalls } = setupRemoteFileSystem({
+      [sessionFile]: jsonLines([
+        {
+          type: "user",
+          sessionId: "remote-claude",
+          cwd: repoPath,
+          timestamp: "2026-01-01T00:01:00.000Z",
+          message: { role: "user", content: [{ type: "text", text: "load repo claude history" }] },
+        },
+        {
+          type: "assistant",
+          sessionId: "remote-claude",
+          cwd: repoPath,
+          timestamp: "2026-01-01T00:02:00.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "Claude history loaded remotely." }] },
+        },
+      ]),
+    });
+    const { readClaudeSessionDetail, readClaudeSessions } = await import("@/lib/aiSessions/readClaudeSessions");
+
+    const sessions = await readClaudeSessions({ worktreePath, repoPath, includeRepoSessions: true, sshHost: "remote-host" });
+    expect(sessions).toMatchObject({ provider: "claude", available: true, sessionCount: 1 });
+    expect(sessions.sessions[0]).toMatchObject({
+      id: "remote-claude",
+      provider: "claude",
+      matchedPath: repoPath,
+      matchScope: "repo",
+      firstUserPrompt: "load repo claude history",
+      sourceRef: sessionFile,
+    });
+
+    const detail = await readClaudeSessionDetail(
+      { worktreePath, repoPath, includeRepoSessions: true, sshHost: "remote-host" },
+      "remote-claude",
+      sessionFile,
+      null,
+      20,
+    );
+
+    expect(detail?.messages.map((message) => [message.role, message.fullText])).toEqual([
+      ["assistant", "Claude history loaded remotely."],
+      ["user", "load repo claude history"],
+    ]);
+    expect(execCalls.length).toBeGreaterThan(0);
+    expect(execCalls.every((call) => call.sshHost === "remote-host")).toBe(true);
+  });
+
+  it("reads remote Codex repo sessions and detail over SSH", async () => {
+    const worktreePath = "/remote/repo__worktrees/task";
+    const repoPath = "/remote/repo";
+    const sessionFile = "/remote/home/.codex/sessions/2026/remote-codex.jsonl";
+
+    vi.resetModules();
+    const { execCalls } = setupRemoteFileSystem({
+      [sessionFile]: jsonLines([
+        {
+          type: "session_meta",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          payload: { id: "remote-codex", cwd: repoPath, timestamp: "2026-01-01T00:00:00.000Z" },
+        },
+        {
+          type: "response_item",
+          timestamp: "2026-01-01T00:01:00.000Z",
+          payload: { type: "message", role: "user", content: [{ type: "input_text", text: "load repo codex history" }] },
+        },
+        {
+          type: "response_item",
+          timestamp: "2026-01-01T00:02:00.000Z",
+          payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "Codex history loaded remotely." }] },
+        },
+      ]),
+    });
+    const { readCodexSessionDetail, readCodexSessions } = await import("@/lib/aiSessions/readCodexSessions");
+
+    const sessions = await readCodexSessions({ worktreePath, repoPath, includeRepoSessions: true, sshHost: "remote-host" });
+    expect(sessions).toMatchObject({ provider: "codex", available: true, sessionCount: 1 });
+    expect(sessions.sessions[0]).toMatchObject({
+      id: "remote-codex",
+      provider: "codex",
+      matchedPath: repoPath,
+      matchScope: "repo",
+      firstUserPrompt: "load repo codex history",
+      sourceRef: sessionFile,
+    });
+
+    const detail = await readCodexSessionDetail(
+      { worktreePath, repoPath, includeRepoSessions: true, sshHost: "remote-host" },
+      "remote-codex",
+      sessionFile,
+      null,
+      20,
+    );
+
+    expect(detail?.messages.map((message) => [message.role, message.fullText])).toEqual([
+      ["assistant", "Codex history loaded remotely."],
+      ["user", "load repo codex history"],
+    ]);
+    expect(execCalls.length).toBeGreaterThan(0);
+    expect(execCalls.every((call) => call.sshHost === "remote-host")).toBe(true);
+  });
+
+  it("reads remote Gemini CLI repo sessions and detail over SSH", async () => {
+    const worktreePath = "/remote/repo__worktrees/task";
+    const repoPath = "/remote/repo";
+    const projectsFile = "/remote/home/.gemini/projects.json";
+    const chatFile = "/remote/home/.gemini/tmp/remote-repo/chats/remote-gemini.json";
+
+    vi.resetModules();
+    const { execCalls } = setupRemoteFileSystem({
+      [projectsFile]: JSON.stringify({ projects: { [repoPath]: "remote-repo" } }),
+      [chatFile]: JSON.stringify({
+        sessionId: "remote-gemini",
+        startTime: "2026-01-01T00:00:00.000Z",
+        lastUpdated: "2026-01-01T00:02:00.000Z",
+        messages: [
+          { id: "user-1", timestamp: "2026-01-01T00:01:00.000Z", type: "user", content: [{ text: "load repo gemini history" }] },
+          { id: "assistant-1", timestamp: "2026-01-01T00:02:00.000Z", type: "gemini", content: [{ text: "Gemini history loaded remotely." }] },
+        ],
+      }),
+    });
+    const { readGeminiSessionDetail, readGeminiSessions } = await import("@/lib/aiSessions/readGeminiSessions");
+
+    const sessions = await readGeminiSessions({ worktreePath, repoPath, includeRepoSessions: true, sshHost: "remote-host" });
+    expect(sessions).toMatchObject({ provider: "gemini", available: true, sessionCount: 1 });
+    expect(sessions.sessions[0]).toMatchObject({
+      id: "remote-gemini",
+      provider: "gemini",
+      matchedPath: repoPath,
+      matchScope: "repo",
+      firstUserPrompt: "load repo gemini history",
+      sourceRef: chatFile,
+    });
+
+    const detail = await readGeminiSessionDetail(
+      { worktreePath, repoPath, includeRepoSessions: true, sshHost: "remote-host" },
+      "remote-gemini",
+      chatFile,
+      null,
+      20,
+    );
+
+    expect(detail?.messages.map((message) => [message.role, message.fullText])).toEqual([
+      ["assistant", "Gemini history loaded remotely."],
+      ["user", "load repo gemini history"],
+    ]);
+    expect(execCalls.length).toBeGreaterThan(0);
+    expect(execCalls.every((call) => call.sshHost === "remote-host")).toBe(true);
   });
 
   it("reads remote OpenCode sessions and detail over SSH", async () => {

--- a/src/lib/aiSessions/readClaudeSessions.ts
+++ b/src/lib/aiSessions/readClaudeSessions.ts
@@ -17,7 +17,7 @@ import {
   toIsoString,
   truncateText,
 } from "@/lib/aiSessions/shared";
-import { getHomeDirectory, pathExists, readDirectoryFilesBySuffix } from "@/lib/hostFileAccess";
+import { getHomeDirectory, listFilesRecursivelyBySuffix, pathExists, readDirectoryFilesBySuffix } from "@/lib/hostFileAccess";
 import type {
   AggregatedAiMessage,
   AggregatedAiSession,
@@ -176,7 +176,19 @@ async function findProjectFiles(context: AiSessionReaderContext): Promise<string
     files.push(...await readDirectoryFilesBySuffix(directoryPath, ".jsonl", context.sshHost));
   }
 
-  return files;
+  const uniqueFiles = Array.from(new Set(files));
+  if (uniqueFiles.length > 0) {
+    return uniqueFiles;
+  }
+
+  // Claude Code stores the canonical cwd inside each JSONL event, but the outer
+  // ~/.claude/projects/<encoded-path> directory can diverge when paths are
+  // symlinked, migrated, or encoded by a different CLI version. If the direct
+  // encoded-directory lookup misses, scan project JSONL files and let cwd-based
+  // parsing decide which sessions belong to this task/repo.
+  return Array.from(new Set(
+    await listFilesRecursivelyBySuffix(claudeProjectsDirectory, ".jsonl", context.sshHost),
+  ));
 }
 
 async function getClaudeRootDirectory(context: AiSessionReaderContext): Promise<string> {

--- a/src/lib/aiSessions/readCodexSessions.ts
+++ b/src/lib/aiSessions/readCodexSessions.ts
@@ -78,6 +78,7 @@ async function parseCodexSessionSummary(filePath: string, context: AiSessionRead
   let firstUserPrompt: string | null = null;
   let messageCount = 0;
   let hasQueryMatch = false;
+  const seenMessages = new Set<string>();
 
   for (const rawEvent of events) {
     const event = rawEvent as CodexRolloutEvent;
@@ -98,10 +99,17 @@ async function parseCodexSessionSummary(filePath: string, context: AiSessionRead
       continue;
     }
 
-    if (event.type !== "response_item") continue;
-
-    const parsedMessages = extractCodexPayloadMessages(event.payload ?? {});
+    const parsedMessages = extractCodexEventMessages(event);
     for (const message of parsedMessages) {
+      if (shouldSkipCodexMessage(message.role, message.text)) {
+        continue;
+      }
+      const messageKey = createCodexMessageKey(message.role, event.timestamp, message.text);
+      if (seenMessages.has(messageKey)) {
+        continue;
+      }
+      seenMessages.add(messageKey);
+
       if (message.role === "user" && !firstUserPrompt) {
         firstUserPrompt = message.text;
       }
@@ -143,6 +151,7 @@ async function parseCodexSessionDetail(
   let matchedPath: string | null = null;
   let title: string | null = null;
   const messages: AggregatedAiMessage[] = [];
+  const seenMessages = new Set<string>();
 
   for (const rawEvent of events) {
     const event = rawEvent as CodexRolloutEvent;
@@ -157,9 +166,16 @@ async function parseCodexSessionDetail(
       continue;
     }
 
-    if (event.type !== "response_item") continue;
+    for (const message of extractCodexEventMessages(event)) {
+      if (shouldSkipCodexMessage(message.role, message.text)) {
+        continue;
+      }
+      const messageKey = createCodexMessageKey(message.role, event.timestamp, message.text);
+      if (seenMessages.has(messageKey)) {
+        continue;
+      }
+      seenMessages.add(messageKey);
 
-    for (const message of extractCodexPayloadMessages(event.payload ?? {})) {
       if (context.roles && context.roles.length > 0 && !context.roles.includes(message.role)) {
         continue;
       }
@@ -188,6 +204,51 @@ async function parseCodexSessionDetail(
     messages: paginated.items,
     nextCursor: paginated.nextCursor,
   });
+}
+
+function extractCodexEventMessages(event: CodexRolloutEvent): Array<{ role: AiMessageRole; text: string }> {
+  if (event.type === "response_item") {
+    return extractCodexPayloadMessages(event.payload ?? {});
+  }
+
+  if (event.type === "event_msg") {
+    const payload = event.payload ?? {};
+    if (payload.type === "agent_message") {
+      const text = typeof payload.message === "string"
+        ? payload.message
+        : extractPlainText(payload.message ?? payload);
+      return text ? [{ role: "assistant", text }] : [];
+    }
+  }
+
+  return [];
+}
+
+function createCodexMessageKey(role: AiMessageRole, timestamp: string | undefined, text: string): string {
+  return `${role}\u0000${timestamp ?? ""}\u0000${text}`;
+}
+
+function shouldSkipCodexMessage(role: AiMessageRole, text: string): boolean {
+  const trimmed = text.trim();
+
+  if (role === "user") {
+    return [
+      /^<environment_context>/,
+      /^<skill>/,
+      /^<system-reminder>/,
+    ].some((pattern) => pattern.test(trimmed));
+  }
+
+  if (role === "developer") {
+    return [
+      /<permissions instructions>/,
+      /<apps_instructions>/,
+      /<skills_instructions>/,
+      /<collaboration_mode>/,
+    ].some((pattern) => pattern.test(trimmed));
+  }
+
+  return false;
 }
 
 function extractCodexPayloadMessages(payload: Record<string, unknown>): Array<{ role: AiMessageRole; text: string }> {

--- a/src/lib/aiSessions/readGeminiSessions.ts
+++ b/src/lib/aiSessions/readGeminiSessions.ts
@@ -169,7 +169,7 @@ async function parseGeminiChatFile(
   if (!value || typeof value !== "object") return null;
 
   const projectId = getGeminiProjectIdFromChatPath(filePath);
-  const matchedPath = resolveGeminiMatchedPath(value, projectId, projectPathById);
+  const matchedPath = await resolveGeminiMatchedPath(value, filePath, projectId, projectPathById, context);
   const matchScope = determineMatchScope(matchedPath, context);
   if (!matchedPath || !matchScope) return null;
 
@@ -275,14 +275,28 @@ function resolveGeminiSessionId(value: GeminiChatFile, filePath: string): string
   return value.sessionId ?? value.id ?? path.basename(filePath, ".json");
 }
 
-function resolveGeminiMatchedPath(
+async function resolveGeminiMatchedPath(
   value: GeminiChatFile,
+  filePath: string,
   projectId: string | null,
   projectPathById: Map<string, string>,
-): string | null {
+  context: AiSessionReaderContext,
+): Promise<string | null> {
   const directPath = value.cwd ?? value.projectPath ?? value.directory;
   if (directPath) return directPath;
-  return projectId ? projectPathById.get(projectId) ?? null : null;
+
+  if (projectId) {
+    const mappedProjectPath = projectPathById.get(projectId);
+    if (mappedProjectPath) return mappedProjectPath;
+
+    const projectRoot = (await readTextFile(path.join(path.dirname(path.dirname(filePath)), ".project_root"), context.sshHost)).trim();
+    if (projectRoot) {
+      projectPathById.set(projectId, projectRoot);
+      return projectRoot;
+    }
+  }
+
+  return null;
 }
 
 function getGeminiProjectIdFromChatPath(filePath: string): string | null {

--- a/src/lib/aiSessions/readOpenCodeSessions.ts
+++ b/src/lib/aiSessions/readOpenCodeSessions.ts
@@ -1,5 +1,7 @@
 import { homedir } from "os";
 import path from "path";
+import { execGit } from "@/lib/gitOperations";
+import { getHomeDirectory, pathExists, quoteShellArgument } from "@/lib/hostFileAccess";
 import {
   createReaderResult,
   createSessionDetail,
@@ -17,6 +19,21 @@ import type { AggregatedAiMessage, AiMessageRole, AiSessionDetailReaderResult, A
 const OPENCODE_DB_PATH = path.join(homedir(), ".local", "share", "opencode", "opencode.db");
 const OPEN_CODE_QUERY_LIMIT = 120;
 const DEFAULT_DETAIL_LIMIT = 20;
+const REMOTE_SQLITE_QUERY_SCRIPT = `
+import base64
+import json
+import sqlite3
+import sys
+
+payload = json.loads(base64.b64decode(sys.argv[1]).decode("utf-8"))
+conn = sqlite3.connect(payload["dbPath"])
+try:
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(payload["sql"], payload.get("parameters") or {}).fetchall()
+    print(json.dumps([dict(row) for row in rows], ensure_ascii=False))
+finally:
+    conn.close()
+`.trim();
 
 interface OpenCodeSessionRow {
   id: string;
@@ -41,23 +58,11 @@ interface OpenCodeDetailRow {
 }
 
 export async function readOpenCodeSessions(context: AiSessionReaderContext): Promise<AiSessionReaderResult> {
-  if (context.sshHost) {
-    return createReaderResult("opencode", {
-      available: false,
-      reason: "Remote OpenCode session reading is not available yet",
-    });
-  }
-
-  const db = getSqliteConnection(OPENCODE_DB_PATH);
-  if (!db) {
-    return createReaderResult("opencode", { available: false, reason: "OpenCode database not found" });
-  }
-
   const normalizedQuery = context.query?.toLowerCase();
   const escapedLikeQuery = normalizedQuery ? escapeSqliteLikePattern(normalizedQuery) : null;
-  let rows: OpenCodeSessionRow[];
+  let rows: OpenCodeSessionRow[] | null;
   try {
-    rows = querySqlite<OpenCodeSessionRow>(db,
+    rows = await queryOpenCodeRows<OpenCodeSessionRow>(context,
       `SELECT
         s.id,
         s.directory,
@@ -88,6 +93,10 @@ export async function readOpenCodeSessions(context: AiSessionReaderContext): Pro
       available: false,
       reason: error instanceof Error ? error.message : "Failed to query OpenCode database",
     });
+  }
+
+  if (!rows) {
+    return createReaderResult("opencode", { available: false, reason: "OpenCode database not found" });
   }
 
   const sessions = rows
@@ -129,17 +138,10 @@ export async function readOpenCodeSessionDetail(
   cursor?: string | null,
   limit = DEFAULT_DETAIL_LIMIT
 ): Promise<AiSessionDetailReaderResult | null> {
-  if (context.sshHost) {
-    return null;
-  }
-
   const sid = sessionId;
 
-  const db = getSqliteConnection(OPENCODE_DB_PATH);
-  if (!db) return null;
-
   // 전체 메시지를 가져와서 서버에서 필터링 후 페이징 (SQLite JSON 필터링이 복잡하므로)
-  const allRows = querySqlite<OpenCodeDetailRow>(db,
+  const allRows = await queryOpenCodeRows<OpenCodeDetailRow>(context,
     `SELECT
       s.id AS session_id,
       s.directory,
@@ -156,7 +158,7 @@ export async function readOpenCodeSessionDetail(
     { sessionId: sid }
   );
 
-  if (allRows.length === 0) return null;
+  if (!allRows || allRows.length === 0) return null;
 
   const firstRow = allRows[0];
   if (!determineMatchScope(firstRow.directory, context)) return null;
@@ -191,6 +193,46 @@ export async function readOpenCodeSessionDetail(
     messages: pageItems,
     nextCursor,
   });
+}
+
+async function queryOpenCodeRows<T>(
+  context: AiSessionReaderContext,
+  sql: string,
+  parameters?: Record<string, unknown>,
+): Promise<T[] | null> {
+  const dbPath = await getOpenCodeDatabasePath(context);
+  if (!context.sshHost) {
+    const db = getSqliteConnection(dbPath);
+    return db ? querySqlite<T>(db, sql, parameters) : null;
+  }
+
+  if (!await pathExists(dbPath, context.sshHost)) {
+    return null;
+  }
+
+  const encodedPayload = Buffer.from(JSON.stringify({
+    dbPath,
+    sql,
+    parameters: parameters ?? {},
+  }), "utf-8").toString("base64");
+  const output = await execGit(
+    `python3 -c ${quoteShellArgument(REMOTE_SQLITE_QUERY_SCRIPT)} ${quoteShellArgument(encodedPayload)}`,
+    context.sshHost,
+  );
+  const parsedRows = safeJsonParse<unknown>(output.trim());
+  if (!Array.isArray(parsedRows)) {
+    throw new Error("Failed to parse remote OpenCode database query result");
+  }
+
+  return parsedRows as T[];
+}
+
+async function getOpenCodeDatabasePath(context: AiSessionReaderContext): Promise<string> {
+  if (!context.sshHost) {
+    return OPENCODE_DB_PATH;
+  }
+
+  return path.posix.join(await getHomeDirectory(context.sshHost), ".local", "share", "opencode", "opencode.db");
 }
 
 function matchesOpenCodeQuery(query: string | undefined, ...values: Array<string | null | undefined>): boolean {

--- a/src/lib/aiSessions/readOpenCodeSessions.ts
+++ b/src/lib/aiSessions/readOpenCodeSessions.ts
@@ -1,5 +1,7 @@
+import { execFile } from "child_process";
 import { homedir } from "os";
 import path from "path";
+import { promisify } from "util";
 import { execGit } from "@/lib/gitOperations";
 import { getHomeDirectory, pathExists, quoteShellArgument } from "@/lib/hostFileAccess";
 import {
@@ -13,13 +15,12 @@ import {
   toIsoString,
   truncateText,
 } from "@/lib/aiSessions/shared";
-import { getSqliteConnection, querySqlite } from "@/lib/sqliteConnectionPool";
 import type { AggregatedAiMessage, AiMessageRole, AiSessionDetailReaderResult, AiSessionReaderContext, AiSessionReaderResult } from "@/lib/aiSessions/types";
 
-const OPENCODE_DB_PATH = path.join(homedir(), ".local", "share", "opencode", "opencode.db");
+const execFileAsync = promisify(execFile);
 const OPEN_CODE_QUERY_LIMIT = 120;
 const DEFAULT_DETAIL_LIMIT = 20;
-const REMOTE_SQLITE_QUERY_SCRIPT = `
+const SQLITE_QUERY_SCRIPT = `
 import base64
 import json
 import sqlite3
@@ -202,26 +203,72 @@ async function queryOpenCodeRows<T>(
 ): Promise<T[] | null> {
   const dbPath = await getOpenCodeDatabasePath(context);
   if (!context.sshHost) {
-    const db = getSqliteConnection(dbPath);
-    return db ? querySqlite<T>(db, sql, parameters) : null;
+    let nativeSqliteError: unknown = null;
+    try {
+      const { getSqliteConnection, querySqlite } = await import("@/lib/sqliteConnectionPool");
+      const db = getSqliteConnection(dbPath);
+      if (db) {
+        return querySqlite<T>(db, sql, parameters);
+      }
+    } catch (error) {
+      nativeSqliteError = error;
+    }
+
+    if (!await pathExists(dbPath)) {
+      return null;
+    }
+
+    try {
+      return await querySqliteRowsWithPython<T>(dbPath, sql, parameters);
+    } catch (error) {
+      if (nativeSqliteError instanceof Error) {
+        throw new Error(`${error instanceof Error ? error.message : "Failed to query OpenCode database with Python sqlite"}; native sqlite unavailable: ${nativeSqliteError.message}`);
+      }
+      throw error;
+    }
   }
 
   if (!await pathExists(dbPath, context.sshHost)) {
     return null;
   }
 
-  const encodedPayload = Buffer.from(JSON.stringify({
+  const output = await execGit(
+    `python3 -c ${quoteShellArgument(SQLITE_QUERY_SCRIPT)} ${quoteShellArgument(encodeSqliteQueryPayload(dbPath, sql, parameters))}`,
+    context.sshHost,
+  );
+  return parseSqliteQueryRows<T>(output);
+}
+
+async function querySqliteRowsWithPython<T>(
+  dbPath: string,
+  sql: string,
+  parameters?: Record<string, unknown>,
+): Promise<T[]> {
+  const { stdout } = await execFileAsync(
+    "python3",
+    ["-c", SQLITE_QUERY_SCRIPT, encodeSqliteQueryPayload(dbPath, sql, parameters)],
+    { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 },
+  );
+
+  return parseSqliteQueryRows<T>(stdout);
+}
+
+function encodeSqliteQueryPayload(
+  dbPath: string,
+  sql: string,
+  parameters?: Record<string, unknown>,
+): string {
+  return Buffer.from(JSON.stringify({
     dbPath,
     sql,
     parameters: parameters ?? {},
   }), "utf-8").toString("base64");
-  const output = await execGit(
-    `python3 -c ${quoteShellArgument(REMOTE_SQLITE_QUERY_SCRIPT)} ${quoteShellArgument(encodedPayload)}`,
-    context.sshHost,
-  );
+}
+
+function parseSqliteQueryRows<T>(output: string): T[] {
   const parsedRows = safeJsonParse<unknown>(output.trim());
   if (!Array.isArray(parsedRows)) {
-    throw new Error("Failed to parse remote OpenCode database query result");
+    throw new Error("Failed to parse OpenCode database query result");
   }
 
   return parsedRows as T[];
@@ -229,7 +276,7 @@ async function queryOpenCodeRows<T>(
 
 async function getOpenCodeDatabasePath(context: AiSessionReaderContext): Promise<string> {
   if (!context.sshHost) {
-    return OPENCODE_DB_PATH;
+    return path.join(homedir(), ".local", "share", "opencode", "opencode.db");
   }
 
   return path.posix.join(await getHomeDirectory(context.sshHost), ".local", "share", "opencode", "opencode.db");


### PR DESCRIPTION
## Summary
- Load AI chat history reliably for both local and remote KanVibe tasks across Claude Code, Codex, OpenCode, and Gemini CLI.
- Keep remote OpenCode support by querying the remote `opencode.db` over SSH with Python/sqlite3, and add a local Python/sqlite3 fallback when native `better-sqlite3` is unavailable or mismatched.
- Make Claude Code discovery resilient to `~/.claude/projects/<encoded-path>` mismatches by falling back to JSONL `cwd` parsing, and make Gemini CLI discovery use `.gemini/tmp/<project>/.project_root` metadata when `projects.json` does not contain the chat directory mapping.
- Include repository-level AI sessions in the task detail inline chat history so worktree-backed tasks can show repo-root chat history.
- Fix Codex `exec` history parsing so internal environment/developer bootstrap messages are not used as the displayed prompt, and final `event_msg.agent_message` answers are included in list/detail/search results.
- Extend the reusable Electron QA flow with a real Codex headless CLI request. Missing CLI/auth, usage limits, and transient runtime/network blockers are reported as non-blocking skips; a successful live request must persist a JSONL session and appear in the KanVibe history UI.

## Test Plan
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js exec vitest run src/lib/aiSessions/__tests__/readAiSessions.test.ts` — 12 tests passed
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js exec vitest run src/lib/aiSessions src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx` — 49 tests passed
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js check` — passed
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js lint` — passed with 10 existing unrelated warnings
- `git diff --check` — passed
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js test` — 92 files / 754 tests passed after rebuilding `better-sqlite3` for Node 24
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js qa:ai-session-history` — passed; included a real Codex headless request via `npx -y @openai/codex exec`

## QA Evidence
- Latest AI session history report: `qa-output/ai-session-history-20260603T090249Z-233527/report.md`
- Latest AI session history video: `qa-output/ai-session-history-20260603T090249Z-233527/run.mp4` (18.6s, 265,287 bytes)
- Latest Playwright trace: `qa-output/ai-session-history-20260603T090249Z-233527/diagnostics/playwright-trace.zip`
- Latest CDP diagnostics: `qa-output/ai-session-history-20260603T090249Z-233527/diagnostics/cdp-diagnostics.json`
- Live Codex headless marker verified in the UI: `KANVIBE_CODEX_HEADLESS_OK_ai_session_history_20260603T090249Z_233527`
- Earlier repo-history gap report showing Claude/Codex/Gemini/OpenCode repo-root history in the UI: `qa-output/repo-history-gap-20260603T071647Z-3177530/report.md`
- Earlier repo-history gap video: `qa-output/repo-history-gap-20260603T071647Z-3177530/run.mp4`
