### PR TITLE
fix: prevent remote tmux bootstrap from stalling login prompt

### DIFF
--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -76,6 +76,17 @@ function expectValidPosixShellSyntax(command: string): void {
   expect(result.status, result.stderr).toBe(0);
 }
 
+function extractRemoteShellPayload(remoteShellCommand: string): string {
+  const result = spawnSync(
+    "sh",
+    ["-c", `set -- ${remoteShellCommand}; printf '%s' "$3"`],
+    { encoding: "utf-8" },
+  );
+  expect(result.status, result.stderr).toBe(0);
+  expect(result.stdout).not.toBe("");
+  return result.stdout;
+}
+
 describe("attachLocalSession — tmux 세션 자동 생성", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -469,7 +480,7 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
         expect.objectContaining({ cwd: expect.any(String) }),
       );
       const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
-      expect(sshArgs).toEqual([
+      expect(sshArgs.slice(0, -1)).toEqual([
         "-i",
         "/tmp/test-key",
         "-p",
@@ -489,12 +500,10 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
       ]);
       expect(sshArgs).not.toContain("-Y");
       expect(sshArgs).not.toContain("ControlMaster=auto");
-      expect(mockPtyWrite).toHaveBeenCalledWith(
-        expect.stringContaining('tmux has-session -t "remote-session"'),
-      );
-      expect(mockPtyWrite).toHaveBeenCalledWith(
-        expect.stringContaining("tmux new-session -d -s 'remote-session' -c '/remote/worktree'"),
-      );
+      const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
+      expect(attachCommand).toContain("tmux has-session -t 'remote-session'");
+      expect(attachCommand).toContain("tmux new-session -d -s 'remote-session' -c '/remote/worktree'");
+      expect(mockPtyWrite).not.toHaveBeenCalled();
     } finally {
       if (originalDisplay === undefined) {
         delete process.env.DISPLAY;
@@ -531,8 +540,12 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
       );
 
       // Then
-      const attachCommand = String(mockPtyWrite.mock.calls[0]?.[0] ?? "").trim();
+      const sshArgs = vi.mocked((await import("node-pty")).spawn).mock.calls[0][1] as string[];
+      const remoteShellCommand = sshArgs.at(-1) ?? "";
+      const attachCommand = extractRemoteShellPayload(remoteShellCommand);
+      expectValidPosixShellSyntax(remoteShellCommand);
       expectValidPosixShellSyntax(attachCommand);
+      expect(mockPtyWrite).not.toHaveBeenCalled();
     } finally {
       if (originalDisplay === undefined) {
         delete process.env.DISPLAY;
@@ -542,7 +555,7 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     }
   });
 
