### PR TITLE
feat: 보드 작업 유형(Project/Task/All) 필터 추가

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -68,6 +68,19 @@
     "title": "",
     "newTask": "+ New Task",
     "allProjects": "All Projects",
+    "taskKindFilter": {
+      "label": "Task type filter",
+      "options": {
+        "project": "Project",
+        "task": "Task",
+        "all": "All"
+      },
+      "descriptions": {
+        "project": "Show only project-root tasks",
+        "task": "Show tasks except project roots",
+        "all": "Show project roots and tasks"
+      }
+    },
     "pageFind": {
       "label": "Find on board",
       "placeholder": "Find visible text on this board...",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -68,6 +68,19 @@
     "title": "",
     "newTask": "+ 새 작업",
     "allProjects": "전체 프로젝트",
+    "taskKindFilter": {
+      "label": "작업 유형 필터",
+      "options": {
+        "project": "Project",
+        "task": "Task",
+        "all": "All"
+      },
+      "descriptions": {
+        "project": "프로젝트 root task만 보기",
+        "task": "프로젝트 root를 제외한 task만 보기",
+        "all": "프로젝트 root와 task 모두 보기"
+      }
+    },
     "pageFind": {
       "label": "보드에서 찾기",
       "placeholder": "이 보드에서 보이는 텍스트 찾기...",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -67,6 +67,19 @@
     "title": "",
     "newTask": "+ 新任务",
     "allProjects": "所有项目",
+    "taskKindFilter": {
+      "label": "任务类型筛选",
+      "options": {
+        "project": "Project",
+        "task": "Task",
+        "all": "All"
+      },
+      "descriptions": {
+        "project": "仅显示项目根任务",
+        "task": "仅显示项目根以外的任务",
+        "all": "显示项目根和任务"
+      }
+    },
     "pageFind": {
       "label": "在看板中查找",
       "placeholder": "查找当前看板中可见的文本...",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "qa:electron": "pnpm qa:electron:prepare && bash scripts/qa-electron.sh",
     "qa:electron:video": "pnpm qa:electron:prepare && bash scripts/qa-electron-video.sh",
     "qa:move-autocomplete": "pnpm exec vitest run src/components/__tests__/Board.test.tsx -t \"자동 완성\" && pnpm qa:electron:prepare && bash scripts/qa-move-autocomplete-video.sh",
+    "qa:task-kind-filter": "pnpm exec vitest run src/components/__tests__/Board.test.tsx src/desktop/renderer/hooks/__tests__/useTaskKindFilterParams.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-task-kind-filter-video.sh",
     "qa:ai-session-history": "pnpm exec vitest run src/lib/aiSessions && pnpm exec vitest run src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-ai-session-history-video.sh",
     "qa:pr275-pr276": "bash scripts/qa-pr275-pr276.sh",
     "test": "vitest run",

--- a/qa/electron/flows/task-kind-filter.cjs
+++ b/qa/electron/flows/task-kind-filter.cjs
@@ -1,0 +1,414 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+const { createQaRun } = require("../lib/report.cjs");
+const { launchKanVibeElectron } = require("../lib/launchElectron.cjs");
+
+const TASK_KIND_FILTER_SCOPE = "Project/Task/All task-kind filter UI: seed an isolated project-root task plus branch/plain tasks, then verify the Board filter buttons hide/show the expected cards in Electron";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--run-dir") args.runDir = argv[++index];
+    else if (arg === "--run-id") args.runId = argv[++index];
+    else if (arg === "--output-root") args.outputRoot = argv[++index];
+  }
+  return args;
+}
+
+function gitValue(args) {
+  try {
+    return execFileSync("git", args, { encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function execGit(args, cwd) {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function renderReport(result) {
+  const lines = [];
+  lines.push("# KanVibe Task Kind Filter Electron QA Report");
+  lines.push("");
+  lines.push(`- Run ID: \`${result.runId}\``);
+  lines.push(`- Branch: \`${result.branch || "unknown"}\``);
+  lines.push(`- Commit: \`${result.commit || "unknown"}\``);
+  lines.push(`- Scope: ${result.scope}`);
+  lines.push(`- Status: **${result.ok ? "PASS" : "FAIL"}**`);
+  lines.push("");
+  lines.push("## Checks");
+  lines.push("");
+  for (const check of result.checks) {
+    lines.push(`- ${check.ok ? "✅" : "❌"} **${check.name}**${check.detail ? ` — ${check.detail}` : ""}`);
+  }
+  lines.push("");
+  lines.push("## Console / Runtime Errors");
+  lines.push("");
+  if (result.errors.length > 0) {
+    for (const error of result.errors) lines.push(`- ${error}`);
+  } else {
+    lines.push("No blocking console/runtime errors captured.");
+  }
+  lines.push("");
+  lines.push("## Evidence");
+  lines.push("");
+  for (const shot of result.screenshots) {
+    lines.push(`- ${shot.label}: \`${shot.path}\``);
+  }
+  if (result.videoPath) lines.push(`- Video: \`${result.videoPath}\``);
+  if (result.tracePath) lines.push(`- Playwright trace: \`${result.tracePath}\``);
+  lines.push("");
+  lines.push("## Notes");
+  lines.push("");
+  for (const note of result.notes) lines.push(`- ${note}`);
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeReport(run, result) {
+  const fullResult = { ...result, runId: run.runId };
+  writeJson(run.jsonPath, fullResult);
+  fs.writeFileSync(run.reportPath, renderReport(fullResult), "utf8");
+}
+
+async function optionalStep(checks, name, fn) {
+  try {
+    const detail = await fn();
+    checks.push({ name, ok: true, detail: detail || "ok" });
+    return detail;
+  } catch (error) {
+    checks.push({ name, ok: false, detail: error instanceof Error ? error.message : String(error) });
+    return null;
+  }
+}
+
+async function takeScreenshot(page, run, label, screenshots) {
+  const fileName = `${String(screenshots.length + 1).padStart(2, "0")}-${label}.png`;
+  const shotPath = path.join(run.screenshotsDir, fileName);
+  await page.screenshot({ path: shotPath, fullPage: true });
+  screenshots.push({ label, path: shotPath });
+}
+
+async function invokeDesktop(page, namespace, method, ...args) {
+  return page.evaluate(
+    async ({ namespace: serviceNamespace, method: serviceMethod, args: serviceArgs }) => (
+      window.kanvibeDesktop.invoke(serviceNamespace, serviceMethod, serviceArgs)
+    ),
+    { namespace, method, args },
+  );
+}
+
+async function dismissUpdateDialogIfPresent(page) {
+  const closeButton = page.getByRole("button", { name: /닫기|Close/i }).first();
+  try {
+    await closeButton.click({ timeout: 2500 });
+    await page.waitForTimeout(500);
+  } catch {
+    // Optional release/update dialog is not always present.
+  }
+}
+
+function createLocalFixtureRepository(run) {
+  const projectDir = path.join(run.runDir, "fixtures", `task-kind-filter-${run.runId}`);
+  const projectName = `Task Kind Filter QA ${run.runId}`;
+  const defaultBranch = "main";
+  fs.rmSync(projectDir, { recursive: true, force: true });
+  ensureDir(projectDir);
+
+  try {
+    execGit(["init", "--initial-branch", defaultBranch], projectDir);
+  } catch {
+    execGit(["init"], projectDir);
+    execGit(["checkout", "-B", defaultBranch], projectDir);
+  }
+  execGit(["config", "user.email", "qa@kanvibe.local"], projectDir);
+  execGit(["config", "user.name", "KanVibe QA"], projectDir);
+  fs.writeFileSync(path.join(projectDir, "README.md"), `# ${projectName}\n`, "utf8");
+  execGit(["add", "README.md"], projectDir);
+  execGit(["commit", "-m", "Initial QA fixture"], projectDir);
+
+  return { projectDir, projectName, defaultBranch };
+}
+
+function cardSelector(taskId) {
+  return `[data-kanban-task-card='true'][data-kanban-task-id='${taskId}']`;
+}
+
+async function expectCardVisible(page, taskId, label) {
+  const card = page.locator(cardSelector(taskId));
+  await card.waitFor({ state: "visible", timeout: 15000 });
+  await card.scrollIntoViewIfNeeded();
+  return `${label}:${taskId}`;
+}
+
+async function expectCardHidden(page, taskId, label) {
+  await page.waitForFunction(
+    (id) => !document.querySelector(`[data-kanban-task-card='true'][data-kanban-task-id='${id}']`),
+    taskId,
+    { timeout: 15000 },
+  );
+  return `${label}:${taskId}`;
+}
+
+async function expectVisibleAndHidden(page, visible, hidden) {
+  const visibleDetails = [];
+  for (const item of visible) {
+    visibleDetails.push(await expectCardVisible(page, item.id, item.label));
+  }
+  const hiddenDetails = [];
+  for (const item of hidden) {
+    hiddenDetails.push(await expectCardHidden(page, item.id, item.label));
+  }
+  return `visible=[${visibleDetails.join(", ")}], hidden=[${hiddenDetails.join(", ")}]`;
+}
+
+async function clickTaskKindFilter(page, name) {
+  await page.getByTestId("task-kind-filter").getByRole("button", { name }).click();
+  await page.waitForTimeout(900);
+}
+
+async function seedTaskKindFilterData(page, fixture, runId) {
+  const projectResult = await invokeDesktop(page, "project", "registerProject", fixture.projectName, fixture.projectDir);
+  if (!projectResult.success || !projectResult.project) {
+    throw new Error(projectResult.error || "QA project registration failed");
+  }
+
+  const project = projectResult.project;
+  const rootTaskId = await invokeDesktop(page, "kanban", "getTaskIdByProjectAndBranch", project.id, fixture.defaultBranch);
+  if (!rootTaskId) {
+    throw new Error("Project root task was not created for the fixture project");
+  }
+
+  const branchTask = await invokeDesktop(page, "kanban", "createTask", {
+    title: `qa-filter-branch-${runId}`,
+    description: "Electron QA branch task for the Project/Task/All filter.",
+    branchName: `qa/filter-${runId}`,
+    baseBranch: fixture.defaultBranch,
+    projectId: project.id,
+  });
+  const plainTask = await invokeDesktop(page, "kanban", "createTask", {
+    title: `qa-filter-plain-${runId}`,
+    description: "Electron QA plain task for the Project/Task/All filter.",
+    projectId: project.id,
+  });
+
+  await page.evaluate(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    window.location.hash = "#/ko";
+  });
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await dismissUpdateDialogIfPresent(page);
+
+  return {
+    project,
+    rootTask: { id: rootTaskId, label: "project-root" },
+    branchTask: { id: branchTask.id, label: "branch-task" },
+    plainTask: { id: plainTask.id, label: "plain-task" },
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv);
+  const run = createQaRun({ ...options, rootDir: process.cwd() });
+  const fixture = createLocalFixtureRepository(run);
+  const checks = [];
+  const screenshots = [];
+  const consoleErrors = [];
+  const notes = [];
+  let app = null;
+  let page = null;
+  let traceStarted = false;
+
+  try {
+    const launched = await launchKanVibeElectron({
+      rootDir: run.rootDir,
+      outputDir: run.runDir,
+      appDataDir: path.join(run.runDir, "app-data"),
+      viewport: { width: 1500, height: 950 },
+      actionTimeoutMs: 15000,
+    });
+    app = launched.app;
+    page = launched.page;
+
+    page.on("console", (message) => {
+      if (["error", "warning"].includes(message.type())) {
+        consoleErrors.push(`${message.type()}: ${message.text()}`);
+      }
+    });
+    page.on("pageerror", (error) => consoleErrors.push(`pageerror: ${error.message}`));
+    page.on("requestfailed", (request) => {
+      const failure = request.failure();
+      consoleErrors.push(`requestfailed: ${request.url()} ${failure?.errorText || "unknown"}`);
+    });
+
+    await page.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
+    traceStarted = true;
+
+    await optionalStep(checks, "Electron window opens on the KanVibe board", async () => {
+      await page.waitForLoadState("domcontentloaded");
+      await page.locator("body").waitFor({ state: "visible", timeout: 20000 });
+      await dismissUpdateDialogIfPresent(page);
+      return page.url();
+    });
+
+    let seeded = null;
+    await optionalStep(checks, "Seed isolated project-root, branch, and plain tasks through app IPC", async () => {
+      seeded = await seedTaskKindFilterData(page, fixture, run.runId);
+      return `project=${seeded.project.name}, root=${seeded.rootTask.id}, branch=${seeded.branchTask.id}, plain=${seeded.plainTask.id}`;
+    });
+    if (!seeded) throw new Error("QA seed failed; cannot continue task-kind filter flow");
+
+    await optionalStep(checks, "Task kind filter is left of the project selector with matching control sizing", async () => {
+      await page.getByTestId("task-kind-filter").waitFor({ state: "visible", timeout: 15000 });
+      await page.getByTestId("project-filter-control").waitFor({ state: "visible", timeout: 15000 });
+      const metrics = await page.evaluate(() => {
+        const filter = document.querySelector("[data-testid='task-kind-filter']");
+        const project = document.querySelector("[data-testid='project-filter-control']");
+        if (!filter || !project) return null;
+        const filterRect = filter.getBoundingClientRect();
+        const projectRect = project.getBoundingClientRect();
+        return {
+          filterLeft: filterRect.left,
+          filterRight: filterRect.right,
+          filterWidth: filterRect.width,
+          filterHeight: filterRect.height,
+          projectLeft: projectRect.left,
+          projectHeight: projectRect.height,
+          filterClassName: filter.className,
+        };
+      });
+      if (!metrics) throw new Error("filter/project selector controls were not found");
+      if (metrics.filterRight > metrics.projectLeft) {
+        throw new Error(`task-kind filter is not left of project selector: filterRight=${metrics.filterRight}, projectLeft=${metrics.projectLeft}`);
+      }
+      if (Math.abs(metrics.filterHeight - metrics.projectHeight) > 2) {
+        throw new Error(`control heights differ: filter=${metrics.filterHeight}, project=${metrics.projectHeight}`);
+      }
+      if (Math.abs(metrics.filterWidth - 180) > 2 || Math.abs(metrics.filterHeight - 34) > 2) {
+        throw new Error(`unexpected task-kind filter size: ${metrics.filterWidth}x${metrics.filterHeight}`);
+      }
+      if (!String(metrics.filterClassName).includes("bg-bg-page")) {
+        throw new Error(`task-kind filter is missing bg-bg-page styling: ${metrics.filterClassName}`);
+      }
+      return `filter=${Math.round(metrics.filterWidth)}x${Math.round(metrics.filterHeight)} left of project selector (${Math.round(metrics.filterRight)} <= ${Math.round(metrics.projectLeft)})`;
+    });
+
+    await optionalStep(checks, "All filter shows project root, branch task, and plain task", async () => {
+      await clickTaskKindFilter(page, "All");
+      const detail = await expectVisibleAndHidden(
+        page,
+        [seeded.rootTask, seeded.branchTask, seeded.plainTask],
+        [],
+      );
+      await takeScreenshot(page, run, "all-filter-shows-root-branch-plain", screenshots);
+      return detail;
+    });
+
+    await optionalStep(checks, "Project filter shows only the project-root task", async () => {
+      await clickTaskKindFilter(page, "Project");
+      const detail = await expectVisibleAndHidden(
+        page,
+        [seeded.rootTask],
+        [seeded.branchTask, seeded.plainTask],
+      );
+      await takeScreenshot(page, run, "project-filter-shows-root-only", screenshots);
+      return detail;
+    });
+
+    await optionalStep(checks, "Task filter hides project root and shows branch/plain tasks", async () => {
+      await clickTaskKindFilter(page, "Task");
+      const detail = await expectVisibleAndHidden(
+        page,
+        [seeded.branchTask, seeded.plainTask],
+        [seeded.rootTask],
+      );
+      await takeScreenshot(page, run, "task-filter-hides-root", screenshots);
+      return detail;
+    });
+
+    await optionalStep(checks, "Filter buttons keep their pressed state visible", async () => {
+      const taskPressed = await page.getByTestId("task-kind-filter").getByRole("button", { name: "Task" }).getAttribute("aria-pressed");
+      await clickTaskKindFilter(page, "All");
+      const allPressed = await page.getByTestId("task-kind-filter").getByRole("button", { name: "All" }).getAttribute("aria-pressed");
+      if (taskPressed !== "true" || allPressed !== "true") {
+        throw new Error(`unexpected pressed states: Task=${taskPressed}, All=${allPressed}`);
+      }
+      await takeScreenshot(page, run, "all-filter-restored", screenshots);
+      return "Task and All buttons expose aria-pressed=true when active";
+    });
+
+    await optionalStep(checks, "No blocking console errors", async () => {
+      const blocking = consoleErrors.filter((line) => !/favicon|DevTools|Electron Security Warning|Insecure Content-Security-Policy/i.test(line));
+      if (blocking.length > 0) throw new Error(blocking.join("\n"));
+      return "none";
+    });
+  } catch (error) {
+    checks.push({ name: "Electron task-kind filter QA flow", ok: false, detail: error instanceof Error ? error.stack || error.message : String(error) });
+  } finally {
+    if (page && traceStarted) {
+      await page.context().tracing.stop({ path: run.tracePath }).catch((error) => {
+        checks.push({ name: "Playwright trace artifact", ok: false, detail: error instanceof Error ? error.message : String(error) });
+      });
+    }
+    if (app) await app.close().catch(() => {});
+  }
+
+  await optionalStep(checks, "Playwright trace artifact written", async () => {
+    if (!fs.existsSync(run.tracePath) || fs.statSync(run.tracePath).size === 0) {
+      throw new Error(`trace missing or empty: ${run.tracePath}`);
+    }
+    return run.tracePath;
+  });
+
+  await optionalStep(checks, "Isolated app-data database written inside run directory", async () => {
+    const isolatedDatabasePath = path.join(run.runDir, "app-data", "kanvibe.db");
+    if (!fs.existsSync(isolatedDatabasePath) || fs.statSync(isolatedDatabasePath).size === 0) {
+      throw new Error(`isolated QA database missing or empty: ${isolatedDatabasePath}`);
+    }
+    return isolatedDatabasePath;
+  });
+
+  const ok = checks.every((check) => check.ok);
+  const videoExists = fs.existsSync(run.videoPath) && fs.statSync(run.videoPath).size > 0;
+  notes.push(`Fixture project: ${fixture.projectName} / ${fixture.projectDir}`);
+  notes.push("QA uses an isolated KANVIBE_APP_DATA_DIR inside the run directory, not the user's app database.");
+  notes.push(videoExists ? "Actual X11 screen recording captured with ffmpeg." : "No mp4 was present when flow finished; wrapper script can synthesize one from screenshots.");
+  notes.push(`Node: ${process.version}; platform: ${process.platform}/${process.arch}; tmp: ${os.tmpdir()}`);
+
+  const result = {
+    ok,
+    scope: TASK_KIND_FILTER_SCOPE,
+    branch: gitValue(["branch", "--show-current"]),
+    commit: gitValue(["rev-parse", "--short", "HEAD"]),
+    checks,
+    errors: consoleErrors,
+    screenshots,
+    videoPath: videoExists ? run.videoPath : null,
+    tracePath: fs.existsSync(run.tracePath) ? run.tracePath : null,
+    notes,
+  };
+
+  writeReport(run, result);
+  console.log(JSON.stringify({ ok, runDir: run.runDir, reportPath: run.reportPath, videoPath: run.videoPath }, null, 2));
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/qa-task-kind-filter-video.sh
+++ b/scripts/qa-task-kind-filter-video.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN_ID="${KANVIBE_QA_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+RUN_DIR="${KANVIBE_QA_RUN_DIR:-$ROOT_DIR/qa-output/$RUN_ID}"
+VIDEO_PATH="$RUN_DIR/run.mp4"
+LOG_PATH="$RUN_DIR/ffmpeg.log"
+NODE_BIN="${KANVIBE_QA_NODE_BIN:-${npm_node_execpath:-node}}"
+mkdir -p "$RUN_DIR"
+
+run_flow() {
+  "$NODE_BIN" qa/electron/flows/task-kind-filter.cjs --run-dir "$RUN_DIR" --run-id "$RUN_ID"
+}
+
+record_and_run() {
+  local ffmpeg_pid=""
+  if command -v ffmpeg >/dev/null 2>&1 && [[ -n "${DISPLAY:-}" ]]; then
+    ffmpeg -y \
+      -video_size "${KANVIBE_QA_VIDEO_SIZE:-1600x1000}" \
+      -framerate "${KANVIBE_QA_FRAMERATE:-15}" \
+      -f x11grab \
+      -i "${DISPLAY}" \
+      -pix_fmt yuv420p \
+      "$VIDEO_PATH" >"$LOG_PATH" 2>&1 &
+    ffmpeg_pid="$!"
+    sleep 1
+  fi
+
+  set +e
+  run_flow
+  local flow_status="$?"
+  set -e
+
+  if [[ -n "$ffmpeg_pid" ]]; then
+    kill -INT "$ffmpeg_pid" >/dev/null 2>&1 || true
+    wait "$ffmpeg_pid" >/dev/null 2>&1 || true
+  fi
+
+  if [[ ! -s "$VIDEO_PATH" ]] && command -v ffmpeg >/dev/null 2>&1; then
+    local first_shot
+    first_shot="$(find "$RUN_DIR/screenshots" -type f -name '*.png' | sort | head -n 1 || true)"
+    if [[ -n "$first_shot" ]]; then
+      ffmpeg -y -loop 1 -i "$first_shot" -t 5 -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" -pix_fmt yuv420p "$VIDEO_PATH" >>"$LOG_PATH" 2>&1 || true
+    fi
+  fi
+
+  exit "$flow_status"
+}
+
+cd "$ROOT_DIR"
+
+if [[ -z "${DISPLAY:-}" && -z "${WAYLAND_DISPLAY:-}" ]]; then
+  if ! command -v xvfb-run >/dev/null 2>&1; then
+    echo "[kanvibe-qa] xvfb-run is required for headless Electron QA. Install xvfb or run under a desktop DISPLAY." >&2
+    exit 127
+  fi
+  xvfb-run -a -s "-screen 0 ${KANVIBE_QA_VIDEO_SIZE:-1600x1000}x24" bash -lc "DISPLAY=\$DISPLAY KANVIBE_QA_RUN_ID='$RUN_ID' KANVIBE_QA_RUN_DIR='$RUN_DIR' KANVIBE_QA_NODE_BIN='$NODE_BIN' '$0' --inside-xvfb"
+  exit "$?"
+fi
+
+record_and_run

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -20,6 +20,11 @@ import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask"
 import type { Project } from "@/entities/Project";
 import { useAutoRefresh } from "@/desktop/renderer/hooks/useAutoRefresh";
 import { useProjectFilterParams } from "@/desktop/renderer/hooks/useProjectFilterParams";
+import {
+  TASK_KIND_FILTER_VALUES,
+  useTaskKindFilterParams,
+  type TaskKindFilter,
+} from "@/desktop/renderer/hooks/useTaskKindFilterParams";
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from "@/desktop/renderer/utils/locales";
 import { computeProjectColor } from "@/lib/projectColor";
 import type { NotificationCenterButtonHandle } from "./NotificationCenterButton";
@@ -65,6 +70,8 @@ const VIM_NEW_TASK_KEY = "n";
 const VIM_COMMAND_KEY = ":";
 const TASK_DELETE_SEQUENCE_KEY = "d";
 const TASK_DELETE_SEQUENCE_TIMEOUT_MS = 1_000;
+
+type BoardTaskFilter = (task: KanbanTask) => boolean;
 
 const VIM_MOVE_COMMAND_ALIASES = new Set(["move", "m"]);
 const VIM_MOVE_STATUSES = [
@@ -361,6 +368,28 @@ function extractMainRepoPath(repoPath: string): string | null {
   return repoPath.slice(0, worktreeIndex);
 }
 
+function isProjectRootTask(task: KanbanTask, projectLookup: Map<string, Project>): boolean {
+  if (!task.projectId || !task.branchName) return false;
+
+  const project = projectLookup.get(task.projectId);
+  return Boolean(project && !project.isWorktree && task.branchName === project.defaultBranch);
+}
+
+function matchesTaskKindFilter(
+  task: KanbanTask,
+  taskKindFilter: TaskKindFilter,
+  projectLookup: Map<string, Project>,
+): boolean {
+  if (taskKindFilter === "all") return true;
+
+  const isRootTask = isProjectRootTask(task, projectLookup);
+  return taskKindFilter === "project" ? isRootTask : !isRootTask;
+}
+
+function matchesProjectFilter(task: KanbanTask, projectFilterSet: Set<string> | null): boolean {
+  return !projectFilterSet || Boolean(task.projectId && projectFilterSet.has(task.projectId));
+}
+
 function openSettingsPage() {
   window.location.hash = `#/${getCurrentBoardLocale()}/settings`;
 }
@@ -374,16 +403,16 @@ function insertAtFilteredIndex(
   fullArray: KanbanTask[],
   task: KanbanTask,
   filteredIndex: number,
-  filterSet: Set<string> | null
+  taskFilter: BoardTaskFilter | null
 ): KanbanTask[] {
   const arr = [...fullArray];
 
-  if (!filterSet) {
+  if (!taskFilter) {
     arr.splice(filteredIndex, 0, task);
     return arr;
   }
 
-  const filtered = arr.filter((t) => t.projectId && filterSet.has(t.projectId));
+  const filtered = arr.filter(taskFilter);
 
   if (filteredIndex < filtered.length) {
     const targetTask = filtered[filteredIndex];
@@ -412,7 +441,7 @@ interface DragMovePlan {
 function buildDragMovePlan(
   currentTasks: TasksByStatus,
   result: DropResult,
-  projectFilterSet: Set<string> | null,
+  taskFilter: BoardTaskFilter | null,
 ): DragMovePlan | null {
   const { source, destination, draggableId } = result;
   if (!destination) return null;
@@ -432,14 +461,12 @@ function buildDragMovePlan(
       newSource,
       movedTask,
       destination.index,
-      projectFilterSet,
+      taskFilter,
     );
 
     const orderedIds = (
-      projectFilterSet
-        ? updated[sourceStatus].filter(
-            (task) => task.projectId && projectFilterSet.has(task.projectId),
-          )
+      taskFilter
+        ? updated[sourceStatus].filter(taskFilter)
         : updated[sourceStatus]
     ).map((task) => task.id);
 
@@ -461,14 +488,12 @@ function buildDragMovePlan(
     updated[destStatus],
     updatedTask,
     destination.index,
-    projectFilterSet,
+    taskFilter,
   );
 
   const orderedIds = (
-    projectFilterSet
-      ? updated[destStatus].filter(
-          (task) => task.projectId && projectFilterSet.has(task.projectId),
-        )
+    taskFilter
+      ? updated[destStatus].filter(taskFilter)
       : updated[destStatus]
   ).map((task) => task.id);
 
@@ -522,6 +547,7 @@ export default function Board({
   const [selectedProjectIds, setSelectedProjectIds] = useProjectFilterParams(
     projects.map((p) => p.id),
   );
+  const [taskKindFilter, setTaskKindFilter] = useTaskKindFilterParams();
   const [doneTotal, setDoneTotal] = useState(initialDoneTotal);
   const [doneOffset, setDoneOffset] = useState(initialDoneLimit);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -588,6 +614,11 @@ export default function Board({
     return colorMap;
   }, [projectNameMap, projects]);
 
+  const projectLookup = useMemo(
+    () => new Map(projects.map((project) => [project.id, project])),
+    [projects],
+  );
+
   /** 필터 드롭다운에 표시할 메인 프로젝트 목록 (worktree 제외) */
   const filterableProjects = useMemo(
     () => projects.filter((p) => !p.isWorktree),
@@ -615,9 +646,15 @@ export default function Board({
     return matchingIds.size > 0 ? matchingIds : null;
   }, [selectedProjectIds, projects]);
 
-  /** 프로젝트 필터가 적용된 태스크 목록 */
+  /** 프로젝트 + task kind 필터가 적용된 태스크 목록 */
+  const hasActiveBoardTaskFilter = projectFilterSet !== null || taskKindFilter !== "all";
+  const boardTaskFilter = useCallback<BoardTaskFilter>((task) => (
+    matchesProjectFilter(task, projectFilterSet)
+    && matchesTaskKindFilter(task, taskKindFilter, projectLookup)
+  ), [projectFilterSet, projectLookup, taskKindFilter]);
+
   const filteredTasks = useMemo(() => {
-    if (!projectFilterSet) return tasks;
+    if (!hasActiveBoardTaskFilter) return tasks;
 
     const filtered: TasksByStatus = {
       [TaskStatus.TODO]: [],
@@ -628,13 +665,11 @@ export default function Board({
     };
 
     for (const status of Object.values(TaskStatus)) {
-      filtered[status] = tasks[status].filter(
-        (task) => task.projectId && projectFilterSet.has(task.projectId)
-      );
+      filtered[status] = tasks[status].filter(boardTaskFilter);
     }
 
     return filtered;
-  }, [tasks, projectFilterSet]);
+  }, [boardTaskFilter, hasActiveBoardTaskFilter, tasks]);
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     isOpen: false,
@@ -917,7 +952,11 @@ export default function Board({
   /** 드래그 결과를 받아 state 업데이트 + DB 반영을 수행한다 */
   const executeDragMove = useCallback(
     (result: DropResult) => {
-      const plan = buildDragMovePlan(tasks, result, projectFilterSet);
+      const plan = buildDragMovePlan(
+        tasks,
+        result,
+        hasActiveBoardTaskFilter ? boardTaskFilter : null,
+      );
       if (!plan) return;
 
       setTasks(plan.updatedTasks);
@@ -943,7 +982,7 @@ export default function Board({
         );
       });
     },
-    [projectFilterSet, startDragPersistenceTransition, tasks]
+    [boardTaskFilter, hasActiveBoardTaskFilter, startDragPersistenceTransition, tasks]
   );
 
   const moveTaskToStatus = useCallback(
@@ -1102,7 +1141,33 @@ export default function Board({
       <BoardPageFindBar vimModeEnabled={vimModeEnabled} />
       <header className={headerClassName}>
         <div className="flex items-center gap-3 [-webkit-app-region:no-drag]">
-          <div className="w-64">
+          <div
+            role="group"
+            aria-label={t("taskKindFilter.label")}
+            className="flex h-[34px] w-[180px] shrink-0 items-stretch rounded-md border border-border-default bg-bg-page p-0.5"
+            data-testid="task-kind-filter"
+          >
+            {TASK_KIND_FILTER_VALUES.map((filter) => {
+              const isActive = taskKindFilter === filter;
+              return (
+                <button
+                  key={filter}
+                  type="button"
+                  aria-pressed={isActive}
+                  title={t(`taskKindFilter.descriptions.${filter}`)}
+                  onClick={() => setTaskKindFilter(filter)}
+                  className={`flex flex-1 items-center justify-center rounded text-sm font-medium transition-colors ${
+                    isActive
+                      ? "bg-brand-primary text-text-inverse shadow-sm"
+                      : "text-text-secondary hover:bg-bg-surface hover:text-text-primary"
+                  }`}
+                >
+                  {t(`taskKindFilter.options.${filter}`)}
+                </button>
+              );
+            })}
+          </div>
+          <div className="w-64" data-testid="project-filter-control">
             <ProjectSelector
               ref={projectSelectorRef}
               multiple

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -4,6 +4,7 @@ import { createEvent, fireEvent, render, screen, waitFor } from "@testing-librar
 import { MemoryRouter } from "react-router-dom";
 import Board from "../Board";
 import { deleteTask, moveTaskToColumn, reorderTasks } from "@/desktop/renderer/actions/kanban";
+import { useTaskKindFilterParams } from "@/desktop/renderer/hooks/useTaskKindFilterParams";
 import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
@@ -68,6 +69,11 @@ vi.mock("@/desktop/renderer/hooks/useAutoRefresh", () => ({
 
 vi.mock("@/desktop/renderer/hooks/useProjectFilterParams", () => ({
   useProjectFilterParams: vi.fn().mockReturnValue([[], vi.fn()]),
+}));
+
+vi.mock("@/desktop/renderer/hooks/useTaskKindFilterParams", () => ({
+  TASK_KIND_FILTER_VALUES: ["project", "task", "all"],
+  useTaskKindFilterParams: vi.fn().mockReturnValue(["all", vi.fn()]),
 }));
 
 vi.mock("../Column", () => ({
@@ -161,7 +167,7 @@ vi.mock("../CreateTaskModal", () => ({
   ) : null,
 }));
 
-function createProject(): Project {
+function createProject(overrides: Partial<Project> = {}): Project {
   return {
     id: "project-1",
     name: "kanvibe",
@@ -171,6 +177,28 @@ function createProject(): Project {
     isWorktree: false,
     color: null,
     createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function createTask(overrides: Partial<KanbanTask> & Pick<KanbanTask, "id" | "title" | "status">): KanbanTask {
+  return {
+    description: null,
+    branchName: null,
+    worktreePath: null,
+    sessionType: null,
+    sessionName: null,
+    sshHost: null,
+    agentType: null,
+    project: null,
+    projectId: "project-1",
+    baseBranch: null,
+    prUrl: null,
+    priority: null,
+    displayOrder: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
   };
 }
 
@@ -267,6 +295,65 @@ function createTasksWithTodoAndProgress(): TasksByStatus {
   };
 }
 
+function createTaskKindFilterTasks(): TasksByStatus {
+  return {
+    [TaskStatus.TODO]: [
+      createTask({
+        id: "project-root-task",
+        title: "Root Project Task",
+        status: TaskStatus.TODO,
+        branchName: "main",
+        baseBranch: "main",
+      }),
+      createTask({
+        id: "branch-worktree-task",
+        title: "Branch Worktree Task",
+        status: TaskStatus.TODO,
+        branchName: "feat/filter-ui",
+        baseBranch: "main",
+        worktreePath: "/repo/kanvibe__worktrees/feat-filter-ui",
+      }),
+      createTask({
+        id: "plain-task",
+        title: "Plain Task",
+        status: TaskStatus.TODO,
+      }),
+    ],
+    [TaskStatus.PROGRESS]: [],
+    [TaskStatus.PENDING]: [],
+    [TaskStatus.REVIEW]: [],
+    [TaskStatus.DONE]: [],
+  };
+}
+
+function renderBoardForTaskKindFilter() {
+  return render(
+    <Board
+      initialTasks={createTaskKindFilterTasks()}
+      initialDoneTotal={0}
+      initialDoneLimit={20}
+      sshHosts={[]}
+      projects={[createProject()]}
+      sidebarDefaultCollapsed={false}
+      doneAlertDismissed={false}
+      notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+      defaultSessionType={SessionType.TMUX}
+      taskSearchShortcut="Mod+Shift+O"
+    />,
+  );
+}
+
+function expectTaskKindFilterVisibleTasks(names: string[]) {
+  for (const name of ["Root Project Task", "Branch Worktree Task", "Plain Task"]) {
+    const assertion = expect(screen.queryByRole("link", { name }));
+    if (names.includes(name)) {
+      assertion.toBeTruthy();
+    } else {
+      assertion.toBeNull();
+    }
+  }
+}
+
 function BoardCommandRequester() {
   const boardCommands = useBoardCommands();
 
@@ -299,6 +386,7 @@ function BoardShortcutBlocker() {
 describe("Board defaultSessionType sync", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useTaskKindFilterParams).mockReturnValue(["all", vi.fn()] as const);
     delete window.kanvibeDesktop;
     mockNavigatorPlatform("Linux x86_64");
     mockWindowFind();
@@ -356,7 +444,7 @@ describe("Board defaultSessionType sync", () => {
     expect(window.location.hash).toBe("#/ko/settings");
   });
 
-  it("프로젝트 스캔 아이콘 버튼을 프로젝트 필터와 새 작업 버튼 사이에 렌더링한다", () => {
+  it("프로젝트/태스크 필터를 전체 프로젝트 필터 왼쪽에 같은 높이/포인트 컬러로 렌더링한다", () => {
     render(
       <Board
         initialTasks={createEmptyTasks()}
@@ -372,20 +460,66 @@ describe("Board defaultSessionType sync", () => {
       />,
     );
 
-    const projectSelectorContainer = screen.getByTestId("project-selector").parentElement;
+    const projectSelectorContainer = screen.getByTestId("project-filter-control");
+    const taskKindFilter = screen.getByTestId("task-kind-filter");
     const scanButton = screen.getByRole("button", { name: "scanTitle" });
     const newTaskButton = screen.getByRole("button", { name: "newTask" });
     const toolbarItems = Array.from(scanButton.parentElement?.children ?? []);
+    const allFilterButton = screen.getByRole("button", { name: "taskKindFilter.options.all" });
 
-    expect(projectSelectorContainer).toBeTruthy();
+    expect(taskKindFilter.getAttribute("aria-label")).toBe("taskKindFilter.label");
+    expect(taskKindFilter.className).toContain("h-[34px]");
+    expect(taskKindFilter.className).toContain("w-[180px]");
+    expect(allFilterButton.className).toContain("bg-brand-primary");
+    expect(allFilterButton.className).toContain("text-text-inverse");
+    expect(projectSelectorContainer.className).toContain("w-64");
     expect(scanButton.getAttribute("aria-label")).toBe("scanTitle");
     expect(scanButton.textContent).toBe("");
-    expect(toolbarItems.indexOf(projectSelectorContainer as Element)).toBeLessThan(toolbarItems.indexOf(scanButton));
+    expect(toolbarItems.indexOf(taskKindFilter)).toBeLessThan(toolbarItems.indexOf(projectSelectorContainer));
+    expect(toolbarItems.indexOf(projectSelectorContainer)).toBeLessThan(toolbarItems.indexOf(scanButton));
     expect(toolbarItems.indexOf(scanButton)).toBeLessThan(toolbarItems.indexOf(newTaskButton));
 
     fireEvent.click(scanButton);
 
     expect(screen.getByRole("dialog", { name: "scanTitle" })).toBeTruthy();
+  });
+
+  it("task kind filter 버튼을 프로젝트 필터 옆에 렌더링하고 선택 변경을 요청한다", () => {
+    const setTaskKindFilter = vi.fn();
+    vi.mocked(useTaskKindFilterParams).mockReturnValue(["all", setTaskKindFilter] as const);
+
+    renderBoardForTaskKindFilter();
+
+    expect(screen.getByRole("group", { name: "taskKindFilter.label" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "taskKindFilter.options.all" }).getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "taskKindFilter.options.project" }));
+
+    expect(setTaskKindFilter).toHaveBeenCalledWith("project");
+  });
+
+  it("Project 필터 선택 시 기본 브랜치 root task만 표시한다", () => {
+    vi.mocked(useTaskKindFilterParams).mockReturnValue(["project", vi.fn()] as const);
+
+    renderBoardForTaskKindFilter();
+
+    expectTaskKindFilterVisibleTasks(["Root Project Task"]);
+  });
+
+  it("Task 필터 선택 시 project root를 제외한 작업만 표시한다", () => {
+    vi.mocked(useTaskKindFilterParams).mockReturnValue(["task", vi.fn()] as const);
+
+    renderBoardForTaskKindFilter();
+
+    expectTaskKindFilterVisibleTasks(["Branch Worktree Task", "Plain Task"]);
+  });
+
+  it("All 필터 선택 시 project root와 일반 작업을 모두 표시한다", () => {
+    vi.mocked(useTaskKindFilterParams).mockReturnValue(["all", vi.fn()] as const);
+
+    renderBoardForTaskKindFilter();
+
+    expectTaskKindFilterVisibleTasks(["Root Project Task", "Branch Worktree Task", "Plain Task"]);
   });
 
   it("드래그 종료 시 reorder action을 이벤트 이후에 호출한다", async () => {

--- a/src/desktop/renderer/hooks/__tests__/useTaskKindFilterParams.test.tsx
+++ b/src/desktop/renderer/hooks/__tests__/useTaskKindFilterParams.test.tsx
@@ -85,4 +85,16 @@ describe("useTaskKindFilterParams", () => {
       expect(screen.getByTestId("query").textContent).toBe("");
     });
   });
+
+  it("알 수 없는 query 값으로 진입하면 sessionStorage에 남은 필터도 함께 비운다", async () => {
+    sessionStorage.setItem("kanvibe_task_kind_filter", "project");
+
+    renderHarness("/ko?taskKind=unknown");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("all");
+      expect(screen.getByTestId("query").textContent).toBe("");
+    });
+    expect(sessionStorage.getItem("kanvibe_task_kind_filter")).toBeNull();
+  });
 });

--- a/src/desktop/renderer/hooks/__tests__/useTaskKindFilterParams.test.tsx
+++ b/src/desktop/renderer/hooks/__tests__/useTaskKindFilterParams.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useSearchParams } from "react-router-dom";
+import { describe, expect, it, beforeEach } from "vitest";
+import { useTaskKindFilterParams } from "../useTaskKindFilterParams";
+
+function TaskKindFilterHarness() {
+  const [filter, setFilter] = useTaskKindFilterParams();
+  const [searchParams] = useSearchParams();
+
+  return (
+    <div>
+      <div data-testid="filter">{filter}</div>
+      <div data-testid="query">{searchParams.get("taskKind") ?? ""}</div>
+      <button type="button" onClick={() => setFilter("project")}>project</button>
+      <button type="button" onClick={() => setFilter("task")}>task</button>
+      <button type="button" onClick={() => setFilter("all")}>all</button>
+    </div>
+  );
+}
+
+function renderHarness(initialEntry = "/ko") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <TaskKindFilterHarness />
+    </MemoryRouter>,
+  );
+}
+
+describe("useTaskKindFilterParams", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("taskKind query가 없으면 All을 기본값으로 사용한다", () => {
+    renderHarness();
+
+    expect(screen.getByTestId("filter").textContent).toBe("all");
+    expect(screen.getByTestId("query").textContent).toBe("");
+  });
+
+  it("Project/Task 선택을 URL query와 sessionStorage에 반영하고 All 선택 시 query를 제거한다", async () => {
+    renderHarness();
+
+    fireEvent.click(screen.getByRole("button", { name: "project" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("project");
+      expect(screen.getByTestId("query").textContent).toBe("project");
+    });
+    expect(sessionStorage.getItem("kanvibe_task_kind_filter")).toBe("project");
+
+    fireEvent.click(screen.getByRole("button", { name: "task" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("task");
+      expect(screen.getByTestId("query").textContent).toBe("task");
+    });
+    expect(sessionStorage.getItem("kanvibe_task_kind_filter")).toBe("task");
+
+    fireEvent.click(screen.getByRole("button", { name: "all" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("all");
+      expect(screen.getByTestId("query").textContent).toBe("");
+    });
+    expect(sessionStorage.getItem("kanvibe_task_kind_filter")).toBeNull();
+  });
+
+  it("query가 없으면 sessionStorage에 저장된 필터를 복원한다", async () => {
+    sessionStorage.setItem("kanvibe_task_kind_filter", "task");
+
+    renderHarness();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("task");
+      expect(screen.getByTestId("query").textContent).toBe("task");
+    });
+  });
+
+  it("알 수 없는 query 값은 제거하고 기본값으로 되돌린다", async () => {
+    renderHarness("/ko?taskKind=unknown");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("all");
+      expect(screen.getByTestId("query").textContent).toBe("");
+    });
+  });
+});

--- a/src/desktop/renderer/hooks/useTaskKindFilterParams.ts
+++ b/src/desktop/renderer/hooks/useTaskKindFilterParams.ts
@@ -48,6 +48,10 @@ export function useTaskKindFilterParams() {
     if (paramValue) {
       const normalizedParam = normalizeTaskKindFilter(paramValue);
       if (normalizedParam !== paramValue) {
+        // 저장된 필터를 함께 기본값으로 되돌린다. 지우지 않으면 query를 제거한 다음 렌더에서
+        // 세션 복원이 일어나 잘못된 값으로 진입한 사용자가 이전 필터로 끌려간다.
+        syncToSessionStorage(normalizedParam);
+
         const nextParams = new URLSearchParams(searchParams);
         nextParams.delete(QUERY_PARAM_KEY);
         setSearchParams(nextParams, { replace: true });

--- a/src/desktop/renderer/hooks/useTaskKindFilterParams.ts
+++ b/src/desktop/renderer/hooks/useTaskKindFilterParams.ts
@@ -1,0 +1,82 @@
+import { useEffect, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export const TASK_KIND_FILTER_VALUES = ["project", "task", "all"] as const;
+export type TaskKindFilter = typeof TASK_KIND_FILTER_VALUES[number];
+
+const QUERY_PARAM_KEY = "taskKind";
+const SESSION_STORAGE_KEY = "kanvibe_task_kind_filter";
+const DEFAULT_TASK_KIND_FILTER: TaskKindFilter = "all";
+
+function normalizeTaskKindFilter(value: string | null): TaskKindFilter {
+  if (value && TASK_KIND_FILTER_VALUES.includes(value as TaskKindFilter)) {
+    return value as TaskKindFilter;
+  }
+
+  return DEFAULT_TASK_KIND_FILTER;
+}
+
+function syncToSessionStorage(filter: TaskKindFilter) {
+  try {
+    if (filter === DEFAULT_TASK_KIND_FILTER) {
+      sessionStorage.removeItem(SESSION_STORAGE_KEY);
+    } else {
+      sessionStorage.setItem(SESSION_STORAGE_KEY, filter);
+    }
+  } catch {
+    /* sessionStorage 접근 불가 시 무시 */
+  }
+}
+
+function restoreFromSessionStorage(): TaskKindFilter {
+  try {
+    return normalizeTaskKindFilter(sessionStorage.getItem(SESSION_STORAGE_KEY));
+  } catch {
+    return DEFAULT_TASK_KIND_FILTER;
+  }
+}
+
+export function useTaskKindFilterParams() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const paramValue = searchParams.get(QUERY_PARAM_KEY);
+  const taskKindFilter = useMemo(
+    () => normalizeTaskKindFilter(paramValue),
+    [paramValue],
+  );
+
+  useEffect(() => {
+    if (paramValue) {
+      const normalizedParam = normalizeTaskKindFilter(paramValue);
+      if (normalizedParam !== paramValue) {
+        const nextParams = new URLSearchParams(searchParams);
+        nextParams.delete(QUERY_PARAM_KEY);
+        setSearchParams(nextParams, { replace: true });
+        return;
+      }
+
+      syncToSessionStorage(normalizedParam);
+      return;
+    }
+
+    const restored = restoreFromSessionStorage();
+    if (restored !== DEFAULT_TASK_KIND_FILTER) {
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.set(QUERY_PARAM_KEY, restored);
+      setSearchParams(nextParams, { replace: true });
+    }
+  }, [paramValue, searchParams, setSearchParams]);
+
+  const setTaskKindFilter = (filter: TaskKindFilter) => {
+    syncToSessionStorage(filter);
+
+    const nextParams = new URLSearchParams(searchParams);
+    if (filter === DEFAULT_TASK_KIND_FILTER) {
+      nextParams.delete(QUERY_PARAM_KEY);
+    } else {
+      nextParams.set(QUERY_PARAM_KEY, filter);
+    }
+    setSearchParams(nextParams, { replace: true });
+  };
+
+  return [taskKindFilter, setTaskKindFilter] as const;
+}


### PR DESCRIPTION
## 어떤 작업인가요?
- 보드 헤더의 프로젝트 선택기 옆에 `Project / Task / All` 3분할 작업 유형 필터를 추가해, 프로젝트 root task와 일반 task를 구분해서 볼 수 있게 합니다. 기존 프로젝트 필터와 조합되어 동작하며, 선택값은 URL 쿼리(`taskKind`)와 세션에 유지됩니다.

## 어떻게 해결했나요?
**작업 유형 필터 상태 관리 훅 추가**
- 목적: 필터 값을 URL과 세션 사이에서 일관되게 유지
- `useTaskKindFilterParams`가 `taskKind` 쿼리 파라미터를 단일 소스로 사용하고, 기본값(`all`)일 때는 파라미터를 제거해 URL을 깨끗하게 유지합니다. 유효하지 않은 값은 기본값으로 정규화하고, 파라미터가 없을 때만 세션에 저장된 값을 복원합니다.

**보드 필터링 로직을 합성 가능한 술어(predicate)로 리팩터링**
- 목적: 프로젝트 필터와 작업 유형 필터를 동시에 적용
- `Set<string>` 형태의 프로젝트 필터를 직접 받던 내부 함수들을 `BoardTaskFilter` 술어를 받도록 일반화했습니다. 이로써 두 필터가 함께 적용된 상태에서도 드래그 앤 드롭의 인덱스 변환이 정상 동작합니다.

**project root task 판별 기준 정의**
- 목적: `Project`와 `Task` 구분 기준 확립
- worktree가 아닌 프로젝트에 속하고, `branchName`이 그 프로젝트의 `defaultBranch`와 일치하는 task를 project root로 판별합니다.

**i18n 문구 및 QA 플로우 추가**
- 목적: 다국어 지원과 회귀 검증 확보
- ko/en/zh 3개 로케일에 라벨·옵션·설명 문구를 추가하고, 단위 테스트와 Electron QA 녹화 플로우를 함께 추가했습니다.

## 중요한 변경 사항은 무엇인가요?
### 작업 유형 필터 상태 관리

**`taskKind` 쿼리 파라미터를 상태의 단일 소스로 사용**
- **변경 이유**: 필터 상태를 URL로 공유·복원할 수 있게 하고, 기본값일 때 불필요한 쿼리 파라미터가 남지 않게 하기 위함
- **수정 파일**: `src/desktop/renderer/hooks/useTaskKindFilterParams.ts` (신규)

**유효하지 않은 값 정규화 및 세션 복원 순서**
- **변경 이유**: 외부에서 잘못된 `taskKind` 값이 들어와도 보드가 빈 화면이 되지 않도록 방어하고, URL 파라미터가 세션 저장값보다 우선하도록 우선순위를 명확히 하기 위함
- **수정 파일**: `src/desktop/renderer/hooks/useTaskKindFilterParams.ts`

### 보드 필터링 및 드래그 앤 드롭

**필터 인터페이스를 `Set<string>` → `BoardTaskFilter` 술어로 일반화**
- **변경 이유**: 기존 구조는 프로젝트 ID 집합만 다룰 수 있어 작업 유형 필터를 함께 적용할 수 없었음
- **수정 파일**: `src/components/Board.tsx` (`insertAtFilteredIndex`, `buildDragMovePlan`, `executeDragMove`)

**필터가 걸린 상태의 드롭 인덱스 계산 경로 유지**
- **변경 이유**: 화면에 보이는 인덱스와 전체 배열 인덱스가 다르기 때문에, 필터 조건이 늘어나도 순서 저장 결과가 어긋나지 않아야 함
- **수정 파일**: `src/components/Board.tsx`

**`hasActiveBoardTaskFilter`로 필터 미적용 시 원본 참조 유지**
- **변경 이유**: 필터가 모두 비활성일 때 불필요한 배열 재생성을 피하고 기존 렌더 동작을 보존하기 위함
- **수정 파일**: `src/components/Board.tsx`

### project root task 판별

**`isProjectRootTask` / `matchesTaskKindFilter` 도입**
- **변경 이유**: `Project`와 `Task`를 구분할 판별 기준이 없었고, `projectLookup` 맵으로 프로젝트 메타데이터를 O(1) 조회하도록 하기 위함
- **수정 파일**: `src/components/Board.tsx`

### UI 및 i18n

**3분할 토글 버튼 그룹 추가**
- **변경 이유**: 프로젝트 선택기 옆에서 즉시 전환 가능한 컨트롤이 필요했고, 활성 상태는 `--color-brand-primary` 계열 시맨틱 토큰(`bg-brand-primary`)으로 표현
- **수정 파일**: `src/components/Board.tsx`

**로케일 문구 추가**
- **변경 이유**: 라벨/옵션/툴팁 설명을 3개 로케일에 동일하게 제공
- **수정 파일**: `messages/ko.json`, `messages/en.json`, `messages/zh.json`

### 검증

**단위 테스트 및 QA 플로우 추가**
- **변경 이유**: 필터 조합·드래그 순서·파라미터 정규화에 대한 회귀 커버리지와 Electron 시연 증적을 확보
- **수정 파일**: `src/components/__tests__/Board.test.tsx`, `src/desktop/renderer/hooks/__tests__/useTaskKindFilterParams.test.tsx` (신규), `qa/electron/flows/task-kind-filter.cjs` (신규), `scripts/qa-task-kind-filter-video.sh` (신규), `package.json` (`qa:task-kind-filter` 스크립트)

---

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
