### PR TITLE
fix: quote tmux pane bootstrap commands safely

### DIFF
--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -104,8 +104,8 @@ describe("attachLocalSession — tmux 세션 자동 생성", () => {
     // Then
     const newSessionCmd = findExecSyncCall("new-session");
     expect(newSessionCmd).toBeDefined();
-    expect(newSessionCmd).toContain('-s "feat-login"');
-    expect(newSessionCmd).toContain('-c "/workspace"');
+    expect(newSessionCmd).toContain("-s 'feat-login'");
+    expect(newSessionCmd).toContain("-c '/workspace'");
     const newSessionCall = mockExecSync.mock.calls.find((call) => String(call[0]).includes("new-session"));
     expect(newSessionCall?.[1]).toEqual(expect.objectContaining({
       env: expect.objectContaining({
@@ -146,10 +146,46 @@ describe("attachLocalSession — tmux 세션 자동 생성", () => {
 
     // Then
     const bootstrapCmd = findExecSyncCall("new-session");
-    expect(bootstrapCmd).toContain('tmux new-session -d -s "feat-login" -c "/workspace"');
-    expect(bootstrapCmd).toContain('tmux split-window -h -t "feat-login":0 -c "/workspace"');
-    expect(bootstrapCmd).toContain('tmux send-keys -t "feat-login":0.0 "pnpm dev" Enter');
-    expect(bootstrapCmd).toContain('tmux send-keys -t "feat-login":0.1 "pnpm test" Enter');
+    expect(bootstrapCmd).toContain("tmux new-session -d -s 'feat-login' -c '/workspace'");
+    expect(bootstrapCmd).toContain("tmux split-window -h -t 'feat-login:0' -c '/workspace'");
+    expect(bootstrapCmd).toContain("tmux send-keys -t 'feat-login:0.0' -- 'pnpm dev' Enter");
+    expect(bootstrapCmd).toContain("tmux send-keys -t 'feat-login:0.1' -- 'pnpm test' Enter");
+  });
+
+  it("should build POSIX-valid local tmux bootstrap commands for multiline quoted pane commands", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) {
+        throw new Error("session not found");
+      }
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-layout-quoted",
+      SessionType.TMUX,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+      120,
+      30,
+      {
+        layoutType: PaneLayoutType.VERTICAL_2,
+        panes: [
+          {
+            position: 0,
+            command: "nvm use 24 && \nnode -e \"console.log('ok')\"",
+          },
+        ],
+      },
+    );
+
+    // Then
+    const bootstrapCmd = findExecSyncCall("new-session");
+    expect(bootstrapCmd).toBeDefined();
+    expectValidPosixShellSyntax(bootstrapCmd ?? "");
   });
 
   it("should skip session creation when tmux session already exists", async () => {
@@ -457,7 +493,7 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
         expect.stringContaining('tmux has-session -t "remote-session"'),
       );
       expect(mockPtyWrite).toHaveBeenCalledWith(
-        expect.stringContaining('tmux new-session -d -s "remote-session" -c "/remote/worktree"'),
+        expect.stringContaining("tmux new-session -d -s 'remote-session' -c '/remote/worktree'"),
       );
     } finally {
       if (originalDisplay === undefined) {
@@ -615,13 +651,47 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     );
 
     expect(mockPtyWrite).toHaveBeenCalledWith(
-      expect.stringContaining('tmux split-window -h -t "remote-session":0 -c "/remote/worktree"'),
+      expect.stringContaining("tmux split-window -h -t 'remote-session:0' -c '/remote/worktree'"),
     );
     expect(mockPtyWrite).toHaveBeenCalledWith(
-      expect.stringContaining('tmux send-keys -t "remote-session":0.0 "pnpm dev" Enter'),
+      expect.stringContaining("tmux send-keys -t 'remote-session:0.0' -- 'pnpm dev' Enter"),
     );
     expect(mockPtyWrite).toHaveBeenCalledWith(
-      expect.stringContaining('tmux send-keys -t "remote-session":0.1 "pnpm test" Enter'),
+      expect.stringContaining("tmux send-keys -t 'remote-session:0.1' -- 'pnpm test' Enter"),
     );
+  });
+
+  it("should build POSIX-valid remote tmux attach commands for multiline quoted pane commands", async () => {
+    const { attachRemoteSession } = await import("@/lib/terminal");
+
+    await attachRemoteSession(
+      "task-r-quoted",
+      "remote-host",
+      SessionType.TMUX,
+      "remote-session",
+      createMockWs(),
+      {
+        host: "remote-host",
+        hostname: "example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/tmp/test-key",
+      },
+      120,
+      30,
+      "/remote/worktree",
+      {
+        layoutType: PaneLayoutType.VERTICAL_2,
+        panes: [
+          {
+            position: 0,
+            command: "nvm use 24 && \nnode -e \"console.log('ok')\"",
+          },
+        ],
+      },
+    );
+
+    const attachCommand = String(mockPtyWrite.mock.calls[0]?.[0] ?? "").trim();
+    expectValidPosixShellSyntax(attachCommand);
   });
 });

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -40,12 +40,20 @@ export function sanitizeZellijSessionName(sessionName: string): string {
   return sessionName.slice(0, ZELLIJ_SESSION_NAME_MAX_LENGTH);
 }
 
-function buildTmuxCreateSessionCommand(sessionName: string, workingDir: string): string {
-  return `tmux new-session -d -s "${sessionName}" -c "${workingDir}"`;
+function quoteForPosixShell(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
-function buildTmuxTarget(sessionName: string): string {
-  return `"${sessionName}":0`;
+function buildTmuxCreateSessionCommand(sessionName: string, workingDir: string): string {
+  return `tmux new-session -d -s ${quoteForPosixShell(sessionName)} -c ${quoteForPosixShell(workingDir)}`;
+}
+
+function buildTmuxWindowTarget(sessionName: string): string {
+  return quoteForPosixShell(`${sessionName}:0`);
+}
+
+function buildTmuxPaneTarget(sessionName: string, position: number): string {
+  return quoteForPosixShell(`${sessionName}:0.${position}`);
 }
 
 export function buildTmuxPaneLayoutCommands(
@@ -54,35 +62,35 @@ export function buildTmuxPaneLayoutCommands(
   panes: PaneCommand[],
   worktreePath: string,
 ): string[] {
-  const target = buildTmuxTarget(sessionName);
+  const target = buildTmuxWindowTarget(sessionName);
 
   const splitCommands: Record<PaneLayoutType, string[]> = {
     [PaneLayoutType.SINGLE]: [],
     [PaneLayoutType.HORIZONTAL_2]: [
-      `tmux split-window -v -t ${target} -c "${worktreePath}"`,
+      `tmux split-window -v -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
     ],
     [PaneLayoutType.VERTICAL_2]: [
-      `tmux split-window -h -t ${target} -c "${worktreePath}"`,
+      `tmux split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
     ],
     [PaneLayoutType.LEFT_RIGHT_TB]: [
-      `tmux split-window -h -t ${target} -c "${worktreePath}"`,
-      `tmux split-window -v -t ${target}.1 -c "${worktreePath}"`,
+      `tmux split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
+      `tmux split-window -v -t ${buildTmuxPaneTarget(sessionName, 1)} -c ${quoteForPosixShell(worktreePath)}`,
     ],
     [PaneLayoutType.LEFT_TB_RIGHT]: [
-      `tmux split-window -h -t ${target} -c "${worktreePath}"`,
-      `tmux split-window -v -t ${target}.0 -c "${worktreePath}"`,
+      `tmux split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
+      `tmux split-window -v -t ${buildTmuxPaneTarget(sessionName, 0)} -c ${quoteForPosixShell(worktreePath)}`,
     ],
     [PaneLayoutType.QUAD]: [
-      `tmux split-window -h -t ${target} -c "${worktreePath}"`,
-      `tmux split-window -v -t ${target}.0 -c "${worktreePath}"`,
-      `tmux split-window -v -t ${target}.2 -c "${worktreePath}"`,
+      `tmux split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
+      `tmux split-window -v -t ${buildTmuxPaneTarget(sessionName, 0)} -c ${quoteForPosixShell(worktreePath)}`,
+      `tmux split-window -v -t ${buildTmuxPaneTarget(sessionName, 2)} -c ${quoteForPosixShell(worktreePath)}`,
     ],
   };
 
   const sendKeysCommands = panes
     .filter((pane) => pane.command.trim())
     .map((pane) => (
-      `tmux send-keys -t ${target}.${pane.position} "${pane.command}" Enter`
+      `tmux send-keys -t ${buildTmuxPaneTarget(sessionName, pane.position)} -- ${quoteForPosixShell(pane.command)} Enter`
     ));
 
   return [
@@ -208,10 +216,6 @@ export function generateZellijLayoutKdl(
 
 /** Zellij KDL 레이아웃 파일의 기본 파일명 */
 export const ZELLIJ_LAYOUT_FILENAME = ".zellij-layout.kdl";
-
-function quoteForPosixShell(value: string): string {
-  return `'${value.replace(/'/g, `'"'"'`)}'`;
-}
 
 /**
  * KDL 레이아웃 파일을 worktree 디렉토리에 저장한다.


### PR DESCRIPTION
## Summary
- Quote tmux session names, pane targets, working directories, and pane command text with POSIX-safe shell quoting in bootstrap commands.
- Send pane commands with `tmux send-keys ... -- <literal> Enter` so multiline commands, nested quotes, and leading dashes are treated as literal key input.
- Add local and remote regression coverage for multiline pane commands containing nested quotes.

## Test Plan
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js exec vitest run src/lib/__tests__/terminal.test.ts`
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js exec vitest run src/lib/__tests__/worktree.test.ts`
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js check`
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js lint` (passes with existing warnings)
- `npx -y node@24 scripts/ensure-native-runtime.cjs && npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js test` (92 files, 759 tests passed)
- Manual isolated tmux smoke test for a multiline quoted `send-keys --` command passed
