### PR TITLE
fix(tasks): preserve resources on Done transitions

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -36,13 +36,13 @@
     },
     "prMergeAlert": {
       "title": "PR merge detected",
-      "message": "Kanvibe detected that worktree PR {branchName} was merged. Move the task \"{taskTitle}\" to Done?",
-      "batchMessage": "These PRs were detected as merged during the latest scan. Check the tasks you want to move to Done and handle them together.",
+      "message": "Kanvibe detected that worktree PR {branchName} was merged. Delete the task \"{taskTitle}\" and its resources?",
+      "batchMessage": "These PRs were detected as merged during the latest scan. Check the tasks you want to delete and handle them together.",
       "prLinkLabel": "PR Link"
     },
     "backgroundSyncReview": {
       "title": "Background Sync Review",
-      "message": "The latest background scan found items to review. Check merged PR tasks you want to move to Done, and review newly registered worktrees as well.",
+      "message": "The latest background scan found items to review. Check merged PR tasks you want to delete, and review newly registered worktrees as well.",
       "mergedSection": "Merged PRs",
       "registeredSection": "New TODO worktrees",
       "pulledSection": "Pull results",
@@ -52,7 +52,7 @@
       "pullRequestFailure": "Pull Request check failed",
       "taskPullFailure": "Task pull failed",
       "worktreeFailure": "Worktree sync failed",
-      "emptyMerged": "There are no merged PR tasks to move to Done in this review.",
+      "emptyMerged": "There are no merged PR tasks to delete in this review.",
       "emptyRegistered": "There are no newly registered worktrees in this review."
     },
     "releaseUpdate": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -29,7 +29,7 @@
     },
     "doneAlert": {
       "title": "Move to Done",
-      "message": "Moving to Done will delete the worktree, branch, and tmux session.",
+      "message": "Moving to Done keeps the worktree, branch, and tmux session. Resources are deleted only when you delete the task.",
       "dontAskAgain": "Don't ask again",
       "confirm": "Move",
       "cancel": "Cancel"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -29,7 +29,7 @@
     },
     "doneAlert": {
       "title": "Done 이동 경고",
-      "message": "Done으로 이동하면 worktree, branch, tmux session이 삭제됩니다.",
+      "message": "Done으로 이동해도 worktree, branch, tmux session은 보존됩니다. 리소스 삭제는 task 삭제 액션에서만 실행됩니다.",
       "dontAskAgain": "다시 묻지 않기",
       "confirm": "이동",
       "cancel": "취소"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -36,13 +36,13 @@
     },
     "prMergeAlert": {
       "title": "PR merge 감지",
-      "message": "worktree PR {branchName} 가 merge 된 것을 확인했습니다. \"{taskTitle}\" task를 Done으로 옮길까요?",
-      "batchMessage": "이번 탐색에서 merge가 확인된 PR 목록입니다. Done으로 옮길 task를 체크해서 한 번에 처리하세요.",
+      "message": "worktree PR {branchName} 가 merge 된 것을 확인했습니다. \"{taskTitle}\" task와 리소스를 삭제할까요?",
+      "batchMessage": "이번 탐색에서 merge가 확인된 PR 목록입니다. 삭제할 task를 체크해서 한 번에 처리하세요.",
       "prLinkLabel": "PR 링크"
     },
     "backgroundSyncReview": {
       "title": "백그라운드 sync 검토",
-      "message": "이번 백그라운드 탐색에서 정리하거나 확인할 항목을 찾았습니다. merge 완료 PR은 체크 후 Done으로 옮기고, 새로 등록된 worktree도 함께 확인하세요.",
+      "message": "이번 백그라운드 탐색에서 정리하거나 확인할 항목을 찾았습니다. merge 완료 PR은 체크 후 task 삭제로 정리하고, 새로 등록된 worktree도 함께 확인하세요.",
       "mergedSection": "Merge 완료 PR",
       "registeredSection": "새 TODO worktree",
       "pulledSection": "Pull 결과",
@@ -52,7 +52,7 @@
       "pullRequestFailure": "Pull Request 조회 실패",
       "taskPullFailure": "Task pull 실패",
       "worktreeFailure": "Worktree sync 실패",
-      "emptyMerged": "이번 검토에서 Done으로 옮길 merge PR이 없습니다.",
+      "emptyMerged": "이번 검토에서 삭제할 merge PR task가 없습니다.",
       "emptyRegistered": "이번 검토에서 새로 등록된 worktree가 없습니다."
     },
     "releaseUpdate": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -29,7 +29,7 @@
     },
     "doneAlert": {
       "title": "移动到完成",
-      "message": "移动到完成状态将删除 worktree、branch 和 tmux session。",
+      "message": "移动到完成状态会保留 worktree、branch 和 tmux session。只有删除任务时才会删除这些资源。",
       "dontAskAgain": "不再提示",
       "confirm": "移动",
       "cancel": "取消"

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -36,12 +36,12 @@
     },
     "prMergeAlert": {
       "title": "检测到 PR 已合并",
-      "message": "已确认 worktree PR {branchName} 已被合并。要将任务“{taskTitle}”移动到 Done 吗？",
+      "message": "已确认 worktree PR {branchName} 已被合并。要删除任务“{taskTitle}”及其资源吗？",
       "prLinkLabel": "PR 链接"
     },
     "backgroundSyncReview": {
       "title": "后台同步检查",
-      "message": "最近一次后台扫描发现了需要检查的项目。请勾选要移动到 Done 的已合并 PR 任务，并同时确认新注册的 worktree。",
+      "message": "最近一次后台扫描发现了需要检查的项目。请勾选要删除的已合并 PR 任务，并同时确认新注册的 worktree。",
       "mergedSection": "已合并 PR",
       "registeredSection": "新 TODO worktree",
       "pulledSection": "Pull 结果",
@@ -51,7 +51,7 @@
       "pullRequestFailure": "Pull Request 检查失败",
       "taskPullFailure": "Task pull 失败",
       "worktreeFailure": "Worktree 同步失败",
-      "emptyMerged": "本次检查中没有需要移动到 Done 的已合并 PR 任务。",
+      "emptyMerged": "本次检查中没有需要删除的已合并 PR 任务。",
       "emptyRegistered": "本次检查中没有新注册的 worktree。"
     },
     "releaseUpdate": {

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1017,7 +1017,7 @@ export default function Board({
       const sourceStatus = source.droppableId as TaskStatus;
       const destStatus = destination.droppableId as TaskStatus;
 
-      /** Done 이동 시 리소스 삭제 경고 (dismissed 아닌 경우만) */
+      /** Done 이동 시 리소스 보존 안내 (dismissed 아닌 경우만) */
       if (destStatus === TaskStatus.DONE && sourceStatus !== destStatus && !isDoneAlertDismissed) {
         const task = tasks[sourceStatus].find((task) => task.id === draggableId);
         const hasCleanableResources = task && (task.branchName || task.sessionType);

--- a/src/components/DoneConfirmDialog.tsx
+++ b/src/components/DoneConfirmDialog.tsx
@@ -11,7 +11,7 @@ interface DoneConfirmDialogProps {
   onCancel: () => void;
 }
 
-/** Done 이동 시 리소스 삭제 경고 모달. "다시 묻지 않기" 체크 시 DB에 설정을 저장한다 */
+/** Done 이동 시 리소스 보존 안내 모달. "다시 묻지 않기" 체크 시 DB에 설정을 저장한다 */
 export default function DoneConfirmDialog({
   isOpen,
   onConfirm,

--- a/src/components/DoneStatusButton.tsx
+++ b/src/components/DoneStatusButton.tsx
@@ -10,7 +10,7 @@ interface DoneStatusButtonProps {
   doneAlertDismissed: boolean;
 }
 
-/** Done 상태 전환 버튼. 정리 대상 리소스가 있으면 확인 모달을 표시한다 */
+/** Done 상태 전환 버튼. 연결 리소스가 있으면 보존 안내 모달을 표시한다 */
 export default function DoneStatusButton({
   statusChangeAction,
   label,

--- a/src/components/__tests__/DoneConfirmDialog.test.tsx
+++ b/src/components/__tests__/DoneConfirmDialog.test.tsx
@@ -14,7 +14,7 @@ vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => {
     const messages: Record<string, string> = {
       title: "Move to Done",
-      message: "Moving to Done will delete resources.",
+      message: "Moving to Done keeps resources.",
       dontAskAgain: "Don't ask again",
       confirm: "Move",
       cancel: "Cancel",
@@ -57,7 +57,7 @@ describe("DoneConfirmDialog", () => {
 
     // Then
     expect(screen.getByText("Move to Done")).toBeTruthy();
-    expect(screen.getByText("Moving to Done will delete resources.")).toBeTruthy();
+    expect(screen.getByText("Moving to Done keeps resources.")).toBeTruthy();
     expect(screen.getByText("Don't ask again")).toBeTruthy();
     expect(screen.getByText("Move")).toBeTruthy();
     expect(screen.getByText("Cancel")).toBeTruthy();

--- a/src/components/__tests__/DoneStatusButton.test.tsx
+++ b/src/components/__tests__/DoneStatusButton.test.tsx
@@ -12,7 +12,7 @@ vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => {
     const messages: Record<string, string> = {
       title: "Move to Done",
-      message: "Moving to Done will delete resources.",
+      message: "Moving to Done keeps resources.",
       dontAskAgain: "Don't ask again",
       confirm: "Move",
       cancel: "Cancel",
@@ -49,7 +49,7 @@ describe("DoneStatusButton", () => {
     expect(screen.getByText("Done")).toBeTruthy();
   });
 
-  it("should show confirm dialog when clicked with cleanable resources and not dismissed", async () => {
+  it("should show resource preservation notice when clicked with cleanable resources and not dismissed", async () => {
     // Given
     const user = userEvent.setup();
     render(<DoneStatusButton {...defaultProps} />);
@@ -59,7 +59,7 @@ describe("DoneStatusButton", () => {
 
     // Then
     expect(screen.getByText("Move to Done")).toBeTruthy();
-    expect(screen.getByText("Moving to Done will delete resources.")).toBeTruthy();
+    expect(screen.getByText("Moving to Done keeps resources.")).toBeTruthy();
   });
 
   it("should not show confirm dialog when doneAlertDismissed is true", async () => {

--- a/src/desktop/main/services/__tests__/hookService.test.ts
+++ b/src/desktop/main/services/__tests__/hookService.test.ts
@@ -29,9 +29,9 @@ const mocks = vi.hoisted(() => ({
   broadcastHookStatusTargetMissing: vi.fn(),
   broadcastTaskStatusChanged: vi.fn(),
   installTaskHooksImmediately: vi.fn(),
-  prepareOptimisticDoneTransition: vi.fn(),
-  scheduleDoneCleanupWithRollback: vi.fn(),
   writeTextFile: vi.fn(),
+  readTextFile: vi.fn(),
+  execGit: vi.fn(),
 }));
 
 vi.mock("@/entities/KanbanTask", () => entityMocks);
@@ -55,12 +55,16 @@ vi.mock("@/lib/boardNotifier", () => ({
 
 vi.mock("@/desktop/main/services/kanbanService", () => ({
   installTaskHooksImmediately: mocks.installTaskHooksImmediately,
-  prepareOptimisticDoneTransition: mocks.prepareOptimisticDoneTransition,
-  scheduleDoneCleanupWithRollback: mocks.scheduleDoneCleanupWithRollback,
+}));
+
+vi.mock("@/lib/gitOperations", () => ({
+  execGit: mocks.execGit,
 }));
 
 vi.mock("@/lib/hostFileAccess", () => ({
+  readTextFile: mocks.readTextFile,
   writeTextFile: mocks.writeTextFile,
+  quoteShellArgument: (value: string) => `'${value.replaceAll("'", `'\''`)}'`,
 }));
 
 async function flushMicrotasks(count = 8): Promise<void> {
@@ -73,28 +77,8 @@ describe("hookService.updateHookTaskStatus", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    mocks.prepareOptimisticDoneTransition.mockImplementation((task, options = {}) => {
-      const cleanupTask = { ...task };
-      const rollbackSnapshot = {
-        id: task.id,
-        status: task.status,
-        sessionType: task.sessionType,
-        sessionName: task.sessionName,
-        worktreePath: task.worktreePath,
-        sshHost: task.sshHost,
-      };
-
-      task.status = TaskStatus.DONE;
-      task.sessionType = null;
-      task.sessionName = null;
-      task.worktreePath = null;
-
-      if ((options as { clearSshHost?: boolean }).clearSshHost) {
-        task.sshHost = null;
-      }
-
-      return { cleanupTask, rollbackSnapshot };
-    });
+    mocks.readTextFile.mockResolvedValue("");
+    mocks.execGit.mockResolvedValue(".git");
   });
 
   it("taskId로 작업 상태를 변경한다", async () => {
@@ -138,6 +122,53 @@ describe("hookService.updateHookTaskStatus", () => {
       data: {
         id: task.id,
         status: TaskStatus.REVIEW,
+        branchName: task.branchName,
+        projectName: project.name,
+      },
+    });
+  });
+
+  it("hook Done 상태 변경은 세션/worktree 정보를 보존하고 Done cleanup을 예약하지 않는다", async () => {
+    const { updateHookTaskStatus } = await import("@/desktop/main/services/hookService");
+    const project = { id: "project-1", name: "kanvibe", repoPath: "/workspace/api", sshHost: "remote-host" };
+    const task = {
+      id: "task-done-hook",
+      title: "Preserve hook resources",
+      description: null,
+      branchName: "feature-hook-done",
+      projectId: project.id,
+      project,
+      status: TaskStatus.REVIEW,
+      sessionType: "tmux" as never,
+      sessionName: "api-feature-hook-done",
+      worktreePath: "/workspace/api__worktrees/feature-hook-done",
+      sshHost: "remote-host",
+    };
+    mocks.taskRepo.findOne.mockResolvedValue(task);
+    mocks.taskRepo.save.mockImplementation(async (value) => value);
+
+    const result = await updateHookTaskStatus({
+      taskId: task.id,
+      status: TaskStatus.DONE,
+    });
+
+    expect(mocks.execGit).toHaveBeenCalledWith(
+      "git -C '/workspace/api__worktrees/feature-hook-done' rev-parse --path-format=absolute --git-common-dir",
+      "remote-host",
+    );
+    expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
+      id: task.id,
+      status: TaskStatus.DONE,
+      sessionType: "tmux",
+      sessionName: "api-feature-hook-done",
+      worktreePath: "/workspace/api__worktrees/feature-hook-done",
+      sshHost: "remote-host",
+    }));
+    expect(result).toEqual({
+      success: true,
+      data: {
+        id: task.id,
+        status: TaskStatus.DONE,
         branchName: task.branchName,
         projectName: project.name,
       },
@@ -190,7 +221,9 @@ describe("hookService.updateHookTaskStatus", () => {
       };
       mocks.taskRepo.findOne.mockResolvedValue(task);
       mocks.taskRepo.save.mockImplementation(async (value) => value);
-      mocks.writeTextFile.mockRejectedValueOnce(new Error("state write failed"));
+      mocks.writeTextFile
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("state write failed"));
 
       const result = await updateHookTaskStatus({ taskId: task.id, status: TaskStatus.REVIEW });
 
@@ -239,6 +272,9 @@ describe("hookService.startHookTask", () => {
     vi.clearAllMocks();
     mocks.taskRepo.create.mockImplementation((value) => value);
     mocks.installTaskHooksImmediately.mockResolvedValue(undefined);
+    mocks.readTextFile.mockResolvedValue("");
+    mocks.writeTextFile.mockResolvedValue(undefined);
+    mocks.execGit.mockResolvedValue(".git");
   });
 
   it("새 hook task는 기존 .kanvibe 상태가 없으면 todo로 생성한다", async () => {

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -1020,6 +1020,60 @@ describe("kanbanService.createTask", () => {
     );
   });
 
+  it("deleteTasks는 선택 task들을 순서대로 정리하고 삭제한 뒤 board update를 한 번만 브로드캐스트한다", async () => {
+    // Given
+    const taskA = {
+      id: "task-merge-a",
+      projectId: "project-1",
+      branchName: "feature/merge-a",
+      worktreePath: "/workspace/repo__worktrees/feature-merge-a",
+      sshHost: null,
+      sessionType: null,
+      sessionName: null,
+    };
+    const taskB = {
+      id: "task-merge-b",
+      projectId: "project-1",
+      branchName: "feature/merge-b",
+      worktreePath: "/workspace/repo__worktrees/feature-merge-b",
+      sshHost: null,
+      sessionType: null,
+      sessionName: null,
+    };
+    mocks.taskRepo.find.mockResolvedValue([taskB, taskA]);
+    mocks.taskRepo.remove.mockImplementation(async (value) => value);
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      sshHost: null,
+    });
+
+    const { deleteTasks } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await deleteTasks(["task-merge-a", "missing-task", "task-merge-b", "task-merge-a"]);
+
+    // Then
+    expect(result).toEqual(["task-merge-a", "task-merge-b"]);
+    expect(mocks.removeWorktreeAndBranch).toHaveBeenNthCalledWith(
+      1,
+      "/workspace/repo",
+      "feature/merge-a",
+      null,
+      { throwOnError: true, worktreePath: "/workspace/repo__worktrees/feature-merge-a" },
+    );
+    expect(mocks.removeWorktreeAndBranch).toHaveBeenNthCalledWith(
+      2,
+      "/workspace/repo",
+      "feature/merge-b",
+      null,
+      { throwOnError: true, worktreePath: "/workspace/repo__worktrees/feature-merge-b" },
+    );
+    expect(mocks.taskRepo.remove).toHaveBeenNthCalledWith(1, taskA);
+    expect(mocks.taskRepo.remove).toHaveBeenNthCalledWith(2, taskB);
+    expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
   it("task 내용 수정 후 board update를 브로드캐스트한다", async () => {
     // Given
     const task = {

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -1177,88 +1177,43 @@ describe("kanbanService.createTask", () => {
     }
   });
 
-  it("Done 전환 백그라운드 정리가 성공하면 보존했던 리소스 필드를 비운다", async () => {
+  it("Done 상태 변경은 타이머가 실행돼도 세션/worktree/브랜치를 정리하지 않는다", async () => {
     vi.useFakeTimers();
 
     try {
       // Given
       const task = {
-        id: "task-done-cleanup-success",
-        title: "Remote cleanup",
+        id: "task-done-preserve-resources",
+        title: "Preserve resources on Done",
         description: null,
         status: "review",
-        branchName: null,
-        projectId: null,
+        branchName: "feature/preserve-resources",
+        projectId: "project-1",
         sessionType: "tmux" as never,
-        sessionName: "repo-fix-done",
-        worktreePath: "/remote/repo__worktrees/fix-done",
+        sessionName: "repo-feature-preserve-resources",
+        worktreePath: "/remote/repo__worktrees/feature-preserve-resources",
         sshHost: "remote-host",
       };
-      mocks.taskRepo.findOneBy
-        .mockResolvedValueOnce(task)
-        .mockResolvedValueOnce({ ...task, status: "done" });
+      mocks.taskRepo.findOneBy.mockResolvedValue(task);
       mocks.taskRepo.save.mockImplementation(async (value) => value);
       mocks.taskRepo.update.mockResolvedValue({ affected: 1 });
-      mocks.removeSessionOnly.mockResolvedValue(undefined);
-
-      const { updateTaskStatus } = await import("@/desktop/main/services/kanbanService");
-
-      // When
-      await updateTaskStatus("task-done-cleanup-success", "done" as never);
-      await vi.runAllTimersAsync();
-
-      // Then
-      expect(mocks.taskRepo.update).toHaveBeenCalledWith("task-done-cleanup-success", {
-        sessionType: null,
-        sessionName: null,
-        worktreePath: null,
-      });
-      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.clearAllTimers();
-      vi.useRealTimers();
-    }
-  });
-
-  it("오래된 Done 정리 성공은 새로 연결된 리소스를 비우지 않는다", async () => {
-    vi.useFakeTimers();
-
-    try {
-      // Given
-      const task = {
-        id: "task-stale-cleanup-success",
-        title: "Remote cleanup",
-        description: null,
-        status: "review",
-        branchName: null,
-        projectId: null,
-        sessionType: "tmux" as never,
-        sessionName: "repo-old-done",
-        worktreePath: "/remote/repo__worktrees/old-done",
+      mocks.projectRepo.findOneBy.mockResolvedValue({
+        id: "project-1",
+        repoPath: "/remote/repo",
         sshHost: "remote-host",
-      };
-      mocks.taskRepo.findOneBy
-        .mockResolvedValueOnce(task)
-        .mockResolvedValueOnce({
-          ...task,
-          status: "done",
-          branchName: "feature/new-done",
-          projectId: "project-new",
-          sessionName: "repo-new-done",
-          worktreePath: "/remote/repo__worktrees/new-done",
-          sshHost: "remote-new",
-        });
-      mocks.taskRepo.save.mockImplementation(async (value) => value);
-      mocks.removeSessionOnly.mockResolvedValue(undefined);
+      });
 
       const { updateTaskStatus } = await import("@/desktop/main/services/kanbanService");
 
       // When
-      await updateTaskStatus("task-stale-cleanup-success", "done" as never);
+      await updateTaskStatus("task-done-preserve-resources", "done" as never);
       await vi.runAllTimersAsync();
 
       // Then
-      expect(mocks.taskRepo.update).not.toHaveBeenCalledWith("task-stale-cleanup-success", {
+      expect(mocks.detachSession).not.toHaveBeenCalled();
+      expect(mocks.removeSessionOnly).not.toHaveBeenCalled();
+      expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
+      expect(mocks.taskRepo.update).not.toHaveBeenCalledWith("task-done-preserve-resources", {
         sessionType: null,
         sessionName: null,
         worktreePath: null,
@@ -1313,6 +1268,63 @@ describe("kanbanService.createTask", () => {
     }
   });
 
+  it("Done 컬럼 이동은 타이머가 실행돼도 세션/worktree/브랜치를 정리하지 않는다", async () => {
+    vi.useFakeTimers();
+
+    try {
+      // Given
+      const task = {
+        id: "task-done-move-preserve-resources",
+        title: "Preserve resources on Done move",
+        description: null,
+        status: "review",
+        branchName: "feature/move-preserve-resources",
+        projectId: "project-1",
+        sessionType: "tmux" as never,
+        sessionName: "repo-feature-move-preserve-resources",
+        worktreePath: "/remote/repo__worktrees/feature-move-preserve-resources",
+        sshHost: "remote-host",
+      };
+      mocks.taskRepo.findOneBy.mockResolvedValue(task);
+      mocks.taskRepo.update.mockResolvedValue({ affected: 1 });
+      mocks.projectRepo.findOneBy.mockResolvedValue({
+        id: "project-1",
+        repoPath: "/remote/repo",
+        sshHost: "remote-host",
+      });
+
+      const { moveTaskToColumn } = await import("@/desktop/main/services/kanbanService");
+
+      // When
+      await moveTaskToColumn(
+        "task-done-move-preserve-resources",
+        "done" as never,
+        ["task-a", "task-done-move-preserve-resources"],
+      );
+      await vi.runAllTimersAsync();
+
+      // Then
+      expect(mocks.detachSession).not.toHaveBeenCalled();
+      expect(mocks.removeSessionOnly).not.toHaveBeenCalled();
+      expect(mocks.removeWorktreeAndBranch).not.toHaveBeenCalled();
+      expect(mocks.taskRepo.update).toHaveBeenCalledWith("task-done-move-preserve-resources", {
+        status: "done",
+        sessionType: "tmux",
+        sessionName: "repo-feature-move-preserve-resources",
+        worktreePath: "/remote/repo__worktrees/feature-move-preserve-resources",
+      });
+      expect(mocks.taskRepo.update).not.toHaveBeenCalledWith("task-done-move-preserve-resources", {
+        sessionType: null,
+        sessionName: null,
+        worktreePath: null,
+      });
+      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("Done 컬럼 이동 중 순서 저장이 실패하면 이전 상태와 리소스 필드로 롤백한다", async () => {
     // Given
     const task = {
@@ -1327,12 +1339,7 @@ describe("kanbanService.createTask", () => {
       worktreePath: "/remote/repo__worktrees/fix-done",
       sshHost: "remote-host",
     };
-    mocks.taskRepo.findOneBy
-      .mockResolvedValueOnce(task)
-      .mockResolvedValueOnce({
-        ...task,
-        status: "done",
-      });
+    mocks.taskRepo.findOneBy.mockResolvedValue(task);
     mocks.taskRepo.update.mockImplementation(async (id, updates) => {
       if (id === "task-a" && "displayOrder" in updates) {
         throw new Error("display order failed");
@@ -1360,166 +1367,6 @@ describe("kanbanService.createTask", () => {
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
 
     consoleErrorSpy.mockRestore();
-  });
-
-  it("백그라운드 Done 정리가 실패하면 이전 상태와 리소스 필드로 롤백한다", async () => {
-    vi.useFakeTimers();
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    try {
-      // Given
-      const task = {
-        id: "task-done",
-        title: "Remote cleanup",
-        description: null,
-        status: "review",
-        branchName: null,
-        projectId: null,
-        sessionType: "tmux" as never,
-        sessionName: "repo-fix-done",
-        worktreePath: "/remote/repo__worktrees/fix-done",
-        sshHost: "remote-host",
-      };
-      mocks.taskRepo.findOneBy
-        .mockResolvedValueOnce(task)
-        .mockResolvedValueOnce({
-          ...task,
-          status: "done",
-        });
-      mocks.taskRepo.save.mockImplementation(async (value) => value);
-      mocks.taskRepo.update.mockResolvedValue({ affected: 1 });
-      mocks.removeSessionOnly.mockRejectedValueOnce(new Error("ssh failed"));
-
-      const { updateTaskStatus } = await import("@/desktop/main/services/kanbanService");
-
-      // When
-      await updateTaskStatus("task-done", "done" as never);
-      await vi.runAllTimersAsync();
-
-      // Then
-      expect(mocks.taskRepo.update).toHaveBeenCalledWith("task-done", {
-        status: "review",
-        sessionType: "tmux",
-        sessionName: "repo-fix-done",
-        worktreePath: "/remote/repo__worktrees/fix-done",
-        sshHost: "remote-host",
-      });
-      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(2);
-      expect(consoleErrorSpy).toHaveBeenCalled();
-    } finally {
-      mocks.taskRepo.findOneBy.mockReset();
-      mocks.removeSessionOnly.mockReset();
-      consoleErrorSpy.mockRestore();
-      vi.clearAllTimers();
-      vi.useRealTimers();
-    }
-  });
-
-  it("오래된 Done 정리 실패는 새로 연결된 리소스를 롤백하지 않는다", async () => {
-    vi.useFakeTimers();
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    try {
-      // Given
-      const task = {
-        id: "task-stale-cleanup-failure",
-        title: "Remote cleanup",
-        description: null,
-        status: "review",
-        branchName: null,
-        projectId: null,
-        sessionType: "tmux" as never,
-        sessionName: "repo-old-done",
-        worktreePath: "/remote/repo__worktrees/old-done",
-        sshHost: "remote-host",
-      };
-      mocks.taskRepo.findOneBy
-        .mockResolvedValueOnce(task)
-        .mockResolvedValueOnce({
-          ...task,
-          status: "done",
-          branchName: "feature/new-done",
-          projectId: "project-new",
-          sessionName: "repo-new-done",
-          worktreePath: "/remote/repo__worktrees/new-done",
-          sshHost: "remote-new",
-        });
-      mocks.taskRepo.save.mockImplementation(async (value) => value);
-      mocks.taskRepo.update.mockResolvedValue({ affected: 1 });
-      mocks.removeSessionOnly.mockRejectedValueOnce(new Error("ssh failed"));
-
-      const { updateTaskStatus } = await import("@/desktop/main/services/kanbanService");
-
-      // When
-      await updateTaskStatus("task-stale-cleanup-failure", "done" as never);
-      await vi.runAllTimersAsync();
-
-      // Then
-      expect(mocks.taskRepo.update).not.toHaveBeenCalledWith("task-stale-cleanup-failure", {
-        status: "review",
-        sessionType: "tmux",
-        sessionName: "repo-old-done",
-        worktreePath: "/remote/repo__worktrees/old-done",
-        sshHost: "remote-host",
-      });
-      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
-      expect(consoleErrorSpy).toHaveBeenCalled();
-    } finally {
-      mocks.taskRepo.findOneBy.mockReset();
-      mocks.removeSessionOnly.mockReset();
-      consoleErrorSpy.mockRestore();
-      vi.clearAllTimers();
-      vi.useRealTimers();
-    }
-  });
-
-
-  it("Done 전환 백그라운드 정리도 DB worktreePath 없이 프로젝트와 브랜치 기준 공통 삭제 정책을 사용한다", async () => {
-    vi.useFakeTimers();
-
-    try {
-      // Given
-      const task = {
-        id: "task-done-no-db-worktree-path",
-        title: "Done cleanup",
-        description: null,
-        status: "review",
-        branchName: "feature/actual-worktree",
-        projectId: "project-1",
-        sessionType: null,
-        sessionName: null,
-        worktreePath: null,
-        sshHost: null,
-      };
-      mocks.taskRepo.findOneBy.mockResolvedValue(task);
-      mocks.projectRepo.findOneBy.mockResolvedValue({
-        id: "project-1",
-        repoPath: "/workspace/repo",
-        sshHost: "remote-host",
-      });
-      mocks.taskRepo.save.mockImplementation(async (value) => value);
-
-      const { updateTaskStatus } = await import("@/desktop/main/services/kanbanService");
-
-      // When
-      await updateTaskStatus("task-done-no-db-worktree-path", "done" as never);
-      await vi.runAllTimersAsync();
-
-      // Then
-      expect(mocks.removeWorktreeAndBranch).toHaveBeenCalledWith(
-        "/workspace/repo",
-        "feature/actual-worktree",
-        "remote-host",
-        { throwOnError: true, worktreePath: null },
-      );
-      expect(mocks.taskRepo.update).not.toHaveBeenCalledWith(
-        "task-done-no-db-worktree-path",
-        expect.objectContaining({ status: "review" }),
-      );
-    } finally {
-      vi.clearAllTimers();
-      vi.useRealTimers();
-    }
   });
 
   it("PR URL 조회는 셸 없이 gh CLI를 직접 실행한다", async () => {

--- a/src/desktop/main/services/hookService.ts
+++ b/src/desktop/main/services/hookService.ts
@@ -2,12 +2,7 @@ import { TaskStatus, SessionType } from "@/entities/KanbanTask";
 import { getProjectRepository, getTaskRepository } from "@/lib/database";
 import { createWorktreeWithSession } from "@/lib/worktree";
 import { broadcastBoardUpdate, broadcastHookStatusTargetMissing, broadcastTaskStatusChanged } from "@/lib/boardNotifier";
-import {
-  installTaskHooksImmediately,
-  prepareOptimisticDoneTransition,
-  scheduleDoneCleanupWithRollback,
-  type DoneCleanupPlan,
-} from "@/desktop/main/services/kanbanService";
+import { installTaskHooksImmediately } from "@/desktop/main/services/kanbanService";
 import { persistTaskStateAtPath as persistHookTaskState } from "@/desktop/main/services/kanvibeTaskStateService";
 
 const STATUS_MAP: Record<string, TaskStatus> = {
@@ -143,13 +138,7 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
   const projectName = task.project?.name || task.projectId || "Unknown project";
   const taskStatePath = task.worktreePath || task.project?.repoPath || null;
   const taskStateSshHost = task.sshHost || task.project?.sshHost || null;
-  let doneCleanupPlan: DoneCleanupPlan | null = null;
-
-  if (taskStatus === TaskStatus.DONE) {
-    doneCleanupPlan = prepareOptimisticDoneTransition(task, { clearSshHost: true });
-  } else {
-    task.status = taskStatus;
-  }
+  task.status = taskStatus;
 
   const saved = await taskRepo.save(task);
 
@@ -166,10 +155,6 @@ export async function updateHookTaskStatus(input: HookStatusInput) {
     newStatus: taskStatus,
     taskId: saved.id,
   });
-
-  if (doneCleanupPlan) {
-    scheduleDoneCleanupWithRollback(doneCleanupPlan);
-  }
 
   return {
     success: true,

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -63,24 +63,6 @@ interface CleanupTaskResourcesOptions {
 
 const TASK_RESOURCE_DELETE_CLEANUP_OPTIONS = { throwOnError: true } as const;
 
-type TaskRepository = Awaited<ReturnType<typeof getTaskRepository>>;
-
-interface DoneRollbackSnapshot {
-  id: string;
-  status: TaskStatus;
-  sessionType: SessionType | null;
-  sessionName: string | null;
-  worktreePath: string | null;
-  sshHost: string | null;
-  projectId: string | null;
-  branchName: string | null;
-}
-
-export interface DoneCleanupPlan {
-  cleanupTask: KanbanTask;
-  rollbackSnapshot: DoneRollbackSnapshot;
-}
-
 interface GitHubPullRequestInfo {
   url: string | null;
   state: string | null;
@@ -243,110 +225,6 @@ function reportTaskHookInstallFailure(
     taskTitle: task.title,
     error: errorMessage,
   });
-}
-
-export function prepareOptimisticDoneTransition(
-  task: KanbanTask,
-  options: { clearSshHost?: boolean } = {},
-): DoneCleanupPlan {
-  const cleanupTask = { ...task } as KanbanTask;
-  const rollbackSnapshot: DoneRollbackSnapshot = {
-    id: task.id,
-    status: task.status,
-    sessionType: task.sessionType,
-    sessionName: task.sessionName,
-    worktreePath: task.worktreePath,
-    sshHost: task.sshHost,
-    projectId: task.projectId,
-    branchName: task.branchName,
-  };
-
-  task.status = TaskStatus.DONE;
-
-  if (options.clearSshHost) {
-    task.sshHost = null;
-  }
-
-  return { cleanupTask, rollbackSnapshot };
-}
-
-export function scheduleDoneCleanupWithRollback(plan: DoneCleanupPlan): void {
-  setTimeout(() => {
-    void deleteTaskResources(plan.cleanupTask)
-      .then(() => clearDoneCleanupResources(plan.rollbackSnapshot))
-      .catch((error) => rollbackDoneTransition(plan.rollbackSnapshot, error));
-  }, 0);
-}
-
-function matchesDoneCleanupSnapshot(
-  current: KanbanTask,
-  snapshot: DoneRollbackSnapshot,
-): boolean {
-  return current.sessionType === snapshot.sessionType
-    && current.sessionName === snapshot.sessionName
-    && current.worktreePath === snapshot.worktreePath
-    && current.sshHost === snapshot.sshHost
-    && current.projectId === snapshot.projectId
-    && current.branchName === snapshot.branchName;
-}
-
-async function getDoneCleanupRepositoryForCurrentSnapshot(
-  snapshot: DoneRollbackSnapshot,
-): Promise<TaskRepository | null> {
-  const repo = await getTaskRepository();
-  const current = await repo.findOneBy({ id: snapshot.id });
-  if (
-    !current
-    || current.status !== TaskStatus.DONE
-    || !matchesDoneCleanupSnapshot(current, snapshot)
-  ) {
-    return null;
-  }
-
-  return repo;
-}
-
-async function clearDoneCleanupResources(snapshot: DoneRollbackSnapshot): Promise<void> {
-  const repo = await getDoneCleanupRepositoryForCurrentSnapshot(snapshot);
-  if (!repo) {
-    return;
-  }
-
-  await repo.update(snapshot.id, {
-    sessionType: null,
-    sessionName: null,
-    worktreePath: null,
-  });
-  broadcastBoardUpdate();
-}
-
-async function rollbackDoneTransition(
-  snapshot: DoneRollbackSnapshot,
-  cleanupError: unknown,
-): Promise<void> {
-  console.error("Done 리소스 백그라운드 정리 실패, 상태를 롤백합니다:", {
-    taskId: snapshot.id,
-    error: getErrorMessage(cleanupError),
-  });
-
-  try {
-    const repo = await getDoneCleanupRepositoryForCurrentSnapshot(snapshot);
-    if (!repo) {
-      return;
-    }
-
-    await repo.update(snapshot.id, {
-      status: snapshot.status,
-      sessionType: snapshot.sessionType,
-      sessionName: snapshot.sessionName,
-      worktreePath: snapshot.worktreePath,
-      sshHost: snapshot.sshHost,
-    });
-    await persistTaskState(snapshot);
-    broadcastBoardUpdate();
-  } catch (rollbackError) {
-    console.error("Done 상태 롤백 실패:", rollbackError);
-  }
 }
 
 async function getPrUrlFromGitHubCli(branchName: string, cwd: string, sshHost?: string | null): Promise<string | null> {
@@ -714,15 +592,6 @@ export async function updateTaskStatus(
   const task = await repo.findOneBy({ id: taskId });
   if (!task) return null;
 
-  if (newStatus === TaskStatus.DONE) {
-    const doneCleanupPlan = prepareOptimisticDoneTransition(task);
-    const saved = await repo.save(task);
-    await persistTaskState({ ...doneCleanupPlan.cleanupTask, status: TaskStatus.DONE });
-    broadcastBoardUpdate();
-    scheduleDoneCleanupWithRollback(doneCleanupPlan);
-    return serialize(saved);
-  }
-
   task.status = newStatus;
   const saved = await repo.save(task);
   await persistTaskState(saved);
@@ -879,7 +748,7 @@ async function cleanupTaskResources(
   }
 }
 
-/** task 삭제/Done 전환에서 사용하는 공통 리소스 삭제 정책 */
+/** task 삭제 액션에서 사용하는 리소스 삭제 정책 */
 async function deleteTaskResources(task: KanbanTask): Promise<void> {
   await cleanupTaskResources(task, TASK_RESOURCE_DELETE_CLEANUP_OPTIONS);
 }
@@ -1022,26 +891,24 @@ export async function moveTaskToColumn(
   destOrderedIds: string[]
 ): Promise<void> {
   const repo = await getTaskRepository();
-  let doneCleanupPlan: DoneCleanupPlan | null = null;
+  const task = await repo.findOneBy({ id: taskId });
 
   try {
-    const task = await repo.findOneBy({ id: taskId });
     if (newStatus === TaskStatus.DONE) {
       if (task) {
-        doneCleanupPlan = prepareOptimisticDoneTransition(task);
         await repo.update(taskId, {
           status: newStatus,
           sessionType: task.sessionType,
           sessionName: task.sessionName,
           worktreePath: task.worktreePath,
         });
-        await persistTaskState({ ...doneCleanupPlan.cleanupTask, status: TaskStatus.DONE });
       }
     } else {
       await repo.update(taskId, { status: newStatus });
-      if (task) {
-        await persistTaskState({ ...task, status: newStatus });
-      }
+    }
+
+    if (task) {
+      await persistTaskState({ ...task, status: newStatus });
     }
 
     const reorderUpdates = destOrderedIds.map((id, index) =>
@@ -1051,14 +918,18 @@ export async function moveTaskToColumn(
     await Promise.all(reorderUpdates);
     broadcastBoardUpdate();
   } catch (error) {
-    if (doneCleanupPlan) {
-      await rollbackDoneTransition(doneCleanupPlan.rollbackSnapshot, error);
+    if (newStatus === TaskStatus.DONE && task) {
+      await repo.update(taskId, {
+        status: task.status,
+        sessionType: task.sessionType,
+        sessionName: task.sessionName,
+        worktreePath: task.worktreePath,
+        sshHost: task.sshHost,
+      });
+      await persistTaskState(task);
+      broadcastBoardUpdate();
     }
     throw error;
-  }
-
-  if (doneCleanupPlan) {
-    scheduleDoneCleanupWithRollback(doneCleanupPlan);
   }
 }
 

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -766,6 +766,40 @@ export async function deleteTask(taskId: string): Promise<boolean> {
   return true;
 }
 
+/** 여러 작업을 삭제한다. worktree와 세션이 있으면 함께 정리하고 board update는 한 번만 보낸다 */
+export async function deleteTasks(taskIds: string[]): Promise<string[]> {
+  const uniqueTaskIds = [...new Set(taskIds)];
+  if (uniqueTaskIds.length === 0) {
+    return [];
+  }
+
+  const repo = await getTaskRepository();
+  const tasks = await repo.find({
+    where: { id: In(uniqueTaskIds) },
+  });
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  const deletedTaskIds: string[] = [];
+
+  try {
+    for (const taskId of uniqueTaskIds) {
+      const task = taskById.get(taskId);
+      if (!task) {
+        continue;
+      }
+
+      await deleteTaskResources(task);
+      await repo.remove(task);
+      deletedTaskIds.push(task.id);
+    }
+  } finally {
+    if (deletedTaskIds.length > 0) {
+      broadcastBoardUpdate();
+    }
+  }
+
+  return deletedTaskIds;
+}
+
 /**
  * 기존 작업에서 브랜치를 분기한다.
  * worktree + 세션을 생성하고 상태를 progress로 변경한다.

--- a/src/desktop/renderer/__tests__/App.test.tsx
+++ b/src/desktop/renderer/__tests__/App.test.tsx
@@ -1,14 +1,17 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "@/desktop/renderer/App";
 import type { AppNotification } from "@/desktop/shared/notifications";
 
 const mocks = vi.hoisted(() => ({
   triggerDesktopRefresh: vi.fn(),
+  updateTaskStatus: vi.fn(),
+  deleteTasks: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/desktop/renderer/actions/kanban", () => ({
-  updateTaskStatus: vi.fn(),
+  updateTaskStatus: mocks.updateTaskStatus,
+  deleteTasks: mocks.deleteTasks,
 }));
 
 vi.mock("@/desktop/renderer/utils/refresh", () => ({
@@ -284,5 +287,12 @@ describe("App", () => {
     expect(screen.getByText("gh auth failed")).toBeTruthy();
     expect(window.kanvibeDesktop.consumePendingNotificationActivation).not.toHaveBeenCalled();
     expect(window.location.hash).toBe("#/en/task/task-1");
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(mocks.deleteTasks).toHaveBeenCalledWith(["task-1"]);
+    });
+    expect(mocks.updateTaskStatus).not.toHaveBeenCalled();
   });
 });

--- a/src/desktop/renderer/actions/kanban.ts
+++ b/src/desktop/renderer/actions/kanban.ts
@@ -48,6 +48,10 @@ export function deleteTask(taskId: string): Promise<boolean> {
   return invokeDesktop("kanban", "deleteTask", taskId);
 }
 
+export function deleteTasks(taskIds: string[]): Promise<string[]> {
+  return invokeDesktop("kanban", "deleteTasks", taskIds);
+}
+
 export function branchFromTask(
   taskId: string,
   projectId: string,

--- a/src/desktop/renderer/components/BackgroundSyncReviewDialog.tsx
+++ b/src/desktop/renderer/components/BackgroundSyncReviewDialog.tsx
@@ -2,9 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { useTranslations } from "next-intl";
-import { updateTaskStatus } from "@/desktop/renderer/actions/kanban";
+import { deleteTasks } from "@/desktop/renderer/actions/kanban";
 import type { AppNotification } from "@/desktop/shared/notifications";
-import { TaskStatus } from "@/entities/KanbanTask";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import type {
   BackgroundSyncFailurePayload,
@@ -46,7 +45,7 @@ export default function BackgroundSyncReviewDialog() {
   const tc = useTranslations("common");
   const tr = useTranslations("common.backgroundSyncReview");
   const tm = useTranslations("common.prMergeAlert");
-  const [isPrMergeActionPending, startPrMergeActionTransition] = useTransition();
+  const [isPrMergeDeletePending, startPrMergeDeleteTransition] = useTransition();
   const [backgroundSyncReview, setBackgroundSyncReview] = useState<BackgroundSyncReviewPayload | null>(null);
   const [selectedPrMergeEventKeys, setSelectedPrMergeEventKeys] = useState<string[]>([]);
 
@@ -96,7 +95,7 @@ export default function BackgroundSyncReviewDialog() {
   }, []);
 
   useEscapeKey(handlePrMergeCancel, {
-    enabled: Boolean(backgroundSyncReview) && !isPrMergeActionPending,
+    enabled: Boolean(backgroundSyncReview) && !isPrMergeDeletePending,
   });
 
   const handlePrMergeConfirm = useCallback(() => {
@@ -116,12 +115,10 @@ export default function BackgroundSyncReviewDialog() {
       return;
     }
 
-    startPrMergeActionTransition(async () => {
-      for (const taskId of selectedTaskIds) {
-        await updateTaskStatus(taskId, TaskStatus.DONE);
-      }
+    startPrMergeDeleteTransition(async () => {
+      await deleteTasks(selectedTaskIds);
     });
-  }, [backgroundSyncReview, selectedPrMergeEventKeys, startPrMergeActionTransition]);
+  }, [backgroundSyncReview, selectedPrMergeEventKeys, startPrMergeDeleteTransition]);
 
   if (!backgroundSyncReview) {
     return null;
@@ -129,6 +126,7 @@ export default function BackgroundSyncReviewDialog() {
 
   const pulledTasks = backgroundSyncReview.pulledTasks ?? [];
   const backgroundSyncFailures = backgroundSyncReview.failures ?? [];
+  const hasSelectedPrMergeTasks = selectedPrMergeEventKeys.length > 0;
 
   return (
     <div className="fixed inset-0 z-[520] flex items-center justify-center bg-bg-overlay">
@@ -294,7 +292,7 @@ export default function BackgroundSyncReviewDialog() {
           <button
             type="button"
             onClick={handlePrMergeCancel}
-            disabled={isPrMergeActionPending}
+            disabled={isPrMergeDeletePending}
             className="rounded-md border border-border-default bg-bg-page px-4 py-1.5 text-sm text-text-secondary transition-colors hover:border-brand-primary"
           >
             {tc("cancel")}
@@ -302,10 +300,10 @@ export default function BackgroundSyncReviewDialog() {
           <button
             type="button"
             onClick={handlePrMergeConfirm}
-            disabled={isPrMergeActionPending}
+            disabled={isPrMergeDeletePending}
             className="rounded-md bg-brand-primary px-4 py-1.5 text-sm text-text-inverse transition-colors hover:bg-brand-hover disabled:opacity-50"
           >
-            {tc("confirm")}
+            {tc(hasSelectedPrMergeTasks ? "delete" : "confirm")}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Remove automatic branch/worktree/tmux cleanup from Done status transitions so Done preserves task resources.
- Keep resource cleanup on explicit task deletion only.
- Change the background sync merged-PR review action from moving selected tasks to Done to deleting the selected tasks in bulk.
- Update the review dialog copy and translations to describe deletion instead of Done movement.

## Implementation
- `updateTaskStatus` / `moveTaskToColumn` preserve resource fields when moving to Done.
- `deleteTasks(taskIds)` deletes selected tasks through the same resource cleanup policy as explicit task deletion, while broadcasting one board update for the batch.
- `BackgroundSyncReviewDialog` calls `deleteTasks(...)` for checked merged PR items instead of `updateTaskStatus(..., TaskStatus.DONE)`.

## Test Plan
- [x] `npx -y node@24 node_modules/vitest/vitest.mjs run src/desktop/renderer/__tests__/App.test.tsx src/desktop/main/services/__tests__/kanbanService.test.ts src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts src/desktop/shared/__tests__/taskNotifications.test.ts src/desktop/main/services/__tests__/desktopNotificationService.test.ts src/desktop/renderer/components/__tests__/NotificationListener.test.tsx` — 73 tests passed
- [x] `npx -y node@24 node_modules/typescript/bin/tsc --noEmit`
- [x] `npx -y node@24 node_modules/eslint/bin/eslint.js` — 0 errors, existing 10 warnings
- [x] `npx -y node@24 node_modules/vitest/vitest.mjs run` — 93 files / 791 tests passed
- [x] `git diff --check`
