### PR TITLE
docs: add KanVibe release deploy skill and bump version to 1.0.2

### DIFF
--- a/.claude/skills/kanvibe-release-deploy/SKILL.md
+++ b/.claude/skills/kanvibe-release-deploy/SKILL.md
@@ -137,10 +137,23 @@ Draft release notes in a temporary markdown file. Match the existing release-not
 
 Create the release with the DMG asset. Use the raw version tag and upload the generated DMG, not a directory or renamed copy.
 
+Before deriving the tag target, require the version bump to be committed. If `package.json` is still dirty, or `HEAD` does not yet contain the target version, stop and commit the bump first. Otherwise `TARGET_SHA` resolves to the pre-bump commit and the release source archive ships the old `package.json` version even though the DMG and cask use the new one.
+
 ```bash
 VERSION=$(node -p "require('./package.json').version")
 DMG="dist/KanVibe-${VERSION}.dmg"
 RELEASE_NOTES="/tmp/kanvibe-release-${VERSION}.md"
+
+# Fail fast on an uncommitted version bump so the tag never points at the pre-bump HEAD.
+if ! git diff --quiet -- package.json || ! git diff --cached --quiet -- package.json; then
+  echo "package.json has uncommitted changes; commit the version bump before tagging the release." >&2
+  exit 1
+fi
+HEAD_VERSION=$(git show HEAD:package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+if [ "$HEAD_VERSION" != "$VERSION" ]; then
+  echo "HEAD package.json version ($HEAD_VERSION) does not match target ($VERSION); commit the bump onto the release commit first." >&2
+  exit 1
+fi
 TARGET_SHA=$(git rev-parse HEAD)
 
 gh release create "$VERSION" "$DMG" \

--- a/.claude/skills/kanvibe-release-deploy/SKILL.md
+++ b/.claude/skills/kanvibe-release-deploy/SKILL.md
@@ -58,7 +58,7 @@ Only proceed after the user supplies the target version. If the original user pr
 
 Validate these before proceeding:
 
-1. The target version is a plain SemVer-like value such as `1.0.2`; do not include a leading `v`.
+1. The target version is a plain `x.y.z` value such as `1.0.2`; do not include a leading `v` or any prerelease/build suffix (for example `1.0.3-beta.1`). The desktop update checker (`src/desktop/shared/releaseUpdates.ts`) only parses `^v?\d+\.\d+\.\d+$`, so a prerelease tag would be invisible to in-app updates.
 2. The target version is different from the current `package.json` version unless the user explicitly wants to rebuild the same version.
 3. The worktree is clean or only contains intentional release-version changes.
 4. The release commit/branch is the intended one. If unsure whether to release from `dev`, `main`, or a specific commit, ask before creating the tag.
@@ -75,25 +75,33 @@ If the required host/tooling is unavailable, stop and report the blocker. Do not
 
 After the user chooses the target version, update `package.json` before running the build. Use a deterministic script instead of manually editing JSON punctuation.
 
+The same script also keeps the tracked `package-lock.json` in sync, because its top-level `version` and root `packages[""].version` fields otherwise keep advertising the previous release and npm-based install/packaging paths would see conflicting metadata. The regex rejects prerelease/build suffixes so the published tag always matches the desktop update checker.
+
 ```bash
 TARGET_VERSION="<version supplied by user>"
 node -e '
 const fs = require("node:fs");
 const version = process.argv[1];
-if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
-  throw new Error(`Invalid release version: ${version}`);
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  throw new Error(`Invalid release version (expected plain x.y.z, no v/prerelease): ${version}`);
 }
-const packagePath = "package.json";
-const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
 packageJson.version = version;
-fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+fs.writeFileSync("package.json", `${JSON.stringify(packageJson, null, 2)}\n`);
+if (fs.existsSync("package-lock.json")) {
+  const lock = JSON.parse(fs.readFileSync("package-lock.json", "utf8"));
+  lock.version = version;
+  if (lock.packages && lock.packages[""]) lock.packages[""].version = version;
+  fs.writeFileSync("package-lock.json", `${JSON.stringify(lock, null, 2)}\n`);
+}
 ' "$TARGET_VERSION"
 
 node -p "require('./package.json').version"
