### PR TITLE
docs: align localized README media sections

### DIFF
--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -2,11 +2,11 @@
 
 # KanVibe
 
-**AI 에이전트 작업 관리 칸반 보드**
+**AI 코딩 에이전트를 위한 키보드 중심 칸반 워크스페이스**
 
-AI 코딩 에이전트(Claude Code, Gemini CLI, Codex CLI 등)의 작업을 실시간으로 관리하는 웹 기반 터미널 칸반 보드.
-브라우저에서 tmux/zellij 세션을 직접 모니터링하며, 드래그 앤 드롭 칸반 보드로 작업 진행 상황을 추적합니다.
-[AI 에이전트 Hooks](#ai-에이전트-hooks---자동-상태-추적) 기반 자동 상태 트래킹을 지원하여 수동 업데이트가 필요 없습니다.
+KanVibe는 AI 코딩 작업이 여러 터미널 탭에 흩어지지 않도록 도와줍니다. 브랜치 기반 태스크를 실시간 칸반 보드에서 추적하고, 각 태스크의 tmux/zellij 세션을 브라우저나 데스크톱 앱에서 열며, Claude Code, Gemini CLI, Codex CLI, OpenCode hooks가 워크플로우에 맞춰 태스크 상태를 자동으로 이동하게 할 수 있습니다.
+
+터미널 포커스를 잃지 않고 프로젝트 필터, 태스크 검색, 알림, 태스크 상세 패널, 자주 쓰는 태스크 액션을 단축키로 실행하세요.
 
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-FFDD00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/rookedsysc)
 
@@ -18,18 +18,70 @@ AI 코딩 에이전트(Claude Code, Gemini CLI, Codex CLI 등)의 작업을 실�
 
 <div align="center">
 
