### PR TITLE
chore(release): publish KanVibe 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary
- Bump KanVibe desktop to 1.0.3 (`package.json` + `package-lock.json`).
- Headline change: the default **Done** behavior no longer deletes a task's branch/worktree/session; resource cleanup now runs only on explicit delete and merged-PR removal.

## Release
- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.0.3
- DMG asset: `dist/KanVibe-1.0.3.dmg` (signed + notarized: Accepted, stapled, validated)
- SHA-256: `f2e43184ebb4378d86150ca6ace5786e7882f5b7f9476653ffc9f4af6a352b14`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@main` commit `1d4d69e`

## Test Plan
- `pnpm run deploy` — built, codesigned, notarized (Accepted), stapled, validated on macOS.
- `gh release download 1.0.3` — asset SHA-256 matches the cask and local DMG exactly.
- `ruby -c Casks/kanvibe.rb` — Syntax OK; cask diff limited to `version` and `sha256`.