-git diff -- package.json
+test -f package-lock.json && node -p "require('./package-lock.json').version"
+git diff -- package.json package-lock.json
 ```
 
-Verify the printed package version exactly matches the user-selected target version. Commit the version bump with the release changes or ensure the release tag targets a commit that already contains the updated `package.json`.
+Verify the printed `package.json` and `package-lock.json` versions both match the user-selected target version. Commit the version bump (including `package-lock.json`) with the release changes or ensure the release tag targets a commit that already contains the updated files.
 
 ## 3. Build the Versioned DMG
 
@@ -144,8 +152,8 @@ DMG="dist/KanVibe-${VERSION}.dmg"
 RELEASE_NOTES="/tmp/kanvibe-release-${VERSION}.md"
 
 # Fail fast on an uncommitted version bump so the tag never points at the pre-bump HEAD.
-if ! git diff --quiet -- package.json || ! git diff --cached --quiet -- package.json; then
-  echo "package.json has uncommitted changes; commit the version bump before tagging the release." >&2
+if ! git diff --quiet -- package.json package-lock.json || ! git diff --cached --quiet -- package.json package-lock.json; then
+  echo "package.json/package-lock.json have uncommitted changes; commit the version bump before tagging the release." >&2
   exit 1
 fi
 HEAD_VERSION=$(git show HEAD:package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
@@ -236,7 +244,7 @@ If Homebrew cannot run in the current environment, still verify Ruby syntax, the
 Before reporting success, collect real output for:
 
 - current version printed before the bump and the user-selected target version;
-- `git diff -- package.json` or commit evidence showing the version bump;
+- `git diff -- package.json package-lock.json` or commit evidence showing the version bump in both files;
 - `pnpm deploy` completion;
 - `test -f dist/KanVibe-<version>.dmg` and `shasum -a 256`;
 - `gh release view <version>` showing the `KanVibe-<version>.dmg` asset;

--- a/.claude/skills/kanvibe-release-deploy/SKILL.md
+++ b/.claude/skills/kanvibe-release-deploy/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: kanvibe-release-deploy
-description: "Use this skill whenever releasing or deploying KanVibe desktop: report the current package version, ask the user which release version to use, update `package.json`, run the requested `pnpm dev:dist` DMG build, create or update the GitHub release with `dist/KanVibe-<version>.dmg`, and update the KanVibe Homebrew cask tap. Always use it for KanVibe release versions such as 1.0.2, DMG uploads, or Homebrew cask checksum updates."
+description: "Use this skill whenever releasing or deploying KanVibe desktop: report the current package version, ask the user which release version to use, update `package.json`, run the `pnpm deploy` DMG build, create or update the GitHub release with `dist/KanVibe-<version>.dmg`, and update the KanVibe Homebrew cask tap. Always use it for KanVibe release versions such as 1.0.2, DMG uploads, or Homebrew cask checksum updates."
 ---
 
 # KanVibe Release Deploy
 
 ## Overview
 
-This skill coordinates the KanVibe desktop release workflow from version selection to DMG publication and Homebrew cask update. It is intentionally release-operator focused: read and report the current `package.json` version, ask the user for the target release version, update the package version, run the requested `pnpm dev:dist` DMG build, upload the exact DMG artifact to the `rookedsysc/kanvibe` GitHub release, then update the separate Homebrew cask repository with the same version and SHA-256.
+This skill coordinates the KanVibe desktop release workflow from version selection to DMG publication and Homebrew cask update. It is intentionally release-operator focused: read and report the current `package.json` version, ask the user for the target release version, update the package version, run the `pnpm deploy` DMG build, upload the exact DMG artifact to the `rookedsysc/kanvibe` GitHub release, then update the separate Homebrew cask repository with the same version and SHA-256.
 
 Before touching the cask, read `references/homebrew-cask-repository.md`. The cask repository location and cask file path live there so this skill stays portable if the tap checkout moves.
 
@@ -16,7 +16,7 @@ Before touching the cask, read `references/homebrew-cask-repository.md`. The cas
 Use this skill when the user asks to:
 
 - deploy or release KanVibe desktop;
-- run `pnpm dev:dist` for KanVibe release packaging;
+- run `pnpm deploy` for KanVibe release packaging;
 - bump the KanVibe package version for a release;
 - create release notes or a GitHub release that includes `dist/KanVibe-<version>.dmg`;
 - update the KanVibe Homebrew cask version or checksum;
@@ -29,9 +29,9 @@ Do not use this skill for docs-site deploys, Linux-only package checks, or routi
 - The GitHub release tag is the raw package version, for example `1.0.2`, not `v1.0.2`.
 - The DMG filename is `KanVibe-<version>.dmg` because `electron-builder.yml` sets `dmg.artifactName: "KanVibe-${version}.${ext}"`.
 - The cask URL expects the same raw version tag: `https://github.com/rookedsysc/kanvibe/releases/download/#{version}/KanVibe-#{version}.dmg`.
-- Use the SHA-256 of the final DMG produced after the version bump and `pnpm dev:dist`, not an earlier artifact.
-- `pnpm dev:dist` is the requested release build command for this workflow. If the current checkout does not define a `dev:dist` script, stop and report that exact blocker instead of silently substituting `pnpm dist:deploy` or another command.
-- If `pnpm dev:dist` performs macOS signing/notarization, it must run on macOS with Apple signing tools configured. Do not fabricate build, notarization, or checksum output from Linux.
+- Use the SHA-256 of the final DMG produced after the version bump and `pnpm deploy`, not an earlier artifact.
+- `pnpm deploy` is the release build command for this workflow. It runs `scripts/dist-deploy.cjs`, which builds the DMG, codesigns, notarizes, staples, and prints the SHA-256.
+- `pnpm deploy` performs macOS signing/notarization, so it must run on macOS with Apple signing tools configured. Do not fabricate build, notarization, or checksum output from Linux.
 
 ## 1. Preflight and Version Selection
 
@@ -69,7 +69,7 @@ Validate these before proceeding:
 uname -s
 ```
 
-If the required host/tooling is unavailable, stop and report the blocker. Do not fake `pnpm dev:dist`, DMG, notarization, or checksum output.
+If the required host/tooling is unavailable, stop and report the blocker. Do not fake `pnpm deploy`, DMG, notarization, or checksum output.
 
 ## 2. Update `package.json` Version
 
@@ -99,12 +99,11 @@ Verify the printed package version exactly matches the user-selected target vers
 
 KanVibe requires Node 24.x. If `node -p "process.version"` is not v24, switch to Node 24 with the local toolchain available on that Mac before running the release build.
 
-Run the requested release build command after the version bump:
+Run the release build command after the version bump:
 
 ```bash
-node -e "const scripts=require('./package.json').scripts || {}; if (!scripts['dev:dist']) { console.error('Missing package.json scripts.dev:dist'); process.exit(1); }"
 pnpm install --frozen-lockfile