-[![▶ YouTube에서 데모 보기](https://img.youtube.com/vi/8JTrvd3T_Z0/maxresdefault.jpg)](https://www.youtube.com/watch?v=8JTrvd3T_Z0)
-
-**▶ [YouTube에서 데모 보기](https://www.youtube.com/watch?v=8JTrvd3T_Z0)**
-
 <table>
   <tr>
-    <td width="50%"><img src="./images/detail-page.png" alt="칸반 보드" width="100%"></td>
-    <td width="50%"><img src="./images/detail-page.png" alt="태스크 상세 & 터미널" width="100%"></td>
+    <td width="50%">
+      <img src="./images/readme/kanvibe-main.png" alt="KanVibe 칸반 보드" width="100%">
+      <br>
+      <strong>메인 칸반 보드</strong>
+    </td>
+    <td width="50%">
+      <img src="./images/readme/kanvibe-detail.png" alt="태스크 상세 터미널 워크스페이스" width="100%">
+      <br>
+      <strong>태스크 상세 워크스페이스</strong>
+    </td>
   </tr>
 </table>
 
+<a href="https://www.youtube.com/watch?v=8JTrvd3T_Z0">
+  <img src="https://img.youtube.com/vi/8JTrvd3T_Z0/maxresdefault.jpg" alt="KanVibe 데모 영상 썸네일" width="100%">
+</a>
+
+<strong><a href="https://www.youtube.com/watch?v=8JTrvd3T_Z0">YouTube에서 데모 보기</a></strong>
+
 </div>
+
+---
+
+## 주요 워크플로우
+
+### 1. 빠른 태스크 검색
+
+어디서든 태스크 검색을 열고 프로젝트나 브랜치명으로 필터링한 뒤, 보드로 돌아가지 않고 바로 태스크 워크스페이스로 이동합니다.
+
+<img src="./images/readme/kanvibe-search-shortcut.png" alt="빠른 태스크 검색 단축키" width="100%">
+
+### 2. 태스크 상세 단축키
+
+태스크 상세 페이지의 번호형 dock 단축키로, 키 입력이 임베디드 터미널에 도달하기 전에 태스크 메타데이터, hook 상태, AI 채팅, PR 액션을 열 수 있습니다.
+
+<img src="./images/readme/kanvibe-detail-shortcut.png" alt="태스크 상세 단축키 패널" width="100%">
+
+### 3. 프로젝트 필터
+
+관심 있는 활성 프로젝트만 보이도록 보드를 좁히고, 키보드 네비게이션으로 저장소 사이를 빠르게 전환합니다.
+
+<img src="./images/readme/kanvibe-project-search-shortcut.png" alt="프로젝트 필터 단축키" width="100%">
+
+### 4. 알림
+
+알림 패널을 열어 AI 에이전트 상태 변경, 백그라운드 동기화 결과, 태스크 이벤트를 확인하고 관련 태스크로 이동합니다.
+
+<img src="./images/readme/kanvibe-notification-shortcut.png" alt="알림 단축키 패널" width="100%">
+
+### 5. 빠른 태스크 액션
+
+검색 결과에서 하이라이트된 태스크를 기준으로 후속 브랜치 TODO를 바로 만들고, 다음 작업에 필요한 프로젝트와 브랜치 컨텍스트를 유지합니다.
+
+<img src="./images/readme/kanvibe-quick-action-shortcut.png" alt="빠른 태스크 액션 단축키" width="100%">
+
+### 6. Vim 스타일 보드 조작
+
+**설정 → 키보드**에서 Vim 스타일 보드 조작을 켠 뒤 `h/j/k/l`로 태스크 카드를 이동하고, `/`로 보이는 태스크 텍스트를 검색하며, `n`으로 새 태스크 모달을 열고, `:move progress`로 상태를 이동하고, 포커스된 태스크를 `dd`로 삭제합니다.
+
+<video src="./images/readme/kanvibe-vim-controls.mp4" poster="./images/readme/kanvibe-vim-controls.png" controls muted playsinline width="100%"></video>
+
+[Vim 조작 데모 영상 열기](./images/readme/kanvibe-vim-controls.mp4)
 
 ---
 
@@ -79,22 +131,22 @@ brew untap rookedsysc/kanvibe
 
 ### 1. 프로젝트 등록
 
-프로젝트 설정에서 **fzf 스타일 폴더 검색**으로 로컬 git 저장소를 검색하고 등록합니다. KanVibe가 디렉토리를 스캔하여 기존 worktree 브랜치를 자동 감지합니다.
+프로젝트 설정에서 **fzf 스타일 폴더 검색**으로 로컬 git 저장소를 검색합니다. KanVibe가 디렉터리를 스캔하여 기존 worktree 브랜치를 자동 감지합니다.
 
-프로젝트 관리를 중단하려면 프로젝트 설정에서 삭제하세요. 이 동작은 내장 SQLite 데이터베이스에서 해당 프로젝트와 KanVibe task만 삭제하며, 디스크의 git branch, worktree, 파일은 보존합니다.
+프로젝트 관리를 중단하려면 프로젝트 설정에서 삭제하세요. 이 동작은 내장 SQLite 데이터베이스에서 해당 프로젝트와 KanVibe 태스크만 삭제하며, 디스크의 git 브랜치, worktree, 파일은 보존합니다.
 
 ### 2. 태스크 생성
 
 칸반 보드에서 TODO 태스크를 추가합니다. 브랜치명으로 태스크를 생성하면 KanVibe가 자동으로:
-- 해당 브랜치의 **git worktree** 생성
-- **tmux window** 또는 **zellij tab**으로 터미널 세션 생성
-- 터미널 세션을 태스크에 연결
+- 해당 브랜치의 **git worktree**를 생성합니다
+- 세션용 **tmux window** 또는 **zellij tab**을 생성합니다
+- 터미널 세션을 태스크에 연결합니다
 
 ### 3. 칸반 보드에서 작업
 
-5단계 상태로 태스크를 관리합니다: **TODO** → **PROGRESS** → **PENDING** → **REVIEW** → **DONE**
+태스크는 5단계 상태로 관리됩니다: **TODO** → **PROGRESS** → **PENDING** → **REVIEW** → **DONE**
 
-드래그 앤 드롭으로 상태를 변경하거나, [AI 에이전트 Hooks](#ai-에이전트-hooks---자동-상태-추적)를 통해 자동으로 전환됩니다. 태스크가 **DONE**으로 이동하면 브랜치, worktree, 터미널 세션이 **자동으로 삭제**됩니다.
+드래그 앤 드롭으로 상태를 변경하거나 [AI 에이전트 Hooks](#ai-에이전트-hooks---자동-상태-추적)가 자동으로 상태를 전환하게 할 수 있습니다. 태스크가 **DONE**으로 이동하면 브랜치, worktree, 터미널 세션이 **자동으로 삭제**됩니다.
 
 ### 4. Pane 레이아웃 선택
 
@@ -105,36 +157,43 @@ brew untap rookedsysc/kanvibe
 | **Single** | 전체 화면 단일 pane |
 | **Horizontal 2** | 좌우 2분할 |
 | **Vertical 2** | 상하 2분할 |
-| **Left + Right TB** | 왼쪽 + 오른쪽 상하 분할 |
-| **Left TB + Right** | 왼쪽 상하 분할 + 오른쪽 |
+| **Left + Right TB** | 왼쪽 pane + 오른쪽 상하 분할 |
+| **Left TB + Right** | 왼쪽 상하 분할 + 오른쪽 pane |
 | **Quad** | 4등분 |
 
-각 pane에 커스텀 명령어를 설정할 수 있습니다 (예: `vim`, `htop`, `lazygit`, 테스트 러너 등). 레이아웃은 전역 또는 프로젝트별로 설정 가능합니다.
+각 pane에 커스텀 명령어를 설정할 수 있습니다(예: `vim`, `htop`, `lazygit`, 테스트 러너 등). 레이아웃은 설정 다이얼로그에서 전역 또는 프로젝트별로 설정할 수 있습니다.
 
 ---
 
 ## 기능
 
-### 칸반 보드
-- 5단계 상태 관리 (TODO / PROGRESS / PENDING / REVIEW / DONE)
-- 사용자 정의 태스크 정렬
-- 다중 프로젝트 필터링
-- Done 컬럼 페이지네이션
-- WebSocket 기반 실시간 업데이트
+### 실시간 칸반 보드
+- 5단계 태스크 관리(TODO / PROGRESS / PENDING / REVIEW / DONE)
+- 프로젝트 색상, 우선순위 표시, PR 배지, 세션 라벨을 포함한 드래그 앤 드롭 태스크 정렬
+- 보이는 프로젝트와 태스크 텍스트를 키보드로 검색할 수 있는 다중 프로젝트 필터링
+- 장기 프로젝트를 위한 Done 컬럼 페이지네이션
+- 브라우저와 데스크톱 창 전체에 WebSocket 기반 실시간 업데이트
 
-### Git Worktree 연동
-- 브랜치 기반 태스크 생성 시 git worktree 자동 생성
-- Worktree 스캔: 기존 브랜치를 TODO 태스크로 자동 등록
-- DONE 상태 전환 시 브랜치 + worktree + 세션 자동 정리
-- 설정에서 프로젝트를 삭제하면 해당 프로젝트와 task의 KanVibe DB 레코드만 삭제되며, 기존 branch와 worktree는 건드리지 않습니다
+### 브랜치 기반 태스크 워크스페이스
+- git worktree와 터미널 세션을 자동으로 준비하는 브랜치 TODO 생성
+- 기존 worktree 브랜치를 스캔하여 TODO 태스크로 등록
+- 각 태스크를 전용 터미널 워크스페이스로 열고, 사이드 dock에서 태스크 메타데이터, hook 컨트롤, 채팅, PR 액션 사용
+- 태스크를 DONE으로 이동하여 브랜치, worktree, 터미널 세션 자동 정리
+- 기존 git 브랜치, worktree, 디스크 파일을 건드리지 않고 설정에서 프로젝트 삭제
 
 ### 터미널 세션 (tmux / zellij)
 - **tmux**와 **zellij** 모두 터미널 멀티플렉서로 지원
-- xterm.js + WebSocket 기반 브라우저 터미널
-- SSH 원격 터미널 지원 (`~/.ssh/config` 읽기)
+- xterm.js와 WebSocket 기반 브라우저 터미널 스트리밍
+- `~/.ssh/config`를 읽는 SSH 원격 터미널 지원
 - 비대화형 원격 SSH 명령은 `~/.kanvibe` 아래의 앱 전용 ControlMaster 소켓 풀을 재사용하며 host별 동시성을 사용 가능한 CPU 코어 수의 4배까지 제한합니다
 - 원격 터미널 attach는 SSH에서 tmux/zellij를 직접 실행하며, 로컬 `DISPLAY`, 원격 `X11Forwarding`, `xauth`가 준비된 경우에만 trusted X11 forwarding(`ssh -Y`)을 요청합니다
 - Nerd Font 렌더링 지원
+
+### 키보드 중심 조작
+- 어디서든 브랜치명이나 프로젝트명으로 빠른 태스크 검색 열기
+- 보드를 떠나지 않고 프로젝트 필터링, 알림 확인, 태스크 액션 실행
+- 키 입력이 터미널에 도달하기 전에 번호형 상세 단축키로 태스크 정보, 상태/hooks, AI 채팅, PR 및 다른 dock 패널 전환
+- 설정된 단축키로 빠른 태스크 검색에서 브랜치 TODO 바로 생성
 
 ### 키보드 단축키
 
@@ -142,36 +201,32 @@ brew untap rookedsysc/kanvibe
 |--------|------|------|
 | `Cmd/Ctrl+F` 또는 Vim 스타일 조작이 켜진 상태의 `/` | 보드 | 현재 보이는 프로젝트/태스크 텍스트를 보드 안에서 검색. `Enter`로 다음, `Shift+Enter`로 이전 결과 이동 |
 | `h / j / k / l` 또는 `← / ↓ / ↑ / →` | 보드 태스크 카드 | 보이는 태스크 카드 포커스를 좌/하/상/우로 이동. 포커스된 태스크가 없으면 첫 번째 보이는 태스크로 진입 |
-| `n` | 보드 | 새 작업 모달 즉시 열기 |
+| `n` | 보드 | 새 태스크 모달 즉시 열기 |
 | `:move todo\|progress\|pending\|review\|done` | 포커스된 보드 태스크 카드 | 드래그 없이 포커스된 태스크를 대상 상태로 이동. 명령 입력창에서 `Tab`을 누르면 유일한 상태 prefix를 자동 완성 |
 | `dd` | 포커스된 보드 태스크 카드 | 확인 후 포커스된 태스크 삭제 |
-| `Cmd/Ctrl+Shift+O` | 전역 | 브랜치명/프로젝트명 기준 태스크 빠른 검색 열기 (기본값, 변경 가능) |
+| `Cmd/Ctrl+Shift+O` | 전역 | 브랜치명/프로젝트명 기준 빠른 태스크 검색 열기(기본값, 변경 가능) |
 | `Cmd/Ctrl+Shift+P` | 보드 | 프로젝트 필터 드롭다운 열기 |
 | `Cmd/Ctrl+Shift+I` | 보드 | 알림 드롭다운 열기 |
 | `Cmd+[` / `Cmd+]` (macOS), `Alt+[` / `Alt+]` (Linux) | 전역 | 앱 히스토리 뒤로/앞으로 이동. 더 뒤로 갈 곳이 없으면 보드 홈으로 이동 |
-| `Cmd/Ctrl+N` | 태스크 빠른 검색 | 현재 하이라이트된 태스크 기준으로 새 branch TODO 만들기 |
-| `↑ / ↓ / Enter / Shift+Enter / Esc` | 태스크 빠른 검색 | 선택 이동, 태스크 열기, 태스크 새 창 열기, 다이얼로그 닫기 |
+| `Cmd+1/2/3` (macOS), `Alt+1/2/3` (Linux) | 태스크 상세 | 번호형 상세 dock 항목인 정보, 상태/hooks, AI 채팅을 활성화. 이 단축키는 터미널 입력보다 먼저 가로챕니다 |
+| `Cmd+4` (macOS), `Alt+4` (Linux) | 태스크 상세 | PR이 있는 태스크에서는 브라우저로 태스크 PR을 열고, PR이 없으면 보이는 네 번째 dock 항목에 할당됩니다 |
+| `Cmd/Ctrl+N` | 빠른 태스크 검색 | 현재 하이라이트된 태스크 기준으로 새 브랜치 TODO 만들기 |
+| `↑ / ↓ / Enter / Shift+Enter / Esc` | 빠른 태스크 검색 | 선택 이동, 태스크 열기, 태스크 새 창 열기, 다이얼로그 닫기 |
 | `↑ / ↓ / Enter / Esc` | 프로젝트 필터 드롭다운 | 선택 이동, 프로젝트 필터 토글, 드롭다운 닫기 |
 | `↑ / ↓ / Enter / Esc` | 알림 드롭다운 | 선택 이동, 알림 대상 열기, 드롭다운 닫기 |
 
-Vim 스타일 보드 조작(`h/j/k/l`, `/`, `n`, `dd`, `:move ...`)은 **설정 → 키보드**에서 켜고 끌 수 있습니다. 꺼도 방향키 태스크 이동과 `Cmd/Ctrl+F` 보드 검색은 계속 사용할 수 있습니다.
+태스크 상세 dock 번호는 보드로 돌아가기 버튼을 제외하고 보이는 dock 항목 순서를 따릅니다. 태스크에 PR URL이 있으면 PR이 4번 슬롯을 차지하고 이후 dock 항목은 5번 이후로 밀립니다. PR이 없으면 다음 dock 항목이 4번 슬롯을 사용합니다.
 
-#### Vim 스타일 보드 조작 데모
-
-아래 영상은 **설정 → 키보드**에서 Vim 스타일 보드 조작을 켠 뒤 `h/j/k/l`, `/`, `:move progress`, `n`, `dd`를 실제 보드에서 사용하는 흐름을 보여줍니다.
-
-<video src="./images/readme/kanvibe-vim-controls.mp4" poster="./images/readme/kanvibe-vim-controls.png" controls muted playsinline width="100%"></video>
-
-[데모 영상 열기](./images/readme/kanvibe-vim-controls.mp4)
+Vim 스타일 보드 조작(`h/j/k/l`, `/`, `n`, `dd`, `:move ...`)은 **설정 → 키보드**에서 켜고 끌 수 있습니다. 꺼도 방향키 태스크 이동과 `Cmd/Ctrl+F` 페이지 검색은 계속 사용할 수 있습니다.
 
 ### AI 에이전트 Hooks - 자동 상태 추적
 KanVibe는 **Claude Code Hooks**, **Gemini CLI Hooks**, **Codex CLI**, **OpenCode**와 연동하여 태스크 상태를 자동 추적합니다. 태스크는 5가지 상태로 관리됩니다:
 
 | 상태 | 설명 |
 |------|------|
-| **TODO** | 생성된 태스크의 초기 상태 |
-| **PROGRESS** | AI가 작업 중인 상태 |
-| **PENDING** | AI가 사용자에게 재질문하여 답변 대기 중인 상태 (Claude Code만 지원) |
+| **TODO** | 태스크 생성 시 초기 상태 |
+| **PROGRESS** | AI가 태스크를 적극적으로 작업 중인 상태 |
+| **PENDING** | AI가 후속 질문을 하여 사용자 응답을 기다리는 상태(Claude Code만 지원) |
 | **REVIEW** | AI 작업이 완료되어 리뷰 대기 중인 상태 |
 | **DONE** | 작업 완료 — 브랜치, worktree, 터미널 세션이 **자동 삭제**됩니다 |
 
@@ -193,13 +248,13 @@ AfterAgent (에이전트 완료)   → REVIEW
 
 #### Codex CLI
 ```
-UserPromptSubmit               → PROGRESS
+UserPromptSubmit              → PROGRESS
 PermissionRequest (Bash 전용) → PENDING
 PreToolUse (Bash 전용)        → PROGRESS
 Stop                          → REVIEW
 ```
 
-KanVibe는 이제 Codex 최신 lifecycle hooks 방식인 `.codex/hooks.json`과 `.codex/config.toml`의 `[features].hooks = true` 조합을 사용합니다. 기준 문서는 다음 공식 문서입니다.
+KanVibe는 이제 Codex 최신 lifecycle hooks 방식인 `.codex/hooks.json`과 `.codex/config.toml`의 `[features].hooks = true` 조합을 사용합니다:
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference
@@ -212,16 +267,16 @@ Codex는 신뢰된 프로젝트/worktree 경로에서만 project-local `.codex/`
 ```
 사용자 메시지 전송 (message.updated, role=user) → PROGRESS
 AI 질문 대기 (question.asked)                   → PENDING
-사용자 질문 답변 (question.replied)              → PROGRESS
+사용자 질문 답변 (question.replied)             → PROGRESS
 세션 대기 (session.idle)                        → REVIEW
 ```
 
 OpenCode는 셸 스크립트 hooks 대신 자체 [플러그인 시스템](https://opencode.ai/docs/plugins/)을 사용합니다. KanVibe는 `.opencode/plugins/kanvibe-plugin.ts`에 TypeScript 플러그인을 생성하여 `@opencode-ai/plugin` SDK를 통해 OpenCode의 네이티브 이벤트 hooks(`message.updated`, `question.asked`, `question.replied`, `session.idle`)를 구독합니다. 외부 셸 명령을 실행하지 않고 프로세스 내에서 상태 업데이트를 처리합니다.
 
-모든 에이전트 Hook은 KanVibe 디렉토리 스캔으로 프로젝트를 등록하거나 worktree와 함께 태스크를 생성하면 **자동 설치**됩니다. 태스크 상세 페이지에서 개별 설치도 가능합니다.
+모든 에이전트 Hook은 KanVibe 디렉터리 스캔으로 프로젝트를 등록하거나 worktree와 함께 태스크를 생성하면 **자동 설치**됩니다. 태스크 상세 페이지에서 개별 설치도 가능합니다.
 
-| 에이전트 | Hook 디렉토리 | 설정 파일 |
-|---------|-------------|----------|
+| 에이전트 | Hook 디렉터리 | 설정 파일 |
+|---------|--------------|----------|
 | Claude Code | `.claude/hooks/` | `.claude/settings.json` |
 | Gemini CLI | `.gemini/hooks/` | `.gemini/settings.json` |
 | Codex CLI | `.codex/hooks/` | `.codex/config.toml`, `.codex/hooks.json` |
@@ -229,12 +284,12 @@ OpenCode는 셸 스크립트 hooks 대신 자체 [플러그인 시스템](https:
 
 #### 브라우저 알림
 
-AI 에이전트 Hooks를 통한 태스크 상태 변경이 **브라우저 알림**으로 전달됩니다. 프로젝트명, 브랜치명, 변경된 상태를 표시하며, **알림을 클릭하면 해당 작업 상세 페이지로 이동**합니다.
+AI 에이전트 Hooks를 통한 태스크 상태 변경이 **브라우저 알림**으로 전달됩니다. 프로젝트명, 브랜치명, 변경된 상태를 표시하며, **알림을 클릭하면 해당 태스크 상세 페이지로 이동**합니다.
 
 - **실시간 알림** — 태스크 상태 변경 시 즉시 알림 수신
 - **백그라운드 모드** — KanVibe가 포커스되지 않아도 알림 수신
-- **스마트 네비게이션** — 알림 클릭 → 작업 상세 페이지 이동 (현재 언어 유지)
-- **커스터마이징** — 프로젝트별 알림 활성화/비활성화 및 상태별 필터링 지원
+- **스마트 네비게이션** — 알림 클릭 → 태스크 상세 페이지(현재 언어 유지)
+- **커스터마이징 가능** — 프로젝트별 알림 활성화/비활성화 및 상태별 필터링 지원(PROGRESS, PENDING, REVIEW, DONE)
 
 설정: 최초 접속 시 브라우저 알림 권한을 허용해 주세요. **프로젝트 설정** → **알림**에서 상태별 필터를 조정할 수 있습니다.
 
@@ -249,20 +304,13 @@ AI 에이전트 Hooks를 통한 태스크 상태 변경이 **브라우저 알림
 
 브라우저에서 GitHub 스타일의 diff 뷰어로 코드 변경사항을 바로 확인할 수 있습니다. 태스크 상세 페이지의 **Diff** 뱃지를 클릭하면 base 브랜치 대비 변경된 모든 파일을 확인할 수 있습니다.
 
-<table>
-  <tr>
-    <td width="30%"><img src="./images/diff-view-button.png" alt="태스크 상세의 Diff 뱃지" width="100%"></td>
-    <td width="70%"><img src="./images/diff-view.png" alt="Diff 뷰 페이지" width="100%"></td>
-  </tr>
-</table>
-
 - 변경 파일 수가 표시되는 파일 트리 사이드바
 - Monaco Editor 기반 인라인 diff 뷰어
 - 브라우저에서 바로 수정 가능한 에딧 모드
 - 체크박스로 확인한 파일 추적
 
 ### Pane 레이아웃 에디터
-- 6가지 레이아웃 프리셋 (Single, Horizontal 2, Vertical 2, Left+Right TB, Left TB+Right, Quad)
+- 6가지 레이아웃 프리셋(Single, Horizontal 2, Vertical 2, Left+Right TB, Left TB+Right, Quad)
 - pane별 커스텀 명령어 설정
 - 전역 및 프로젝트별 레이아웃 설정
 
@@ -287,9 +335,9 @@ AI 에이전트 Hooks를 통한 태스크 상태 변경이 **브라우저 알림
 
 ---
 
-## 라이센스
+## 라이선스
 
-이 프로젝트는 **AGPL-3.0** 라이센스를 따릅니다. 오픈소스 목적으로 자유롭게 사용, 수정, 확장할 수 있습니다. 상업적 SaaS 배포는 이 라이센스에서 허용되지 않습니다. 자세한 내용은 [LICENSE](../LICENSE)를 참조하세요.
+이 프로젝트는 **AGPL-3.0** 라이선스를 따릅니다. 오픈소스 목적으로 자유롭게 사용, 수정, 확장할 수 있습니다. 상업적 SaaS 배포는 이 라이선스에서 허용되지 않습니다. 자세한 내용은 [LICENSE](../LICENSE)를 참조하세요.
 
 ---
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -2,11 +2,11 @@
 
 # KanVibe
 
-**AI 代理任务管理看板**
+**面向 AI 编程代理的键盘优先 Kanban 工作区**
 
-用于实时管理 AI 编程代理（Claude Code、Gemini CLI、Codex CLI 等）任务的基于 Web 的终端看板。
-在浏览器中直接监控 tmux/zellij 会话，同时通过拖放看板追踪任务进度。
-通过 [AI 代理 Hooks](#ai-代理-hooks---自动状态追踪) 自动追踪任务状态，无需手动更新。
+KanVibe 让 AI 编程工作不再散落在一堆终端标签中。你可以在实时 Kanban 看板上跟踪基于分支的任务，在浏览器或桌面应用中打开每个任务的 tmux/zellij 会话，并让 Claude Code、Gemini CLI、Codex CLI 和 OpenCode hooks 自动推动任务在工作流中流转。
+
+使用快捷键处理项目筛选、任务搜索、通知、任务详情面板和常用任务操作，同时不丢失终端焦点。
 
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-FFDD00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/rookedsysc)
 
@@ -18,18 +18,70 @@
 
 <div align="center">
 
-[![▶ 在 YouTube 上观看演示](https://img.youtube.com/vi/8JTrvd3T_Z0/maxresdefault.jpg)](https://www.youtube.com/watch?v=8JTrvd3T_Z0)
-
-**▶ [在 YouTube 上观看演示](https://www.youtube.com/watch?v=8JTrvd3T_Z0)**
-
 <table>
   <tr>
-    <td width="50%"><img src="./images/detail-page.png" alt="看板" width="100%"></td>
-    <td width="50%"><img src="./images/detail-page.png" alt="任务详情 & 终端" width="100%"></td>
+    <td width="50%">
+      <img src="./images/readme/kanvibe-main.png" alt="KanVibe Kanban 看板" width="100%">
+      <br>
+      <strong>主 Kanban 看板</strong>
+    </td>
+    <td width="50%">
+      <img src="./images/readme/kanvibe-detail.png" alt="任务详情终端工作区" width="100%">
+      <br>
+      <strong>任务详情工作区</strong>
+    </td>
   </tr>
 </table>
 
+<a href="https://www.youtube.com/watch?v=8JTrvd3T_Z0">
+  <img src="https://img.youtube.com/vi/8JTrvd3T_Z0/maxresdefault.jpg" alt="KanVibe 演示视频缩略图" width="100%">
+</a>
+
+<strong><a href="https://www.youtube.com/watch?v=8JTrvd3T_Z0">在 YouTube 上观看演示</a></strong>
+
 </div>
+
+---
+
+## 主要工作流
+
+### 1. 快速任务搜索
+
+从任何位置打开任务搜索，按项目或分支名筛选，并无需先回到看板即可直接进入任务工作区。
+
+<img src="./images/readme/kanvibe-search-shortcut.png" alt="快速任务搜索快捷键" width="100%">
+
+### 2. 任务详情快捷键
+
+在任务详情页面使用编号 dock 快捷键，在按键进入嵌入式终端之前打开任务元数据、hook 状态、AI 聊天和 PR 操作。
+
+<img src="./images/readme/kanvibe-detail-shortcut.png" alt="任务详情快捷键面板" width="100%">
+
+### 3. 项目筛选
+
+将看板缩小到你关心的活动项目，并通过键盘导航在仓库之间快速切换。
+
+<img src="./images/readme/kanvibe-project-search-shortcut.png" alt="项目筛选快捷键" width="100%">
+
+### 4. 通知
+
+打开通知面板，查看 AI 代理状态变化、后台同步结果和任务事件，然后跳转到相关任务。
+
+<img src="./images/readme/kanvibe-notification-shortcut.png" alt="通知快捷键面板" width="100%">
+
+### 5. 快速任务操作
+
+直接从高亮的搜索结果创建后续分支 TODO，保留下一项工作所需的项目和分支上下文。
+
+<img src="./images/readme/kanvibe-quick-action-shortcut.png" alt="快速任务操作快捷键" width="100%">
+
+### 6. Vim 风格看板控制
+
+在**设置 → 键盘**中启用 Vim 风格看板控制后，可以用 `h/j/k/l` 在任务卡片间移动，用 `/` 查找可见任务文本，用 `n` 打开新任务弹窗，用 `:move progress` 移动状态，并用 `dd` 删除当前聚焦任务。
+
+<video src="./images/readme/kanvibe-vim-controls.mp4" poster="./images/readme/kanvibe-vim-controls.png" controls muted playsinline width="100%"></video>
+
+[打开 Vim 控制演示视频](./images/readme/kanvibe-vim-controls.mp4)
 
 ---
 
@@ -55,7 +107,7 @@ brew install --cask rookedsysc/kanvibe/kanvibe
 open -a KanVibe
 ```
 
-官方 Homebrew Cask 收录后，可以用下面的一行命令安装：
+官方 Homebrew Cask 收录后，安装命令将变为：
 
 ```bash
 brew install --cask kanvibe
@@ -79,20 +131,22 @@ brew untap rookedsysc/kanvibe
 
 ### 1. 注册项目
 
-在项目设置中使用 **fzf 风格的文件夹搜索** 查找并注册本地 git 仓库。KanVibe 会扫描目录并自动检测现有的 worktree 分支。
+在项目设置中使用 **fzf 风格的文件夹搜索**查找本地 git 仓库。KanVibe 会扫描目录并自动检测现有的 worktree 分支。
+
+如果要停止管理某个项目，请在项目设置中删除它。此操作只会从嵌入式 SQLite 数据库中移除该项目及其 KanVibe 任务；磁盘上的 git 分支、worktree 和文件都会保留。
 
 ### 2. 创建任务
 
-在看板中添加 TODO 任务。使用分支名创建任务时，KanVibe 会自动：
+在 Kanban 看板中添加 TODO 任务。使用分支名创建任务时，KanVibe 会自动：
 - 为该分支创建 **git worktree**
-- 生成 **tmux window** 或 **zellij tab** 终端会话
+- 为会话生成 **tmux window** 或 **zellij tab**
 - 将终端会话链接到任务
 
 ### 3. 在看板中工作
 
 任务通过 5 个状态进行管理：**TODO** → **PROGRESS** → **PENDING** → **REVIEW** → **DONE**
 
-通过拖放更改状态，或通过 [AI 代理 Hooks](#ai-代理-hooks---自动状态追踪) 自动转换。当任务移至 **DONE** 时，分支、worktree 和终端会话会**自动删除**。
+通过拖放更改状态，或让 [AI 代理 Hooks](#ai-代理-hooks---自动状态追踪) 自动转换。当任务移至 **DONE** 时，分支、worktree 和终端会话会**自动删除**。
 
 ### 4. 选择面板布局
 
@@ -103,35 +157,43 @@ brew untap rookedsysc/kanvibe
 | **Single** | 全屏单面板 |
 | **Horizontal 2** | 左右两分 |
 | **Vertical 2** | 上下两分 |
-| **Left + Right TB** | 左侧 + 右侧上下分割 |
-| **Left TB + Right** | 左侧上下分割 + 右侧 |
+| **Left + Right TB** | 左侧面板 + 右侧上下分割 |
+| **Left TB + Right** | 左侧上下分割 + 右侧面板 |
 | **Quad** | 四等分 |
 
-每个面板可以配置自定义命令（如 `vim`、`htop`、`lazygit`、测试运行器等）。布局可以全局设置或按项目设置。
+每个面板可以运行自定义命令（如 `vim`、`htop`、`lazygit`、测试运行器等）。布局可在设置对话框中全局配置，也可按项目配置。
 
 ---
 
 ## 功能
 
-### 看板
+### 实时 Kanban 看板
 - 5 状态任务管理（TODO / PROGRESS / PENDING / REVIEW / DONE）
-- 自定义任务排序
-- 多项目筛选
-- Done 列分页
-- 基于 WebSocket 的实时更新
+- 带项目颜色、优先级标记、PR 徽章和会话标签的拖放任务排序
+- 支持键盘搜索可见项目和任务文本的多项目筛选
+- 面向长期项目的 Done 列分页
+- 跨浏览器和桌面窗口的实时 WebSocket 更新
 
-### Git Worktree 集成
-- 创建基于分支的任务时自动创建 git worktree
-- Worktree 扫描：自动将现有分支注册为 TODO 任务
-- 任务移至 DONE 时自动清理分支 + worktree + 会话
+### 基于分支的任务工作区
+- 创建会自动准备 git worktree 和终端会话的分支 TODO
+- 扫描现有 worktree 分支并注册为 TODO 任务
+- 将每个任务打开到专用终端工作区，并在侧边 dock 中使用任务元数据、hook 控制、聊天和 PR 操作
+- 将任务移至 DONE 时自动清理其分支、worktree 和终端会话
+- 在设置中删除项目时，不会触碰现有 git 分支、worktree 或磁盘文件
 
 ### 终端会话（tmux / zellij）
 - 同时支持 **tmux** 和 **zellij** 作为终端复用器
-- 基于 xterm.js + WebSocket 的浏览器终端
-- SSH 远程终端支持（读取 `~/.ssh/config`）
+- 通过 xterm.js 和 WebSocket 进行基于浏览器的终端流式传输
+- 读取 `~/.ssh/config` 的 SSH 远程终端支持
 - 非交互式远程 SSH 命令会复用 `~/.kanvibe` 下的应用专用 ControlMaster socket 池，并将每个 host 的并发数限制为可用 CPU 核心数的 4 倍
 - 远程终端 attach 会通过 SSH 直接执行 tmux/zellij；仅在本地 `DISPLAY`、远程 `X11Forwarding` 和 `xauth` 可用时请求 trusted X11 forwarding（`ssh -Y`）
 - Nerd Font 渲染支持
+
+### 键盘优先控制
+- 从任何位置按分支名或项目名打开快速任务搜索
+- 不离开看板即可筛选项目、检查通知并触发任务操作
+- 在按键进入终端之前，使用编号详情快捷键切换任务信息、状态/hooks、AI 聊天、PR 和其他 dock 面板
+- 使用配置的快捷键直接从快速任务搜索创建分支 TODO
 
 ### 键盘快捷键
 
@@ -142,24 +204,20 @@ brew untap rookedsysc/kanvibe
 | `n` | 看板 | 立即打开新任务弹窗 |
 | `:move todo\|progress\|pending\|review\|done` | 已聚焦的看板任务卡片 | 无需拖放，将当前聚焦任务移动到目标状态；在命令输入框按 `Tab` 可补全唯一的状态前缀 |
 | `dd` | 已聚焦的看板任务卡片 | 确认后删除当前聚焦任务 |
-| `Cmd/Ctrl+Shift+O` | 全局 | 按分支名或项目名打开任务快速搜索（默认值，可配置） |
+| `Cmd/Ctrl+Shift+O` | 全局 | 按分支名或项目名打开快速任务搜索（默认值，可配置） |
 | `Cmd/Ctrl+Shift+P` | 看板 | 打开项目筛选下拉框 |
 | `Cmd/Ctrl+Shift+I` | 看板 | 打开通知下拉框 |
 | `Cmd+[` / `Cmd+]` (macOS), `Alt+[` / `Alt+]` (Linux) | 全局 | 在应用历史中后退/前进；没有上一页时后退到看板首页 |
-| `Cmd/Ctrl+N` | 任务快速搜索 | 基于当前高亮任务创建新的 branch TODO |
-| `↑ / ↓ / Enter / Esc` | 任务快速搜索 | 移动选择、打开任务、关闭对话框 |
+| `Cmd+1/2/3` (macOS), `Alt+1/2/3` (Linux) | 任务详情 | 激活编号详情 dock 项：信息、状态/hooks 和 AI 聊天。这些快捷键会先于终端输入被拦截 |
+| `Cmd+4` (macOS), `Alt+4` (Linux) | 任务详情 | 任务有 PR 时在浏览器中打开该 PR；否则该快捷键属于当前可见的第四个 dock 项 |
+| `Cmd/Ctrl+N` | 快速任务搜索 | 基于当前高亮任务创建新的分支 TODO |
+| `↑ / ↓ / Enter / Shift+Enter / Esc` | 快速任务搜索 | 移动选择、打开任务、在新窗口打开任务、关闭对话框 |
 | `↑ / ↓ / Enter / Esc` | 项目筛选下拉框 | 移动选择、切换项目筛选、关闭下拉框 |
 | `↑ / ↓ / Enter / Esc` | 通知下拉框 | 移动选择、打开通知目标、关闭下拉框 |
 
-Vim 风格看板控制（`h/j/k/l`、`/`、`n`、`dd`、`:move ...`）可在**设置 → 键盘**中启用或关闭。关闭后仍可使用方向键移动任务焦点，也可继续使用 `Cmd/Ctrl+F` 页面查找。
+任务详情 dock 编号会排除返回看板按钮，并遵循可见 dock 项顺序。如果任务有 PR URL，PR 会占用第 4 个位置，后续 dock 项会顺延到 5+；如果没有 PR，下一个 dock 项会使用第 4 个位置。
 
-#### Vim 风格看板控制演示
-
-下面的视频从**设置 → 键盘**启用 Vim 风格看板控制开始，然后展示在真实看板中使用 `h/j/k/l`、`/`、`:move progress`、`n` 和 `dd` 的流程。
-
-<video src="./images/readme/kanvibe-vim-controls.mp4" poster="./images/readme/kanvibe-vim-controls.png" controls muted playsinline width="100%"></video>
-
-[打开演示视频](./images/readme/kanvibe-vim-controls.mp4)
+Vim 风格看板控制（`h/j/k/l`、`/`、`n`、`dd`、`:move ...`）可在**设置 → 键盘**中启用或关闭。即使禁用 Vim 风格控制，方向键任务导航和 `Cmd/Ctrl+F` 页面查找仍然可用。
 
 ### AI 代理 Hooks - 自动状态追踪
 KanVibe 与 **Claude Code Hooks**、**Gemini CLI Hooks**、**Codex CLI** 和 **OpenCode** 集成，自动追踪任务状态。任务通过 5 个状态进行管理：
@@ -167,10 +225,10 @@ KanVibe 与 **Claude Code Hooks**、**Gemini CLI Hooks**、**Codex CLI** 和 **O
 | 状态 | 说明 |
 |------|------|
 | **TODO** | 任务创建时的初始状态 |
-| **PROGRESS** | AI 正在处理任务 |
-| **PENDING** | AI 向用户提出追问，等待用户回复（仅 Claude Code 支持） |
+| **PROGRESS** | AI 正在主动处理任务 |
+| **PENDING** | AI 提出后续问题，等待用户回复（仅 Claude Code 支持） |
 | **REVIEW** | AI 已完成工作，等待审查 |
-| **DONE** | 任务完成 — 分支、worktree、终端会话会**自动删除** |
+| **DONE** | 任务完成 — 分支、worktree 和终端会话会**自动删除** |
 
 #### Claude Code
 ```
@@ -190,13 +248,13 @@ AfterAgent（代理完成）       → REVIEW
 
 #### Codex CLI
 ```
-UserPromptSubmit                → PROGRESS
-PermissionRequest（仅 Bash）   → PENDING
-PreToolUse（仅 Bash）          → PROGRESS
-Stop                           → REVIEW
+UserPromptSubmit              → PROGRESS
+PermissionRequest（仅 Bash）  → PENDING
+PreToolUse（仅 Bash）         → PROGRESS
+Stop                          → REVIEW
 ```
 
-KanVibe 现在使用 Codex 当前的 lifecycle hooks 方案：`.codex/hooks.json` 加上 `.codex/config.toml` 中的 `[features].hooks = true`。对应的官方文档如下：
+KanVibe 现在使用 Codex 当前的 lifecycle hooks 方案：`.codex/hooks.json` 加上 `.codex/config.toml` 中的 `[features].hooks = true`：
 
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/config-reference
@@ -231,7 +289,7 @@ AI 代理 Hooks 触发的任务状态变更会发送**浏览器通知**，显示
 - **实时通知** — 任务状态变更时立即收到通知
 - **后台模式** — KanVibe 不在焦点时也能收到通知
 - **智能导航** — 点击通知 → 任务详情页面（保持当前语言）
-- **可自定义** — 按项目启用/禁用，并可按状态筛选（PROGRESS、PENDING、REVIEW、DONE）
+- **可配置** — 按项目启用/禁用，并可按状态筛选（PROGRESS、PENDING、REVIEW、DONE）
 
 设置：首次访问时请允许浏览器通知权限。在**项目设置** → **通知**中配置筛选条件。
 
@@ -240,18 +298,11 @@ AI 代理 Hooks 触发的任务状态变更会发送**浏览器通知**，显示
 | 端点 | 方法 | 说明 |
 |------|------|------|
 | `/api/hooks/start` | POST | 创建新任务 |
-| `/api/hooks/status` | POST | 通过 `branchName` + `projectName` 更新任务状态；如果目标不存在，则只发送浏览器通知并保持 `404` 响应，不会修改状态 |
+| `/api/hooks/status` | POST | 通过 `branchName` + `projectName` 更新任务状态；如果目标不存在，则只发送浏览器通知并返回 `404`，不会修改状态 |
 
 ### GitHub 风格 Diff 视图
 
 在浏览器中使用 GitHub 风格的 diff 查看器直接审查代码变更。点击任务详情页面上的 **Diff** 徽章，即可查看与 base 分支相比的所有修改文件。
-
-<table>
-  <tr>
-    <td width="30%"><img src="./images/diff-view-button.png" alt="任务详情中的 Diff 徽章" width="100%"></td>
-    <td width="70%"><img src="./images/diff-view.png" alt="Diff 视图页面" width="100%"></td>
-  </tr>
-</table>
 
 - 显示变更文件数量的文件树侧边栏
 - 基于 Monaco Editor 的内联 diff 查看器
@@ -286,7 +337,7 @@ AI 代理 Hooks 触发的任务状态变更会发送**浏览器通知**，显示
 
 ## 许可证
 
-本项目使用 **AGPL-3.0** 许可证。您可以自由地用于开源目的进行使用、修改和扩展。此许可证不允许商业 SaaS 分发。详情请参阅 [LICENSE](../LICENSE)。
+本项目使用 **AGPL-3.0** 许可证。你可以自由地用于开源目的进行使用、修改和扩展。此许可证不允许商业 SaaS 分发。详情请参阅 [LICENSE](../LICENSE)。
 
 ---
 


### PR DESCRIPTION
## Summary
- Align the Korean and Chinese README intro/media blocks with the English README after #287.
- Add localized translations for the English README's Key Workflows section and current shortcut/workspace descriptions.
- Replace the older duplicated `detail-page.png` localized screenshots with the current README screenshot set and clickable YouTube thumbnail pattern.

## Test Plan
- [x] `git diff --check`
- [x] Verified `docs/README.ko.md` and `docs/README.zh.md` contain no iframe or deleted logo reference.
- [x] Verified localized README heading counts match the English README shape.
- [x] Verified all referenced localized README media files exist.
- [x] Rendered both localized READMEs with GitHub Markdown API and confirmed the YouTube thumbnail plus README screenshots appear.
- [x] Verified the YouTube thumbnail URL responds with `200 image/jpeg`.
