### PR TITLE
chore(release): publish KanVibe 1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Publish KanVibe 1.0.4. This PR contains only the version bump; the DMG release and Homebrew cask update are already live.

- Version: `1.0.3` → `1.0.4`
- Release branch cut from `origin/dev` at `50845e0`

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.0.4
- DMG asset: `dist/KanVibe-1.0.4.dmg` (168,248,599 bytes)
- SHA-256: `077148c37e2c19245313ff66d1632ba1e887bef10cd5d4a1254633246e9e0ebe`
- Notarization: submission `de620265-77e5-45c6-9db0-9420eb35358a`, status `Accepted`, ticket stapled
- Homebrew cask: `rookedsysc/homebrew-kanvibe@22cb6e0` — `Update KanVibe cask to 1.0.4`

## Test Plan

- `pnpm run deploy` completed: signed with `Developer ID Application: Jong In Baek (3SDH4HX6H8)`, notarized, stapled.
- `xcrun stapler validate dist/KanVibe-1.0.4.dmg` → validate action worked.
- `spctl -a -t exec -vv` on the app inside the mounted DMG → `accepted`, `source=Notarized Developer ID`.
- Published asset downloaded and hashed; SHA-256 matches the local DMG exactly.
- `brew fetch --cask rookedsysc/kanvibe/kanvibe` → `✔︎ Cask kanvibe (1.0.4)`.
