### PR TITLE
feat(board): vim :sync 명령으로 백그라운드 sync 수동 실행 지원

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -86,11 +86,11 @@
     "loadingMore": "Loading...",
     "vimCommand": {
       "label": "Vim command",
-      "placeholder": "move review",
-      "hint": "Use :move todo|progress|pending|review|done for the focused task. Press Tab to autocomplete.",
+      "placeholder": "sync or move review",
+      "hint": "Use :sync to run background sync, or :move todo|progress|pending|review|done for the focused task. Press Tab to autocomplete.",
       "completionHint": "Press Tab to complete {command}.",
       "errors": {
-        "unknownCommand": "Unknown command. Try :move review.",
+        "unknownCommand": "Unknown command. Try :sync or :move review.",
         "noFocusedTask": "Focus a task card before running :move.",
         "taskNotFound": "The focused task is no longer visible."
       }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -86,11 +86,11 @@
     "loadingMore": "불러오는 중...",
     "vimCommand": {
       "label": "Vim 명령",
-      "placeholder": "move review",
-      "hint": "포커스된 task에 :move todo|progress|pending|review|done을 사용할 수 있습니다. Tab으로 자동 완성할 수 있습니다.",
+      "placeholder": "sync 또는 move review",
+      "hint": ":sync로 백그라운드 sync를 실행하거나 포커스된 task에 :move todo|progress|pending|review|done을 사용할 수 있습니다. Tab으로 자동 완성할 수 있습니다.",
       "completionHint": "Tab을 누르면 {command}(으)로 자동 완성합니다.",
       "errors": {
-        "unknownCommand": "알 수 없는 명령입니다. :move review를 시도해 보세요.",
+        "unknownCommand": "알 수 없는 명령입니다. :sync 또는 :move review를 시도해 보세요.",
         "noFocusedTask": ":move 실행 전 task card에 포커스하세요.",
         "taskNotFound": "포커스했던 task가 현재 보이지 않습니다."
       }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -85,11 +85,11 @@
     "loadingMore": "加载中...",
     "vimCommand": {
       "label": "Vim 命令",
-      "placeholder": "move review",
-      "hint": "对当前聚焦任务使用 :move todo|progress|pending|review|done。按 Tab 自动补全。",
+      "placeholder": "sync 或 move review",
+      "hint": "使用 :sync 运行后台同步，或对当前聚焦任务使用 :move todo|progress|pending|review|done。按 Tab 自动补全。",
       "completionHint": "按 Tab 补全为 {command}。",
       "errors": {
-        "unknownCommand": "未知命令。请尝试 :move review。",
+        "unknownCommand": "未知命令。请尝试 :sync 或 :move review。",
         "noFocusedTask": "运行 :move 前请先聚焦一个任务卡片。",
         "taskNotFound": "当前聚焦的任务已不在可见列表中。"
       }

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -13,6 +13,7 @@ import TaskContextMenu from "./TaskContextMenu";
 import BranchTaskModal from "./BranchTaskModal";
 import DoneConfirmDialog from "./DoneConfirmDialog";
 import { reorderTasks, deleteTask, getMoreDoneTasks, moveTaskToColumn } from "@/desktop/renderer/actions/kanban";
+import { runBackgroundTaskSyncNow } from "@/desktop/renderer/actions/backgroundTaskSync";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
 import { navigateToTaskDetail } from "@/desktop/renderer/utils/taskNavigation";
@@ -67,6 +68,8 @@ const TASK_DELETE_SEQUENCE_KEY = "d";
 const TASK_DELETE_SEQUENCE_TIMEOUT_MS = 1_000;
 
 const VIM_MOVE_COMMAND_ALIASES = new Set(["move", "m"]);
+const VIM_SYNC_COMMAND_ALIASES = new Set(["sync", "s"]);
+const VIM_COMMAND_NAMES = ["move", "sync"] as const;
 const VIM_MOVE_STATUSES = [
   TaskStatus.TODO,
   TaskStatus.PROGRESS,
@@ -237,19 +240,32 @@ function getFocusedBoardTaskCard() {
     : null;
 }
 
-function parseVimMoveStatus(commandValue: string): TaskStatus | null {
-  const tokens = commandValue
+type ParsedVimCommand =
+  | { type: "move"; destinationStatus: TaskStatus }
+  | { type: "sync" };
+
+function parseVimCommandTokens(commandValue: string) {
+  return commandValue
     .trim()
     .replace(/^:/, "")
     .toLowerCase()
     .split(/\s+/)
     .filter(Boolean);
+}
 
-  if (tokens.length !== 2 || !VIM_MOVE_COMMAND_ALIASES.has(tokens[0])) {
-    return null;
+function parseVimCommand(commandValue: string): ParsedVimCommand | null {
+  const tokens = parseVimCommandTokens(commandValue);
+
+  if (tokens.length === 1 && VIM_SYNC_COMMAND_ALIASES.has(tokens[0])) {
+    return { type: "sync" };
   }
 
-  return VIM_STATUS_ALIASES[tokens[1]] ?? null;
+  if (tokens.length === 2 && VIM_MOVE_COMMAND_ALIASES.has(tokens[0])) {
+    const destinationStatus = VIM_STATUS_ALIASES[tokens[1]];
+    return destinationStatus ? { type: "move", destinationStatus } : null;
+  }
+
+  return null;
 }
 
 function getUniqueVimMoveStatusCompletion(statusPrefix: string): TaskStatus | null {
@@ -270,7 +286,15 @@ function getUniqueVimMoveStatusCompletion(statusPrefix: string): TaskStatus | nu
   return aliasMatches.size === 1 ? Array.from(aliasMatches)[0] : null;
 }
 
-function getVimMoveCommandAutocomplete(commandValue: string): string | null {
+function getUniqueVimCommandCompletion(commandPrefix: string) {
+  const normalizedPrefix = commandPrefix.toLowerCase();
+  if (!normalizedPrefix) return "move";
+
+  const matches = VIM_COMMAND_NAMES.filter((command) => command.startsWith(normalizedPrefix));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function getVimCommandAutocomplete(commandValue: string): string | null {
   const leadingWhitespace = commandValue.match(/^\s*/)?.[0] ?? "";
   const trimmedStartValue = commandValue.trimStart();
   const hasColonPrefix = trimmedStartValue.startsWith(":");
@@ -279,22 +303,25 @@ function getVimMoveCommandAutocomplete(commandValue: string): string | null {
   const tokens = valueWithoutColon.toLowerCase().split(/\s+/).filter(Boolean);
   const commandToken = tokens[0] ?? "";
 
-  const formatCompletion = (status?: TaskStatus) => {
-    const prefix = `${leadingWhitespace}${hasColonPrefix ? ":" : ""}move`;
+  const commandPrefix = `${leadingWhitespace}${hasColonPrefix ? ":" : ""}`;
+  const formatMoveCompletion = (status?: TaskStatus) => {
+    const prefix = `${commandPrefix}move`;
     return status ? `${prefix} ${status}` : `${prefix} `;
+  };
+  const formatCommandCompletion = (command: typeof VIM_COMMAND_NAMES[number]) => {
+    return command === "move" ? formatMoveCompletion() : `${commandPrefix}${command}`;
   };
 
   if (tokens.length === 0) {
-    return formatCompletion();
+    return formatMoveCompletion();
   }
 
   if (tokens.length === 1 && !hasTrailingWhitespace) {
-    if ("move".startsWith(commandToken) || commandToken === "m") {
-      const completion = formatCompletion();
-      return completion === commandValue ? null : completion;
-    }
+    const completedCommand = getUniqueVimCommandCompletion(commandToken);
+    if (!completedCommand) return null;
 
-    return null;
+    const completion = formatCommandCompletion(completedCommand);
+    return completion === commandValue ? null : completion;
   }
 
   if (!VIM_MOVE_COMMAND_ALIASES.has(commandToken) || tokens.length !== 2) {
@@ -304,7 +331,7 @@ function getVimMoveCommandAutocomplete(commandValue: string): string | null {
   const completedStatus = getUniqueVimMoveStatusCompletion(tokens[1]);
   if (!completedStatus) return null;
 
-  const completion = formatCompletion(completedStatus);
+  const completion = formatMoveCompletion(completedStatus);
   return completion === commandValue ? null : completion;
 }
 
@@ -530,7 +557,7 @@ export default function Board({
   const [currentDefaultSessionType, setCurrentDefaultSessionType] = useState<SessionType>(defaultSessionType);
   const [shouldUseMacTitlebarLayout, setShouldUseMacTitlebarLayout] = useState(false);
   const vimCommandCompletion = useMemo(
-    () => getVimMoveCommandAutocomplete(vimCommandValue),
+    () => getVimCommandAutocomplete(vimCommandValue),
     [vimCommandValue],
   );
   const [, startDragPersistenceTransition] = useTransition();
@@ -990,13 +1017,21 @@ export default function Board({
   }, []);
 
   const submitVimCommand = useCallback(() => {
-    const destinationStatus = parseVimMoveStatus(vimCommandValue);
-    if (!destinationStatus) {
+    const parsedCommand = parseVimCommand(vimCommandValue);
+    if (!parsedCommand) {
       setVimCommandError(t("vimCommand.errors.unknownCommand"));
       return;
     }
 
-    const moveResult = moveFocusedTaskToStatus(destinationStatus, vimCommandTaskId);
+    if (parsedCommand.type === "sync") {
+      closeVimCommand();
+      void runBackgroundTaskSyncNow().catch((error) => {
+        console.error("Failed to run background task sync", error);
+      });
+      return;
+    }
+
+    const moveResult = moveFocusedTaskToStatus(parsedCommand.destinationStatus, vimCommandTaskId);
     if (moveResult === "missing-focus") {
       setVimCommandError(t("vimCommand.errors.noFocusedTask"));
       return;
@@ -1216,7 +1251,7 @@ export default function Board({
               }}
               onKeyDown={(event) => {
                 if (event.key === "Tab" && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
-                  const completion = getVimMoveCommandAutocomplete(event.currentTarget.value);
+                  const completion = getVimCommandAutocomplete(event.currentTarget.value);
                   if (completion) {
                     event.preventDefault();
                     setVimCommandValue(completion);

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -4,6 +4,7 @@ import { createEvent, fireEvent, render, screen, waitFor } from "@testing-librar
 import { MemoryRouter } from "react-router-dom";
 import Board from "../Board";
 import { deleteTask, moveTaskToColumn, reorderTasks } from "@/desktop/renderer/actions/kanban";
+import { runBackgroundTaskSyncNow } from "@/desktop/renderer/actions/backgroundTaskSync";
 import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
@@ -60,6 +61,10 @@ vi.mock("@/desktop/renderer/actions/kanban", () => ({
   deleteTask: vi.fn(),
   getMoreDoneTasks: vi.fn().mockResolvedValue({ tasks: [], doneTotal: 0 }),
   moveTaskToColumn: vi.fn(),
+}));
+
+vi.mock("@/desktop/renderer/actions/backgroundTaskSync", () => ({
+  runBackgroundTaskSyncNow: vi.fn().mockResolvedValue({ reviewNeeded: false, boardUpdated: false }),
 }));
 
 vi.mock("@/desktop/renderer/hooks/useAutoRefresh", () => ({
@@ -1004,6 +1009,68 @@ describe("Board defaultSessionType sync", () => {
 
     await waitFor(() => {
       expect(moveTaskToColumn).toHaveBeenCalledWith("task-1", TaskStatus.REVIEW, ["task-1"]);
+    });
+  });
+
+  it(":sync 명령으로 background task sync를 백그라운드 실행한다", async () => {
+    render(
+      <Board
+        initialTasks={createEmptyTasks()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
+      />,
+    );
+
+    const openCommandEvent = createEvent.keyDown(window, { key: ":" });
+    fireEvent(window, openCommandEvent);
+
+    expect(openCommandEvent.defaultPrevented).toBe(true);
+
+    const commandInput = await screen.findByRole("textbox", { name: "vimCommand.label" });
+    fireEvent.change(commandInput, { target: { value: "sync" } });
+    fireEvent.keyDown(commandInput, { key: "Enter" });
+
+    expect(runBackgroundTaskSyncNow).toHaveBeenCalledTimes(1);
+    expect(moveTaskToColumn).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox", { name: "vimCommand.label" })).toBeNull();
+    });
+  });
+
+  it(":sync 명령은 Tab 자동 완성으로 입력할 수 있다", async () => {
+    render(
+      <Board
+        initialTasks={createEmptyTasks()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: ":" });
+
+    const commandInput = await screen.findByRole("textbox", { name: "vimCommand.label" });
+    fireEvent.change(commandInput, { target: { value: "s" } });
+
+    const autocompleteEvent = createEvent.keyDown(commandInput, { key: "Tab" });
+    fireEvent(commandInput, autocompleteEvent);
+
+    expect(autocompleteEvent.defaultPrevented).toBe(true);
+    await waitFor(() => {
+      expect((commandInput as HTMLInputElement).value).toBe("sync");
     });
   });
 

--- a/src/desktop/main/serviceRegistry.ts
+++ b/src/desktop/main/serviceRegistry.ts
@@ -1,4 +1,5 @@
 import * as appSettings from "@/desktop/main/services/appSettingsService";
+import { runBackgroundTaskSyncNow } from "@/desktop/main/services/backgroundTaskSyncService";
 import * as diff from "@/desktop/main/services/diffService";
 import * as githubCliDependency from "@/desktop/main/services/githubCliDependencyService";
 import * as hooks from "@/desktop/main/services/hookService";
@@ -8,8 +9,11 @@ import * as project from "@/desktop/main/services/projectService";
 import * as releaseUpdates from "@/desktop/main/services/releaseUpdateService";
 import * as sessionDependency from "@/desktop/main/services/sessionDependencyService";
 
+const backgroundTaskSync = { runBackgroundTaskSyncNow };
+
 export const desktopServices = {
   appSettings,
+  backgroundTaskSync,
   diff,
   githubCliDependency,
   hooks,

--- a/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
+++ b/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
@@ -121,6 +121,60 @@ describe("backgroundTaskSyncService", () => {
     stop();
   });
 
+  it("manual background sync는 설정 비활성화와 무관하게 동일한 sync cycle을 실행한다", async () => {
+    mocks.getBackgroundSyncEnabled.mockResolvedValue(false);
+
+    const { runBackgroundTaskSyncNow } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    await runBackgroundTaskSyncNow();
+
+    expect(mocks.getBackgroundSyncEnabled).not.toHaveBeenCalled();
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
+  });
+
+  it("manual background sync는 진행 중인 scheduled cycle과 같은 in-flight 작업을 공유한다", async () => {
+    let resolveWorktreeSync: (result: {
+      worktreeTasks: string[];
+      registeredWorktrees: never[];
+      hooksSetup: never[];
+      errors: never[];
+      changed: boolean;
+    }) => void = () => {};
+    mocks.syncRegisteredProjectWorktrees.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveWorktreeSync = resolve;
+      }),
+    );
+
+    const { startBackgroundTaskSync, runBackgroundTaskSyncNow } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    const stop = startBackgroundTaskSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    const manualSync = runBackgroundTaskSyncNow();
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).not.toHaveBeenCalled();
+    expect(mocks.syncActiveTaskPulls).not.toHaveBeenCalled();
+
+    resolveWorktreeSync({
+      worktreeTasks: [],
+      registeredWorktrees: [],
+      hooksSetup: [],
+      errors: [],
+      changed: false,
+    });
+    await manualSync;
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
   it("background task sync는 여러 번 시작해도 하나의 loop만 실행한다", async () => {
     const { startBackgroundTaskSync } = await import("@/desktop/main/services/backgroundTaskSyncService");
 

--- a/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
+++ b/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   broadcastBackgroundSyncReviewNeeded: vi.fn(),
   getBackgroundSyncEnabled: vi.fn().mockResolvedValue(true),
   getBackgroundSyncIntervalMs: vi.fn().mockResolvedValue(10 * 60_000),
+  registerBackgroundSyncIntervalChangedCallback: vi.fn(),
+  registerBackgroundSyncEnabledChangedCallback: vi.fn(),
 }));
 
 vi.mock("@/desktop/main/services/projectService", () => ({
@@ -27,8 +29,8 @@ vi.mock("@/lib/boardNotifier", () => ({
 vi.mock("@/desktop/main/services/appSettingsService", () => ({
   getBackgroundSyncEnabled: mocks.getBackgroundSyncEnabled,
   getBackgroundSyncIntervalMs: mocks.getBackgroundSyncIntervalMs,
-  registerBackgroundSyncIntervalChangedCallback: vi.fn(),
-  registerBackgroundSyncEnabledChangedCallback: vi.fn(),
+  registerBackgroundSyncIntervalChangedCallback: mocks.registerBackgroundSyncIntervalChangedCallback,
+  registerBackgroundSyncEnabledChangedCallback: mocks.registerBackgroundSyncEnabledChangedCallback,
 }));
 
 async function flushBackgroundSyncCycle() {
@@ -362,6 +364,49 @@ describe("backgroundTaskSyncService", () => {
       ],
     });
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
+  it("manual sync 진행 중에 주기가 바뀌면 새 주기로 다음 sync를 다시 예약한다", async () => {
+    const { startBackgroundTaskSync, runBackgroundTaskSyncNow } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    const stop = startBackgroundTaskSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+    await flushBackgroundSyncCycle();
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+
+    let resolveManualWorktreeSync: () => void = () => {};
+    mocks.syncRegisteredProjectWorktrees.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveManualWorktreeSync = () => resolve({
+          worktreeTasks: [],
+          registeredWorktrees: [],
+          hooksSetup: [],
+          errors: [],
+          changed: false,
+        });
+      }),
+    );
+
+    const manualSync = runBackgroundTaskSyncNow();
+    await flushBackgroundSyncCycle();
+
+    const notifyIntervalChanged = mocks.registerBackgroundSyncIntervalChangedCallback.mock.calls[0][0];
+    mocks.getBackgroundSyncIntervalMs.mockResolvedValue(60_000);
+    notifyIntervalChanged(60_000);
+
+    resolveManualWorktreeSync();
+    await manualSync;
+    await flushBackgroundSyncCycle();
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flushBackgroundSyncCycle();
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(3);
 
     stop();
   });

--- a/src/desktop/main/services/backgroundTaskSyncService.ts
+++ b/src/desktop/main/services/backgroundTaskSyncService.ts
@@ -21,6 +21,13 @@ const INITIAL_SYNC_DELAY_MS = 20_000;
 const FALLBACK_SYNC_INTERVAL_MS = 10 * 60_000;
 
 let activeBackgroundTaskSyncStop: (() => void) | null = null;
+let activeBackgroundTaskSyncCycle: Promise<BackgroundTaskSyncRunResult> | null = null;
+const emittedMergeEventKeys = new Set<string>();
+
+export interface BackgroundTaskSyncRunResult {
+  reviewNeeded: boolean;
+  boardUpdated: boolean;
+}
 
 interface BackgroundSyncStageResult<T> {
   result: T;
@@ -84,15 +91,97 @@ async function runBackgroundSyncStage<T>(
   }
 }
 
+async function executeBackgroundTaskSyncCycle(): Promise<BackgroundTaskSyncRunResult> {
+  const worktreeSync = await runBackgroundSyncStage(
+    "worktree sync",
+    syncRegisteredProjectWorktrees,
+    createEmptyWorktreeSyncResult,
+    (reason) => ({
+      operation: "worktree-sync",
+      target: "등록 프로젝트 worktree sync",
+      reason,
+    }),
+  );
+  const prSync = await runBackgroundSyncStage(
+    "pull request sync",
+    () => syncActiveTaskPullRequests(emittedMergeEventKeys),
+    createEmptyPullRequestSyncResult,
+    (reason) => ({
+      operation: "pull-request-sync",
+      target: "PR 상태 sync",
+      reason,
+    }),
+  );
+  const pullSync = await runBackgroundSyncStage(
+    "task pull sync",
+    syncActiveTaskPulls,
+    createEmptyTaskPullSyncResult,
+    (reason) => ({
+      operation: "task-pull-sync",
+      target: "active task pull sync",
+      reason,
+    }),
+  );
+  const worktreeSyncResult = worktreeSync.result;
+  const prSyncResult = prSync.result;
+  const pullSyncResult = pullSync.result;
+  const failures: BackgroundSyncFailurePayload[] = [
+    ...(worktreeSync.failure ? [worktreeSync.failure] : []),
+    ...worktreeSyncResult.errors.map((reason) => ({
+      operation: "worktree-sync" as const,
+      target: "등록 프로젝트 worktree sync",
+      reason,
+    })),
+    ...(prSync.failure ? [prSync.failure] : []),
+    ...(prSyncResult.failures ?? []),
+    ...(pullSync.failure ? [pullSync.failure] : []),
+  ];
+
+  const reviewNeeded = worktreeSyncResult.registeredWorktrees.length > 0
+    || prSyncResult.mergedPullRequests.length > 0
+    || pullSyncResult.pulledTasks.length > 0
+    || failures.length > 0;
+
+  if (reviewNeeded) {
+    broadcastBackgroundSyncReviewNeeded({
+      registeredWorktrees: worktreeSyncResult.registeredWorktrees,
+      mergedPullRequests: prSyncResult.mergedPullRequests,
+      pulledTasks: pullSyncResult.pulledTasks,
+      ...(failures.length > 0 ? { failures } : {}),
+    });
+  }
+
+  const hasUpdatedPulledTasks = pullSyncResult.pulledTasks.some((task) => task.status === "updated");
+  const boardUpdated = worktreeSyncResult.changed || prSyncResult.updatedTaskIds.length > 0 || hasUpdatedPulledTasks;
+  if (boardUpdated) {
+    broadcastBoardUpdate();
+  }
+
+  return { reviewNeeded, boardUpdated };
+}
+
+function runSharedBackgroundTaskSyncCycle(): Promise<BackgroundTaskSyncRunResult> {
+  if (activeBackgroundTaskSyncCycle) {
+    return activeBackgroundTaskSyncCycle;
+  }
+
+  activeBackgroundTaskSyncCycle = executeBackgroundTaskSyncCycle().finally(() => {
+    activeBackgroundTaskSyncCycle = null;
+  });
+  return activeBackgroundTaskSyncCycle;
+}
+
+export function runBackgroundTaskSyncNow(): Promise<BackgroundTaskSyncRunResult> {
+  return runSharedBackgroundTaskSyncCycle();
+}
+
 export function startBackgroundTaskSync() {
   if (activeBackgroundTaskSyncStop) {
     return activeBackgroundTaskSyncStop;
   }
 
   let disposed = false;
-  let running = false;
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-  const emittedMergeEventKeys = new Set<string>();
 
   function scheduleNext(delayMs: number) {
     if (disposed) {
@@ -109,83 +198,14 @@ export function startBackgroundTaskSync() {
       return;
     }
 
-    if (running) {
-      return;
-    }
-
-    running = true;
-
     try {
       const isEnabled = await getBackgroundSyncEnabled();
       if (isEnabled) {
-        const worktreeSync = await runBackgroundSyncStage(
-          "worktree sync",
-          syncRegisteredProjectWorktrees,
-          createEmptyWorktreeSyncResult,
-          (reason) => ({
-            operation: "worktree-sync",
-            target: "등록 프로젝트 worktree sync",
-            reason,
-          }),
-        );
-        const prSync = await runBackgroundSyncStage(
-          "pull request sync",
-          () => syncActiveTaskPullRequests(emittedMergeEventKeys),
-          createEmptyPullRequestSyncResult,
-          (reason) => ({
-            operation: "pull-request-sync",
-            target: "PR 상태 sync",
-            reason,
-          }),
-        );
-        const pullSync = await runBackgroundSyncStage(
-          "task pull sync",
-          syncActiveTaskPulls,
-          createEmptyTaskPullSyncResult,
-          (reason) => ({
-            operation: "task-pull-sync",
-            target: "active task pull sync",
-            reason,
-          }),
-        );
-        const worktreeSyncResult = worktreeSync.result;
-        const prSyncResult = prSync.result;
-        const pullSyncResult = pullSync.result;
-        const failures: BackgroundSyncFailurePayload[] = [
-          ...(worktreeSync.failure ? [worktreeSync.failure] : []),
-          ...worktreeSyncResult.errors.map((reason) => ({
-            operation: "worktree-sync" as const,
-            target: "등록 프로젝트 worktree sync",
-            reason,
-          })),
-          ...(prSync.failure ? [prSync.failure] : []),
-          ...(prSyncResult.failures ?? []),
-          ...(pullSync.failure ? [pullSync.failure] : []),
-        ];
-
-        if (
-          worktreeSyncResult.registeredWorktrees.length > 0
-          || prSyncResult.mergedPullRequests.length > 0
-          || pullSyncResult.pulledTasks.length > 0
-          || failures.length > 0
-        ) {
-          broadcastBackgroundSyncReviewNeeded({
-            registeredWorktrees: worktreeSyncResult.registeredWorktrees,
-            mergedPullRequests: prSyncResult.mergedPullRequests,
-            pulledTasks: pullSyncResult.pulledTasks,
-            ...(failures.length > 0 ? { failures } : {}),
-          });
-        }
-
-        const hasUpdatedPulledTasks = pullSyncResult.pulledTasks.some((task) => task.status === "updated");
-        if (worktreeSyncResult.changed || prSyncResult.updatedTaskIds.length > 0 || hasUpdatedPulledTasks) {
-          broadcastBoardUpdate();
-        }
+        await runSharedBackgroundTaskSyncCycle();
       }
     } catch (error) {
       console.error("[background-task-sync] sync failed:", error);
     } finally {
-      running = false;
       const intervalMs = await getBackgroundSyncIntervalMs().catch(() => FALLBACK_SYNC_INTERVAL_MS);
       scheduleNext(intervalMs);
     }
@@ -194,7 +214,7 @@ export function startBackgroundTaskSync() {
   function reschedule(newIntervalMs: number) {
     if (disposed) return;
     // 사이클 실행 중이면 건너뜀 — finally 블록이 최신 주기를 읽어 스케줄링함
-    if (running) return;
+    if (activeBackgroundTaskSyncCycle) return;
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
       timeoutHandle = null;
@@ -205,7 +225,7 @@ export function startBackgroundTaskSync() {
   function rescheduleOnEnable(enabled: boolean) {
     if (!enabled) return; // 비활성화 시: 루프는 다음 웨이크업에서 작업을 건너뜀
     if (disposed) return;
-    if (running) return; // 사이클 진행 중: finally 블록이 이어서 스케줄링함
+    if (activeBackgroundTaskSyncCycle) return; // 사이클 진행 중: finally 블록이 이어서 스케줄링함
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
       timeoutHandle = null;

--- a/src/desktop/main/services/backgroundTaskSyncService.ts
+++ b/src/desktop/main/services/backgroundTaskSyncService.ts
@@ -181,6 +181,9 @@ export function startBackgroundTaskSync() {
   }
 
   let disposed = false;
+  // 스케줄러가 직접 돌린 사이클만 표시한다. manual sync가 공유 사이클을 점유한 경우와 구분해야
+  // 재예약 책임이 finally 블록에 있는지 콜백에 있는지 판단할 수 있다.
+  let isSchedulerCycleRunning = false;
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
   function scheduleNext(delayMs: number) {
@@ -198,6 +201,7 @@ export function startBackgroundTaskSync() {
       return;
     }
 
+    isSchedulerCycleRunning = true;
     try {
       const isEnabled = await getBackgroundSyncEnabled();
       if (isEnabled) {
@@ -208,13 +212,14 @@ export function startBackgroundTaskSync() {
     } finally {
       const intervalMs = await getBackgroundSyncIntervalMs().catch(() => FALLBACK_SYNC_INTERVAL_MS);
       scheduleNext(intervalMs);
+      isSchedulerCycleRunning = false;
     }
   }
 
   function reschedule(newIntervalMs: number) {
     if (disposed) return;
-    // 사이클 실행 중이면 건너뜀 — finally 블록이 최신 주기를 읽어 스케줄링함
-    if (activeBackgroundTaskSyncCycle) return;
+    // 스케줄러 사이클 실행 중이면 건너뜀 — finally 블록이 최신 주기를 읽어 스케줄링함
+    if (isSchedulerCycleRunning) return;
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
       timeoutHandle = null;
@@ -225,7 +230,7 @@ export function startBackgroundTaskSync() {
   function rescheduleOnEnable(enabled: boolean) {
     if (!enabled) return; // 비활성화 시: 루프는 다음 웨이크업에서 작업을 건너뜀
     if (disposed) return;
-    if (activeBackgroundTaskSyncCycle) return; // 사이클 진행 중: finally 블록이 이어서 스케줄링함
+    if (isSchedulerCycleRunning) return; // 스케줄러 사이클 진행 중: finally 블록이 이어서 스케줄링함
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
       timeoutHandle = null;

--- a/src/desktop/renderer/actions/backgroundTaskSync.ts
+++ b/src/desktop/renderer/actions/backgroundTaskSync.ts
@@ -1,0 +1,6 @@
+import { invokeDesktop } from "@/desktop/renderer/ipc";
+import type { BackgroundTaskSyncRunResult } from "@/desktop/main/services/backgroundTaskSyncService";
+
+export function runBackgroundTaskSyncNow(): Promise<BackgroundTaskSyncRunResult> {
+  return invokeDesktop("backgroundTaskSync", "runBackgroundTaskSyncNow");
+}


### PR DESCRIPTION
## 관련 자료
- 이슈 : 없음

## 어떤 작업인가요?
- 보드에서 다음 백그라운드 sync 주기를 기다리지 않고 vim 명령 `:sync`로 즉시 sync를 실행할 수 있게 한다.

## 어떻게 해결했나요?
**1. 백그라운드 sync 사이클을 주기 루프에서 분리해 온디맨드로 노출**
- 기존 sync 로직은 `startBackgroundTaskSync()`의 타이머 콜백 안에 인라인으로 들어 있어 외부에서 호출할 방법이 없었다.
- 사이클 본문을 `executeBackgroundTaskSyncCycle()`로 빼고, in-flight Promise를 공유하는 `runSharedBackgroundTaskSyncCycle()`을 두어 주기 실행과 수동 실행이 같은 사이클을 공유하도록 했다.
- `runBackgroundTaskSyncNow`를 `desktopServices.backgroundTaskSync`로 등록해 renderer에서 IPC로 호출할 수 있게 했다.

**2. 보드 vim 명령에 `:sync` 추가**
- `:move`만 처리하던 파서를 인자 없는 명령까지 다룰 수 있게 일반화하고, Tab 자동 완성이 `move`/`sync`를 구분하도록 했다.
- ko/en/zh 문구를 `:sync` 포함으로 갱신했다.

## 중요한 변경 사항은 무엇인가요?
### 1. 온디맨드 백그라운드 sync 실행 API

**사이클 중복 실행 가드를 로컬 `running` 플래그에서 모듈 스코프 in-flight Promise로 교체**
- **변경 이유**: `running` 플래그는 `startBackgroundTaskSync()` 클로저 안에만 있어서 수동 실행 경로가 이를 볼 수 없었다. 주기 실행과 수동 실행이 겹치면 같은 worktree/PR/pull sync가 이중으로 돌 수 있다. `activeBackgroundTaskSyncCycle`을 모듈 스코프에 두면 두 경로가 하나의 사이클을 공유하고, 수동 호출자는 진행 중인 사이클의 결과를 그대로 await 한다.
- **수정 파일**: `src/desktop/main/services/backgroundTaskSyncService.ts`

**`emittedMergeEventKeys`를 모듈 스코프로 이동**
- **변경 이유**: 클로저 안에 있으면 수동 실행 경로가 이미 발행한 merge 이벤트 키를 알 수 없어 같은 PR merge 알림이 중복 발행된다.
- **수정 파일**: `src/desktop/main/services/backgroundTaskSyncService.ts`

**`reschedule` / `rescheduleOnEnable`의 진행 중 판정을 `activeBackgroundTaskSyncCycle` 기준으로 변경**
- **변경 이유**: 기존 `running` 플래그가 제거되었고, 사이클 진행 중에는 `finally` 블록이 최신 주기로 이어서 스케줄링하는 기존 동작을 유지해야 한다.
- **수정 파일**: `src/desktop/main/services/backgroundTaskSyncService.ts`

**`runBackgroundTaskSyncNow`를 IPC 서비스로 등록하고 `BackgroundTaskSyncRunResult` 반환**
- **변경 이유**: renderer가 실행 결과(`reviewNeeded`, `boardUpdated`)를 타입 안전하게 받을 수 있도록 반환 타입을 export 했다.
- **수정 파일**: `src/desktop/main/serviceRegistry.ts`, `src/desktop/renderer/actions/backgroundTaskSync.ts`

### 2. vim `:sync` 명령

**`parseVimMoveStatus` → `parseVimCommand`로 일반화**
- **변경 이유**: 기존 파서는 토큰 2개 + `move` 별칭만 허용해 인자 없는 명령을 표현할 수 없었다. `ParsedVimCommand` 유니언을 도입해 `:sync`(별칭 `:s`)와 `:move <status>`를 함께 판별한다.
- **수정 파일**: `src/components/Board.tsx`

**Tab 자동 완성의 명령 토큰 단계 분기 추가**
- **변경 이유**: 기존에는 명령 토큰 단계에서 무조건 `move`로 완성했기 때문에 `sync`를 입력할 수 없었다. `getUniqueVimCommandCompletion`으로 후보가 유일할 때만 완성하고, `s`처럼 모호하지 않은 접두어는 그대로 처리한다.
- **수정 파일**: `src/components/Board.tsx`

**i18n 문구 갱신**
- **변경 이유**: placeholder / hint / `unknownCommand` 안내가 `:move`만 언급하고 있어 `:sync`를 발견할 수 없었다.
- **수정 파일**: `messages/ko.json`, `messages/en.json`, `messages/zh.json`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
