### PR TITLE
fix: prevent background sync from repairing root hooks

### DIFF
--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -741,7 +741,7 @@ describe("projectService local hook installation", () => {
     );
   });
 
-  it("이미 등록된 레거시 프로젝트 목록 조회는 즉시 반환하고 root hooks 복구는 백그라운드에서 진행한다", async () => {
+  it("이미 등록된 레거시 프로젝트 목록 조회는 즉시 반환하고 root task 복구는 백그라운드에서 진행한다", async () => {
     vi.useFakeTimers();
 
     mocks.getProjectRepository.mockResolvedValue({
@@ -794,7 +794,7 @@ describe("projectService local hook installation", () => {
       await vi.runAllTimersAsync();
 
       expect(mocks.broadcastBoardUpdate).toHaveBeenCalled();
-      expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
+      expect(mocks.installKanvibeHooks).not.toHaveBeenCalledWith(
         "/workspace/api",
         "task-main",
         null,
@@ -804,8 +804,13 @@ describe("projectService local hook installation", () => {
     }
   });
 
-  it("기존 root hooks 백그라운드 복구가 한 번 실패해도 다음 조회에서 다시 재시도한다", async () => {
+  it("기존 root task 백그라운드 복구가 한 번 실패해도 다음 조회에서 다시 재시도한다", async () => {
     vi.useFakeTimers();
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const taskSave = vi.fn()
+      .mockRejectedValueOnce(new Error("database offline"))
+      .mockImplementation(async (value) => ({ id: "task-main", ...value }));
 
     mocks.getProjectRepository.mockResolvedValue({
       find: vi.fn().mockResolvedValue([
@@ -819,16 +824,9 @@ describe("projectService local hook installation", () => {
       ]),
     });
     mocks.getTaskRepository.mockResolvedValue({
-      findOneBy: vi.fn().mockResolvedValue({
-        id: "task-main",
-        branchName: "main",
-        projectId: "project-1",
-        baseBranch: "main",
-        worktreePath: "/workspace/api",
-        sshHost: null,
-      }),
+      findOneBy: vi.fn().mockResolvedValue(null),
       create: vi.fn((value) => value),
-      save: vi.fn(async (value) => ({ id: "task-main", ...value })),
+      save: taskSave,
     });
     mocks.listWorktrees.mockResolvedValue([
       {
@@ -837,9 +835,7 @@ describe("projectService local hook installation", () => {
         isBare: false,
       },
     ]);
-    mocks.installKanvibeHooks
-      .mockRejectedValueOnce(new Error("hook server offline"))
-      .mockResolvedValueOnce(undefined);
+    mocks.createSessionWithoutWorktree.mockResolvedValue({ sessionName: "api-main" });
 
     const { getAllProjects } = await import("@/desktop/main/services/projectService");
 
@@ -847,29 +843,30 @@ describe("projectService local hook installation", () => {
       await getAllProjects();
       await vi.runAllTimersAsync();
 
-      expect(mocks.installKanvibeHooks).toHaveBeenCalledTimes(1);
+      expect(taskSave).toHaveBeenCalledTimes(1);
+      expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
       expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
 
       await getAllProjects();
       await vi.runAllTimersAsync();
 
-      expect(mocks.installKanvibeHooks).toHaveBeenCalledTimes(2);
-      expect(mocks.installKanvibeHooks).toHaveBeenLastCalledWith(
-        "/workspace/api",
-        "task-main",
-        null,
-      );
+      expect(taskSave).toHaveBeenCalledTimes(2);
+      expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
       expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "api 기본 브랜치 task 백그라운드 복구 실패:",
+        expect.any(Error),
+      );
     } finally {
+      consoleErrorSpy.mockRestore();
       vi.useRealTimers();
     }
   });
 
-  it("원격 hook 상태 조회가 SSH 연결 오류로 실패해도 백그라운드 복구 로그를 남기지 않는다", async () => {
+  it("원격 root hook 상태 조회는 getAllProjects 백그라운드에서 발생하지 않는다", async () => {
     vi.useFakeTimers();
 
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const remoteConnectionError = new Error("remote-host 원격 명령 실패: Connection reset by 100.73.171.123 port 22");
 
     mocks.getProjectRepository.mockResolvedValue({
       find: vi.fn().mockResolvedValue([
@@ -894,14 +891,16 @@ describe("projectService local hook installation", () => {
       create: vi.fn((value) => value),
       save: vi.fn(async (value) => ({ id: "task-main", ...value })),
     });
-    mocks.getClaudeHooksStatus.mockRejectedValueOnce(remoteConnectionError);
-
     const { getAllProjects } = await import("@/desktop/main/services/projectService");
 
     try {
       await getAllProjects();
       await vi.runAllTimersAsync();
 
+      expect(mocks.getClaudeHooksStatus).not.toHaveBeenCalled();
+      expect(mocks.getGeminiHooksStatus).not.toHaveBeenCalled();
+      expect(mocks.getCodexHooksStatus).not.toHaveBeenCalled();
+      expect(mocks.getOpenCodeHooksStatus).not.toHaveBeenCalled();
       expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
       expect(consoleErrorSpy).not.toHaveBeenCalled();
     } finally {
@@ -909,11 +908,10 @@ describe("projectService local hook installation", () => {
     }
   });
 
-  it("원격 hook 설치가 SSH 연결 오류로 실패해도 백그라운드 복구 로그를 남기지 않는다", async () => {
+  it("원격 root hook 설치 오류는 getAllProjects 백그라운드에서 발생하지 않는다", async () => {
     vi.useFakeTimers();
 
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const remoteConnectionError = new Error("remote-host 원격 명령 실패: Connection closed by 100.73.171.123 port 22");
 
     mocks.getProjectRepository.mockResolvedValue({
       find: vi.fn().mockResolvedValue([
@@ -938,19 +936,13 @@ describe("projectService local hook installation", () => {
       create: vi.fn((value) => value),
       save: vi.fn(async (value) => ({ id: "task-main", ...value })),
     });
-    mocks.installKanvibeHooks.mockRejectedValueOnce(remoteConnectionError);
-
     const { getAllProjects } = await import("@/desktop/main/services/projectService");
 
     try {
       await getAllProjects();
       await vi.runAllTimersAsync();
 
-      expect(mocks.installKanvibeHooks).toHaveBeenCalledWith(
-        "/remote/techtaurant-be",
-        "task-main",
-        "remote-host",
-      );
+      expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
       expect(consoleErrorSpy).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
@@ -1439,6 +1431,126 @@ describe("projectService local hook installation", () => {
       "task-worktree",
       null,
     );
+  });
+
+  it("등록된 프로젝트 background sync는 기존 root hooks를 자동 복구하지 않는다", async () => {
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: false });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: false });
+    mocks.listWorktrees.mockResolvedValue([
+      {
+        path: "/workspace/api",
+        branch: "main",
+        isBare: false,
+      },
+    ]);
+
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          id: "project-1",
+          name: "api",
+          repoPath: "/workspace/api",
+          defaultBranch: "main",
+          sshHost: null,
+        },
+      ]),
+    });
+
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => {
+        if (criteria.projectId === "project-1" && criteria.branchName === "main") {
+          return {
+            id: "task-main",
+            branchName: "main",
+            projectId: "project-1",
+            baseBranch: "main",
+            worktreePath: "/workspace/api",
+            sshHost: null,
+          };
+        }
+
+        return null;
+      }),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => value),
+    });
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+    const result = await syncRegisteredProjectWorktrees();
+
+    expect(result.changed).toBe(false);
+    expect(mocks.getClaudeHooksStatus).not.toHaveBeenCalled();
+    expect(mocks.getGeminiHooksStatus).not.toHaveBeenCalled();
+    expect(mocks.getCodexHooksStatus).not.toHaveBeenCalled();
+    expect(mocks.getOpenCodeHooksStatus).not.toHaveBeenCalled();
+    expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
+  });
+
+  it("등록된 원격 프로젝트 background sync는 기존 root hook 복구를 예약하지 않는다", async () => {
+    vi.useFakeTimers();
+
+    try {
+      mocks.getClaudeHooksStatus.mockResolvedValue({ installed: false });
+      mocks.getGeminiHooksStatus.mockResolvedValue({ installed: false });
+      mocks.getCodexHooksStatus.mockResolvedValue({ installed: false });
+      mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: false });
+      mocks.listWorktrees.mockResolvedValue([
+        {
+          path: "/remote/api",
+          branch: "main",
+          isBare: false,
+        },
+      ]);
+
+      mocks.getProjectRepository.mockResolvedValue({
+        find: vi.fn().mockResolvedValue([
+          {
+            id: "project-1",
+            name: "api",
+            repoPath: "/remote/api",
+            defaultBranch: "main",
+            sshHost: "remote-host",
+          },
+        ]),
+      });
+
+      mocks.getTaskRepository.mockResolvedValue({
+        findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => {
+          if (criteria.projectId === "project-1" && criteria.branchName === "main") {
+            return {
+              id: "task-main",
+              branchName: "main",
+              projectId: "project-1",
+              baseBranch: "main",
+              worktreePath: "/remote/api",
+              sshHost: "remote-host",
+            };
+          }
+
+          return null;
+        }),
+        create: vi.fn((value) => value),
+        save: vi.fn(async (value) => value),
+      });
+
+      const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+      const result = await syncRegisteredProjectWorktrees();
+      await vi.runAllTimersAsync();
+
+      expect(result.changed).toBe(false);
+      expect(mocks.getClaudeHooksStatus).not.toHaveBeenCalled();
+      expect(mocks.getGeminiHooksStatus).not.toHaveBeenCalled();
+      expect(mocks.getCodexHooksStatus).not.toHaveBeenCalled();
+      expect(mocks.getOpenCodeHooksStatus).not.toHaveBeenCalled();
+      expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("등록된 프로젝트 background sync는 새 worktree를 TODO task로 등록한다", async () => {

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -200,7 +200,6 @@ function scheduleProjectRootTaskRepair(project: Project) {
         }
 
         const { repaired } = await ensureProjectRootTask(project);
-        scheduleProjectRootHookRepair(project);
 
         if (repaired) {
           broadcastBoardUpdate();
@@ -633,19 +632,11 @@ async function syncProjectWorktrees(
   };
 
   try {
-    const shouldRepairHooksSynchronously = !project.sshHost;
     const { repaired } = await ensureProjectRootTask(project, {
-      repairHooks: shouldRepairHooksSynchronously,
+      repairHooks: false,
       throwOnHookRepairFailure: false,
     });
-    if (shouldRepairHooksSynchronously && repaired) {
-      result.hooksSetup.push(project.name);
-    }
     result.changed = result.changed || repaired;
-
-    if (project.sshHost) {
-      scheduleProjectRootHookRepair(project);
-    }
 
     const worktrees = await listWorktrees(project.repoPath, project.sshHost);
 

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -97,8 +97,6 @@ function isRemoteConnectionError(error: unknown): boolean {
   return /원격 명령 실패:.*(Connection (?:reset|closed)|kex_exchange_identification|operation timed out|no route to host|connection refused|could not resolve hostname|broken pipe)/i.test(message);
 }
 
-const projectRootHookRepairJobs = new Map<string, Promise<void>>();
-const projectRootHookRepairScheduled = new Set<string>();
 const projectRootTaskRepairJobs = new Map<string, Promise<void>>();
 const projectRootTaskRepairScheduled = new Set<string>();
 const projectRootRepairDeletingProjectIds = new Set<string>();
@@ -106,48 +104,6 @@ const projectRootRepairDeletedProjectIds = new Set<string>();
 
 function isProjectRootRepairBlocked(projectId: string): boolean {
   return projectRootRepairDeletingProjectIds.has(projectId) || projectRootRepairDeletedProjectIds.has(projectId);
-}
-
-function scheduleProjectRootHookRepair(project: Project) {
-  if (isProjectRootRepairBlocked(project.id)) {
-    return;
-  }
-
-  const projectPathKey = buildProjectPathKey(project.repoPath, project.sshHost);
-  if (projectRootHookRepairScheduled.has(projectPathKey)) {
-    return;
-  }
-
-  projectRootHookRepairScheduled.add(projectPathKey);
-
-  setTimeout(() => {
-    const repairJob = (async () => {
-      try {
-        if (isProjectRootRepairBlocked(project.id)) {
-          return;
-        }
-
-        const { repaired } = await ensureProjectRootTask(project, {
-          repairHooks: true,
-          throwOnHookRepairFailure: false,
-          suppressRemoteConnectionErrorLogging: true,
-        });
-
-        if (repaired) {
-          broadcastBoardUpdate();
-        }
-      } catch (error) {
-        if (!isRemoteConnectionError(error)) {
-          console.error(`${project.name} 기본 브랜치 hooks 백그라운드 복구 실패:`, error);
-        }
-      } finally {
-        projectRootHookRepairJobs.delete(projectPathKey);
-        projectRootHookRepairScheduled.delete(projectPathKey);
-      }
-    })();
-
-    projectRootHookRepairJobs.set(projectPathKey, repairJob);
-  }, 0);
 }
 
 async function installSyncedWorktreeHooks(
@@ -532,9 +488,6 @@ export async function registerProject(
       repairHooks: !saved.sshHost,
       throwOnHookRepairFailure: false,
     });
-    if (saved.sshHost) {
-      scheduleProjectRootHookRepair(saved);
-    }
   } catch (error) {
     await repo.remove(saved);
     return {
@@ -887,9 +840,6 @@ export async function scanAndRegisterProjects(
       /** 기본 브랜치 작업이 준비되면 hooks가 보장된다 */
       if (defaultTask && shouldRepairHooksSynchronously) {
         result.hooksSetup.push(projectName);
-      }
-      if (saved.sshHost) {
-        scheduleProjectRootHookRepair(saved);
       }
     } catch (error) {
       result.errors.push(


### PR DESCRIPTION
## Summary
- Stop registered-project background sync from checking or repairing existing root/default worktree hooks.
- Delete the `scheduleProjectRootHookRepair` scheduler and remove its remaining remote registration/scan call sites.
- Keep root task repair separated from hook installation so root hook setup remains explicit/manual.
- Add local and remote regression coverage to ensure background sync does not call hook status checks or install root hooks.

## Test Plan
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js vitest run src/desktop/main/services/__tests__/projectService.test.ts` — 45 tests passed
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js test` — 92 files / 757 tests passed
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js check` — passed