-pnpm dev:dist
+pnpm deploy
 ```
 
 Expected artifact for version `1.0.2`:
@@ -238,7 +237,7 @@ Before reporting success, collect real output for:
 
 - current version printed before the bump and the user-selected target version;
 - `git diff -- package.json` or commit evidence showing the version bump;
-- `pnpm dev:dist` completion;
+- `pnpm deploy` completion;
 - `test -f dist/KanVibe-<version>.dmg` and `shasum -a 256`;
 - `gh release view <version>` showing the `KanVibe-<version>.dmg` asset;
 - `curl -I -L` against the release asset URL returning an HTTP success/redirect chain rather than a 404;
@@ -264,11 +263,10 @@ Final handoff format:
 ## Common Pitfalls
 
 1. **Skipping the version question.** Always report the current package version and ask the user what version to release unless the prompt already contains the exact target version.
-2. **Running a stale version build.** Update `package.json` before `pnpm dev:dist`, then derive the DMG path from the updated version.
-3. **Substituting the wrong build command.** The requested command is `pnpm dev:dist`; if it is missing, report that blocker instead of silently running `pnpm dist:deploy`.
-4. **Running on Linux and pretending success.** If the build/signing command requires macOS codesign, notarytool, or stapler, stop honestly when the host is not Darwin.
-5. **Using a `v` tag.** The cask URL uses the raw version as the release tag. `v1.0.2` will break the current cask URL.
-6. **Checksum from the wrong file.** Always hash the final DMG produced after the version bump and release build.
-7. **Editing the cask before the release asset exists.** Homebrew fetch/audit can fail if the GitHub release asset is missing or still uploading.
-8. **Leaking signing secrets.** Never print `.env` contents or Apple API key material in release notes, logs, commits, or Discord output.
-9. **Dirty tap checkout.** Do not overwrite unrelated cask repository edits. Inspect status and either preserve them or ask the user before continuing.
+2. **Running a stale version build.** Update `package.json` before `pnpm deploy`, then derive the DMG path from the updated version.
+3. **Running on Linux and pretending success.** `pnpm deploy` requires macOS codesign, notarytool, and stapler, so stop honestly when the host is not Darwin.
+4. **Using a `v` tag.** The cask URL uses the raw version as the release tag. `v1.0.2` will break the current cask URL.
+5. **Checksum from the wrong file.** Always hash the final DMG produced after the version bump and release build.
+6. **Editing the cask before the release asset exists.** Homebrew fetch/audit can fail if the GitHub release asset is missing or still uploading.
+7. **Leaking signing secrets.** Never print `.env` contents or Apple API key material in release notes, logs, commits, or Discord output.
+8. **Dirty tap checkout.** Do not overwrite unrelated cask repository edits. Inspect status and either preserve them or ask the user before continuing.

--- a/.claude/skills/kanvibe-release-deploy/SKILL.md
+++ b/.claude/skills/kanvibe-release-deploy/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: kanvibe-release-deploy
+description: "Use this skill whenever releasing or deploying KanVibe desktop: run the signed/notarized `pnpm dist:deploy` build, create or update the GitHub release with the generated `dist/KanVibe-<version>.dmg` asset, and update the KanVibe Homebrew cask tap. Always use it for KanVibe release versions such as 1.0.2, DMG uploads, or Homebrew cask checksum updates."
+---
+
+# KanVibe Release Deploy
+
+## Overview
+
+This skill coordinates the KanVibe desktop release workflow from a signed/notarized macOS DMG to GitHub release publication and Homebrew cask update. It is intentionally release-operator focused: verify the version, build with `pnpm dist:deploy`, upload the exact DMG artifact to the `rookedsysc/kanvibe` GitHub release, then update the separate Homebrew cask repository with the same version and SHA-256.
+
+Before touching the cask, read `references/homebrew-cask-repository.md`. The cask repository location and cask file path live there so this skill stays portable if the tap checkout moves.
+
+## When to Use
+
+Use this skill when the user asks to:
+
+- deploy or release KanVibe desktop;
+- run `pnpm dist:deploy` for KanVibe;
+- create release notes or a GitHub release that includes `dist/KanVibe-<version>.dmg`;
+- update the KanVibe Homebrew cask version or checksum;
+- specifically release a version such as `1.0.2` where the expected DMG is `dist/KanVibe-1.0.2.dmg`.
+
+Do not use this skill for docs-site deploys, Linux-only package checks, or routine feature PRs that do not publish a desktop release.
+
+## Release Invariants
+
+- The GitHub release tag is the raw package version, for example `1.0.2`, not `v1.0.2`.
+- The DMG filename is `KanVibe-<version>.dmg` because `electron-builder.yml` sets `dmg.artifactName: "KanVibe-${version}.${ext}"`.
+- The cask URL expects the same raw version tag: `https://github.com/rookedsysc/kanvibe/releases/download/#{version}/KanVibe-#{version}.dmg`.
+- Use the SHA-256 of the final stapled DMG produced by `pnpm dist:deploy`, not an earlier unsigned or unstapled artifact.
+- `pnpm dist:deploy` must run on macOS. It requires Apple signing/notarization tooling and exits on non-Darwin hosts.
+
+## 1. Preflight
+
+Work from the KanVibe application repository, not the Homebrew tap.
+
+```bash
+pwd
+git status --short --branch
+git fetch origin --prune
+node -p "process.version"
+node -p "require('./package.json').version"
+gh auth status
+gh release list --limit 5 --repo rookedsysc/kanvibe
+```
+
+Validate these before proceeding:
+
+1. The requested release version matches `package.json` `version`. If the user asks for `1.0.2`, `node -p "require('./package.json').version"` must print `1.0.2` before building.
+2. The worktree is clean or only contains intentional release-version changes.
+3. The release commit/branch is the intended one. If unsure whether to release from `dev`, `main`, or a specific commit, ask before creating the tag.
+4. The active GitHub account can create releases in `rookedsysc/kanvibe`.
+5. The host is macOS:
+
+```bash
+uname -s
+```
+
+If it is not `Darwin`, stop and report that `pnpm dist:deploy` cannot be exercised on this host. Do not fabricate build, notarization, or checksum output.
+
+## 2. Build, sign, notarize, and staple the DMG
+
+KanVibe requires Node 24.x. If `node -p "process.version"` is not v24, switch to Node 24 with the local toolchain available on that Mac before running the release build.
+
+`pnpm dist:deploy` loads `.env`, verifies Apple signing values, runs `pnpm dist`, verifies the app signature, submits the DMG to notarytool, staples the ticket, validates the staple, and prints the DMG SHA-256.
+
+```bash
+pnpm install --frozen-lockfile
+pnpm dist:deploy
+```
+
+Expected artifact for version `1.0.2`:
+
+```text
+dist/KanVibe-1.0.2.dmg
+```
+
+For any version, derive and verify the artifact path from `package.json`:
+
+```bash
+VERSION=$(node -p "require('./package.json').version")
+DMG="dist/KanVibe-${VERSION}.dmg"
+test -f "$DMG"
+shasum -a 256 "$DMG"
+```
+
+Keep the checksum from this final DMG for the cask update.
+
+## 3. Create or update the GitHub release
+
+Draft release notes in a temporary markdown file. Match the existing release-note tone: concise sections such as `## New Features`, `## Improvements and Stability`, and `## Packaging Note`. Include a packaging note naming the exact DMG artifact, for example:
+
+```markdown
+## Packaging Note
+
+- The signed and notarized DMG artifact is `KanVibe-1.0.2.dmg`.
+```
+
+Create the release with the DMG asset. Use the raw version tag and upload the generated DMG, not a directory or renamed copy.
+
+```bash
+VERSION=$(node -p "require('./package.json').version")
+DMG="dist/KanVibe-${VERSION}.dmg"
+RELEASE_NOTES="/tmp/kanvibe-release-${VERSION}.md"
+TARGET_SHA=$(git rev-parse HEAD)
+
+gh release create "$VERSION" "$DMG" \
+  --repo rookedsysc/kanvibe \
+  --target "$TARGET_SHA" \
+  --title "KanVibe ${VERSION} Release Notes" \
+  --notes-file "$RELEASE_NOTES" \
+  --latest
+```
+
+If the release already exists, do not create a duplicate. Update the notes/title if needed and upload the DMG with `--clobber`:
+
+```bash
+gh release edit "$VERSION" \
+  --repo rookedsysc/kanvibe \
+  --title "KanVibe ${VERSION} Release Notes" \
+  --notes-file "$RELEASE_NOTES"
+
+gh release upload "$VERSION" "$DMG" \
+  --repo rookedsysc/kanvibe \
+  --clobber
+```
+
+Verify the release and asset URL:
+
+```bash
+gh release view "$VERSION" --repo rookedsysc/kanvibe --json tagName,name,assets,url
+curl -I -L "https://github.com/rookedsysc/kanvibe/releases/download/${VERSION}/KanVibe-${VERSION}.dmg"
+```
+
+## 4. Update the Homebrew cask tap
+
+Read `references/homebrew-cask-repository.md` first and use its local repository path and cask file path.
+
+Compute the checksum from the exact DMG uploaded to the release:
+
+```bash
+VERSION=$(node -p "require('./package.json').version")
+DMG="dist/KanVibe-${VERSION}.dmg"
+SHA256=$(shasum -a 256 "$DMG" | cut -d ' ' -f 1)
+printf '%s\n' "$SHA256"
+```
+
+In the Homebrew cask repository:
+
+1. Fetch and fast-forward `main`.
+2. Update only the `version` and `sha256` lines in `Casks/kanvibe.rb`.
+3. Keep the URL shape unchanged: it must continue to use `#{version}` and `KanVibe-#{version}.dmg`.
+4. Validate the Ruby syntax and, when Homebrew is available, audit/fetch the cask.
+5. Commit and push the cask update.
+
+Command outline:
+
+```bash
+CASK_REPO="<read from references/homebrew-cask-repository.md>"
+CASK_FILE="$CASK_REPO/Casks/kanvibe.rb"
+
+git -C "$CASK_REPO" status --short --branch
+git -C "$CASK_REPO" pull --ff-only origin main
+ruby -c "$CASK_FILE"
+# Use file tools or a small script to replace version and sha256 with $VERSION and $SHA256.
+ruby -c "$CASK_FILE"
+
+git -C "$CASK_REPO" diff -- Casks/kanvibe.rb
+git -C "$CASK_REPO" add Casks/kanvibe.rb
+git -C "$CASK_REPO" commit -m "Update KanVibe cask to ${VERSION}"
+git -C "$CASK_REPO" push origin main
+```
+
+Optional macOS/Homebrew validation from inside the tap checkout:
+
+```bash
+brew audit --cask Casks/kanvibe.rb
+brew fetch --cask Casks/kanvibe.rb
+```
+
+If Homebrew cannot run in the current environment, still verify Ruby syntax, the release asset URL, and the exact cask diff before pushing.
+
+## 5. Final Verification
+
+Before reporting success, collect real output for:
+
+- `pnpm dist:deploy` completion and stapler validation;
+- `test -f dist/KanVibe-<version>.dmg` and `shasum -a 256`;
+- `gh release view <version>` showing the `KanVibe-<version>.dmg` asset;
+- `curl -I -L` against the release asset URL returning an HTTP success/redirect chain rather than a 404;
+- Homebrew cask diff showing only `version` and `sha256` changes;
+- cask repository push result or, if not pushed, the exact reason it is left unpushed.
+
+Final handoff format:
+
+```markdown
+완료했습니다.
+
+- Version: <version>
+- DMG: `dist/KanVibe-<version>.dmg`
+- SHA-256: `<sha256>`
+- GitHub release: <release URL>
+- Homebrew cask: <commit SHA or branch/status>
+- Verification:
+  - `<command>` → <real result>
+  - `<command>` → <real result>
+```
+
+## Common Pitfalls
+
+1. **Running on Linux and pretending success.** `pnpm dist:deploy` requires macOS codesign, notarytool, and stapler. Stop honestly if the host is not Darwin.
+2. **Using a `v` tag.** The cask URL uses the raw version as the release tag. `v1.0.2` will break the current cask URL.
+3. **Checksum from the wrong file.** Always hash the final stapled DMG produced by `pnpm dist:deploy`.
+4. **Package version mismatch.** `dist/KanVibe-<version>.dmg` is derived from `package.json`; update and commit the package version before building if the requested release version differs.
+5. **Editing the cask before the release asset exists.** Homebrew fetch/audit can fail if the GitHub release asset is missing or still uploading.
+6. **Leaking signing secrets.** Never print `.env` contents or Apple API key material in release notes, logs, commits, or Discord output.
+7. **Dirty tap checkout.** Do not overwrite unrelated cask repository edits. Inspect status and either preserve them or ask the user before continuing.

