### PR TITLE
fix(hooks): refresh shared kanvibe state exclude

### DIFF
--- a/src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts
+++ b/src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   getProjectRepository: vi.fn(),
   readKanvibeTaskState: vi.fn(),
   writeKanvibeTaskState: vi.fn(),
+  addAiToolPatternsToGitExclude: vi.fn(),
 }));
 
 vi.mock("@/entities/KanbanTask", () => entityMocks);
@@ -30,6 +31,10 @@ vi.mock("@/lib/kanvibeProjectState", () => ({
   writeKanvibeTaskState: mocks.writeKanvibeTaskState,
 }));
 
+vi.mock("@/lib/gitExclude", () => ({
+  addAiToolPatternsToGitExclude: mocks.addAiToolPatternsToGitExclude,
+}));
+
 const TaskStatus = entityMocks.TaskStatus as unknown as typeof import("@/entities/KanbanTask").TaskStatus;
 
 describe("kanvibeTaskStateService", () => {
@@ -40,6 +45,7 @@ describe("kanvibeTaskStateService", () => {
     mocks.projectRepo.findOneBy.mockReset();
     mocks.readKanvibeTaskState.mockReset();
     mocks.writeKanvibeTaskState.mockReset();
+    mocks.addAiToolPatternsToGitExclude.mockReset();
     mocks.getProjectRepository.mockResolvedValue(mocks.projectRepo);
   });
 
@@ -49,6 +55,57 @@ describe("kanvibeTaskStateService", () => {
     await persistTaskStateAtPath(null, { id: "task-1", status: TaskStatus.PROGRESS }, "ssh-host");
 
     expect(mocks.writeKanvibeTaskState).not.toHaveBeenCalled();
+    expect(mocks.addAiToolPatternsToGitExclude).not.toHaveBeenCalled();
+  });
+
+  it("path 기반 task 상태 저장은 status 파일 작성 전에 git exclude를 갱신한다", async () => {
+    const { persistTaskStateAtPath } = await import("@/desktop/main/services/kanvibeTaskStateService");
+
+    await persistTaskStateAtPath(
+      "/remote/repo__worktrees/feature-task",
+      { id: "task-1", status: TaskStatus.REVIEW },
+      "remote-host",
+    );
+
+    expect(mocks.addAiToolPatternsToGitExclude).toHaveBeenCalledWith(
+      "/remote/repo__worktrees/feature-task",
+      "remote-host",
+    );
+    expect(mocks.addAiToolPatternsToGitExclude.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.writeKanvibeTaskState.mock.invocationCallOrder[0],
+    );
+    expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
+      "/remote/repo__worktrees/feature-task",
+      { status: TaskStatus.REVIEW },
+      "remote-host",
+    );
+  });
+
+  it("git exclude 갱신 실패는 status 파일 저장을 막지 않는다", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    mocks.addAiToolPatternsToGitExclude.mockRejectedValue(new Error("not a git repo"));
+    const { persistTaskStateAtPath } = await import("@/desktop/main/services/kanvibeTaskStateService");
+
+    await expect(persistTaskStateAtPath(
+      "/workspace/repo",
+      { id: "task-1", status: TaskStatus.PROGRESS },
+      null,
+    )).resolves.toBeUndefined();
+
+    expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
+      "/workspace/repo",
+      { status: TaskStatus.PROGRESS },
+      null,
+    );
+    expect(consoleWarn).toHaveBeenCalledWith(
+      ".kanvibe status 파일 git exclude 갱신 실패:",
+      expect.objectContaining({
+        repoPath: "/workspace/repo",
+        sshHost: null,
+        error: "not a git repo",
+      }),
+    );
+    consoleWarn.mockRestore();
   });
 
   it("path 기반 task 상태 저장은 실패해도 호출자 흐름을 막지 않는다", async () => {

--- a/src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts
+++ b/src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts
@@ -98,7 +98,7 @@ describe("kanvibeTaskStateService", () => {
       null,
     );
     expect(consoleWarn).toHaveBeenCalledWith(
-      ".kanvibe status 파일 git exclude 갱신 실패:",
+      ".kanvibe 상태 디렉터리 git exclude 갱신 실패:",
       expect.objectContaining({
         repoPath: "/workspace/repo",
         sshHost: null,

--- a/src/desktop/main/services/kanvibeTaskStateService.ts
+++ b/src/desktop/main/services/kanvibeTaskStateService.ts
@@ -1,5 +1,6 @@
 import type { KanbanTask, TaskStatus } from "@/entities/KanbanTask";
 import { getProjectRepository } from "@/lib/database";
+import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { readKanvibeTaskState, writeKanvibeTaskState } from "@/lib/kanvibeProjectState";
 
 type TaskStateTask = Pick<KanbanTask, "id" | "status">;
@@ -40,6 +41,7 @@ export async function persistTaskStateAtPath(
   }
 
   try {
+    await ensureKanvibeStatusFileExcluded(repoPath, sshHost);
     await writeKanvibeTaskState(repoPath, { status: task.status }, sshHost);
   } catch (error) {
     console.error(".kanvibe task 상태 저장 실패:", {
@@ -47,6 +49,21 @@ export async function persistTaskStateAtPath(
       targetPath: repoPath,
       taskId: task.id,
       status: task.status,
+      sshHost: sshHost ?? null,
+      error: getErrorMessage(error),
+    });
+  }
+}
+
+async function ensureKanvibeStatusFileExcluded(
+  repoPath: string,
+  sshHost?: string | null,
+): Promise<void> {
+  try {
+    await addAiToolPatternsToGitExclude(repoPath, sshHost);
+  } catch (error) {
+    console.warn(".kanvibe status 파일 git exclude 갱신 실패:", {
+      repoPath,
       sshHost: sshHost ?? null,
       error: getErrorMessage(error),
     });

--- a/src/desktop/main/services/kanvibeTaskStateService.ts
+++ b/src/desktop/main/services/kanvibeTaskStateService.ts
@@ -41,7 +41,7 @@ export async function persistTaskStateAtPath(
   }
 
   try {
-    await ensureKanvibeStatusFileExcluded(repoPath, sshHost);
+    await ensureKanvibeStateDirectoryExcluded(repoPath, sshHost);
     await writeKanvibeTaskState(repoPath, { status: task.status }, sshHost);
   } catch (error) {
     console.error(".kanvibe task 상태 저장 실패:", {
@@ -55,14 +55,14 @@ export async function persistTaskStateAtPath(
   }
 }
 
-async function ensureKanvibeStatusFileExcluded(
+async function ensureKanvibeStateDirectoryExcluded(
   repoPath: string,
   sshHost?: string | null,
 ): Promise<void> {
   try {
     await addAiToolPatternsToGitExclude(repoPath, sshHost);
   } catch (error) {
-    console.warn(".kanvibe status 파일 git exclude 갱신 실패:", {
+    console.warn(".kanvibe 상태 디렉터리 git exclude 갱신 실패:", {
       repoPath,
       sshHost: sshHost ?? null,
       error: getErrorMessage(error),

--- a/src/lib/__tests__/gitExclude.remote.test.ts
+++ b/src/lib/__tests__/gitExclude.remote.test.ts
@@ -33,6 +33,10 @@ describe("gitExclude remote", () => {
 
     await addAiToolPatternsToGitExclude("/remote/worktree/task-1", "remote-host");
 
+    expect(mockExecGit).not.toHaveBeenCalledWith(
+      "git -C '/remote/worktree/task-1' rev-parse --path-format=absolute --git-dir",
+      "remote-host",
+    );
     expect(mockExecGit).toHaveBeenCalledWith(
       "git -C '/remote/worktree/task-1' rev-parse --path-format=absolute --git-common-dir",
       "remote-host",

--- a/src/lib/__tests__/gitExclude.remote.test.ts
+++ b/src/lib/__tests__/gitExclude.remote.test.ts
@@ -48,7 +48,7 @@ describe("gitExclude remote", () => {
     );
     expect(mockWriteTextFile).toHaveBeenCalledWith(
       "/remote/main/.git/info/exclude",
-      expect.stringContaining(".kanvibe/status.json"),
+      expect.stringContaining(".kanvibe/"),
       "remote-host",
     );
     expect(mockWriteTextFile).not.toHaveBeenCalledWith(

--- a/src/lib/__tests__/gitExclude.test.ts
+++ b/src/lib/__tests__/gitExclude.test.ts
@@ -38,7 +38,7 @@ describe("gitExclude", () => {
       expect(content).toContain(".codex/hooks.json");
       expect(content).toContain(".codex/config.toml");
       expect(content).toContain(".opencode/plugins/");
-      expect(content).toContain(".kanvibe/status.json");
+      expect(content).toContain(".kanvibe/");
     });
 
     it("should not duplicate patterns when called multiple times", async () => {
@@ -88,7 +88,7 @@ describe("gitExclude", () => {
       expect(content).toContain(".claude/hooks/");
       expect(content).toContain(".codex/config.toml");
       expect(content).toContain(".opencode/plugins/");
-      expect(content).toContain(".kanvibe/status.json");
+      expect(content).toContain(".kanvibe/");
     });
 
     it("should prune legacy KanVibe state files from the auto-generated block", async () => {
@@ -104,6 +104,7 @@ describe("gitExclude", () => {
           ".kanvibe/hooks-targets.json",
           ".kanvibe/task-state.json",
           ".kanvibe/status.md",
+          ".kanvibe/status.json",
           "",
           "# keep me",
           "dist/",
@@ -120,10 +121,11 @@ describe("gitExclude", () => {
       expect(content).toContain("*.log");
       expect(content).toContain("# keep me");
       expect(content).toContain("dist/");
-      expect(content).toContain(".kanvibe/status.json");
+      expect(content).toContain(".kanvibe/");
       expect(content).not.toContain(".kanvibe/hooks-targets.json");
       expect(content).not.toContain(".kanvibe/task-state.json");
       expect(content).not.toContain(".kanvibe/status.md");
+      expect(content).not.toContain(".kanvibe/status.json");
       expect(content.split("# KanVibe AI hooks (auto-generated)")).toHaveLength(2);
     });
 

--- a/src/lib/__tests__/hookTaskBinding.test.ts
+++ b/src/lib/__tests__/hookTaskBinding.test.ts
@@ -52,6 +52,10 @@ describe("hookTaskBinding", () => {
 
     expect(updater).toContain("KANVIBE_STATUS=\"review\"");
     expect(updater).toContain("status.json");
+    expect(updater).toContain("--git-common-dir");
+    expect(updater).toContain("/info/exclude");
+    expect(updater).toContain(".kanvibe/status.json");
+    expect(updater).toContain("grep -qxF");
     expect(updater).toContain('"schemaVersion":1');
     expect(updater).toContain('"status":"%s"');
     expect(updater).toContain('"updatedAt":"%s"');
@@ -69,6 +73,16 @@ describe("hookTaskBinding", () => {
 
     expect(hasShellKanvibeStatusJsonPersistence(updater)).toBe(true);
     expect(hasShellKanvibeStatusJsonPersistence(legacyUpdater)).toBe(false);
+  });
+
+  it("status json persistence 판정은 common exclude 갱신 없는 hook을 거부한다", () => {
+    const updater = buildShellKanvibeStatusUpdater("review");
+    const updaterWithoutCommonExclude = updater.replace(
+      /\nKANVIBE_GIT_COMMON_DIR=[\s\S]*?fi\n(?=\nmkdir -p)/,
+      "",
+    );
+
+    expect(hasShellKanvibeStatusJsonPersistence(updaterWithoutCommonExclude)).toBe(false);
   });
 
   it("모든 shell hook이 같은 현재 task id를 가리키는지 판정한다", () => {

--- a/src/lib/__tests__/hookTaskBinding.test.ts
+++ b/src/lib/__tests__/hookTaskBinding.test.ts
@@ -54,7 +54,7 @@ describe("hookTaskBinding", () => {
     expect(updater).toContain("status.json");
     expect(updater).toContain("--git-common-dir");
     expect(updater).toContain("/info/exclude");
-    expect(updater).toContain(".kanvibe/status.json");
+    expect(updater).toContain(".kanvibe/");
     expect(updater).toContain("grep -qxF");
     expect(updater).toContain('"schemaVersion":1');
     expect(updater).toContain('"status":"%s"');

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -58,8 +58,14 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).not.toContain("hooks-targets.json");
       expect(pluginContent).not.toContain("task-state.json");
       expect(pluginContent).not.toContain("readFileSync(KANVIBE_TARGETS_FILE");
+      expect(pluginContent).toContain("--git-common-dir");
+      expect(pluginContent).toContain('resolve(gitCommonDir, "info", "exclude")');
+      expect(pluginContent).toContain(".kanvibe/status.json");
+      expect(pluginContent).toContain("includes(KANVIBE_STATUS_EXCLUDE_PATTERN)");
       expect(pluginContent).toContain("writeFileSync(");
       expect(pluginContent).toContain("JSON.stringify({ schemaVersion: 1, status, updatedAt: new Date().toISOString() }");
+      expect(pluginContent).toContain('KANVIBE_URL.endsWith("/")');
+      expect(pluginContent).toContain('baseUrl + "/api/hooks/status"');
       expect(pluginContent).toContain("taskId: TASK_ID");
     });
 
@@ -216,6 +222,31 @@ export const KanvibePlugin: Plugin = async ({ $ }) => {
       await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:3000");
       const pluginContent = await readFile(pluginPath, "utf-8");
       await writeFile(pluginPath, pluginContent.replaceAll("status.json", "status.md"), "utf-8");
+
+      // When
+      const status = await getOpenCodeHooksStatus(repoPath, "task-1");
+
+      // Then
+      expect(status.hasTaskIdBinding).toBe(true);
+      expect(status.hasEventMappings).toBe(true);
+      expect(status.hasStatusJsonPersistence).toBe(false);
+      expect(status.installed).toBe(false);
+    });
+
+    it("common exclude 갱신 없는 OpenCode plugin은 설치된 것으로 보지 않는다", async () => {
+      // Given
+      const repoPath = tempDir;
+      const pluginPath = join(repoPath, ".opencode", "plugins", "kanvibe-plugin.ts");
+      await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:3000");
+      const pluginContent = await readFile(pluginPath, "utf-8");
+      await writeFile(
+        pluginPath,
+        pluginContent.replace(
+          /\n  const KANVIBE_STATUS_EXCLUDE_PATTERN =[\s\S]*?\n  function writeKanvibeTaskState/,
+          "\n  function writeKanvibeTaskState",
+        ),
+        "utf-8",
+      );
 
       // When
       const status = await getOpenCodeHooksStatus(repoPath, "task-1");

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -59,13 +59,9 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).not.toContain("task-state.json");
       expect(pluginContent).not.toContain("readFileSync(KANVIBE_TARGETS_FILE");
       expect(pluginContent).toContain("--git-common-dir");
-      expect(pluginContent).toContain('resolve(gitCommonDir, "info", "exclude")');
-      expect(pluginContent).toContain(".kanvibe/status.json");
-      expect(pluginContent).toContain("includes(KANVIBE_STATUS_EXCLUDE_PATTERN)");
+      expect(pluginContent).toContain(".kanvibe/");
       expect(pluginContent).toContain("writeFileSync(");
-      expect(pluginContent).toContain("JSON.stringify({ schemaVersion: 1, status, updatedAt: new Date().toISOString() }");
-      expect(pluginContent).toContain('KANVIBE_URL.endsWith("/")');
-      expect(pluginContent).toContain('baseUrl + "/api/hooks/status"');
+      expect(pluginContent).toContain("schemaVersion: 1");
       expect(pluginContent).toContain("taskId: TASK_ID");
     });
 
@@ -242,7 +238,7 @@ export const KanvibePlugin: Plugin = async ({ $ }) => {
       await writeFile(
         pluginPath,
         pluginContent.replace(
-          /\n  const KANVIBE_STATUS_EXCLUDE_PATTERN =[\s\S]*?\n  function writeKanvibeTaskState/,
+          /\n  const KANVIBE_STATE_DIR_EXCLUDE_PATTERN =[\s\S]*?\n  function writeKanvibeTaskState/,
           "\n  function writeKanvibeTaskState",
         ),
         "utf-8",

--- a/src/lib/gitExclude.ts
+++ b/src/lib/gitExclude.ts
@@ -3,7 +3,7 @@ import { execGit } from "@/lib/gitOperations";
 import { quoteShellArgument, readTextFile, writeTextFile } from "@/lib/hostFileAccess";
 
 export const KANVIBE_GIT_EXCLUDE_MARKER = "# KanVibe AI hooks (auto-generated)";
-export const KANVIBE_STATUS_FILE_EXCLUDE_PATTERN = ".kanvibe/status.json";
+export const KANVIBE_STATE_DIR_EXCLUDE_PATTERN = ".kanvibe/";
 
 const EXCLUDE_PATTERNS = [
   ".claude/hooks/",
@@ -14,13 +14,14 @@ const EXCLUDE_PATTERNS = [
   ".codex/hooks.json",
   ".codex/config.toml",
   ".opencode/plugins/",
-  KANVIBE_STATUS_FILE_EXCLUDE_PATTERN,
+  KANVIBE_STATE_DIR_EXCLUDE_PATTERN,
 ];
 
 const LEGACY_EXCLUDE_PATTERNS = [
   ".kanvibe/hooks-targets.json",
   ".kanvibe/task-state.json",
   ".kanvibe/status.md",
+  ".kanvibe/status.json",
 ];
 
 function buildExcludeContent(currentContent: string): string {

--- a/src/lib/gitExclude.ts
+++ b/src/lib/gitExclude.ts
@@ -2,7 +2,8 @@ import path from "node:path";
 import { execGit } from "@/lib/gitOperations";
 import { quoteShellArgument, readTextFile, writeTextFile } from "@/lib/hostFileAccess";
 
-const MARKER = "# KanVibe AI hooks (auto-generated)";
+export const KANVIBE_GIT_EXCLUDE_MARKER = "# KanVibe AI hooks (auto-generated)";
+export const KANVIBE_STATUS_FILE_EXCLUDE_PATTERN = ".kanvibe/status.json";
 
 const EXCLUDE_PATTERNS = [
   ".claude/hooks/",
@@ -13,7 +14,7 @@ const EXCLUDE_PATTERNS = [
   ".codex/hooks.json",
   ".codex/config.toml",
   ".opencode/plugins/",
-  ".kanvibe/status.json",
+  KANVIBE_STATUS_FILE_EXCLUDE_PATTERN,
 ];
 
 const LEGACY_EXCLUDE_PATTERNS = [
@@ -28,7 +29,7 @@ function buildExcludeContent(currentContent: string): string {
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
-    if (line !== MARKER) {
+    if (line !== KANVIBE_GIT_EXCLUDE_MARKER) {
       preservedLines.push(line);
       continue;
     }
@@ -45,7 +46,7 @@ function buildExcludeContent(currentContent: string): string {
   }
 
   const preservedContent = preservedLines.join("\n").trimEnd();
-  const markerBlock = [MARKER, ...EXCLUDE_PATTERNS].join("\n");
+  const markerBlock = [KANVIBE_GIT_EXCLUDE_MARKER, ...EXCLUDE_PATTERNS].join("\n");
 
   if (!preservedContent) {
     return `${markerBlock}\n`;
@@ -71,34 +72,24 @@ function resolveAbsoluteGitPath(
   return pathModule.join(repoPath, trimmed);
 }
 
-async function getExcludePaths(
+async function getCommonExcludePath(
   repoPath: string,
   sshHost?: string | null,
-): Promise<string[]> {
+): Promise<string> {
   const pathModule = sshHost ? path.posix : path;
-  const [gitDirOutput, gitCommonDirOutput] = await Promise.all([
-    execGit(
-      `git -C ${quoteShellArgument(repoPath)} rev-parse --path-format=absolute --git-dir`,
-      sshHost,
-    ),
-    execGit(
-      `git -C ${quoteShellArgument(repoPath)} rev-parse --path-format=absolute --git-common-dir`,
-      sshHost,
-    ),
-  ]);
+  const gitCommonDirOutput = await execGit(
+    `git -C ${quoteShellArgument(repoPath)} rev-parse --path-format=absolute --git-common-dir`,
+    sshHost,
+  );
 
-  const gitDir = resolveAbsoluteGitPath(repoPath, gitDirOutput, pathModule);
   const gitCommonDir = resolveAbsoluteGitPath(repoPath, gitCommonDirOutput, pathModule);
 
-  return [...new Set([
-    pathModule.join(gitDir, "info", "exclude"),
-    pathModule.join(gitCommonDir, "info", "exclude"),
-  ])];
+  return pathModule.join(gitCommonDir, "info", "exclude");
 }
 
 /**
  * AI 코딩 도구의 hooks 설정 파일을 git metadata의 info/exclude에 추가하여
- * 현재 worktree와 공용 git common dir 모두에서 git tracking에서 제외한다.
+ * main worktree가 공유하는 git common dir의 info/exclude에서 git tracking에서 제외한다.
  * 마커 블록을 사용해 멱등성을 보장하며, 원격 저장소도 지원한다.
  * @param repoPath - worktree 또는 저장소 경로
  */
@@ -106,15 +97,12 @@ export async function addAiToolPatternsToGitExclude(
   repoPath: string,
   sshHost?: string | null,
 ): Promise<void> {
-  const excludePaths = await getExcludePaths(repoPath, sshHost);
-
-  for (const excludePath of excludePaths) {
-    const content = await readTextFile(excludePath, sshHost);
-    const nextContent = buildExcludeContent(content);
-    if (content === nextContent) {
-      continue;
-    }
-
-    await writeTextFile(excludePath, nextContent, sshHost);
+  const excludePath = await getCommonExcludePath(repoPath, sshHost);
+  const content = await readTextFile(excludePath, sshHost);
+  const nextContent = buildExcludeContent(content);
+  if (content === nextContent) {
+    return;
   }
+
+  await writeTextFile(excludePath, nextContent, sshHost);
 }

--- a/src/lib/hookTaskBinding.ts
+++ b/src/lib/hookTaskBinding.ts
@@ -1,6 +1,6 @@
 import {
   KANVIBE_GIT_EXCLUDE_MARKER,
-  KANVIBE_STATUS_FILE_EXCLUDE_PATTERN,
+  KANVIBE_STATE_DIR_EXCLUDE_PATTERN,
 } from "@/lib/gitExclude";
 
 function escapeShellDoubleQuotedValue(value: string) {
@@ -57,11 +57,11 @@ if [ -n "\${KANVIBE_GIT_COMMON_DIR}" ]; then
   KANVIBE_GIT_EXCLUDE_FILE="\${KANVIBE_GIT_COMMON_DIR}/info/exclude"
   mkdir -p "$(dirname "\${KANVIBE_GIT_EXCLUDE_FILE}")" 2>/dev/null || true
   touch "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null || true
-  if ! grep -qxF "${KANVIBE_STATUS_FILE_EXCLUDE_PATTERN}" "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null; then
+  if ! grep -qxF "${KANVIBE_STATE_DIR_EXCLUDE_PATTERN}" "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null; then
     if ! grep -qxF "${KANVIBE_GIT_EXCLUDE_MARKER}" "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null; then
       printf '\n%s\n' "${KANVIBE_GIT_EXCLUDE_MARKER}" >> "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null || true
     fi
-    printf '%s\n' "${KANVIBE_STATUS_FILE_EXCLUDE_PATTERN}" >> "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null || true
+    printf '%s\n' "${KANVIBE_STATE_DIR_EXCLUDE_PATTERN}" >> "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null || true
   fi
 fi`;
 }
@@ -72,7 +72,7 @@ export function hasShellKanvibeStatusJsonPersistence(content: string): boolean {
     && content.includes("KANVIBE_GIT_COMMON_DIR")
     && content.includes("--git-common-dir")
     && content.includes("KANVIBE_GIT_EXCLUDE_FILE")
-    && content.includes(KANVIBE_STATUS_FILE_EXCLUDE_PATTERN)
+    && content.includes(KANVIBE_STATE_DIR_EXCLUDE_PATTERN)
     && content.includes('"schemaVersion":1')
     && content.includes('"status":"%s"');
 }

--- a/src/lib/hookTaskBinding.ts
+++ b/src/lib/hookTaskBinding.ts
@@ -1,3 +1,8 @@
+import {
+  KANVIBE_GIT_EXCLUDE_MARKER,
+  KANVIBE_STATUS_FILE_EXCLUDE_PATTERN,
+} from "@/lib/gitExclude";
+
 function escapeShellDoubleQuotedValue(value: string) {
   return value
     .replace(/\\/g, "\\\\")
@@ -30,6 +35,7 @@ export function buildShellKanvibeStatusUpdater(status: "progress" | "pending" | 
 KANVIBE_REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "\${BASH_SOURCE[0]}")/../.." && pwd))"
 KANVIBE_STATE_DIR="\${KANVIBE_REPO_ROOT}/.kanvibe"
 KANVIBE_TASK_STATE_FILE="\${KANVIBE_STATE_DIR}/status.json"
+${buildShellKanvibeStatusExcludeUpdater()}
 
 mkdir -p "\${KANVIBE_STATE_DIR}" 2>/dev/null || true
 KANVIBE_UPDATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || true)"
@@ -45,9 +51,28 @@ curl -s -X POST "\${KANVIBE_URL%/}/api/hooks/status" \
   > /dev/null 2>&1 || true`;
 }
 
+function buildShellKanvibeStatusExcludeUpdater() {
+  return `KANVIBE_GIT_COMMON_DIR="$(git -C "\${KANVIBE_REPO_ROOT}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [ -n "\${KANVIBE_GIT_COMMON_DIR}" ]; then
+  KANVIBE_GIT_EXCLUDE_FILE="\${KANVIBE_GIT_COMMON_DIR}/info/exclude"
+  mkdir -p "$(dirname "\${KANVIBE_GIT_EXCLUDE_FILE}")" 2>/dev/null || true
+  touch "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null || true
+  if ! grep -qxF "${KANVIBE_STATUS_FILE_EXCLUDE_PATTERN}" "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null; then
+    if ! grep -qxF "${KANVIBE_GIT_EXCLUDE_MARKER}" "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null; then
+      printf '\n%s\n' "${KANVIBE_GIT_EXCLUDE_MARKER}" >> "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null || true
+    fi
+    printf '%s\n' "${KANVIBE_STATUS_FILE_EXCLUDE_PATTERN}" >> "\${KANVIBE_GIT_EXCLUDE_FILE}" 2>/dev/null || true
+  fi
+fi`;
+}
+
 export function hasShellKanvibeStatusJsonPersistence(content: string): boolean {
   return content.includes("status.json")
     && content.includes("KANVIBE_TASK_STATE_FILE")
+    && content.includes("KANVIBE_GIT_COMMON_DIR")
+    && content.includes("--git-common-dir")
+    && content.includes("KANVIBE_GIT_EXCLUDE_FILE")
+    && content.includes(KANVIBE_STATUS_FILE_EXCLUDE_PATTERN)
     && content.includes('"schemaVersion":1')
     && content.includes('"status":"%s"');
 }

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -1,7 +1,11 @@
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
 import { pathToFileURL } from "node:url";
-import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import {
+  addAiToolPatternsToGitExclude,
+  KANVIBE_GIT_EXCLUDE_MARKER,
+  KANVIBE_STATUS_FILE_EXCLUDE_PATTERN,
+} from "@/lib/gitExclude";
 import { readTextFiles } from "@/lib/hostFileAccess";
 import { extractPluginHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
 import { getOpenCodeRegisteredKanvibePluginUrls } from "@/lib/openCodePluginRegistry";
@@ -18,7 +22,8 @@ export const PLUGIN_DIR_NAME = "plugins";
 /** OpenCode plugin TypeScript 파일 내용을 생성한다 */
 export function generatePluginScript(kanvibeUrl: string, taskId: string): string {
   return `import type { Plugin } from "@opencode-ai/plugin";
-import { mkdirSync, writeFileSync } from "fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { execFileSync } from "child_process";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 
@@ -33,11 +38,39 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
   const KANVIBE_REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
   const KANVIBE_STATE_DIR = resolve(KANVIBE_REPO_ROOT, ".kanvibe");
   const KANVIBE_STATUS_FILE = resolve(KANVIBE_STATE_DIR, "status.json");
+  const KANVIBE_STATUS_EXCLUDE_PATTERN = ${JSON.stringify(KANVIBE_STATUS_FILE_EXCLUDE_PATTERN)};
+  const KANVIBE_GIT_EXCLUDE_MARKER = ${JSON.stringify(KANVIBE_GIT_EXCLUDE_MARKER)};
   const lastStatusBySession = new Map<string, string>();
   const lastUserMessageBySession = new Map<string, string>();
 
+  function ensureKanvibeStatusExcluded(): void {
+    try {
+      const gitCommonDir = execFileSync(
+        "git",
+        ["-C", KANVIBE_REPO_ROOT, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+      ).trim();
+      if (!gitCommonDir) return;
+
+      const excludeFile = resolve(gitCommonDir, "info", "exclude");
+      mkdirSync(dirname(excludeFile), { recursive: true });
+
+      const content = existsSync(excludeFile) ? readFileSync(excludeFile, "utf8") : "";
+      const lines = content.split(/\\r?\\n/);
+      if (lines.includes(KANVIBE_STATUS_EXCLUDE_PATTERN)) return;
+
+      const markerPrefix = lines.includes(KANVIBE_GIT_EXCLUDE_MARKER)
+        ? ""
+        : "\\n" + KANVIBE_GIT_EXCLUDE_MARKER + "\\n";
+      appendFileSync(excludeFile, markerPrefix + KANVIBE_STATUS_EXCLUDE_PATTERN + "\\n", "utf8");
+    } catch {
+      /* git exclude 갱신 에러 무시 */
+    }
+  }
+
   function writeKanvibeTaskState(status: string): void {
     try {
+      ensureKanvibeStatusExcluded();
       mkdirSync(KANVIBE_STATE_DIR, { recursive: true });
       writeFileSync(
         KANVIBE_STATUS_FILE,
@@ -98,7 +131,8 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
     writeKanvibeTaskState(status);
 
     try {
-      await fetch(\`\${KANVIBE_URL.replace(/\/$/, "")}/api/hooks/status\`, {
+      const baseUrl = KANVIBE_URL.endsWith("/") ? KANVIBE_URL.slice(0, -1) : KANVIBE_URL;
+      await fetch(baseUrl + "/api/hooks/status", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ taskId: TASK_ID, status }),
@@ -205,6 +239,9 @@ function hasKanvibePlugin(pluginContent: string): boolean {
 
 function hasOpenCodeStatusJsonPersistence(pluginContent: string): boolean {
   return pluginContent.includes("status.json")
+    && pluginContent.includes("KANVIBE_STATUS_EXCLUDE_PATTERN")
+    && pluginContent.includes("--git-common-dir")
+    && pluginContent.includes("includes(KANVIBE_STATUS_EXCLUDE_PATTERN)")
     && pluginContent.includes("JSON.stringify({ schemaVersion: 1, status, updatedAt: new Date().toISOString() }");
 }
 

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -4,7 +4,7 @@ import { pathToFileURL } from "node:url";
 import {
   addAiToolPatternsToGitExclude,
   KANVIBE_GIT_EXCLUDE_MARKER,
-  KANVIBE_STATUS_FILE_EXCLUDE_PATTERN,
+  KANVIBE_STATE_DIR_EXCLUDE_PATTERN,
 } from "@/lib/gitExclude";
 import { readTextFiles } from "@/lib/hostFileAccess";
 import { extractPluginHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
@@ -38,7 +38,7 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
   const KANVIBE_REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
   const KANVIBE_STATE_DIR = resolve(KANVIBE_REPO_ROOT, ".kanvibe");
   const KANVIBE_STATUS_FILE = resolve(KANVIBE_STATE_DIR, "status.json");
-  const KANVIBE_STATUS_EXCLUDE_PATTERN = ${JSON.stringify(KANVIBE_STATUS_FILE_EXCLUDE_PATTERN)};
+  const KANVIBE_STATE_DIR_EXCLUDE_PATTERN = ${JSON.stringify(KANVIBE_STATE_DIR_EXCLUDE_PATTERN)};
   const KANVIBE_GIT_EXCLUDE_MARKER = ${JSON.stringify(KANVIBE_GIT_EXCLUDE_MARKER)};
   const lastStatusBySession = new Map<string, string>();
   const lastUserMessageBySession = new Map<string, string>();
@@ -57,12 +57,12 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
 
       const content = existsSync(excludeFile) ? readFileSync(excludeFile, "utf8") : "";
       const lines = content.split(/\\r?\\n/);
-      if (lines.includes(KANVIBE_STATUS_EXCLUDE_PATTERN)) return;
+      if (lines.includes(KANVIBE_STATE_DIR_EXCLUDE_PATTERN)) return;
 
       const markerPrefix = lines.includes(KANVIBE_GIT_EXCLUDE_MARKER)
         ? ""
         : "\\n" + KANVIBE_GIT_EXCLUDE_MARKER + "\\n";
-      appendFileSync(excludeFile, markerPrefix + KANVIBE_STATUS_EXCLUDE_PATTERN + "\\n", "utf8");
+      appendFileSync(excludeFile, markerPrefix + KANVIBE_STATE_DIR_EXCLUDE_PATTERN + "\\n", "utf8");
     } catch {
       /* git exclude 갱신 에러 무시 */
     }
@@ -239,9 +239,9 @@ function hasKanvibePlugin(pluginContent: string): boolean {
 
 function hasOpenCodeStatusJsonPersistence(pluginContent: string): boolean {
   return pluginContent.includes("status.json")
-    && pluginContent.includes("KANVIBE_STATUS_EXCLUDE_PATTERN")
+    && pluginContent.includes("KANVIBE_STATE_DIR_EXCLUDE_PATTERN")
     && pluginContent.includes("--git-common-dir")
-    && pluginContent.includes("includes(KANVIBE_STATUS_EXCLUDE_PATTERN)")
+    && pluginContent.includes("includes(KANVIBE_STATE_DIR_EXCLUDE_PATTERN)")
     && pluginContent.includes("JSON.stringify({ schemaVersion: 1, status, updatedAt: new Date().toISOString() }");
 }
 


### PR DESCRIPTION
## Summary
- Write KanVibe hook exclude entries only to the shared git common `info/exclude` instead of linked-worktree-specific git dirs
- Ignore the entire `.kanvibe/` state directory rather than only `.kanvibe/status.json` before status persistence writes
- Add common-exclude refresh logic to generated shell/OpenCode status hooks and reject stale hook installs missing it
- Relax brittle OpenCode plugin assertions while keeping regression coverage for status persistence and shared exclude refresh

## Tests
- `npx -y node@24 $(command -v pnpm) exec vitest run src/lib/__tests__/gitExclude.test.ts src/lib/__tests__/gitExclude.remote.test.ts src/lib/__tests__/hookTaskBinding.test.ts src/lib/__tests__/openCodeHooksSetup.test.ts src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts`
- `npx -y node@24 $(command -v pnpm) check`
- `npx -y node@24 $(command -v pnpm) test`