### PR TITLE
fix: remove create task branch placeholder

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -108,7 +108,6 @@
     "branchCount": "{count} branches",
     "branchNavHint": "↑↓ Navigate · Enter Select · Esc Close",
     "branchName": "Branch name",
-    "branchPlaceholder": "feat/my-feature",
     "sessionType": "Session type",
     "sshHost": "SSH Host (optional)",
     "createTitle": "Create New Task",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -108,7 +108,6 @@
     "branchCount": "{count}개의 브랜치",
     "branchNavHint": "↑↓ 이동 · Enter 선택 · Esc 닫기",
     "branchName": "브랜치 이름",
-    "branchPlaceholder": "feat/my-feature",
     "sessionType": "세션 타입",
     "sshHost": "SSH 호스트 (선택)",
     "createTitle": "새 작업 생성",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -107,7 +107,6 @@
     "branchCount": "{count} 个分支",
     "branchNavHint": "↑↓ 导航 · Enter 选择 · Esc 关闭",
     "branchName": "分支名称",
-    "branchPlaceholder": "feat/my-feature",
     "sessionType": "会话类型",
     "sshHost": "SSH 主机（可选）",
     "createTitle": "创建新任务",

--- a/qa/electron/flows/smoke.cjs
+++ b/qa/electron/flows/smoke.cjs
@@ -333,6 +333,23 @@ async function openCreateTaskModalWithVimN(page) {
   await page.waitForTimeout(700);
 }
 