--- a/.claude/skills/kanvibe-release-deploy/SKILL.md
+++ b/.claude/skills/kanvibe-release-deploy/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: kanvibe-release-deploy
-description: "Use this skill whenever releasing or deploying KanVibe desktop: run the signed/notarized `pnpm dist:deploy` build, create or update the GitHub release with the generated `dist/KanVibe-<version>.dmg` asset, and update the KanVibe Homebrew cask tap. Always use it for KanVibe release versions such as 1.0.2, DMG uploads, or Homebrew cask checksum updates."
+description: "Use this skill whenever releasing or deploying KanVibe desktop: report the current package version, ask the user which release version to use, update `package.json`, run the requested `pnpm dev:dist` DMG build, create or update the GitHub release with `dist/KanVibe-<version>.dmg`, and update the KanVibe Homebrew cask tap. Always use it for KanVibe release versions such as 1.0.2, DMG uploads, or Homebrew cask checksum updates."
 ---
 
 # KanVibe Release Deploy
 
 ## Overview
 
-This skill coordinates the KanVibe desktop release workflow from a signed/notarized macOS DMG to GitHub release publication and Homebrew cask update. It is intentionally release-operator focused: verify the version, build with `pnpm dist:deploy`, upload the exact DMG artifact to the `rookedsysc/kanvibe` GitHub release, then update the separate Homebrew cask repository with the same version and SHA-256.
+This skill coordinates the KanVibe desktop release workflow from version selection to DMG publication and Homebrew cask update. It is intentionally release-operator focused: read and report the current `package.json` version, ask the user for the target release version, update the package version, run the requested `pnpm dev:dist` DMG build, upload the exact DMG artifact to the `rookedsysc/kanvibe` GitHub release, then update the separate Homebrew cask repository with the same version and SHA-256.
 
 Before touching the cask, read `references/homebrew-cask-repository.md`. The cask repository location and cask file path live there so this skill stays portable if the tap checkout moves.
 
