### PR TITLE
chore(toolchain): pnpm 버전 고정 및 CI Node 24 정렬

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "qa:move-autocomplete": "pnpm exec vitest run src/components/__tests__/Board.test.tsx -t \"자동 완성\" && pnpm qa:electron:prepare && bash scripts/qa-move-autocomplete-video.sh",
     "qa:ai-session-history": "pnpm exec vitest run src/lib/aiSessions && pnpm exec vitest run src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-ai-session-history-video.sh",
     "qa:pr275-pr276": "bash scripts/qa-pr275-pr276.sh",
+    "pretest": "node scripts/ensure-native-runtime.cjs",
     "test": "vitest run",
+    "pretest:watch": "node scripts/ensure-native-runtime.cjs",
     "test:watch": "vitest",
     "postinstall": "node scripts/postinstall.cjs"
   },
@@ -101,5 +103,6 @@
     "typescript-eslint": "^8.33.1",
     "vite": "^7.1.10",
     "vitest": "^4.0.18"
-  }
+  },
+  "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e"
 }

--- a/src/lib/aiSessions/__tests__/readAiSessions.test.ts
+++ b/src/lib/aiSessions/__tests__/readAiSessions.test.ts
@@ -711,7 +711,10 @@ conn.close()
   });
 
   it("treats OpenCode body search wildcard characters as literal text", async () => {
-    const worktreePath = path.join(tempHome, "repo", "task");
+    // 세션 필터는 directory 값에도 부분 문자열 매칭을 하므로, OS 임시 경로에 우연히 `_`나 `%`가
+    // 들어 있으면 모든 행이 걸려 검증이 무의미해진다. macOS의 /var/folders/... 경로가 실제로
+    // 그렇기 때문에 이 테스트만 와일드카드 문자가 없는 고정 경로를 쓴다.
+    const worktreePath = "/kanvibe-opencode-fixture/repo/task";
     const rows = [
       {
         id: "literal-percent",


### PR DESCRIPTION
## 관련 자료
- 이슈 : 없음

## 어떤 작업인가요?
- 로컬에서 `pnpm install` 시 `ERR_PNPM_IGNORED_BUILDS`로 네이티브 빌드가 전부 건너뛰어지는 문제를 해결하고, 로컬과 CI의 pnpm/Node 툴체인 기준을 일치시킵니다.

## 어떻게 해결했나요?
**pnpm 버전을 레포에 고정**
- pnpm 11부터 `package.json`의 `pnpm` 필드를 더 이상 읽지 않아 `onlyBuiltDependencies`가 무시되고, `better-sqlite3` / `node-pty` / `electron` / `sharp` 등의 빌드 스크립트가 전부 무시되던 문제를 해결합니다.
- corepack이 `packageManager` 필드 없이 최신 pnpm을 받아오는 구조라 Node를 갈아끼울 때마다 pnpm 메이저 버전이 조용히 바뀔 수 있었습니다. 버전 소스를 레포로 옮겨 이 결합을 끊었습니다.

**CI Node 버전 정렬**
- CI가 Node 22를 쓰고 있어 `engines`(24.x) 및 `.nvmrc`(24.15.0)와 어긋나 있었습니다. 네이티브 모듈은 Node ABI에 민감하므로 CI를 24로 올려 로컬과 기준을 맞췄습니다.

**테스트가 설치 직후에도 통과하도록 수정**
- `postinstall`이 `better-sqlite3`를 Electron ABI로 빌드하는데 `test`에는 대응 훅이 없어, 설치 직후 `pnpm test`를 돌리면 `NODE_MODULE_VERSION` 불일치로 실패했습니다.
- OpenCode 검색 테스트가 OS 임시 경로 문자에 의존해 macOS에서만 실패하던 문제를 함께 수정했습니다.

## 중요한 변경 사항은 무엇인가요?
### pnpm 버전 고정 및 CI Node 정렬

**`packageManager` 필드로 pnpm 10.34.5 고정**
- **변경 이유**: pnpm 11이 `package.json`의 `pnpm.onlyBuiltDependencies`를 읽지 않아 네이티브 빌드가 전부 무시됐습니다. 버전이 Node 설치본(corepack)에 묶여 있어 Node 교체 시 pnpm 메이저가 흔들리는 구조도 함께 해소했습니다.
- **수정 파일**: `package.json`

**`pnpm/action-setup`의 `version: 10` 입력 제거**
- **변경 이유**: `packageManager` 필드가 생겨 버전 출처가 둘로 갈리면 action-setup이 충돌로 실패할 수 있습니다. 필드를 단일 출처로 삼습니다.
- **수정 파일**: `.github/workflows/ci.yml`

**CI Node 22 → 24**
- **변경 이유**: `engines`(24.x)·`.nvmrc`(24.15.0)와 불일치했고, 네이티브 모듈 ABI 기준이 로컬과 달라지는 원인이었습니다.
- **수정 파일**: `.github/workflows/ci.yml`

### 테스트 실행 안정화

**`pretest` / `pretest:watch` 훅 추가**
- **변경 이유**: `postinstall`은 Electron ABI로 빌드하는데 vitest는 Node에서 실행되어, 설치 직후 `databaseMigrations` 테스트가 `NODE_MODULE_VERSION 128 vs 137` 불일치로 실패했습니다. 테스트 실행 전 Node 타깃 런타임을 보장합니다.
- **수정 파일**: `package.json`

**OpenCode 와일드카드 테스트의 경로 의존성 제거**
- **변경 이유**: 세션 필터가 `row.directory`에도 부분 문자열 매칭을 하는데, macOS `os.tmpdir()` 경로(`/var/folders/.../zk50bz755614m_dpwf_v6xn80000gn/T`)에 `_`가 포함되어 쿼리 `_`가 모든 행에 매칭됐습니다. Linux CI의 `/tmp`에는 없어 로컬에서만 실패하던 케이스입니다. SQL 이스케이프(`\_` + `ESCAPE`) 동작 자체는 정상이므로 픽스처 경로만 교체했습니다.
- **수정 파일**: `src/lib/aiSessions/__tests__/readAiSessions.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