+async function assertCreateTaskBranchNameInputStartsBlank(page) {
+  const input = page.locator("input[name='branchName']").first();
+  await input.waitFor({ state: "visible", timeout: 7000 });
+  const placeholder = await input.getAttribute("placeholder");
+  const value = await input.inputValue();
+
+  if (placeholder !== null) {
+    throw new Error(`expected create-task branch input to have no placeholder, got ${JSON.stringify(placeholder)}`);
+  }
+
+  if (value !== "") {
+    throw new Error(`expected create-task branch input to start empty, got ${JSON.stringify(value)}`);
+  }
+
+  return "branch name input has no placeholder and starts empty";
+}
+
 async function assertCreateTaskModalClosed(page, context) {
   await page.waitForTimeout(800);
   const isVisible = await page.locator("input[name='branchName']").first().isVisible().catch(() => false);
@@ -650,11 +667,14 @@ async function main() {
 
     await takeScreenshot(page, run, "vim-command-move-all-statuses", screenshots);
 
-    await optionalStep(checks, "Vim n opens the create-task modal when setting is ON", async () => {
+    await optionalStep(checks, "Vim n opens the create-task modal with a blank branch name field when setting is ON", async () => {
       await openCreateTaskModalWithVimN(page);
+      const branchNameDetail = await assertCreateTaskBranchNameInputStartsBlank(page);
+      await takeScreenshot(page, run, "create-task-modal-blank-branch-name", screenshots);
+      await page.waitForTimeout(1200);
       await page.keyboard.press("Escape");
       await assertCreateTaskModalClosed(page, "Escape should close Vim-created task modal");
-      return "n opened Create Task modal; Escape closed it";
+      return `n opened Create Task modal; ${branchNameDetail}; screenshot captured; Escape closed it`;
     });
 
     await optionalStep(checks, "Vim dd deletes the focused task after confirmation when setting is ON", async () => {
@@ -828,7 +848,7 @@ async function main() {
 
   const result = {
     ok,
-    scope: "Electron UI QA for PR #275/#276 cleanup plus Vim-style board controls: clone fixture repo, seed real tasks, verify h/j/k/l, / page find with Enter/Shift+Enter, n, dd, :move todo|progress|pending|review|done, settings ON/OFF behavior, and external worktree cleanup",
+    scope: "Electron UI QA for PR #275/#276 cleanup plus Vim-style board controls: clone fixture repo, seed real tasks, verify h/j/k/l, / page find with Enter/Shift+Enter, n create-task modal blank branch-name field, dd, :move todo|progress|pending|review|done, settings ON/OFF behavior, and external worktree cleanup",
     branch: gitValue(["branch", "--show-current"]),
     commit: gitValue(["rev-parse", "--short", "HEAD"]),
     checks,

--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -278,14 +278,17 @@ function CreateTaskModalContent({
           )}
 
           <div>
-            <label className="block text-sm text-text-secondary mb-1">
+            <label
+              htmlFor="create-task-branch-name"
+              className="block text-sm text-text-secondary mb-1"
+            >
               {t("branchName")} *
             </label>
             <input
+              id="create-task-branch-name"
               name="branchName"
               required
               className="w-full px-3 py-2 bg-bg-page border border-border-default rounded-md text-text-primary focus:outline-none focus:border-brand-primary font-mono transition-colors"
-              placeholder={t("branchPlaceholder")}
             />
           </div>
 

--- a/src/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/components/__tests__/CreateTaskModal.test.tsx
@@ -70,10 +70,38 @@ function createProject(overrides?: Partial<Project>): Project {
   };
 }
 
+function getBranchNameInput() {
+  return screen.getByLabelText(/branchName/) as HTMLInputElement;
+}
+
 describe("CreateTaskModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetProjectBranches.mockResolvedValue(["main", "develop"]);
+  });
+
+  it("새 작업 브랜치 이름 입력은 예시 브랜치명을 placeholder로 보여주지 않는다", async () => {
+    // Given
+    render(
+      <CreateTaskModal
+        isOpen
+        onClose={vi.fn()}
+        sshHosts={["remote-box"]}
+        projects={[createProject()]}
+        defaultProjectId="project-remote"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetProjectBranches).toHaveBeenCalledWith("project-remote");
+    });
+
+    // When
+    const branchNameInput = getBranchNameInput();
+
+    // Then
+    expect(branchNameInput.getAttribute("placeholder")).toBeNull();
+    expect(branchNameInput.value).toBe("");
   });
 
   it("로컬 프로젝트 task 생성도 세션 도구 프롬프트 없이 생성 요청을 보낸다", async () => {
@@ -98,7 +126,7 @@ describe("CreateTaskModal", () => {
     });
 
     // When
-    fireEvent.change(screen.getByPlaceholderText("branchPlaceholder"), { target: { value: "fix/session-prompt" } });
+    fireEvent.change(getBranchNameInput(), { target: { value: "fix/session-prompt" } });
     fireEvent.click(screen.getByRole("button", { name: "create" }));
 
     // Then
@@ -140,7 +168,7 @@ describe("CreateTaskModal", () => {
     });
 
     // When
-    fireEvent.change(screen.getByPlaceholderText("branchPlaceholder"), { target: { value: "fix/remote-fast" } });
+    fireEvent.change(getBranchNameInput(), { target: { value: "fix/remote-fast" } });
     fireEvent.click(screen.getByRole("button", { name: "create" }));
 
     // Then
@@ -182,7 +210,7 @@ describe("CreateTaskModal", () => {
     });
 
     // When
-    fireEvent.change(screen.getByPlaceholderText("branchPlaceholder"), { target: { value: "fix/session-prompt" } });
+    fireEvent.change(getBranchNameInput(), { target: { value: "fix/session-prompt" } });
     fireEvent.click(screen.getByRole("button", { name: "create" }));
 
     // Then
@@ -246,7 +274,7 @@ describe("CreateTaskModal", () => {
     });
 
     const baseBranchInput = screen.getByLabelText("baseBranch");
-    const branchNameInput = screen.getByPlaceholderText("branchPlaceholder");
+    const branchNameInput = getBranchNameInput();
     const descriptionInput = screen.getByPlaceholderText("descriptionPlaceholder");
 
     // Then
@@ -315,7 +343,7 @@ describe("CreateTaskModal", () => {
     });
 
     // When
-    const branchNameInput = screen.getByPlaceholderText("branchPlaceholder");
+    const branchNameInput = getBranchNameInput();
     fireEvent.change(branchNameInput, { target: { value: "fix/enter-submit" } });
     fireEvent.keyDown(branchNameInput, { key: "Enter" });
 


### PR DESCRIPTION
## Summary
- Remove the `feat/my-feature` example placeholder from the Create Task dialog branch-name input so new tasks start with a blank branch field.
- Link the branch-name label to the input for accessible selectors and update component tests away from placeholder-based lookup.
- Extend the Electron QA smoke flow to assert and capture evidence that `Vim n` opens the Create Task modal with a blank branch-name field.

## Test Plan
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js lint` — passes with existing warnings only
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js check` — passes
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js test` — passes, 92 files / 755 tests
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js qa:electron:video` — passes
  - Report: `qa-output/20260603T110524Z-3846468/report.md`
  - Video: `qa-output/20260603T110524Z-3846468/run.mp4` (65.67s, 830,782 bytes)
  - Blank-field screenshot: `qa-output/20260603T110524Z-3846468/screenshots/06-create-task-modal-blank-branch-name.png`
- `git diff --check` — passes
