### PR TITLE
feat(hooks): fan out status updates to KanVibe targets

### DIFF
--- a/src/lib/__tests__/claudeHooksSetup.test.ts
+++ b/src/lib/__tests__/claudeHooksSetup.test.ts
@@ -29,13 +29,15 @@ describe("claudeHooksSetup", () => {
     expect(questionScript).not.toContain("X-Kanvibe-Token");
     expect(promptScript).toContain(".kanvibe");
     expect(promptScript).toContain("status.json");
+    expect(promptScript).toContain("targets.json");
+    expect(promptScript).toContain("KANVIBE_TARGET_ROWS");
     expect(promptScript).not.toContain("hooks-targets.json");
     expect(promptScript).not.toContain("task-state.json");
-    expect(promptScript).not.toContain("while IFS=");
 
     const status = await getClaudeHooksStatus(repoPath);
     expect(status.installed).toBe(true);
     expect(status.hasStatusJsonPersistence).toBe(true);
+    expect(status.hasTargetFanout).toBe(true);
   });
 
   it("legacy status.md Claude hook은 설치된 것으로 보지 않고 재설치로 복구한다", async () => {

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -233,6 +233,7 @@ describe("codexHooksSetup", () => {
         hasExpectedTaskId: true,
         hasStatusMappings: true,
         hasStatusJsonPersistence: true,
+        hasTargetFanout: true,
         hasExpectedHookServerUrl: true,
         hasReachableHookServer: true,
         boundTaskId: "task-1",

--- a/src/lib/__tests__/hookTaskBinding.test.ts
+++ b/src/lib/__tests__/hookTaskBinding.test.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { accessSync, constants, statSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
-import { delimiter, join } from "node:path";
+import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
@@ -17,12 +17,24 @@ import {
 const execFileAsync = promisify(execFile);
 
 /**
- * `process.env.PATH`에서 실제 실행 파일 경로를 찾는다. shell alias/function이 아닌
- * 진짜 바이너리만 sandbox PATH로 노출해 node 없는 hook 환경을 재현하기 위해 사용한다.
+ * 표준 시스템 디렉터리에서만 실제 실행 파일을 찾는다. `process.env.PATH`에 의존하지
+ * 않으므로, PATH를 물려받지 못하는 설치 프로그램 환경(예: macOS GUI로 실행된 앱은
+ * `/usr/bin:/bin` 수준의 최소 PATH만 가짐)을 그대로 재현한다. bash가 빈 환경에서도
+ * 기본으로 노출하는 디렉터리 집합과 git이 흔히 설치되는 위치를 포함한다.
  */
+const SYSTEM_BIN_DIRS = [
+  "/usr/local/sbin",
+  "/usr/local/bin",
+  "/usr/sbin",
+  "/usr/bin",
+  "/sbin",
+  "/bin",
+  "/opt/homebrew/bin",
+  "/home/linuxbrew/.linuxbrew/bin",
+];
+
 function resolveRealBinary(name: string): string | null {
-  const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
-  for (const dir of dirs) {
+  for (const dir of SYSTEM_BIN_DIRS) {
     const candidate = join(dir, name);
     try {
       if (!statSync(candidate).isFile()) continue;

--- a/src/lib/__tests__/hookTaskBinding.test.ts
+++ b/src/lib/__tests__/hookTaskBinding.test.ts
@@ -117,87 +117,7 @@ describe("hookTaskBinding", () => {
     expect(hasShellKanvibeTargetFanout(updaterWithoutTargets)).toBe(false);
   });
 
-  it("생성된 shell updater는 targets.json 대상별 task id로 status POST를 fan-out 한다", async () => {
-    const repoPath = await mkdtemp(join(tmpdir(), "kanvibe-hook-fanout-"));
-
-    try {
-      const hookDir = join(repoPath, ".claude", "hooks");
-      const fakeBinDir = join(repoPath, "bin");
-      await mkdir(join(repoPath, ".kanvibe"), { recursive: true });
-      await mkdir(hookDir, { recursive: true });
-      await mkdir(fakeBinDir, { recursive: true });
-
-      await writeFile(
-        join(repoPath, ".kanvibe", "targets.json"),
-        JSON.stringify({
-          schemaVersion: 1,
-          targets: [
-            { url: "http://127.0.0.1:9736/", taskId: "local-task" },
-            { url: "http://127.0.0.1:9736", taskId: "dev-task" },
-          ],
-        }),
-        "utf8",
-      );
-
-      const curlLogPath = join(repoPath, "curl.log");
-      const fakeCurlPath = join(fakeBinDir, "curl");
-      await writeFile(
-        fakeCurlPath,
-        [
-          "#!/usr/bin/env node",
-          "const fs = require('fs');",
-          "fs.appendFileSync(process.env.KANVIBE_CURL_LOG, JSON.stringify(process.argv.slice(2)) + '\\n');",
-        ].join("\n"),
-        "utf8",
-      );
-      await chmod(fakeCurlPath, 0o755);
-
-      const scriptPath = join(hookDir, "kanvibe-test-hook.sh");
-      await writeFile(
-        scriptPath,
-        [
-          "#!/bin/bash",
-          'KANVIBE_URL="http://fallback:9736"',
-          buildShellTaskIdResolver("fallback-task"),
-          buildShellKanvibeStatusUpdater("review"),
-        ].join("\n"),
-        "utf8",
-      );
-      await chmod(scriptPath, 0o755);
-
-      await execFileAsync("bash", [scriptPath], {
-        cwd: repoPath,
-        env: {
-          ...process.env,
-          KANVIBE_CURL_LOG: curlLogPath,
-          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
-        },
-      });
-
-      const status = JSON.parse(await readFile(join(repoPath, ".kanvibe", "status.json"), "utf8")) as { status?: string };
-      expect(status.status).toBe("review");
-
-      const curlCalls = (await readFile(curlLogPath, "utf8"))
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line) as string[]);
-      const postUrls = curlCalls.map((args) => args.find((arg) => arg.endsWith("/api/hooks/status")));
-      const payloads = curlCalls.map((args) => JSON.parse(args[args.indexOf("-d") + 1]) as { taskId: string; status: string });
-
-      expect(postUrls).toEqual([
-        "http://127.0.0.1:9736/api/hooks/status",
-        "http://127.0.0.1:9736/api/hooks/status",
-      ]);
-      expect(payloads).toEqual([
-        { taskId: "local-task", status: "review" },
-        { taskId: "dev-task", status: "review" },
-      ]);
-    } finally {
-      await rm(repoPath, { recursive: true, force: true });
-    }
-  });
-
-  it("node가 PATH에 없어도 targets.json 모든 대상에 fan-out 한다", async () => {
+  it("node·user env 없이도 targets.json 대상별 task id로 status를 fan-out 한다", async () => {
     const repoPath = await mkdtemp(join(tmpdir(), "kanvibe-hook-nonode-"));
 
     try {
@@ -271,16 +191,31 @@ describe("hookTaskBinding", () => {
         },
       });
 
+      const status = JSON.parse(
+        await readFile(join(repoPath, ".kanvibe", "status.json"), "utf8"),
+      ) as { status?: string };
+      expect(status.status).toBe("review");
+
       const curlCalls = (await readFile(curlLogPath, "utf8"))
         .trim()
         .split("\n")
         .filter((line) => line.length > 0);
-      const postedTaskIds = curlCalls
-        .map((line) => line.match(/"taskId":\s*"([^"]+)"/)?.[1])
-        .filter((value): value is string => Boolean(value));
+      const postedEndpoints = curlCalls.map((line) =>
+        line.split(/\s+/).find((token) => token.endsWith("/api/hooks/status")),
+      );
+      const payloads = curlCalls.map((line) => ({
+        taskId: line.match(/"taskId":\s*"([^"]+)"/)?.[1],
+        status: line.match(/"status":\s*"([^"]+)"/)?.[1],
+      }));
 
-      expect(postedTaskIds).toEqual(["local-task", "dev-task"]);
-      expect(curlCalls.every((line) => line.includes("http://127.0.0.1:9736/api/hooks/status"))).toBe(true);
+      expect(postedEndpoints).toEqual([
+        "http://127.0.0.1:9736/api/hooks/status",
+        "http://127.0.0.1:9736/api/hooks/status",
+      ]);
+      expect(payloads).toEqual([
+        { taskId: "local-task", status: "review" },
+        { taskId: "dev-task", status: "review" },
+      ]);
     } finally {
       await rm(repoPath, { recursive: true, force: true });
     }

--- a/src/lib/__tests__/hookTaskBinding.test.ts
+++ b/src/lib/__tests__/hookTaskBinding.test.ts
@@ -1,3 +1,8 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import {
   buildShellKanvibeStatusUpdater,
@@ -5,7 +10,10 @@ import {
   extractShellTaskId,
   getShellTaskIdBindingStatus,
   hasShellKanvibeStatusJsonPersistence,
+  hasShellKanvibeTargetFanout,
 } from "@/lib/hookTaskBinding";
+
+const execFileAsync = promisify(execFile);
 
 describe("hookTaskBinding", () => {
   it("shell resolver는 hook 파일 안에 task id를 직접 고정한다", () => {
@@ -47,11 +55,13 @@ describe("hookTaskBinding", () => {
     expect(extractShellTaskId(resolver)).toBe(taskId);
   });
 
-  it("status updater는 target fan-out 없이 status.json에 상태만 저장한다", () => {
+  it("status updater는 status.json 저장 후 targets.json의 모든 대상에 fan-out 한다", () => {
     const updater = buildShellKanvibeStatusUpdater("review");
 
     expect(updater).toContain("KANVIBE_STATUS=\"review\"");
     expect(updater).toContain("status.json");
+    expect(updater).toContain("targets.json");
+    expect(updater).toContain("KANVIBE_TARGETS_FILE");
     expect(updater).toContain("--git-common-dir");
     expect(updater).toContain("/info/exclude");
     expect(updater).toContain(".kanvibe/");
@@ -60,11 +70,99 @@ describe("hookTaskBinding", () => {
     expect(updater).toContain('"status":"%s"');
     expect(updater).toContain('"updatedAt":"%s"');
     expect(updater).toContain("${KANVIBE_TASK_STATE_FILE}");
+    expect(updater).toContain("KANVIBE_TARGET_URL");
+    expect(updater).toContain("KANVIBE_TARGET_TASK_ID");
+    expect(updater).toContain("while IFS=");
     expect(updater).not.toContain("hooks-targets.json");
     expect(updater).not.toContain("task-state.json");
-    expect(updater).not.toContain("KANVIBE_TARGET_ROWS");
-    expect(updater).not.toContain("while IFS=");
-    expect(updater).not.toContain("taskId, status");
+  });
+
+  it("target fan-out 판정은 targets.json fan-out 없는 hook을 거부한다", () => {
+    const updater = buildShellKanvibeStatusUpdater("review");
+    const updaterWithoutTargets = updater.replace(/\nKANVIBE_TARGETS_FILE=[\s\S]*$/, "");
+
+    expect(hasShellKanvibeTargetFanout(updater)).toBe(true);
+    expect(hasShellKanvibeTargetFanout(updaterWithoutTargets)).toBe(false);
+  });
+
+  it("생성된 shell updater는 targets.json 대상별 task id로 status POST를 fan-out 한다", async () => {
+    const repoPath = await mkdtemp(join(tmpdir(), "kanvibe-hook-fanout-"));
+
+    try {
+      const hookDir = join(repoPath, ".claude", "hooks");
+      const fakeBinDir = join(repoPath, "bin");
+      await mkdir(join(repoPath, ".kanvibe"), { recursive: true });
+      await mkdir(hookDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeFile(
+        join(repoPath, ".kanvibe", "targets.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          targets: [
+            { url: "http://127.0.0.1:9736/", taskId: "local-task" },
+            { url: "http://127.0.0.1:9736", taskId: "dev-task" },
+          ],
+        }),
+        "utf8",
+      );
+
+      const curlLogPath = join(repoPath, "curl.log");
+      const fakeCurlPath = join(fakeBinDir, "curl");
+      await writeFile(
+        fakeCurlPath,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('fs');",
+          "fs.appendFileSync(process.env.KANVIBE_CURL_LOG, JSON.stringify(process.argv.slice(2)) + '\\n');",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(fakeCurlPath, 0o755);
+
+      const scriptPath = join(hookDir, "kanvibe-test-hook.sh");
+      await writeFile(
+        scriptPath,
+        [
+          "#!/bin/bash",
+          'KANVIBE_URL="http://fallback:9736"',
+          buildShellTaskIdResolver("fallback-task"),
+          buildShellKanvibeStatusUpdater("review"),
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(scriptPath, 0o755);
+
+      await execFileAsync("bash", [scriptPath], {
+        cwd: repoPath,
+        env: {
+          ...process.env,
+          KANVIBE_CURL_LOG: curlLogPath,
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      const status = JSON.parse(await readFile(join(repoPath, ".kanvibe", "status.json"), "utf8")) as { status?: string };
+      expect(status.status).toBe("review");
+
+      const curlCalls = (await readFile(curlLogPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      const postUrls = curlCalls.map((args) => args.find((arg) => arg.endsWith("/api/hooks/status")));
+      const payloads = curlCalls.map((args) => JSON.parse(args[args.indexOf("-d") + 1]) as { taskId: string; status: string });
+
+      expect(postUrls).toEqual([
+        "http://127.0.0.1:9736/api/hooks/status",
+        "http://127.0.0.1:9736/api/hooks/status",
+      ]);
+      expect(payloads).toEqual([
+        { taskId: "local-task", status: "review" },
+        { taskId: "dev-task", status: "review" },
+      ]);
+    } finally {
+      await rm(repoPath, { recursive: true, force: true });
+    }
   });
 
   it("status json persistence 판정은 legacy status.md hook을 거부한다", () => {

--- a/src/lib/__tests__/hookTaskBinding.test.ts
+++ b/src/lib/__tests__/hookTaskBinding.test.ts
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { accessSync, constants, statSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { delimiter, join } from "node:path";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import {
@@ -14,6 +15,25 @@ import {
 } from "@/lib/hookTaskBinding";
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * `process.env.PATH`에서 실제 실행 파일 경로를 찾는다. shell alias/function이 아닌
+ * 진짜 바이너리만 sandbox PATH로 노출해 node 없는 hook 환경을 재현하기 위해 사용한다.
+ */
+function resolveRealBinary(name: string): string | null {
+  const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    const candidate = join(dir, name);
+    try {
+      if (!statSync(candidate).isFile()) continue;
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      /* 다음 후보 탐색 */
+    }
+  }
+  return null;
+}
 
 describe("hookTaskBinding", () => {
   it("shell resolver는 hook 파일 안에 task id를 직접 고정한다", () => {
@@ -160,6 +180,95 @@ describe("hookTaskBinding", () => {
         { taskId: "local-task", status: "review" },
         { taskId: "dev-task", status: "review" },
       ]);
+    } finally {
+      await rm(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it("node가 PATH에 없어도 targets.json 모든 대상에 fan-out 한다", async () => {
+    const repoPath = await mkdtemp(join(tmpdir(), "kanvibe-hook-nonode-"));
+
+    try {
+      const hookDir = join(repoPath, ".claude", "hooks");
+      const sandboxBinDir = join(repoPath, "sandbox-bin");
+      await mkdir(join(repoPath, ".kanvibe"), { recursive: true });
+      await mkdir(hookDir, { recursive: true });
+      await mkdir(sandboxBinDir, { recursive: true });
+
+      await writeFile(
+        join(repoPath, ".kanvibe", "targets.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          targets: [
+            { url: "http://127.0.0.1:9736/", taskId: "local-task" },
+            { url: "http://127.0.0.1:9736", taskId: "dev-task" },
+          ],
+        }),
+        "utf8",
+      );
+
+      // hook이 사용하는 POSIX 도구만 sandbox PATH로 노출한다. node는 의도적으로 제외해
+      // node 미설치 hook 환경(예: Codex CLI)을 재현한다.
+      const requiredTools = ["bash", "grep", "awk", "sed", "date", "mkdir", "touch", "dirname"];
+      for (const tool of requiredTools) {
+        const real = resolveRealBinary(tool);
+        if (!real) {
+          throw new Error(`테스트에 필요한 ${tool} 바이너리를 PATH에서 찾을 수 없습니다`);
+        }
+        await symlink(real, join(sandboxBinDir, tool));
+      }
+      const gitBinary = resolveRealBinary("git");
+      if (gitBinary) {
+        await symlink(gitBinary, join(sandboxBinDir, "git"));
+      }
+
+      // fake curl을 node가 아닌 POSIX shell script로 작성해 node 의존성을 제거한다.
+      const curlLogPath = join(repoPath, "curl.log");
+      const fakeCurlPath = join(sandboxBinDir, "curl");
+      await writeFile(
+        fakeCurlPath,
+        [
+          "#!/bin/sh",
+          'printf \'%s\\n\' "$*" >> "$KANVIBE_CURL_LOG"',
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(fakeCurlPath, 0o755);
+
+      const scriptPath = join(hookDir, "kanvibe-test-hook.sh");
+      await writeFile(
+        scriptPath,
+        [
+          "#!/bin/bash",
+          'KANVIBE_URL="http://fallback:9736"',
+          buildShellTaskIdResolver("fallback-task"),
+          buildShellKanvibeStatusUpdater("review"),
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(scriptPath, 0o755);
+
+      const bashBinary = resolveRealBinary("bash");
+      await execFileAsync(bashBinary!, [scriptPath], {
+        cwd: repoPath,
+        env: {
+          // process.env를 펼치지 않아 node가 들어 있는 디렉터리를 PATH에서 배제한다.
+          PATH: sandboxBinDir,
+          HOME: repoPath,
+          KANVIBE_CURL_LOG: curlLogPath,
+        },
+      });
+
+      const curlCalls = (await readFile(curlLogPath, "utf8"))
+        .trim()
+        .split("\n")
+        .filter((line) => line.length > 0);
+      const postedTaskIds = curlCalls
+        .map((line) => line.match(/"taskId":\s*"([^"]+)"/)?.[1])
+        .filter((value): value is string => Boolean(value));
+
+      expect(postedTaskIds).toEqual(["local-task", "dev-task"]);
+      expect(curlCalls.every((line) => line.includes("http://127.0.0.1:9736/api/hooks/status"))).toBe(true);
     } finally {
       await rm(repoPath, { recursive: true, force: true });
     }

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -11,6 +11,7 @@ const mockGetOpenCodeHooksStatus = vi.fn();
 const mockExecGit = vi.fn();
 const mockGetHookServerUrl = vi.fn();
 const mockAddAiToolPatternsToGitExclude = vi.fn();
+const mockUpsertKanvibeHookTarget = vi.fn();
 
 vi.mock("@/lib/claudeHooksSetup", () => ({
   setupClaudeHooks: (...args: unknown[]) => mockSetupClaudeHooks(...args),
@@ -64,6 +65,10 @@ vi.mock("@/lib/gitExclude", () => ({
   addAiToolPatternsToGitExclude: (...args: unknown[]) => mockAddAiToolPatternsToGitExclude(...args),
 }));
 
+vi.mock("@/lib/kanvibeProjectState", () => ({
+  upsertKanvibeHookTarget: (...args: unknown[]) => mockUpsertKanvibeHookTarget(...args),
+}));
+
 function extractWrittenContent(calls: unknown[][], filePath: string): string {
   const targetCall = calls.find(([command]) => typeof command === "string"
     && (command.includes(`> "${filePath}"`) || command.includes(`> '${filePath}'`)));
@@ -105,11 +110,13 @@ describe("kanvibeHooksInstaller", () => {
     mockExecGit.mockReset();
     mockGetHookServerUrl.mockReset();
     mockAddAiToolPatternsToGitExclude.mockReset();
+    mockUpsertKanvibeHookTarget.mockReset();
     mockSetupClaudeHooks.mockResolvedValue(undefined);
     mockSetupGeminiHooks.mockResolvedValue(undefined);
     mockSetupCodexHooks.mockResolvedValue(undefined);
     mockSetupOpenCodeHooks.mockResolvedValue(undefined);
     mockGetHookServerUrl.mockReturnValue("http://192.168.0.8:9736");
+    mockUpsertKanvibeHookTarget.mockResolvedValue(undefined);
     mockExecGit.mockResolvedValue("");
     mockAddAiToolPatternsToGitExclude.mockResolvedValue(undefined);
     mockGetClaudeHooksStatus.mockResolvedValue({ installed: true });
@@ -133,6 +140,11 @@ describe("kanvibeHooksInstaller", () => {
     expect(mockSetupGeminiHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
     expect(mockSetupCodexHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
     expect(mockSetupOpenCodeHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
+    expect(mockUpsertKanvibeHookTarget).toHaveBeenCalledWith(
+      "/repo",
+      { url: "http://192.168.0.8:9736", taskId: "task-1" },
+      null,
+    );
     expect(mockExecGit).not.toHaveBeenCalled();
   });
 
@@ -148,6 +160,11 @@ describe("kanvibeHooksInstaller", () => {
     expect(mockSetupGeminiHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
     expect(mockSetupCodexHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
     expect(mockSetupOpenCodeHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
+    expect(mockUpsertKanvibeHookTarget).toHaveBeenCalledWith(
+      "/repo",
+      { url: "http://192.168.0.8:9736", taskId: "task-1" },
+      null,
+    );
     expect(mockGetClaudeHooksStatus).not.toHaveBeenCalled();
     expect(mockGetGeminiHooksStatus).not.toHaveBeenCalled();
     expect(mockGetCodexHooksStatus).not.toHaveBeenCalled();
@@ -235,6 +252,11 @@ describe("kanvibeHooksInstaller", () => {
 
     // Then
     expect(mockSetupCodexHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
+    expect(mockUpsertKanvibeHookTarget).toHaveBeenCalledWith(
+      "/repo",
+      { url: "http://192.168.0.8:9736", taskId: "task-1" },
+      null,
+    );
     expect(mockSetupClaudeHooks).not.toHaveBeenCalled();
     expect(mockSetupGeminiHooks).not.toHaveBeenCalled();
     expect(mockSetupOpenCodeHooks).not.toHaveBeenCalled();
@@ -469,7 +491,7 @@ describe("kanvibeHooksInstaller", () => {
     ["gemini", "/remote/repo/.gemini/settings.json", "/remote/repo/.claude/settings.json"],
     ["codex", "/remote/repo/.codex/hooks.json", "/remote/repo/.opencode/plugins/kanvibe-plugin.ts"],
     ["openCode", "/remote/repo/.opencode/plugins/kanvibe-plugin.ts", "/remote/repo/.codex/hooks.json"],
-  ] as const)("원격 %s 단독 hook 설치도 provider 파일만 쓰고 hook target registry는 쓰지 않는다", async (provider, expectedProviderFile, unexpectedProviderFile) => {
+  ] as const)("원격 %s 단독 hook 설치도 target registry를 갱신하고 provider 파일만 쓴다", async (provider, expectedProviderFile, unexpectedProviderFile) => {
     // Given
     const { installKanvibeHookProvider } = await import("@/lib/kanvibeHooksInstaller");
 
@@ -483,6 +505,11 @@ describe("kanvibeHooksInstaller", () => {
     expect(writeCommands.join("\n")).toContain(expectedProviderFile);
     expect(writeCommands.join("\n")).not.toContain(unexpectedProviderFile);
     expect(writeCommands.join("\n")).not.toContain("/remote/repo/.kanvibe/hooks-targets.json");
+    expect(mockUpsertKanvibeHookTarget).toHaveBeenCalledWith(
+      "/remote/repo",
+      { url: "http://192.168.0.8:9736", taskId: "task-2" },
+      "remote-host",
+    );
   });
 
   it("원격 전체 hook 설치는 기존 설정 파일을 한 번의 SSH 명령으로 읽는다", async () => {

--- a/src/lib/__tests__/kanvibeProjectState.test.ts
+++ b/src/lib/__tests__/kanvibeProjectState.test.ts
@@ -12,11 +12,15 @@ vi.mock("@/lib/hostFileAccess", () => ({
 }));
 
 import {
+  buildKanvibeTargetsContent,
   buildKanvibeTaskStateContent,
+  getKanvibeTargetsPath,
   getKanvibeTaskStatePath,
+  parseKanvibeTargets,
   parseKanvibeTaskState,
   parseTaskStatus,
   readKanvibeTaskState,
+  upsertKanvibeHookTarget,
   writeKanvibeTaskState,
 } from "@/lib/kanvibeProjectState";
 
@@ -92,5 +96,58 @@ describe("kanvibeProjectState", () => {
     expect(writtenContent).not.toContain("url");
 
     expect(getKanvibeTaskStatePath("/local/repo")).toBe("/local/repo/.kanvibe/status.json");
+  });
+
+  it("builds and parses .kanvibe/targets.json as url to task id mappings", () => {
+    const content = buildKanvibeTargetsContent([
+      { url: "http://127.0.0.1:19736/", taskId: "task-local" },
+      { url: "http://127.0.0.1:19736", taskId: "task-dev" },
+      { url: "http://10.0.0.5:19736", taskId: "task-local" },
+    ]);
+    const parsed = JSON.parse(content) as { schemaVersion?: unknown; targets?: unknown; updatedAt?: unknown };
+
+    expect(parsed).toEqual({
+      schemaVersion: 1,
+      targets: [
+        { url: "http://127.0.0.1:19736", taskId: "task-local" },
+        { url: "http://127.0.0.1:19736", taskId: "task-dev" },
+      ],
+      updatedAt: expect.any(String),
+    });
+    expect(parseKanvibeTargets(content)?.targets).toEqual(parsed.targets);
+    expect(parseKanvibeTargets("not-json")).toEqual({ schemaVersion: 1, targets: [] });
+  });
+
+  it("upserts the current KanVibe hook target without dropping other clients", async () => {
+    mockReadTextFile.mockResolvedValueOnce(JSON.stringify({
+      schemaVersion: 1,
+      targets: [
+        { url: "http://127.0.0.1:19736", taskId: "origin-task" },
+        { url: "http://10.0.0.5:19736", taskId: "current-task" },
+      ],
+    }));
+
+    await upsertKanvibeHookTarget(
+      "/remote/repo",
+      { url: "http://127.0.0.1:19736/", taskId: "current-task" },
+      "ssh-host",
+    );
+
+    expect(mockReadTextFile).toHaveBeenCalledWith("/remote/repo/.kanvibe/targets.json", "ssh-host");
+    expect(mockWriteTextFile).toHaveBeenCalledWith(
+      "/remote/repo/.kanvibe/targets.json",
+      expect.any(String),
+      "ssh-host",
+    );
+    const writtenContent = mockWriteTextFile.mock.calls.at(-1)?.[1] as string;
+    expect(JSON.parse(writtenContent)).toEqual({
+      schemaVersion: 1,
+      targets: [
+        { url: "http://127.0.0.1:19736", taskId: "origin-task" },
+        { url: "http://127.0.0.1:19736", taskId: "current-task" },
+      ],
+      updatedAt: expect.any(String),
+    });
+    expect(getKanvibeTargetsPath("/local/repo")).toBe("/local/repo/.kanvibe/targets.json");
   });
 });

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -55,14 +55,16 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toContain('const TASK_ID = "task-1";');
       expect(pluginContent).not.toContain(".kanvibe/task-id");
       expect(pluginContent).toContain("status.json");
+      expect(pluginContent).toContain("targets.json");
+      expect(pluginContent).toContain("readKanvibeTargets");
+      expect(pluginContent).toContain("seenTaskIds");
       expect(pluginContent).not.toContain("hooks-targets.json");
       expect(pluginContent).not.toContain("task-state.json");
-      expect(pluginContent).not.toContain("readFileSync(KANVIBE_TARGETS_FILE");
       expect(pluginContent).toContain("--git-common-dir");
       expect(pluginContent).toContain(".kanvibe/");
       expect(pluginContent).toContain("writeFileSync(");
       expect(pluginContent).toContain("schemaVersion: 1");
-      expect(pluginContent).toContain("taskId: TASK_ID");
+      expect(pluginContent).toContain("taskId: target.taskId");
     });
 
     it("should generate plugin with all event handlers for status tracking", async () => {
@@ -143,6 +145,7 @@ describe("openCodeHooksSetup", () => {
       const status = await getOpenCodeHooksStatus(repoPath);
       expect(status.installed).toBe(true);
       expect(status.hasStatusJsonPersistence).toBe(true);
+      expect(status.hasTargetFanout).toBe(true);
     });
 
     it("should repair stale branch-bound plugin content on reinstall", async () => {

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -8,6 +8,7 @@ import {
   buildShellTaskIdResolver,
   getShellTaskIdBindingStatus,
   hasShellKanvibeStatusJsonPersistence,
+  hasShellKanvibeTargetFanout,
 } from "@/lib/hookTaskBinding";
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
@@ -212,6 +213,7 @@ export interface ClaudeHooksStatus {
   hasExpectedTaskId?: boolean;
   hasStatusMappings?: boolean;
   hasStatusJsonPersistence?: boolean;
+  hasTargetFanout?: boolean;
   hasExpectedHookServerUrl?: boolean;
   hasReachableHookServer?: boolean;
   boundTaskId?: string | null;
@@ -255,6 +257,7 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
     stopContent.includes('\\\"status\\\": \\\"review\\\"') &&
     questionContent.includes('\\\"status\\\": \\\"pending\\\"');
   const hasStatusJsonPersistence = scriptContents.every(hasShellKanvibeStatusJsonPersistence);
+  const hasTargetFanout = scriptContents.every(hasShellKanvibeTargetFanout);
 
   let hasSettingsEntry = false;
   try {
@@ -279,6 +282,7 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
     && hasExpectedTaskId
     && hasStatusMappings
     && hasStatusJsonPersistence
+    && hasTargetFanout
     && hookServerValidation.hasExpectedHookServerUrl;
 
   return {
@@ -291,6 +295,7 @@ export async function getClaudeHooksStatus(repoPath: string, taskId?: string, ss
     hasExpectedTaskId,
     hasStatusMappings,
     hasStatusJsonPersistence,
+    hasTargetFanout,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
     hasReachableHookServer: hookServerValidation.hasReachableHookServer,
     boundTaskId,

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -8,6 +8,7 @@ import {
   buildShellTaskIdResolver,
   getShellTaskIdBindingStatus,
   hasShellKanvibeStatusJsonPersistence,
+  hasShellKanvibeTargetFanout,
 } from "@/lib/hookTaskBinding";
 
 /**
@@ -337,6 +338,7 @@ export interface CodexHooksStatus {
   hasExpectedTaskId?: boolean;
   hasStatusMappings?: boolean;
   hasStatusJsonPersistence?: boolean;
+  hasTargetFanout?: boolean;
   hasExpectedHookServerUrl?: boolean;
   hasReachableHookServer?: boolean;
   boundTaskId?: string | null;
@@ -384,6 +386,7 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
     && preToolContent.includes('\\\"status\\\": \\\"progress\\\"')
     && stopContent.includes('\\\"status\\\": \\\"review\\\"');
   const hasStatusJsonPersistence = hookScripts.every(hasShellKanvibeStatusJsonPersistence);
+  const hasTargetFanout = hookScripts.every(hasShellKanvibeTargetFanout);
   const hookServerValidation = await validateHookServerConfiguration(
     hookScripts.map((content) => extractShellHookServerUrl(content)),
     Boolean(taskId),
@@ -409,6 +412,7 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
     && hasExpectedTaskId
     && hasStatusMappings
     && hasStatusJsonPersistence
+    && hasTargetFanout
     && hookServerValidation.hasExpectedHookServerUrl;
 
   return {
@@ -424,6 +428,7 @@ export async function getCodexHooksStatus(repoPath: string, taskId?: string, ssh
     hasExpectedTaskId,
     hasStatusMappings,
     hasStatusJsonPersistence,
+    hasTargetFanout,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
     hasReachableHookServer: hookServerValidation.hasReachableHookServer,
     boundTaskId,

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -8,6 +8,7 @@ import {
   buildShellTaskIdResolver,
   getShellTaskIdBindingStatus,
   hasShellKanvibeStatusJsonPersistence,
+  hasShellKanvibeTargetFanout,
 } from "@/lib/hookTaskBinding";
 
 /**
@@ -178,6 +179,7 @@ export interface GeminiHooksStatus {
   hasExpectedTaskId?: boolean;
   hasStatusMappings?: boolean;
   hasStatusJsonPersistence?: boolean;
+  hasTargetFanout?: boolean;
   hasExpectedHookServerUrl?: boolean;
   hasReachableHookServer?: boolean;
   boundTaskId?: string | null;
@@ -216,6 +218,7 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
     promptContent.includes('\\\"status\\\": \\\"progress\\\"') &&
     stopContent.includes('\\\"status\\\": \\\"review\\\"');
   const hasStatusJsonPersistence = scriptContents.every(hasShellKanvibeStatusJsonPersistence);
+  const hasTargetFanout = scriptContents.every(hasShellKanvibeTargetFanout);
 
   let hasSettingsEntry = false;
   try {
@@ -237,6 +240,7 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
     && hasExpectedTaskId
     && hasStatusMappings
     && hasStatusJsonPersistence
+    && hasTargetFanout
     && hookServerValidation.hasExpectedHookServerUrl;
 
   return {
@@ -248,6 +252,7 @@ export async function getGeminiHooksStatus(repoPath: string, taskId?: string, ss
     hasExpectedTaskId,
     hasStatusMappings,
     hasStatusJsonPersistence,
+    hasTargetFanout,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
     hasReachableHookServer: hookServerValidation.hasReachableHookServer,
     boundTaskId,

--- a/src/lib/hookTaskBinding.ts
+++ b/src/lib/hookTaskBinding.ts
@@ -48,7 +48,12 @@ fi
 
 KANVIBE_TARGET_ROWS="$(
   if [ -f "\${KANVIBE_TARGETS_FILE}" ]; then
-    node -e 'const fs=require("fs");const file=process.argv[1];const fallbackUrl=process.argv[2];const fallbackTaskId=process.argv[3];const normalize=(value)=>String(value||"").trim().replace(new RegExp("/+$"),"");function printFallback(){const url=normalize(fallbackUrl);if(url&&fallbackTaskId) process.stdout.write(url+"\\t"+fallbackTaskId);}try{const parsed=JSON.parse(fs.readFileSync(file,"utf8"));const targets=Array.isArray(parsed.targets)?parsed.targets:[];const rows=[];const seen=new Set();for(const target of targets){const url=normalize(target&&target.url);const taskId=String(target&&target.taskId||"").trim();if(!url||!taskId||seen.has(taskId)) continue;seen.add(taskId);rows.push(url+"\\t"+taskId);}if(rows.length){process.stdout.write(rows.join("\\n"));}else{printFallback();}}catch{printFallback();}' "\${KANVIBE_TARGETS_FILE}" "\${KANVIBE_URL}" "\${TASK_ID}" 2>/dev/null || true
+    grep -oE '"(url|taskId)"[[:space:]]*:[[:space:]]*"[^"]*"' "\${KANVIBE_TARGETS_FILE}" 2>/dev/null \
+      | awk '
+          { s=$0; sub(/^"[^"]*"[[:space:]]*:[[:space:]]*"/,"",s); sub(/"$/,"",s) }
+          /^"url"/ { u=s; sub(/\\/+$/,"",u); haveUrl=1; next }
+          /^"taskId"/ { if(haveUrl){ if(u!="" && s!="" && !(s in seen)){ seen[s]=1; print u "\\t" s } haveUrl=0 } }
+        ' 2>/dev/null || true
   else
     printf '%s\t%s\n' "\${KANVIBE_URL%/}" "\${TASK_ID}"
   fi

--- a/src/lib/hookTaskBinding.ts
+++ b/src/lib/hookTaskBinding.ts
@@ -35,6 +35,7 @@ export function buildShellKanvibeStatusUpdater(status: "progress" | "pending" | 
 KANVIBE_REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "\${BASH_SOURCE[0]}")/../.." && pwd))"
 KANVIBE_STATE_DIR="\${KANVIBE_REPO_ROOT}/.kanvibe"
 KANVIBE_TASK_STATE_FILE="\${KANVIBE_STATE_DIR}/status.json"
+KANVIBE_TARGETS_FILE="\${KANVIBE_STATE_DIR}/targets.json"
 ${buildShellKanvibeStatusExcludeUpdater()}
 
 mkdir -p "\${KANVIBE_STATE_DIR}" 2>/dev/null || true
@@ -45,10 +46,26 @@ else
   printf '{"schemaVersion":1,"status":"%s"}\\n' "\${KANVIBE_STATUS}" > "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null || true
 fi
 
-curl -s -X POST "\${KANVIBE_URL%/}/api/hooks/status" \
-  -H "Content-Type: application/json" \
-  -d "{\\"taskId\\": \\\"\${TASK_ID}\\\", \\\"status\\\": \\\"${status}\\\"}" \
-  > /dev/null 2>&1 || true`;
+KANVIBE_TARGET_ROWS="$(
+  if [ -f "\${KANVIBE_TARGETS_FILE}" ]; then
+    node -e 'const fs=require("fs");const file=process.argv[1];const fallbackUrl=process.argv[2];const fallbackTaskId=process.argv[3];const normalize=(value)=>String(value||"").trim().replace(new RegExp("/+$"),"");function printFallback(){const url=normalize(fallbackUrl);if(url&&fallbackTaskId) process.stdout.write(url+"\\t"+fallbackTaskId);}try{const parsed=JSON.parse(fs.readFileSync(file,"utf8"));const targets=Array.isArray(parsed.targets)?parsed.targets:[];const rows=[];const seen=new Set();for(const target of targets){const url=normalize(target&&target.url);const taskId=String(target&&target.taskId||"").trim();if(!url||!taskId||seen.has(taskId)) continue;seen.add(taskId);rows.push(url+"\\t"+taskId);}if(rows.length){process.stdout.write(rows.join("\\n"));}else{printFallback();}}catch{printFallback();}' "\${KANVIBE_TARGETS_FILE}" "\${KANVIBE_URL}" "\${TASK_ID}" 2>/dev/null || true
+  else
+    printf '%s\t%s\n' "\${KANVIBE_URL%/}" "\${TASK_ID}"
+  fi
+)"
+if [ -z "\${KANVIBE_TARGET_ROWS}" ]; then
+  KANVIBE_TARGET_ROWS="$(printf '%s\t%s\n' "\${KANVIBE_URL%/}" "\${TASK_ID}")"
+fi
+
+printf '%s\n' "\${KANVIBE_TARGET_ROWS}" | while IFS="$(printf '\\t')" read -r KANVIBE_TARGET_URL KANVIBE_TARGET_TASK_ID; do
+  if [ -z "\${KANVIBE_TARGET_URL}" ] || [ -z "\${KANVIBE_TARGET_TASK_ID}" ]; then
+    continue
+  fi
+  curl -s -X POST "\${KANVIBE_TARGET_URL%/}/api/hooks/status" \
+    -H "Content-Type: application/json" \
+    -d "{\\"taskId\\": \\\"\${KANVIBE_TARGET_TASK_ID}\\\", \\\"status\\\": \\\"${status}\\\"}" \
+    > /dev/null 2>&1 || true
+done`;
 }
 
 function buildShellKanvibeStatusExcludeUpdater() {
@@ -75,6 +92,17 @@ export function hasShellKanvibeStatusJsonPersistence(content: string): boolean {
     && content.includes(KANVIBE_STATE_DIR_EXCLUDE_PATTERN)
     && content.includes('"schemaVersion":1')
     && content.includes('"status":"%s"');
+}
+
+export function hasShellKanvibeTargetFanout(content: string): boolean {
+  return content.includes("targets.json")
+    && content.includes("KANVIBE_TARGETS_FILE")
+    && content.includes("KANVIBE_TARGET_ROWS")
+    && content.includes("KANVIBE_TARGET_URL")
+    && content.includes("KANVIBE_TARGET_TASK_ID")
+    && content.includes("while IFS=")
+    && content.includes("/api/hooks/status")
+    && content.includes("taskId");
 }
 
 export function getShellTaskIdBindingStatus(

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -23,6 +23,7 @@ import { setupOpenCodeHooks, getOpenCodeHooksStatus, generatePluginScript, PLUGI
 import { getHookServerUrl } from "@/lib/hookEndpoint";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import { quoteShellArgument, readTextFiles } from "@/lib/hostFileAccess";
+import { upsertKanvibeHookTarget } from "@/lib/kanvibeProjectState";
 
 const HOOK_INSTALL_MAX_ATTEMPTS = 3;
 const HOOK_INSTALL_RETRY_DELAY_MS = 500;
@@ -378,6 +379,7 @@ async function installKanvibeHookFilesOnce(
   sshHost?: string | null,
 ): Promise<void> {
   const hookServerUrl = await getHookServerUrl(sshHost);
+  await upsertKanvibeHookTarget(targetPath, { url: hookServerUrl, taskId }, sshHost);
 
   if (!sshHost) {
     const installers = Object.values(createHookProviderInstallers(targetPath, taskId, hookServerUrl, sshHost));
@@ -405,6 +407,7 @@ async function installKanvibeHookProviderOnce(
   sshHost?: string | null,
 ): Promise<void> {
   const hookServerUrl = await getHookServerUrl(sshHost);
+  await upsertKanvibeHookTarget(targetPath, { url: hookServerUrl, taskId }, sshHost);
   const installer = createHookProviderInstallers(targetPath, taskId, hookServerUrl, sshHost)[provider];
 
   if (sshHost) {

--- a/src/lib/kanvibeProjectState.ts
+++ b/src/lib/kanvibeProjectState.ts
@@ -4,6 +4,7 @@ import { readTextFile, writeTextFile } from "@/lib/hostFileAccess";
 
 export const KANVIBE_DIR_NAME = ".kanvibe";
 export const TASK_STATE_FILE_NAME = "status.json";
+export const TARGETS_FILE_NAME = "targets.json";
 
 export interface KanvibeTaskState {
   schemaVersion: 1;
@@ -11,8 +12,23 @@ export interface KanvibeTaskState {
   updatedAt?: string;
 }
 
+export interface KanvibeHookTarget {
+  url: string;
+  taskId: string;
+}
+
+export interface KanvibeTargetsState {
+  schemaVersion: 1;
+  targets: KanvibeHookTarget[];
+  updatedAt?: string;
+}
+
 export function getKanvibeTaskStatePath(repoPath: string, sshHost?: string | null): string {
   return getPathModule(sshHost).join(repoPath, KANVIBE_DIR_NAME, TASK_STATE_FILE_NAME);
+}
+
+export function getKanvibeTargetsPath(repoPath: string, sshHost?: string | null): string {
+  return getPathModule(sshHost).join(repoPath, KANVIBE_DIR_NAME, TARGETS_FILE_NAME);
 }
 
 export async function readKanvibeTaskState(
@@ -35,12 +51,39 @@ export async function writeKanvibeTaskState(
   );
 }
 
+export async function upsertKanvibeHookTarget(
+  repoPath: string,
+  target: KanvibeHookTarget,
+  sshHost?: string | null,
+): Promise<void> {
+  const currentState = parseKanvibeTargets(
+    await readTextFile(getKanvibeTargetsPath(repoPath, sshHost), sshHost),
+  );
+  const nextTargets = upsertKanvibeTarget(currentState.targets, target);
+
+  await writeTextFile(
+    getKanvibeTargetsPath(repoPath, sshHost),
+    buildKanvibeTargetsContent(nextTargets),
+    sshHost,
+  );
+}
+
 export function buildKanvibeTaskStateContent(
   taskState: Pick<KanvibeTaskState, "status">,
 ): string {
   const payload: KanvibeTaskState = {
     schemaVersion: 1,
     status: taskState.status,
+    updatedAt: new Date().toISOString(),
+  };
+
+  return JSON.stringify(payload, null, 2) + "\n";
+}
+
+export function buildKanvibeTargetsContent(targets: KanvibeHookTarget[]): string {
+  const payload: KanvibeTargetsState = {
+    schemaVersion: 1,
+    targets: normalizeKanvibeTargets(targets),
     updatedAt: new Date().toISOString(),
   };
 
@@ -77,6 +120,23 @@ export function parseKanvibeTaskState(content: string): KanvibeTaskState | null 
   }
 }
 
+export function parseKanvibeTargets(content: string): KanvibeTargetsState {
+  if (typeof content !== "string" || !content.trim()) {
+    return { schemaVersion: 1, targets: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(content) as { targets?: unknown; updatedAt?: unknown };
+    return {
+      schemaVersion: 1,
+      targets: normalizeKanvibeTargets(Array.isArray(parsed.targets) ? parsed.targets : []),
+      ...(typeof parsed.updatedAt === "string" && parsed.updatedAt.length > 0 ? { updatedAt: parsed.updatedAt } : {}),
+    };
+  } catch {
+    return { schemaVersion: 1, targets: [] };
+  }
+}
+
 export function parseTaskStatus(value: unknown): TaskStatus | null {
   if (typeof value !== "string") {
     return null;
@@ -85,6 +145,57 @@ export function parseTaskStatus(value: unknown): TaskStatus | null {
   const normalized = value.toLowerCase();
   const statuses = new Set<string>(Object.values(TaskStatus));
   return statuses.has(normalized) ? normalized as TaskStatus : null;
+}
+
+function upsertKanvibeTarget(targets: unknown[], target: KanvibeHookTarget): KanvibeHookTarget[] {
+  const normalizedTarget = normalizeKanvibeTarget(target);
+  if (!normalizedTarget) {
+    return normalizeKanvibeTargets(targets);
+  }
+
+  const nextTargets = normalizeKanvibeTargets(targets);
+  const targetIndex = nextTargets.findIndex((value) => value.taskId === normalizedTarget.taskId);
+  if (targetIndex === -1) {
+    return [...nextTargets, normalizedTarget];
+  }
+
+  return nextTargets.map((value, index) => index === targetIndex ? normalizedTarget : value);
+}
+
+function normalizeKanvibeTargets(targets: unknown[]): KanvibeHookTarget[] {
+  const nextTargets: KanvibeHookTarget[] = [];
+  const seenTaskIds = new Set<string>();
+
+  for (const target of targets) {
+    const normalizedTarget = normalizeKanvibeTarget(target);
+    if (!normalizedTarget || seenTaskIds.has(normalizedTarget.taskId)) {
+      continue;
+    }
+
+    seenTaskIds.add(normalizedTarget.taskId);
+    nextTargets.push(normalizedTarget);
+  }
+
+  return nextTargets;
+}
+
+function normalizeKanvibeTarget(target: unknown): KanvibeHookTarget | null {
+  const candidate = target as Partial<KanvibeHookTarget> | null;
+  if (!candidate || typeof candidate.url !== "string" || typeof candidate.taskId !== "string") {
+    return null;
+  }
+
+  const url = normalizeKanvibeTargetUrl(candidate.url);
+  const taskId = candidate.taskId.trim();
+  if (!url || !taskId) {
+    return null;
+  }
+
+  return { url, taskId };
+}
+
+function normalizeKanvibeTargetUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
 }
 
 function getPathModule(sshHost?: string | null): typeof path.posix | typeof path {

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -38,6 +38,7 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
   const KANVIBE_REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
   const KANVIBE_STATE_DIR = resolve(KANVIBE_REPO_ROOT, ".kanvibe");
   const KANVIBE_STATUS_FILE = resolve(KANVIBE_STATE_DIR, "status.json");
+  const KANVIBE_TARGETS_FILE = resolve(KANVIBE_STATE_DIR, "targets.json");
   const KANVIBE_STATE_DIR_EXCLUDE_PATTERN = ${JSON.stringify(KANVIBE_STATE_DIR_EXCLUDE_PATTERN)};
   const KANVIBE_GIT_EXCLUDE_MARKER = ${JSON.stringify(KANVIBE_GIT_EXCLUDE_MARKER)};
   const lastStatusBySession = new Map<string, string>();
@@ -79,6 +80,56 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
       );
     } catch {
       /* 파일 쓰기 에러 무시 */
+    }
+  }
+
+  type KanvibeTarget = { url: string; taskId: string };
+
+  function normalizeKanvibeUrl(url: string): string {
+    return url.trim().replace(/\\/+$/, "");
+  }
+
+  function getFallbackKanvibeTarget(): KanvibeTarget[] {
+    return [{ url: normalizeKanvibeUrl(KANVIBE_URL), taskId: TASK_ID }];
+  }
+
+  function readKanvibeTargets(): KanvibeTarget[] {
+    try {
+      const parsed = JSON.parse(readFileSync(KANVIBE_TARGETS_FILE, "utf8"));
+      const targets = Array.isArray(parsed?.targets) ? parsed.targets : [];
+      const seenTaskIds = new Set<string>();
+      const normalizedTargets: KanvibeTarget[] = [];
+
+      for (const target of targets) {
+        const url = typeof target?.url === "string" ? normalizeKanvibeUrl(target.url) : "";
+        const taskId = typeof target?.taskId === "string" ? target.taskId.trim() : "";
+        if (!url || !taskId || seenTaskIds.has(taskId)) continue;
+
+        seenTaskIds.add(taskId);
+        normalizedTargets.push({ url, taskId });
+      }
+
+      return normalizedTargets.length > 0 ? normalizedTargets : getFallbackKanvibeTarget();
+    } catch {
+      return getFallbackKanvibeTarget();
+    }
+  }
+
+  async function postKanvibeStatus(target: KanvibeTarget, status: string): Promise<void> {
+    try {
+      await fetch(target.url + "/api/hooks/status", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ taskId: target.taskId, status }),
+      });
+    } catch {
+      /* 네트워크 에러 무시 */
+    }
+  }
+
+  async function fanoutKanvibeStatus(status: string): Promise<void> {
+    for (const target of readKanvibeTargets()) {
+      await postKanvibeStatus(target, status);
     }
   }
 
@@ -129,17 +180,7 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
     }
 
     writeKanvibeTaskState(status);
-
-    try {
-      const baseUrl = KANVIBE_URL.endsWith("/") ? KANVIBE_URL.slice(0, -1) : KANVIBE_URL;
-      await fetch(baseUrl + "/api/hooks/status", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ taskId: TASK_ID, status }),
-      });
-    } catch {
-      /* 네트워크 에러 무시 */
-    }
+    await fanoutKanvibeStatus(status);
 
     if (sessionID) {
       lastStatusBySession.set(sessionID, status);
@@ -245,6 +286,16 @@ function hasOpenCodeStatusJsonPersistence(pluginContent: string): boolean {
     && pluginContent.includes("JSON.stringify({ schemaVersion: 1, status, updatedAt: new Date().toISOString() }");
 }
 
+function hasOpenCodeTargetFanout(pluginContent: string): boolean {
+  return pluginContent.includes("targets.json")
+    && pluginContent.includes("KANVIBE_TARGETS_FILE")
+    && pluginContent.includes("readKanvibeTargets")
+    && pluginContent.includes("fanoutKanvibeStatus")
+    && pluginContent.includes("postKanvibeStatus")
+    && pluginContent.includes("taskId: target.taskId")
+    && pluginContent.includes("/api/hooks/status");
+}
+
 function extractPluginTaskId(pluginContent: string): string | null {
   const match = pluginContent.match(/const TASK_ID = ("(?:\\.|[^"\\])*");/);
   if (!match) return null;
@@ -290,6 +341,7 @@ export interface OpenCodeHooksStatus {
   hasStatusEndpoint?: boolean;
   hasEventMappings?: boolean;
   hasStatusJsonPersistence?: boolean;
+  hasTargetFanout?: boolean;
   hasMainSessionGuard?: boolean;
   hasDuplicateProgressGuard?: boolean;
   hasExpectedHookServerUrl?: boolean;
@@ -318,6 +370,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
   let hasStatusEndpoint = false;
   let hasEventMappings = false;
   let hasStatusJsonPersistence = false;
+  let hasTargetFanout = false;
   let hasMainSessionGuard = false;
   let hasDuplicateProgressGuard = false;
   let hasRegisteredPlugin = sshHost ? true : false;
@@ -338,6 +391,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
       hasStatusEndpoint = content.includes("/api/hooks/status");
       hasEventMappings = ["progress", "pending", "review", "done", "message.updated", "question.asked", "question.replied", "session.idle", "session.deleted"].every((fragment) => content.includes(fragment));
       hasStatusJsonPersistence = hasOpenCodeStatusJsonPersistence(content);
+      hasTargetFanout = hasOpenCodeTargetFanout(content);
       hasMainSessionGuard = content.includes("isMainSession(message)") && content.includes("isMainSession(event.properties)");
       hasDuplicateProgressGuard = content.includes("lastUserMessageBySession") && content.includes("buildMessageSignature") && content.includes("dedupeMessage: true");
     } catch {
@@ -365,6 +419,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
     && hasStatusEndpoint
     && hasEventMappings
     && hasStatusJsonPersistence
+    && hasTargetFanout
     && hasMainSessionGuard
     && hasDuplicateProgressGuard
     && hasRegisteredPlugin
@@ -380,6 +435,7 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
     hasStatusEndpoint,
     hasEventMappings,
     hasStatusJsonPersistence,
+    hasTargetFanout,
     hasMainSessionGuard,
     hasDuplicateProgressGuard,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,


### PR DESCRIPTION
## What changed?
- Replace the single branch-bound hook status target with a repo-local `.kanvibe/targets.json` registry.
- Upsert `{ url, taskId }` targets during hook installation for both all-provider and single-provider installs.
- Fan out shell hook and OpenCode plugin status posts to every registered target, while falling back to the current `KANVIBE_URL`/`TASK_ID` when the registry is missing or invalid.
- Require target fan-out detection in hook status checks so stale single-target hooks are reinstalled.

## Important details
- Shell hooks now persist `.kanvibe/status.json` and send `/api/hooks/status` to every normalized target row.
- OpenCode plugin reads the same target registry and posts each status transition to all registered task targets.
- Target registry parsing ignores invalid rows and deduplicates by `taskId`.

## Validation
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js exec vitest run src/lib/__tests__/hookTaskBinding.test.ts src/lib/__tests__/kanvibeProjectState.test.ts src/lib/__tests__/kanvibeHooksInstaller.test.ts src/lib/__tests__/claudeHooksSetup.test.ts src/lib/__tests__/geminiHooksSetup.test.ts src/lib/__tests__/codexHooksSetup.test.ts src/lib/__tests__/openCodeHooksSetup.test.ts` → 86 passed
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js check` → passed
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js lint` → passed with 10 existing warnings, 0 errors