-  it("should start remote tmux through an interactive SSH shell", async () => {
+  it("should pass remote tmux bootstrap as an SSH command instead of typing it into the shell", async () => {
     // Given
     const originalDisplay = process.env.DISPLAY;
     delete process.env.DISPLAY;
@@ -571,11 +584,10 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
 
       // Then
       const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
-      expect(sshArgs.at(-1)).toBe("remote-host");
-      expect(sshArgs).not.toContain(expect.stringContaining("sh -lc "));
-      expect(mockPtyWrite).toHaveBeenCalledWith(
-        expect.stringContaining('tmux has-session -t "remote-session"'),
-      );
+      expect(sshArgs.at(-2)).toBe("remote-host");
+      expect(sshArgs.at(-1)).toEqual(expect.stringMatching(/^sh -lc /));
+      expect(extractRemoteShellPayload(sshArgs.at(-1) ?? "")).toContain("tmux has-session -t 'remote-session'");
+      expect(mockPtyWrite).not.toHaveBeenCalled();
     } finally {
       if (originalDisplay === undefined) {
         delete process.env.DISPLAY;
@@ -650,15 +662,13 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
       },
     );
 
-    expect(mockPtyWrite).toHaveBeenCalledWith(
-      expect.stringContaining("tmux split-window -h -t 'remote-session:0' -c '/remote/worktree'"),
-    );
-    expect(mockPtyWrite).toHaveBeenCalledWith(
-      expect.stringContaining("tmux send-keys -t 'remote-session:0.0' -- 'pnpm dev' Enter"),
-    );
-    expect(mockPtyWrite).toHaveBeenCalledWith(
-      expect.stringContaining("tmux send-keys -t 'remote-session:0.1' -- 'pnpm test' Enter"),
-    );
+    const nodePty = await import("node-pty");
+    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+    const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
+    expect(attachCommand).toContain("tmux split-window -h -t 'remote-session:0' -c '/remote/worktree'");
+    expect(attachCommand).toContain("tmux send-keys -t 'remote-session:0.0' -- 'pnpm dev' Enter");
+    expect(attachCommand).toContain("tmux send-keys -t 'remote-session:0.1' -- 'pnpm test' Enter");
+    expect(mockPtyWrite).not.toHaveBeenCalled();
   });
 
   it("should build POSIX-valid remote tmux attach commands for multiline quoted pane commands", async () => {
@@ -691,7 +701,53 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
       },
     );
 
-    const attachCommand = String(mockPtyWrite.mock.calls[0]?.[0] ?? "").trim();
+    const nodePty = await import("node-pty");
+    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+    const remoteShellCommand = sshArgs.at(-1) ?? "";
+    const attachCommand = extractRemoteShellPayload(remoteShellCommand);
+    expectValidPosixShellSyntax(remoteShellCommand);
     expectValidPosixShellSyntax(attachCommand);
+    expect(mockPtyWrite).not.toHaveBeenCalled();
+  });
+
+  it("should keep long remote tmux bootstrap text out of the login prompt", async () => {
+    const { attachRemoteSession } = await import("@/lib/terminal");
+    const sessionName = "2026-06-toss-node-developer-agent-2026-06-toss-node-developer-export-hermes-session-history-20260605-205232";
+
+    await attachRemoteSession(
+      "task-r-long-bootstrap",
+      "remote-host",
+      SessionType.TMUX,
+      sessionName,
+      createMockWs(),
+      {
+        host: "remote-host",
+        hostname: "example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/tmp/test-key",
+      },
+      120,
+      30,
+      "/home/rookedsysc/Documents/toss/2026-06-toss-node-developer__worktrees/agent-2026-06-toss-node-developer-export-hermes-session-history-20260605-205232",
+      {
+        layoutType: PaneLayoutType.VERTICAL_2,
+        panes: [
+          { position: 0, command: "nvm use 24" },
+        ],
+      },
+    );
+
+    const nodePty = await import("node-pty");
+    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+    const remoteShellCommand = sshArgs.at(-1) ?? "";
+    const attachCommand = extractRemoteShellPayload(remoteShellCommand);
+    expect(sshArgs.at(-2)).toBe("remote-host");
+    expect(remoteShellCommand).toEqual(expect.stringMatching(/^sh -lc /));
+    expect(attachCommand).toContain("nvm use 24");
+    expect(attachCommand).toContain(sessionName);
+    expectValidPosixShellSyntax(remoteShellCommand);
+    expectValidPosixShellSyntax(attachCommand);
+    expect(mockPtyWrite).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -2,11 +2,15 @@ import path from "path";
 import { existsSync } from "fs";
 import { SessionType } from "@/entities/KanbanTask";
 import { PaneLayoutType } from "@/entities/PaneLayoutConfig";
-import { ZELLIJ_LAYOUT_FILENAME } from "@/lib/worktree";
 import { execSync } from "child_process";
 import type { WebSocket } from "ws";
 import { buildSSHArgs, getKanvibeSSHConnectionHealthOptions, hasLocalX11Display } from "@/lib/sshConfig";
-import { buildTmuxSessionBootstrapCommands, type TmuxPaneLayoutConfig } from "@/lib/worktree";
+import {
+  buildTmuxSessionBootstrapCommands,
+  quoteForPosixShell,
+  type TmuxPaneLayoutConfig,
+  ZELLIJ_LAYOUT_FILENAME,
+} from "@/lib/worktree";
 import { createLocalShellEnvironment } from "@/lib/shellEnvironment";
 
 /**
@@ -291,12 +295,15 @@ export async function attachRemoteSession(
   const pty = await import("node-pty");
   const attachCommand = sessionType === SessionType.TMUX
     ? buildRemoteTmuxAttachCommand(sessionName, worktreePath, tmuxPaneLayout)
-    : `exec zellij attach "${sessionName}"`;
-  const args = buildSSHArgs(sshConfig, {
-    forceTty: true,
-    trustedX11Forwarding: hasLocalX11Display(),
-    connectionHealth: getKanvibeSSHConnectionHealthOptions(),
-  });
+    : `exec zellij attach ${quoteForPosixShell(sessionName)}`;
+  const args = [
+    ...buildSSHArgs(sshConfig, {
+      forceTty: true,
+      trustedX11Forwarding: hasLocalX11Display(),
+      connectionHealth: getKanvibeSSHConnectionHealthOptions(),
+    }),
+    buildRemoteShellCommand(attachCommand),
+  ];
 
   if (shouldLogTerminalSpawn()) {
     console.log(`[터미널] Remote PTY spawn: shell=ssh, args=${JSON.stringify(args)}`);
@@ -341,8 +348,7 @@ export async function attachRemoteSession(
     detachSession(taskId, "remote-pty-exit");
   });
 
-  ptyProcess.write(`${attachCommand}\r`);
-  debugLog("Remote PTY attachCommand 전송 완료", { taskId, byteLength: attachCommand.length });
+  debugLog("Remote PTY attachCommand 인자 전달 완료", { taskId, byteLength: attachCommand.length });
 
   ws.on("message", (message) => {
     handleTerminalMessage(ptyProcess, message.toString());
@@ -357,12 +363,17 @@ export async function attachRemoteSession(
   });
 }
 
+function buildRemoteShellCommand(command: string): string {
+  return `sh -lc ${quoteForPosixShell(command)}`;
+}
+
 function buildRemoteTmuxAttachCommand(
   sessionName: string,
   worktreePath?: string | null,
   tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
 ): string {
-  const attachCommand = `exec tmux attach-session -t "${sessionName}"`;
+  const quotedSessionName = quoteForPosixShell(sessionName);
+  const attachCommand = `exec tmux attach-session -t ${quotedSessionName}`;
   const bootstrapCommands = worktreePath
     ? buildTmuxSessionBootstrapCommands(
         sessionName,
@@ -371,10 +382,10 @@ function buildRemoteTmuxAttachCommand(
           ? tmuxPaneLayout
           : null,
       )
-    : [`tmux new-session -d -s "${sessionName}"`];
+    : [`tmux new-session -d -s ${quotedSessionName}`];
 
   return [
-    `if tmux has-session -t "${sessionName}" 2>/dev/null; then ${attachCommand}; fi`,
+    `if tmux has-session -t ${quotedSessionName} 2>/dev/null; then ${attachCommand}; fi`,
     ...bootstrapCommands,
     attachCommand,
   ].join("; ");

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -40,7 +40,7 @@ export function sanitizeZellijSessionName(sessionName: string): string {
   return sessionName.slice(0, ZELLIJ_SESSION_NAME_MAX_LENGTH);
 }
 
-function quoteForPosixShell(value: string): string {
+export function quoteForPosixShell(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 


### PR DESCRIPTION
## Summary
- Send remote tmux bootstrap as the ssh remote command instead of writing it into the interactive PTY after login.
- Reuse POSIX shell quoting for remote tmux/zellij attach commands and quote remote tmux session names consistently.
- Add regression coverage for long task session names and pane bootstrap commands such as `nvm use 24` so they stay out of the login prompt.

## Test Plan
- `pnpm exec vitest run src/lib/__tests__/terminal.test.ts src/lib/__tests__/worktree.test.ts --reporter=dot`
- `pnpm check`
- `pnpm lint src/lib/terminal.ts src/lib/worktree.ts src/lib/__tests__/terminal.test.ts`