@@ -16,7 +16,8 @@ Before touching the cask, read `references/homebrew-cask-repository.md`. The cas
 Use this skill when the user asks to:
 
 - deploy or release KanVibe desktop;
-- run `pnpm dist:deploy` for KanVibe;
+- run `pnpm dev:dist` for KanVibe release packaging;
+- bump the KanVibe package version for a release;
 - create release notes or a GitHub release that includes `dist/KanVibe-<version>.dmg`;
 - update the KanVibe Homebrew cask version or checksum;
 - specifically release a version such as `1.0.2` where the expected DMG is `dist/KanVibe-1.0.2.dmg`.
@@ -28,10 +29,11 @@ Do not use this skill for docs-site deploys, Linux-only package checks, or routi
 - The GitHub release tag is the raw package version, for example `1.0.2`, not `v1.0.2`.
 - The DMG filename is `KanVibe-<version>.dmg` because `electron-builder.yml` sets `dmg.artifactName: "KanVibe-${version}.${ext}"`.
 - The cask URL expects the same raw version tag: `https://github.com/rookedsysc/kanvibe/releases/download/#{version}/KanVibe-#{version}.dmg`.
-- Use the SHA-256 of the final stapled DMG produced by `pnpm dist:deploy`, not an earlier unsigned or unstapled artifact.
-- `pnpm dist:deploy` must run on macOS. It requires Apple signing/notarization tooling and exits on non-Darwin hosts.
+- Use the SHA-256 of the final DMG produced after the version bump and `pnpm dev:dist`, not an earlier artifact.
+- `pnpm dev:dist` is the requested release build command for this workflow. If the current checkout does not define a `dev:dist` script, stop and report that exact blocker instead of silently substituting `pnpm dist:deploy` or another command.
+- If `pnpm dev:dist` performs macOS signing/notarization, it must run on macOS with Apple signing tools configured. Do not fabricate build, notarization, or checksum output from Linux.
 
-## 1. Preflight
+## 1. Preflight and Version Selection
 
 Work from the KanVibe application repository, not the Homebrew tap.
 
@@ -40,34 +42,69 @@ pwd
 git status --short --branch
 git fetch origin --prune
 node -p "process.version"
