### PR TITLE
fix(tasks): preserve status when attaching terminal

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -479,7 +479,7 @@ describe("kanbanService.createTask", () => {
       id: "task-connect",
       sessionType: "tmux",
       sessionName: "repo-feature-remote",
-      status: "progress",
+      status: "todo",
     }));
     expect(mocks.createSessionWithoutWorktree).toHaveBeenCalledWith(
       "/remote/repo",
@@ -506,10 +506,59 @@ describe("kanbanService.createTask", () => {
     expect(mocks.scheduleKanvibeHooksInstall).not.toHaveBeenCalled();
     expect(mocks.writeTextFile).toHaveBeenCalledWith(
       "/remote/repo__worktrees/feature-remote/.kanvibe/status.json",
-      expect.stringContaining('"status": "progress"'),
+      expect.stringContaining('"status": "todo"'),
       "remote-host",
     );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("기존 브랜치 task 터미널 연결은 현재 상태를 보존한다", async () => {
+    // Given
+    const task = {
+      id: "task-connect-review",
+      title: "리뷰 브랜치 연결",
+      projectId: "project-remote",
+      branchName: "feature/review",
+      baseBranch: "main",
+      worktreePath: "/remote/repo__worktrees/feature-review",
+      sshHost: "remote-host",
+      sessionType: null,
+      sessionName: null,
+      status: "review",
+    };
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-remote",
+      repoPath: "/remote/repo",
+      defaultBranch: "main",
+      sshHost: "remote-host",
+    });
+    mocks.createSessionWithoutWorktree.mockResolvedValue({
+      sessionName: "repo-feature-review",
+    });
+    mocks.taskRepo.save.mockImplementation(async (value) => value);
+
+    const { connectTerminalSession } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await connectTerminalSession("task-connect-review", "tmux" as never);
+
+    // Then
+    expect(result).toEqual(expect.objectContaining({
+      id: "task-connect-review",
+      sessionType: "tmux",
+      sessionName: "repo-feature-review",
+      status: "review",
+    }));
+    expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
+      id: "task-connect-review",
+      status: "review",
+    }));
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/remote/repo__worktrees/feature-review/.kanvibe/status.json",
+      expect.stringContaining('"status": "review"'),
+      "remote-host",
+    );
   });
 
   it("기존 브랜치 task 터미널 연결은 hooks 설치가 지연되어도 세션 생성을 계속한다", async () => {
@@ -569,7 +618,7 @@ describe("kanbanService.createTask", () => {
         id: "task-connect-slow-hooks",
         sessionType: "tmux",
         sessionName: "repo-feature-slow-hooks",
-        status: "progress",
+        status: "todo",
       }));
       expect(mocks.createSessionWithoutWorktree).toHaveBeenCalledWith(
         "/remote/repo",

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -989,7 +989,6 @@ export async function connectTerminalSession(
     task.sessionName = session.sessionName;
     task.worktreePath = workingDir;
     task.sshHost = project.sshHost;
-    task.status = TaskStatus.PROGRESS;
 
     const saved = await repo.save(task);
     await persistTaskState(saved);


### PR DESCRIPTION
## Summary
- Keep terminal attachment from changing an existing task's Kanban status
- Preserve the current status in the persisted `.kanvibe/status.json` task-state file
- Add a regression test for attaching a terminal to a review-column task

## Test Plan
- `npx -y node@24 scripts/ensure-native-runtime.cjs`
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js exec vitest run src/desktop/main/services/__tests__/kanbanService.test.ts -t "현재 상태"` (confirmed RED before the fix)
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js exec vitest run src/desktop/main/services/__tests__/kanbanService.test.ts -t "터미널 연결"`
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js exec vitest run src/desktop/main/services/__tests__/kanbanService.test.ts`
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js exec vitest run src/components/__tests__/ConnectTerminalForm.test.tsx`
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js check`
- `npx -y node@24 /usr/lib/node_modules/corepack/dist/pnpm.js lint` (passes with existing warnings)
