### PR TITLE
fix: isolate remote tmux sessions from default socket

### DIFF
--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -501,8 +501,8 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
       expect(sshArgs).not.toContain("-Y");
       expect(sshArgs).not.toContain("ControlMaster=auto");
       const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
-      expect(attachCommand).toContain("tmux has-session -t 'remote-session'");
-      expect(attachCommand).toContain("tmux new-session -d -s 'remote-session' -c '/remote/worktree'");
+      expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null has-session -t 'remote-session'");
+      expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null new-session -d -s 'remote-session' -c '/remote/worktree'");
       expect(mockPtyWrite).not.toHaveBeenCalled();
     } finally {
       if (originalDisplay === undefined) {
@@ -586,7 +586,7 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
       const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
       expect(sshArgs.at(-2)).toBe("remote-host");
       expect(sshArgs.at(-1)).toEqual(expect.stringMatching(/^sh -lc /));
-      expect(extractRemoteShellPayload(sshArgs.at(-1) ?? "")).toContain("tmux has-session -t 'remote-session'");
+      expect(extractRemoteShellPayload(sshArgs.at(-1) ?? "")).toContain("tmux -L 'kanvibe' -f /dev/null has-session -t 'remote-session'");
       expect(mockPtyWrite).not.toHaveBeenCalled();
     } finally {
       if (originalDisplay === undefined) {
@@ -665,9 +665,61 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     const nodePty = await import("node-pty");
     const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
     const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
-    expect(attachCommand).toContain("tmux split-window -h -t 'remote-session:0' -c '/remote/worktree'");
-    expect(attachCommand).toContain("tmux send-keys -t 'remote-session:0.0' -- 'pnpm dev' Enter");
-    expect(attachCommand).toContain("tmux send-keys -t 'remote-session:0.1' -- 'pnpm test' Enter");
+    expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null split-window -h -t 'remote-session:0' -c '/remote/worktree'");
+    expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null send-keys -t 'remote-session:0.0' -- 'pnpm dev' Enter");
+    expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null send-keys -t 'remote-session:0.1' -- 'pnpm test' Enter");
+    expect(mockPtyWrite).not.toHaveBeenCalled();
+  });
+
+  it("should use a KanVibe isolated tmux socket without duplicating the bootstrap flow", async () => {
+    const { attachRemoteSession } = await import("@/lib/terminal");
+
+    await attachRemoteSession(
+      "task-r-tmux-isolated",
+      "remote-host",
+      SessionType.TMUX,
+      "remote-session",
+      createMockWs(),
+      {
+        host: "remote-host",
+        hostname: "example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/tmp/test-key",
+      },
+      120,
+      30,
+      "/remote/worktree",
+      {
+        layoutType: PaneLayoutType.VERTICAL_2,
+        panes: [
+          { position: 0, command: "pnpm dev" },
+        ],
+      },
+    );
+
+    const nodePty = await import("node-pty");
+    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+    const remoteShellCommand = sshArgs.at(-1) ?? "";
+    const attachCommand = extractRemoteShellPayload(remoteShellCommand);
+
+    expect(attachCommand).toContain(
+      "tmux -L 'kanvibe' -f /dev/null has-session -t 'remote-session'",
+    );
+    expect(attachCommand).toContain(
+      "tmux -L 'kanvibe' -f /dev/null new-session -d -s 'remote-session' -c '/remote/worktree' && tmux -L 'kanvibe' -f /dev/null split-window",
+    );
+    expect(attachCommand).toContain(
+      "tmux -L 'kanvibe' -f /dev/null attach-session -t 'remote-session'",
+    );
+    expect(attachCommand).not.toContain("tmux default server failed");
+    expect(attachCommand).not.toContain("kanvibe-fallback");
+    expect(attachCommand.match(/has-session/g)).toHaveLength(1);
+    expect(attachCommand).toContain("tmux session setup failed; leaving the SSH shell open");
+    expect(attachCommand).toContain('exec "${SHELL:-/bin/sh}" -l');
+    expect(Buffer.byteLength(attachCommand)).toBeLessThan(1_000);
+    expectValidPosixShellSyntax(remoteShellCommand);
+    expectValidPosixShellSyntax(attachCommand);
     expect(mockPtyWrite).not.toHaveBeenCalled();
   });
 
@@ -745,6 +797,9 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     expect(sshArgs.at(-2)).toBe("remote-host");
     expect(remoteShellCommand).toEqual(expect.stringMatching(/^sh -lc /));
     expect(attachCommand).toContain("nvm use 24");
+    expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null");
+    expect(attachCommand).not.toContain("kanvibe-fallback");
+    expect(attachCommand).not.toContain("tmux default server failed");
     expect(attachCommand).toContain(sessionName);
     expectValidPosixShellSyntax(remoteShellCommand);
     expectValidPosixShellSyntax(attachCommand);

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -367,14 +367,56 @@ function buildRemoteShellCommand(command: string): string {
   return `sh -lc ${quoteForPosixShell(command)}`;
 }
 
+const REMOTE_TMUX_SOCKET_NAME = "kanvibe";
+
 function buildRemoteTmuxAttachCommand(
   sessionName: string,
   worktreePath?: string | null,
   tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
 ): string {
+  const tmuxFlow = buildRemoteTmuxSessionFlow(
+    buildRemoteTmuxCommand(),
+    sessionName,
+    worktreePath,
+    tmuxPaneLayout,
+  );
+
+  return `${tmuxFlow} || { ${buildRemoteInteractiveShellFallbackCommand()}; }`;
+}
+
+function buildRemoteTmuxCommand(): string {
+  return `tmux -L ${quoteForPosixShell(REMOTE_TMUX_SOCKET_NAME)} -f /dev/null`;
+}
+
+function buildRemoteTmuxSessionFlow(
+  tmuxCommand: string,
+  sessionName: string,
+  worktreePath?: string | null,
+  tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
+): string {
   const quotedSessionName = quoteForPosixShell(sessionName);
-  const attachCommand = `exec tmux attach-session -t ${quotedSessionName}`;
-  const bootstrapCommands = worktreePath
+  const attachCommand = `${tmuxCommand} attach-session -t ${quotedSessionName}`;
+  const bootstrapCommands = buildRemoteTmuxBootstrapCommands(
+    tmuxCommand,
+    sessionName,
+    worktreePath,
+    tmuxPaneLayout,
+  );
+
+  return `if ${tmuxCommand} has-session -t ${quotedSessionName} 2>/dev/null; then ${attachCommand}; else ${[
+    ...bootstrapCommands,
+    attachCommand,
+  ].join(" && ")}; fi`;
+}
+
+function buildRemoteTmuxBootstrapCommands(
+  tmuxCommand: string,
+  sessionName: string,
+  worktreePath?: string | null,
+  tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
+): string[] {
+  const quotedSessionName = quoteForPosixShell(sessionName);
+  const defaultBootstrapCommands = worktreePath
     ? buildTmuxSessionBootstrapCommands(
         sessionName,
         worktreePath,
@@ -384,10 +426,15 @@ function buildRemoteTmuxAttachCommand(
       )
     : [`tmux new-session -d -s ${quotedSessionName}`];
 
+  return defaultBootstrapCommands.map((command) => command.replace(/^tmux(?=\s)/, tmuxCommand));
+}
+
+function buildRemoteInteractiveShellFallbackCommand(): string {
   return [
-    `if tmux has-session -t ${quotedSessionName} 2>/dev/null; then ${attachCommand}; fi`,
-    ...bootstrapCommands,
-    attachCommand,
+    `printf '%s\\n' ${quoteForPosixShell(
+      "KanVibe: tmux session setup failed; leaving the SSH shell open.",
+    )} >&2`,
+    'exec "${SHELL:-/bin/sh}" -l',
   ].join("; ");
 }
 


### PR DESCRIPTION
## Summary
- Run remote tmux attach/bootstrap on a KanVibe-owned isolated tmux socket (`tmux -L kanvibe -f /dev/null`) instead of the remote user's default tmux socket.
- Keep the SSH remote-command bootstrap path from PR #294, but remove the duplicated default-then-fallback bootstrap flow so the SSH command stays bounded.
- Preserve the final login-shell fallback only for true tmux setup failures, so the SSH terminal does not disappear immediately.

## Root cause
QA reproduced that the failure is not caused by SSH command length. The remote default tmux socket can be in a poisoned state: a direct remote bootstrap against plain `tmux` exits with `server exited unexpectedly`, then SSH closes because the remote command exits. Running the same bootstrap through an isolated socket (`tmux -L kanvibe -f /dev/null`) creates/attaches the session and executes pane commands successfully.

The earlier default-then-fallback patch worked around that state, but duplicated the whole bootstrap flow in one SSH command. This update treats the default tmux socket as the brittle dependency and avoids it for KanVibe remote sessions.

## QA evidence
- Reproduced default socket failure over a real local sshd remote command: `default_only_command_bytes=535`, output included `server exited unexpectedly` and `Connection to 127.0.0.1 closed.`
- Verified isolated socket over the same sshd path with KanVibe `attachRemoteSession`: remote PTY spawned `ssh ... sh -lc ...`, attach command byte length was `794`, tmux rendered the split pane, and the pane command printed `kanvibe-pane-ready`.
- Confirmed the new command contains one tmux bootstrap flow (`tmux -L kanvibe -f /dev/null`) and no `kanvibe-fallback` duplicate.

## Verification
- `pnpm exec vitest run src/lib/__tests__/terminal.test.ts --reporter=dot` — 20 passed
- `pnpm exec vitest run src/lib/__tests__/terminal.test.ts src/lib/__tests__/worktree.test.ts --reporter=dot` — 66 passed
- `pnpm check` — passed
- `pnpm lint src/lib/terminal.ts src/lib/__tests__/terminal.test.ts` — passed
- `git diff --check` — passed

## Merge note
Open for review only. Not merged.