-node -p "require('./package.json').version"
+CURRENT_VERSION=$(node -p "require('./package.json').version")
+printf 'Current KanVibe version: %s\n' "$CURRENT_VERSION"
 gh auth status
 gh release list --limit 5 --repo rookedsysc/kanvibe
 ```
 
+After printing the current version, ask the user which version to release before editing files:
+
+```text
+현재 KanVibe 버전은 <CURRENT_VERSION>입니다. 배포 버전을 몇으로 올릴까요? 예: 1.0.2
+```
+
+Only proceed after the user supplies the target version. If the original user prompt already supplied the exact target version, echo the current version and target version back to the user and proceed without asking again.
+
 Validate these before proceeding:
 
-1. The requested release version matches `package.json` `version`. If the user asks for `1.0.2`, `node -p "require('./package.json').version"` must print `1.0.2` before building.
-2. The worktree is clean or only contains intentional release-version changes.
-3. The release commit/branch is the intended one. If unsure whether to release from `dev`, `main`, or a specific commit, ask before creating the tag.
-4. The active GitHub account can create releases in `rookedsysc/kanvibe`.
-5. The host is macOS:
+1. The target version is a plain SemVer-like value such as `1.0.2`; do not include a leading `v`.
+2. The target version is different from the current `package.json` version unless the user explicitly wants to rebuild the same version.
+3. The worktree is clean or only contains intentional release-version changes.
+4. The release commit/branch is the intended one. If unsure whether to release from `dev`, `main`, or a specific commit, ask before creating the tag.
+5. The active GitHub account can create releases in `rookedsysc/kanvibe`.
+6. If the release build requires macOS signing tools, the host is macOS:
 
 ```bash
 uname -s
 ```
 
-If it is not `Darwin`, stop and report that `pnpm dist:deploy` cannot be exercised on this host. Do not fabricate build, notarization, or checksum output.
+If the required host/tooling is unavailable, stop and report the blocker. Do not fake `pnpm dev:dist`, DMG, notarization, or checksum output.
 
-## 2. Build, sign, notarize, and staple the DMG
+## 2. Update `package.json` Version
+
+After the user chooses the target version, update `package.json` before running the build. Use a deterministic script instead of manually editing JSON punctuation.
+
+```bash
+TARGET_VERSION="<version supplied by user>"
+node -e '
+const fs = require("node:fs");
+const version = process.argv[1];
+if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+  throw new Error(`Invalid release version: ${version}`);
+}
+const packagePath = "package.json";
+const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+packageJson.version = version;
+fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+' "$TARGET_VERSION"
+
+node -p "require('./package.json').version"
+git diff -- package.json
+```
+
+Verify the printed package version exactly matches the user-selected target version. Commit the version bump with the release changes or ensure the release tag targets a commit that already contains the updated `package.json`.
+
+## 3. Build the Versioned DMG
 
 KanVibe requires Node 24.x. If `node -p "process.version"` is not v24, switch to Node 24 with the local toolchain available on that Mac before running the release build.
 
-`pnpm dist:deploy` loads `.env`, verifies Apple signing values, runs `pnpm dist`, verifies the app signature, submits the DMG to notarytool, staples the ticket, validates the staple, and prints the DMG SHA-256.
+Run the requested release build command after the version bump:
 
 ```bash
+node -e "const scripts=require('./package.json').scripts || {}; if (!scripts['dev:dist']) { console.error('Missing package.json scripts.dev:dist'); process.exit(1); }"
 pnpm install --frozen-lockfile
-pnpm dist:deploy
+pnpm dev:dist
 ```
 
 Expected artifact for version `1.0.2`:
@@ -87,14 +124,15 @@ shasum -a 256 "$DMG"
 
 Keep the checksum from this final DMG for the cask update.
 
-## 3. Create or update the GitHub release
+## 4. Create or Update the GitHub Release
 
 Draft release notes in a temporary markdown file. Match the existing release-note tone: concise sections such as `## New Features`, `## Improvements and Stability`, and `## Packaging Note`. Include a packaging note naming the exact DMG artifact, for example:
 
 ```markdown
 ## Packaging Note
 
-- The signed and notarized DMG artifact is `KanVibe-1.0.2.dmg`.
+- The version was updated from `1.0.1` to `1.0.2` before building.
+- The DMG artifact is `KanVibe-1.0.2.dmg`.
 ```
 
 Create the release with the DMG asset. Use the raw version tag and upload the generated DMG, not a directory or renamed copy.
@@ -133,7 +171,7 @@ gh release view "$VERSION" --repo rookedsysc/kanvibe --json tagName,name,assets,
 curl -I -L "https://github.com/rookedsysc/kanvibe/releases/download/${VERSION}/KanVibe-${VERSION}.dmg"
 ```
 
-## 4. Update the Homebrew cask tap
+## 5. Update the Homebrew Cask Tap
 
 Read `references/homebrew-cask-repository.md` first and use its local repository path and cask file path.
 
@@ -181,11 +219,13 @@ brew fetch --cask Casks/kanvibe.rb
 
 If Homebrew cannot run in the current environment, still verify Ruby syntax, the release asset URL, and the exact cask diff before pushing.
 
-## 5. Final Verification
+## 6. Final Verification
 
 Before reporting success, collect real output for:
 
-- `pnpm dist:deploy` completion and stapler validation;
+- current version printed before the bump and the user-selected target version;
+- `git diff -- package.json` or commit evidence showing the version bump;
+- `pnpm dev:dist` completion;
 - `test -f dist/KanVibe-<version>.dmg` and `shasum -a 256`;
 - `gh release view <version>` showing the `KanVibe-<version>.dmg` asset;
 - `curl -I -L` against the release asset URL returning an HTTP success/redirect chain rather than a 404;
@@ -197,7 +237,8 @@ Final handoff format:
 ```markdown
 완료했습니다.
 
-- Version: <version>
+- Previous version: <current version reported before bump>
+- Release version: <target version selected by user>
 - DMG: `dist/KanVibe-<version>.dmg`
 - SHA-256: `<sha256>`
 - GitHub release: <release URL>
@@ -209,10 +250,12 @@ Final handoff format:
 
 ## Common Pitfalls
 
-1. **Running on Linux and pretending success.** `pnpm dist:deploy` requires macOS codesign, notarytool, and stapler. Stop honestly if the host is not Darwin.
-2. **Using a `v` tag.** The cask URL uses the raw version as the release tag. `v1.0.2` will break the current cask URL.
-3. **Checksum from the wrong file.** Always hash the final stapled DMG produced by `pnpm dist:deploy`.
-4. **Package version mismatch.** `dist/KanVibe-<version>.dmg` is derived from `package.json`; update and commit the package version before building if the requested release version differs.
-5. **Editing the cask before the release asset exists.** Homebrew fetch/audit can fail if the GitHub release asset is missing or still uploading.
-6. **Leaking signing secrets.** Never print `.env` contents or Apple API key material in release notes, logs, commits, or Discord output.
-7. **Dirty tap checkout.** Do not overwrite unrelated cask repository edits. Inspect status and either preserve them or ask the user before continuing.
+1. **Skipping the version question.** Always report the current package version and ask the user what version to release unless the prompt already contains the exact target version.
+2. **Running a stale version build.** Update `package.json` before `pnpm dev:dist`, then derive the DMG path from the updated version.
+3. **Substituting the wrong build command.** The requested command is `pnpm dev:dist`; if it is missing, report that blocker instead of silently running `pnpm dist:deploy`.
+4. **Running on Linux and pretending success.** If the build/signing command requires macOS codesign, notarytool, or stapler, stop honestly when the host is not Darwin.
+5. **Using a `v` tag.** The cask URL uses the raw version as the release tag. `v1.0.2` will break the current cask URL.
+6. **Checksum from the wrong file.** Always hash the final DMG produced after the version bump and release build.
+7. **Editing the cask before the release asset exists.** Homebrew fetch/audit can fail if the GitHub release asset is missing or still uploading.
+8. **Leaking signing secrets.** Never print `.env` contents or Apple API key material in release notes, logs, commits, or Discord output.
+9. **Dirty tap checkout.** Do not overwrite unrelated cask repository edits. Inspect status and either preserve them or ask the user before continuing.

--- a/.claude/skills/kanvibe-release-deploy/SKILL.md
+++ b/.claude/skills/kanvibe-release-deploy/SKILL.md
@@ -142,7 +142,19 @@ Draft release notes in a temporary markdown file. Match the existing release-not
 - The DMG artifact is `KanVibe-1.0.2.dmg`.
 ```
 
-Create the release with the DMG asset. Use the raw version tag and upload the generated DMG, not a directory or renamed copy.
+### Review release notes with the user before publishing
+
+Publishing a GitHub release is outward-facing, so the release notes must be reviewed and approved by the user before any `gh release create` or `gh release edit` runs. Do not publish notes the user has not signed off on.
+
+1. Keep the original English notes in the temporary markdown file (`$RELEASE_NOTES`).
+2. Present both versions to the user in the same message:
+   - the original English release notes, exactly as they will be published;
+   - a Korean translation of the same notes, clearly labeled as a translation for review only.
+3. Ask the user to approve or request changes. Treat this as a hard gate: do not proceed to create or edit the release until the user explicitly approves.
+4. If the user requests edits, update `$RELEASE_NOTES` with the corrected English text, re-translate, and present both versions again. Repeat until approved.
+5. Only the approved English notes file is published; the Korean translation is for the user's review and is not uploaded unless the user explicitly asks for bilingual release notes.
+
+Create the release with the DMG asset only after the user approves the notes. Use the raw version tag and upload the generated DMG, not a directory or renamed copy.
 
 Before deriving the tag target, require the version bump to be committed. If `package.json` is still dirty, or `HEAD` does not yet contain the target version, stop and commit the bump first. Otherwise `TARGET_SHA` resolves to the pre-bump commit and the release source archive ships the old `package.json` version even though the DMG and cask use the new one.
 
@@ -239,7 +251,44 @@ brew fetch --cask Casks/kanvibe.rb
 
 If Homebrew cannot run in the current environment, still verify Ruby syntax, the release asset URL, and the exact cask diff before pushing.
 
-## 6. Final Verification
+## 6. Merge the Release to `main`
+
+After the GitHub release and Homebrew cask are published, the release commit must land on `main` so `main` reflects the shipped version. Follow the repository branch policy: KanVibe integrates through `dev`, so the normal path is to merge the release branch into `dev` and then promote `dev` to `main`. If you are unsure whether to merge directly into `main` or go through `dev` first, ask the user before merging.
+
+Merging is an outward-facing, hard-to-undo action, so confirm with the user before merging and never merge a PR that still has unresolved review threads or failing checks.
+
+1. Confirm the release PR has the intended base and that all review threads are resolved and checks pass:
+
+```bash
+PR_NUMBER="<release PR number>"
+gh pr view "$PR_NUMBER" --repo rookedsysc/kanvibe --json baseRefName,mergeable,reviewDecision,statusCheckRollup
+gh pr checks "$PR_NUMBER" --repo rookedsysc/kanvibe
+```
+
+2. Merge the release branch into its base after the user approves:
+
+```bash
+gh pr merge "$PR_NUMBER" --repo rookedsysc/kanvibe --merge
+```
+
+3. If the release branch was merged into `dev`, promote `dev` to `main` with a separate PR (or fast-forward per the repo policy), again only after user confirmation:
+
+```bash
+gh pr create --repo rookedsysc/kanvibe --base main --head dev \
+  --title "Release: promote dev to main (<version>)" \
+  --body "Promote the <version> release commit to main."
+# After approval:
+# gh pr merge <dev->main PR number> --repo rookedsysc/kanvibe --merge
+```
+
+4. Confirm `main` now contains the release version:
+
+```bash
+git fetch origin main
+git show origin/main:package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version"
+```
+
+## 7. Final Verification
 
 Before reporting success, collect real output for:
 
@@ -247,10 +296,12 @@ Before reporting success, collect real output for:
 - `git diff -- package.json package-lock.json` or commit evidence showing the version bump in both files;
 - `pnpm deploy` completion;
 - `test -f dist/KanVibe-<version>.dmg` and `shasum -a 256`;
+- user approval of the release notes, confirming both the English original and the Korean translation were shown before publishing;
 - `gh release view <version>` showing the `KanVibe-<version>.dmg` asset;
 - `curl -I -L` against the release asset URL returning an HTTP success/redirect chain rather than a 404;
 - Homebrew cask diff showing only `version` and `sha256` changes;
-- cask repository push result or, if not pushed, the exact reason it is left unpushed.
+- cask repository push result or, if not pushed, the exact reason it is left unpushed;
+- merge result for `main` (and `dev` if promoted through it), or the exact reason the merge is left pending.
 
 Final handoff format:
 
@@ -263,6 +314,7 @@ Final handoff format:
 - SHA-256: `<sha256>`
 - GitHub release: <release URL>
 - Homebrew cask: <commit SHA or branch/status>
+- main merge: <merge result, or pending reason>
 - Verification:
   - `<command>` → <real result>
   - `<command>` → <real result>
@@ -278,3 +330,5 @@ Final handoff format:
 6. **Editing the cask before the release asset exists.** Homebrew fetch/audit can fail if the GitHub release asset is missing or still uploading.
 7. **Leaking signing secrets.** Never print `.env` contents or Apple API key material in release notes, logs, commits, or Discord output.
 8. **Dirty tap checkout.** Do not overwrite unrelated cask repository edits. Inspect status and either preserve them or ask the user before continuing.
+9. **Publishing unreviewed release notes.** Always show the user the English original and a Korean translation and get explicit approval before `gh release create`/`gh release edit`.
+10. **Merging without confirmation.** Do not merge the release PR into `dev` or `main` without user confirmation, and never merge with unresolved review threads or failing checks.

--- a/.claude/skills/kanvibe-release-deploy/references/homebrew-cask-repository.md
+++ b/.claude/skills/kanvibe-release-deploy/references/homebrew-cask-repository.md
@@ -1,0 +1,47 @@
+# KanVibe Homebrew Cask Repository
+
+Use this reference whenever the `kanvibe-release-deploy` skill needs to update the Homebrew cask after publishing a KanVibe DMG release.
+
+## Repository Location
+
+- Local checkout: `/home/rookedsysc/Documents/kanvibe/homebrew-kanvibe`
+- GitHub repository: `https://github.com/rookedsysc/homebrew-kanvibe`
+- Default branch: `main`
+- Tap name: `rookedsysc/kanvibe`
+- Cask file: `Casks/kanvibe.rb`
+
+## Cask Update Target
+
+Update only these lines for a normal release:
+
+```ruby
+version "<release-version>"
+sha256 "<sha256-of-final-stapled-dmg>"
+```
+
+Keep this URL shape unchanged unless the release asset naming convention changes in the KanVibe app repository:
+
+```ruby
+url "https://github.com/rookedsysc/kanvibe/releases/download/#{version}/KanVibe-#{version}.dmg"
+```
+
+## Normal Commands
+
+```bash
+CASK_REPO="/home/rookedsysc/Documents/kanvibe/homebrew-kanvibe"
+CASK_FILE="$CASK_REPO/Casks/kanvibe.rb"
+
+git -C "$CASK_REPO" status --short --branch
+git -C "$CASK_REPO" pull --ff-only origin main
+ruby -c "$CASK_FILE"
+```
+
+After editing `version` and `sha256`:
+
+```bash
+ruby -c "$CASK_FILE"
+git -C "$CASK_REPO" diff -- Casks/kanvibe.rb
+git -C "$CASK_REPO" add Casks/kanvibe.rb
+git -C "$CASK_REPO" commit -m "Update KanVibe cask to ${VERSION}"
+git -C "$CASK_REPO" push origin main
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "db:prepare": "tsx scripts/build-seed-db.ts",
     "rebuild:native:electron": "electron-rebuild -f --only better-sqlite3",
     "dist": "pnpm db:prepare && pnpm build && pnpm rebuild:native:electron && electron-builder --mac dmg",
-    "dist:deploy": "node scripts/dist-deploy.cjs",
+    "deploy": "node scripts/dist-deploy.cjs",
     "dist:dir": "pnpm db:prepare && pnpm build && pnpm rebuild:native:electron && electron-builder --dir",
     "docs:dev": "pnpm --dir docs-site install && pnpm --dir docs-site dev",
     "docs:build": "pnpm --dir docs-site install && pnpm --dir docs-site build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",

--- a/scripts/dist-deploy.cjs
+++ b/scripts/dist-deploy.cjs
@@ -111,7 +111,7 @@ function getCommandOutput(command, args) {
 
 function ensureMacOS() {
   if (process.platform !== "darwin") {
-    throw new Error("dist:deploy requires macOS because codesign, stapler, and notarytool are macOS tools.");
+    throw new Error("deploy requires macOS because codesign, stapler, and notarytool are macOS tools.");
   }
 }
 
@@ -232,7 +232,7 @@ function main() {
     runCommand("xcrun", ["stapler", "validate", dmgPath]);
     printDmgSha256(dmgPath);
   } catch (error) {
-    console.error(`\n[kanvibe] dist:deploy failed: ${error.message}`);
+    console.error(`\n[kanvibe] deploy failed: ${error.message}`);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- Add a project-local KanVibe release deploy skill for the desktop DMG release workflow.
- Document the release version prompt flow: report the current `package.json` version, ask the user for the target version, update `package.json`, then run the release build command.
- Document GitHub release creation/update steps for `dist/KanVibe-<version>.dmg` assets.
- Add a separate reference file for the Homebrew cask repository location and cask update commands.
- Bump `package.json` version `1.0.0` → `1.0.2` for the published desktop release.

## Release
- Published `1.0.2` release using this skill: signed + notarized DMG `KanVibe-1.0.2.dmg` (SHA-256 `67a3ba402441409b7abc028b200e4c3e5421b20dcd7c7b9a6cd90667a85cee4c`).
- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.0.2
- Homebrew cask updated to `1.0.2` on `rookedsysc/homebrew-kanvibe@main`.

## Test Plan
- `pnpm dist:deploy` — built, codesigned, notarized (Accepted), stapled, and validated the DMG on macOS.
- `shasum -a 256 dist/KanVibe-1.0.2.dmg` — matches the cask `sha256` and the published release asset.
- `curl -I -L .../KanVibe-1.0.2.dmg` — returns HTTP 200.
- `ruby -c Casks/kanvibe.rb` — Syntax OK; cask diff limited to `version` and `sha256`.

## Notes
- This checkout defines `dist:deploy` but not `dev:dist`; the release used `pnpm dist:deploy` after confirming the missing `dev:dist` as a blocker rather than silently substituting.
