### PR TITLE
Release: promote KanVibe 1.0.4 to main

### DIFF
--- a/.claude/skills/kanvibe-release-deploy/SKILL.md
+++ b/.claude/skills/kanvibe-release-deploy/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: kanvibe-release-deploy
-description: "Use this skill whenever releasing or deploying KanVibe desktop from a clean, up-to-date `dev` checkout: ask only for the target version and release-note approval, then let the AI update package versions, run `pnpm deploy`, publish the DMG GitHub release, update the Homebrew cask, create the release PR, and auto-merge the release/promotion PRs when checks pass. Always use it for KanVibe release versions, DMG uploads, or Homebrew cask checksum updates."
+description: "Use this skill whenever releasing or deploying KanVibe desktop from a clean, up-to-date `dev` checkout: ask only for the target version and release-note approval, then let the AI update package versions, run `pnpm run deploy`, publish the DMG GitHub release, update the Homebrew cask, create the release PR, and auto-merge the release/promotion PRs when checks pass. Always use it for KanVibe release versions, DMG uploads, or Homebrew cask checksum updates."
 ---
 
 # KanVibe Release Deploy
 
 ## Overview
 
-This skill coordinates the KanVibe desktop release workflow from version selection to DMG publication, Homebrew cask update, release PR creation, and automatic merge. It is intentionally release-operator focused and may only be invoked from a clean, up-to-date local `dev` checkout: read and report the current `package.json` version, ask the user for the target release version, update the package version, run the `pnpm deploy` DMG build, get explicit approval for the release notes, upload the exact DMG artifact to the `rookedsysc/kanvibe` GitHub release, update the separate Homebrew cask repository with the same version and SHA-256, create the KanVibe release PR, then merge the release and promotion PRs automatically once checks and review-thread gates pass.
+This skill coordinates the KanVibe desktop release workflow from version selection to DMG publication, Homebrew cask update, release PR creation, and automatic merge. It is intentionally release-operator focused and may only be invoked from a clean, up-to-date local `dev` checkout: read and report the current `package.json` version, ask the user for the target release version, update the package version, run the `pnpm run deploy` DMG build, get explicit approval for the release notes, upload the exact DMG artifact to the `rookedsysc/kanvibe` GitHub release, update the separate Homebrew cask repository with the same version and SHA-256, create the KanVibe release PR, then merge the release and promotion PRs automatically once checks and review-thread gates pass.
 
 The only routine user gates are target-version selection and release-note approval. After those are approved, do not ask for additional confirmation for build, release publication, cask update, PR creation, auto-merge enablement, or merge completion unless a blocker or branch-policy violation appears.
 
@@ -18,7 +18,7 @@ Before touching the cask, read `references/homebrew-cask-repository.md`. The cas
 Use this skill when the user asks to:
 
 - deploy or release KanVibe desktop;
-- run `pnpm deploy` for KanVibe release packaging;
+- run `pnpm run deploy` for KanVibe release packaging;
 - bump the KanVibe package version for a release;
 - create release notes or a GitHub release that includes `dist/KanVibe-<version>.dmg`;
 - create and merge the KanVibe release PR or pinned main-promotion PR after a desktop release;
@@ -32,9 +32,9 @@ Do not use this skill for docs-site deploys, Linux-only package checks, routine 
 - The GitHub release tag is the raw package version, for example `1.0.2`, not `v1.0.2`.
 - The DMG filename is `KanVibe-<version>.dmg` because `electron-builder.yml` sets `dmg.artifactName: "KanVibe-${version}.${ext}"`.
 - The cask URL expects the same raw version tag: `https://github.com/rookedsysc/kanvibe/releases/download/#{version}/KanVibe-#{version}.dmg`.
-- Use the SHA-256 of the final DMG produced after the version bump and `pnpm deploy`, not an earlier artifact.
-- `pnpm deploy` is the release build command for this workflow. It runs `scripts/dist-deploy.cjs`, which builds the DMG, codesigns, notarizes, staples, and prints the SHA-256.
-- `pnpm deploy` performs macOS signing/notarization, so it must run on macOS with Apple signing tools configured. Do not fabricate build, notarization, or checksum output from Linux.
+- Use the SHA-256 of the final DMG produced after the version bump and `pnpm run deploy`, not an earlier artifact.
+- `pnpm run deploy` is the release build command for this workflow. It runs `scripts/dist-deploy.cjs`, which builds the DMG, codesigns, notarizes, staples, and prints the SHA-256.
+- `pnpm run deploy` performs macOS signing/notarization, so it must run on macOS with Apple signing tools configured. Do not fabricate build, notarization, or checksum output from Linux.
 - Invoke this skill only from a clean, up-to-date local `dev` checkout. Stop on `main`, feature branches, existing release branches, detached HEADs, dirty worktrees, or a local `dev` HEAD that differs from `origin/dev`.
 - The release source is always `origin/dev`. Do not accept, infer, or ask about alternate source branches for this workflow.
 - The user's target-version selection and release-note approval authorize the remaining release actions. After those two gates, the AI should continue through release publication, cask update, release PR creation, auto-merge enablement, and pinned release-branch promotion to `main` without asking for another confirmation.
@@ -91,7 +91,7 @@ Validate these before proceeding:
 uname -s
 ```
 
-If the required host/tooling is unavailable, stop and report the blocker. Do not fake `pnpm deploy`, DMG, notarization, or checksum output.
+If the required host/tooling is unavailable, stop and report the blocker. Do not fake `pnpm run deploy`, DMG, notarization, or checksum output.
 
 After the target version is selected, create a dedicated release branch from the current `origin/dev` SHA. Do not use an existing release branch as the invocation point; reuse an existing release branch only after the `dev` preflight passes and only when it is the same release version with no unrelated files. This keeps the release PR narrow and prevents dirty local feature work from leaking into the release.
 
@@ -151,7 +151,7 @@ Run the release build command after the version bump:
 
 ```bash
 pnpm install --frozen-lockfile
-pnpm deploy
+pnpm run deploy
 ```
 
 Expected artifact for version `1.0.2`:
@@ -462,7 +462,7 @@ Before reporting success, collect real output for:
 - dev-only preflight evidence: current branch `dev`, clean status, and local `HEAD` matching `origin/dev` before the release branch was cut;
 - current version printed before the bump and the user-selected target version;
 - `git diff -- package.json package-lock.json` or commit evidence showing the version bump in both files;
-- `pnpm deploy` completion;
+- `pnpm run deploy` completion;
 - `test -f dist/KanVibe-<version>.dmg` and `shasum -a 256`;
 - user approval of the release notes, confirming both the English original and the Korean translation were shown before publishing;
 - `gh release view <version>` showing the `KanVibe-<version>.dmg` asset;
@@ -496,8 +496,8 @@ Final handoff format:
 ## Common Pitfalls
 
 1. **Skipping the version question.** Always report the current package version and ask the user what version to release unless the prompt already contains the exact target version.
-2. **Running a stale version build.** Update `package.json` before `pnpm deploy`, then derive the DMG path from the updated version.
-3. **Running on Linux and pretending success.** `pnpm deploy` requires macOS codesign, notarytool, and stapler, so stop honestly when the host is not Darwin.
+2. **Running a stale version build.** Update `package.json` before `pnpm run deploy`, then derive the DMG path from the updated version.
+3. **Running on Linux and pretending success.** `pnpm run deploy` requires macOS codesign, notarytool, and stapler, so stop honestly when the host is not Darwin.
 4. **Using a `v` tag.** The cask URL uses the raw version as the release tag. `v1.0.2` will break the current cask URL.
 5. **Checksum from the wrong file.** Always hash the final DMG produced after the version bump and release build.
 6. **Editing the cask before the release asset exists.** Homebrew fetch/audit can fail if the GitHub release asset is missing or still uploading.
@@ -508,3 +508,4 @@ Final handoff format:
 11. **Auto-merging through blockers.** Automatic merge is allowed only after checks pass or auto-merge is enabled from a pending state, active unresolved review threads are zero, GitHub reports the PR mergeable, and the PR file list matches the expected release scope.
 12. **Promoting moving `dev`.** Do not create the `main` promotion PR with `--head dev`; use the pinned release branch/SHA so commits that land on `dev` after the DMG build cannot ride along into `main`.
 13. **Starting from a non-`dev` checkout.** This workflow is dev-only at invocation. Stop instead of switching branches, inferring a different source, or running directly from `main`, feature branches, release branches, or detached HEADs.
+14. **Invoking the build as `pnpm deploy`.** `deploy` is a reserved pnpm command (workspace deploy), so `pnpm deploy` fails with `ERR_PNPM_CANNOT_DEPLOY` and never runs the release script. Always invoke the release build as `pnpm run deploy`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/messages/en.json
+++ b/messages/en.json
@@ -68,6 +68,19 @@
     "title": "",
     "newTask": "+ New Task",
     "allProjects": "All Projects",
+    "taskKindFilter": {
+      "label": "Task type filter",
+      "options": {
+        "project": "Project",
+        "task": "Task",
+        "all": "All"
+      },
+      "descriptions": {
+        "project": "Show only project-root tasks",
+        "task": "Show tasks except project roots",
+        "all": "Show project roots and tasks"
+      }
+    },
     "pageFind": {
       "label": "Find on board",
       "placeholder": "Find visible text on this board...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -86,11 +86,11 @@
     "loadingMore": "Loading...",
     "vimCommand": {
       "label": "Vim command",
-      "placeholder": "move review",
-      "hint": "Use :move todo|progress|pending|review|done for the focused task. Press Tab to autocomplete.",
+      "placeholder": "sync or move review",
+      "hint": "Use :sync to run background sync, or :move todo|progress|pending|review|done for the focused task. Press Tab to autocomplete.",
       "completionHint": "Press Tab to complete {command}.",
       "errors": {
-        "unknownCommand": "Unknown command. Try :move review.",
+        "unknownCommand": "Unknown command. Try :sync or :move review.",
         "noFocusedTask": "Focus a task card before running :move.",
         "taskNotFound": "The focused task is no longer visible."
       }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -86,11 +86,11 @@
     "loadingMore": "불러오는 중...",
     "vimCommand": {
       "label": "Vim 명령",
-      "placeholder": "move review",
-      "hint": "포커스된 task에 :move todo|progress|pending|review|done을 사용할 수 있습니다. Tab으로 자동 완성할 수 있습니다.",
+      "placeholder": "sync 또는 move review",
+      "hint": ":sync로 백그라운드 sync를 실행하거나 포커스된 task에 :move todo|progress|pending|review|done을 사용할 수 있습니다. Tab으로 자동 완성할 수 있습니다.",
       "completionHint": "Tab을 누르면 {command}(으)로 자동 완성합니다.",
       "errors": {
-        "unknownCommand": "알 수 없는 명령입니다. :move review를 시도해 보세요.",
+        "unknownCommand": "알 수 없는 명령입니다. :sync 또는 :move review를 시도해 보세요.",
         "noFocusedTask": ":move 실행 전 task card에 포커스하세요.",
         "taskNotFound": "포커스했던 task가 현재 보이지 않습니다."
       }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -68,6 +68,19 @@
     "title": "",
     "newTask": "+ 새 작업",
     "allProjects": "전체 프로젝트",
+    "taskKindFilter": {
+      "label": "작업 유형 필터",
+      "options": {
+        "project": "Project",
+        "task": "Task",
+        "all": "All"
+      },
+      "descriptions": {
+        "project": "프로젝트 root task만 보기",
+        "task": "프로젝트 root를 제외한 task만 보기",
+        "all": "프로젝트 root와 task 모두 보기"
+      }
+    },
     "pageFind": {
       "label": "보드에서 찾기",
       "placeholder": "이 보드에서 보이는 텍스트 찾기...",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -85,11 +85,11 @@
     "loadingMore": "加载中...",
     "vimCommand": {
       "label": "Vim 命令",
-      "placeholder": "move review",
-      "hint": "对当前聚焦任务使用 :move todo|progress|pending|review|done。按 Tab 自动补全。",
+      "placeholder": "sync 或 move review",
+      "hint": "使用 :sync 运行后台同步，或对当前聚焦任务使用 :move todo|progress|pending|review|done。按 Tab 自动补全。",
       "completionHint": "按 Tab 补全为 {command}。",
       "errors": {
-        "unknownCommand": "未知命令。请尝试 :move review。",
+        "unknownCommand": "未知命令。请尝试 :sync 或 :move review。",
         "noFocusedTask": "运行 :move 前请先聚焦一个任务卡片。",
         "taskNotFound": "当前聚焦的任务已不在可见列表中。"
       }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -67,6 +67,19 @@
     "title": "",
     "newTask": "+ 新任务",
     "allProjects": "所有项目",
+    "taskKindFilter": {
+      "label": "任务类型筛选",
+      "options": {
+        "project": "Project",
+        "task": "Task",
+        "all": "All"
+      },
+      "descriptions": {
+        "project": "仅显示项目根任务",
+        "task": "仅显示项目根以外的任务",
+        "all": "显示项目根和任务"
+      }
+    },
     "pageFind": {
       "label": "在看板中查找",
       "placeholder": "查找当前看板中可见的文本...",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "better-sqlite3": "^12.9.0",
     "dompurify": "^3.4.2",
     "marked": "^18.0.3",
+    "mermaid": "^11.15.0",
     "next-intl": "^4.8.2",
     "node-pty": "^1.1.0",
     "react": "19.2.3",
@@ -95,9 +96,9 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "jsdom": "^28.1.0",
-    "typescript-eslint": "^8.33.1",
     "tailwindcss": "^4",
     "typescript": "5.9.3",
+    "typescript-eslint": "^8.33.1",
     "vite": "^7.1.10",
     "vitest": "^4.0.18"
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "qa:task-kind-filter": "pnpm exec vitest run src/components/__tests__/Board.test.tsx src/desktop/renderer/hooks/__tests__/useTaskKindFilterParams.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-task-kind-filter-video.sh",
     "qa:ai-session-history": "pnpm exec vitest run src/lib/aiSessions && pnpm exec vitest run src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-ai-session-history-video.sh",
     "qa:pr275-pr276": "bash scripts/qa-pr275-pr276.sh",
+    "pretest": "node scripts/ensure-native-runtime.cjs",
     "test": "vitest run",
+    "pretest:watch": "node scripts/ensure-native-runtime.cjs",
     "test:watch": "vitest",
     "postinstall": "node scripts/postinstall.cjs"
   },
@@ -102,5 +104,6 @@
     "typescript-eslint": "^8.33.1",
     "vite": "^7.1.10",
     "vitest": "^4.0.18"
-  }
+  },
+  "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "qa:electron": "pnpm qa:electron:prepare && bash scripts/qa-electron.sh",
     "qa:electron:video": "pnpm qa:electron:prepare && bash scripts/qa-electron-video.sh",
     "qa:move-autocomplete": "pnpm exec vitest run src/components/__tests__/Board.test.tsx -t \"자동 완성\" && pnpm qa:electron:prepare && bash scripts/qa-move-autocomplete-video.sh",
+    "qa:task-kind-filter": "pnpm exec vitest run src/components/__tests__/Board.test.tsx src/desktop/renderer/hooks/__tests__/useTaskKindFilterParams.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-task-kind-filter-video.sh",
     "qa:ai-session-history": "pnpm exec vitest run src/lib/aiSessions && pnpm exec vitest run src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-ai-session-history-video.sh",
     "qa:pr275-pr276": "bash scripts/qa-pr275-pr276.sh",
     "test": "vitest run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       marked:
         specifier: ^18.0.3
         version: 18.0.3
+      mermaid:
+        specifier: ^11.15.0
+        version: 11.15.0
       next-intl:
         specifier: ^4.8.2
         version: 4.8.2(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -151,6 +154,9 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
   '@asamuzakjp/css-color@4.1.2':
     resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
 
@@ -247,9 +253,15 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@csstools/color-helpers@6.0.1':
     resolution: {integrity: sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==}
@@ -580,6 +592,12 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
@@ -767,6 +785,9 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@monaco-editor/loader@1.7.0':
     resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
@@ -1311,6 +1332,99 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1322,6 +1436,9 @@ packages:
 
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
@@ -1425,6 +1542,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.55.0':
     resolution: {integrity: sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-react@5.1.4':
     resolution: {integrity: sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==}
@@ -1754,6 +1874,14 @@ packages:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
@@ -1774,6 +1902,12 @@ packages:
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
   crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
@@ -1798,6 +1932,162 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -1860,6 +2150,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -2002,6 +2295,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -2266,6 +2562,9 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2343,6 +2642,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -2360,6 +2662,13 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   intl-messageformat@11.1.2:
     resolution: {integrity: sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==}
@@ -2553,8 +2862,21 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
@@ -2641,6 +2963,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -2681,6 +3006,11 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   marked@18.0.3:
     resolution: {integrity: sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==}
     engines: {node: '>= 20'}
@@ -2696,6 +3026,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2900,12 +3233,18 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2993,6 +3332,12 @@ packages:
 
   po-parser@2.1.1:
     resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3195,10 +3540,19 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -3426,6 +3780,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -3521,6 +3878,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3885,6 +4246,11 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.0.2
+
   '@asamuzakjp/css-color@4.1.2':
     dependencies:
       '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
@@ -4017,9 +4383,13 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.1.0
+
+  '@chevrotain/types@11.1.2': {}
 
   '@csstools/color-helpers@6.0.1': {}
 
@@ -4332,6 +4702,14 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@img/colour@1.0.0':
     optional: true
 
@@ -4475,6 +4853,10 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@monaco-editor/loader@1.7.0':
     dependencies:
@@ -4858,6 +5240,123 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -4869,6 +5368,8 @@ snapshots:
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 20.19.33
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/http-cache-semantics@4.2.0': {}
 
@@ -5009,6 +5510,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.55.0
       eslint-visitor-keys: 4.2.1
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
@@ -5409,6 +5915,10 @@ snapshots:
 
   commander@5.1.0: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   commander@9.5.0:
     optional: true
 
@@ -5422,6 +5932,14 @@ snapshots:
 
   core-util-is@1.0.2:
     optional: true
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   crc@3.8.0:
     dependencies:
@@ -5454,6 +5972,190 @@ snapshots:
       lru-cache: 11.2.6
 
   csstype@3.2.3: {}
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
 
   data-urls@7.0.0:
     dependencies:
@@ -5511,6 +6213,10 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -5764,6 +6470,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.47.0: {}
 
   es6-error@4.1.1:
     optional: true
@@ -6122,6 +6830,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  hachure-fill@0.5.2: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -6200,6 +6910,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   inflight@1.0.6:
@@ -6216,6 +6928,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   intl-messageformat@11.1.2:
     dependencies:
@@ -6432,9 +7148,19 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lazy-val@1.0.5: {}
 
@@ -6496,6 +7222,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.merge@4.6.2: {}
 
   lodash@4.17.23: {}
@@ -6526,6 +7254,8 @@ snapshots:
 
   marked@14.0.0: {}
 
+  marked@16.4.2: {}
+
   marked@18.0.3: {}
 
   matcher@3.0.0:
@@ -6536,6 +7266,30 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.12.2: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.19
+      dompurify: 3.4.2
+      es-toolkit: 1.47.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 11.1.0
 
   mime-db@1.52.0: {}
 
@@ -6749,6 +7503,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@1.6.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -6756,6 +7512,8 @@ snapshots:
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
+
+  path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
 
@@ -6837,6 +7595,13 @@ snapshots:
       xmlbuilder: 15.1.1
 
   po-parser@2.1.1: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -7050,6 +7815,8 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.57.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -7080,6 +7847,15 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.57.1
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
+
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  rw@1.3.3: {}
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -7363,6 +8139,8 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  stylis@4.4.0: {}
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
@@ -7464,6 +8242,8 @@ snapshots:
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-dedent@2.3.0: {}
 
   tslib@2.8.1: {}
 

--- a/qa/electron/flows/ai-session-history.cjs
+++ b/qa/electron/flows/ai-session-history.cjs
@@ -95,6 +95,10 @@ async function takeScreenshot(page, run, label, screenshots) {
   const shotPath = path.join(run.screenshotsDir, fileName);
   await page.screenshot({ path: shotPath, fullPage: true });
   screenshots.push({ label, path: shotPath });
+  const videoPauseMs = Number.parseInt(process.env.KANVIBE_QA_VIDEO_STEP_PAUSE_MS || "900", 10);
+  if (Number.isFinite(videoPauseMs) && videoPauseMs > 0) {
+    await page.waitForTimeout(videoPauseMs);
+  }
 }
 
 async function dismissUpdateDialogIfPresent(page) {
@@ -255,7 +259,42 @@ function createFakeAiSessionHistory(fakeHome, fixture) {
   writeJsonLines(claudeFile, [
     { type: "system", sessionId: "claude-manual-ai-history", cwd: matchedPath, timestamp: "2026-01-01T00:00:00.000Z", message: { role: "system", content: "Claude system instructions for KanVibe QA." } },
     { type: "user", sessionId: "claude-manual-ai-history", cwd: matchedPath, timestamp: "2026-01-01T00:01:00.000Z", message: { role: "user", content: [{ type: "text", text: "Claude QA prompt: verify manual AI history loading" }] } },
-    { type: "assistant", sessionId: "claude-manual-ai-history", cwd: matchedPath, timestamp: "2026-01-01T00:02:00.000Z", message: { role: "assistant", content: [{ type: "text", text: "Claude QA assistant answer: load only after the user presses the history button. Body-search marker: database migration rollback." }] } },
+    {
+      type: "assistant",
+      sessionId: "claude-manual-ai-history",
+      cwd: matchedPath,
+      timestamp: "2026-01-01T00:02:00.000Z",
+      message: {
+        role: "assistant",
+        content: [{
+          type: "text",
+          text: [
+            "Claude QA assistant answer: load only after the user presses the history button.",
+            "",
+            "## Markdown + Mermaid QA summary",
+            "",
+            "- Markdown bullet renders as a real list item.",
+            "- **Strong text** and `inline code` stay formatted.",
+            "- [Safe KanVibe link](https://example.com/kanvibe) opens with safe link attributes.",
+            "",
+            "```ts",
+            "const qaResult = 'markdown-rendered';",
+            "```",
+            "",
+            "```mermaid",
+            "graph TD",
+            "  A[AI history loaded] --> B[Markdown rendered]",
+            "  B --> C[Mermaid SVG rendered]",
+            "```",
+            "",
+            "<script>KanVibe QA blocked script</script>",
+            "<span style=\"color:red\">Style attribute is stripped but text remains.</span>",
+            "",
+            "Body-search marker: database migration rollback.",
+          ].join("\n"),
+        }],
+      },
+    },
     { type: "user", sessionId: "claude-manual-ai-history", cwd: matchedPath, timestamp: "2026-01-01T00:03:00.000Z", message: { role: "user", content: [{ type: "tool_result", content: "Claude QA tool result text." }] } },
   ]);
 
@@ -534,6 +573,7 @@ async function main() {
   let fixture;
   let seededTask;
   let headlessCodexResult = null;
+  let isExpectedShutdown = false;
 
   const check = async (name, fn) => {
     try {
@@ -585,6 +625,18 @@ async function main() {
     app = launched.app;
     page = launched.page;
 
+    app.process().on("exit", (code, signal) => {
+      if (isExpectedShutdown) return;
+      const output = typeof app?.output === "function" ? app.output() : "";
+      errors.push(`electron exited: code=${code ?? "null"} signal=${signal ?? "null"}${output ? ` output=${output.slice(-4000)}` : ""}`);
+    });
+    page.on("close", () => {
+      if (!isExpectedShutdown) errors.push("page closed before QA flow completed");
+    });
+    page.on("crash", () => {
+      if (!isExpectedShutdown) errors.push("page crashed before QA flow completed");
+    });
+
     page.on("console", (message) => {
       if (["error", "warning"].includes(message.type())) errors.push(`${message.type()}: ${message.text()}`);
     });
@@ -622,29 +674,42 @@ async function main() {
       return `task=${seededTask.id}; repo=${fixture.repoDir}; worktree=${fixture.worktreePath}; fakeHome=${fakeHome}; fixtures=${Object.values(aiFixtures).join(",")}`;
     });
 
-    await setStepOverlay(page, "1/5 상세 화면 진입: AI 히스토리는 아직 자동 로드되지 않아야 함");
+    await setStepOverlay(page, "1/7 상세 화면 진입: AI 히스토리는 아직 자동 로드되지 않아야 함");
     await page.evaluate((taskId) => {
       window.location.hash = `#/ko/task/${taskId}`;
     }, seededTask.id);
     await page.waitForTimeout(1200);
     await dismissUpdateDialogIfPresent(page);
-    await page.getByText("QA manual AI session history", { exact: false }).first().waitFor({ state: "visible", timeout: 20000 });
+    await page.getByText("이 작업에는 연결된 터미널 세션이 없습니다.", { exact: false }).first().waitFor({ state: "visible", timeout: 20000 });
+    await page.getByRole("button", { name: "AI 채팅" }).waitFor({ state: "visible", timeout: 15000 });
     await takeScreenshot(page, run, "task-detail-before-ai-history-load", screenshots);
 
-    await check("Opening AI chat view does not auto-load history", async () => {
+    await check("Opening AI chat view shows the AI session panel without selecting a conversation", async () => {
       await dismissUpdateDialogIfPresent(page);
       await page.getByRole("button", { name: "AI 채팅" }).click({ timeout: 15000 });
       await page.locator("[data-testid='inline-ai-chat']").waitFor({ state: "visible", timeout: 15000 });
-      await waitForText(page, "AI 세션 히스토리는 필요할 때만 불러옵니다.");
-      const listCount = await page.locator("[data-testid='ai-session-list']").count();
-      if (listCount !== 0) throw new Error(`history list appeared before manual load: ${listCount}`);
-      return "inline chat opened with manual-load hint and no session list";
-    });
-    await takeScreenshot(page, run, "inline-chat-manual-load-hint", screenshots);
 
-    await setStepOverlay(page, "2/6 히스토리 불러오기: Claude/Codex/OpenCode/Gemini provider 목록 표시");
-    await check("Manual history load shows Claude, Codex, OpenCode, and Gemini sessions", async () => {
-      await page.getByRole("button", { name: "히스토리 불러오기" }).click({ timeout: 15000 });
+      const manualLoadButton = page.getByRole("button", { name: "히스토리 불러오기" });
+      if (await manualLoadButton.isVisible({ timeout: 1000 }).catch(() => false)) {
+        await waitForText(page, "AI 세션 히스토리는 필요할 때만 불러옵니다.");
+        const listCount = await page.locator("[data-testid='ai-session-list']").count();
+        if (listCount !== 0) throw new Error(`history list appeared before manual load: ${listCount}`);
+        return "inline chat opened with manual-load hint and no session list";
+      }
+
+      await page.locator("[data-testid='ai-session-list']").waitFor({ state: "visible", timeout: 15000 });
+      await waitForText(page, "왼쪽 목록에서 AI 세션을 선택하세요.");
+      return "inline chat opened with the session list visible and no conversation selected";
+    });
+    await takeScreenshot(page, run, "inline-chat-session-panel-opened", screenshots);
+
+    await setStepOverlay(page, "2/7 히스토리 목록 확인: Claude/Codex/OpenCode/Gemini provider 목록 표시");
+    await check("History panel shows Claude, Codex, OpenCode, and Gemini sessions", async () => {
+      const manualLoadButton = page.getByRole("button", { name: "히스토리 불러오기" });
+      const clickedManualLoad = await manualLoadButton.isVisible({ timeout: 1000 }).catch(() => false);
+      if (clickedManualLoad) {
+        await manualLoadButton.click({ timeout: 15000 });
+      }
       await page.locator("[data-testid='ai-session-list']").waitFor({ state: "visible", timeout: 20000 });
       await assertProviderBadges(page);
       for (const text of [
@@ -670,7 +735,7 @@ async function main() {
       return `live Codex exec marker visible in session list: ${headlessCodexResult.marker}`;
     });
 
-    await setStepOverlay(page, "3/6 왼쪽 provider 아이콘 rail: Claude+Gemini OR 필터 동작 검증");
+    await setStepOverlay(page, "3/7 왼쪽 provider 아이콘 rail: Claude+Gemini OR 필터 동작 검증");
     await check("Provider icon rail filters sessions with OR semantics", async () => {
       for (const provider of ["claude", "opencode", "gemini", "codex"]) {
         await page.locator(`[data-testid='ai-session-filter-${provider}']`).waitFor({ state: "visible", timeout: 10000 });
@@ -711,7 +776,7 @@ async function main() {
     });
     await takeScreenshot(page, run, "provider-or-filter-rail", screenshots);
 
-    await setStepOverlay(page, "4/6 Claude 세션 선택: 말풍선 왼쪽 위 provider 아이콘과 user/assistant/system/tool 메시지 표시");
+    await setStepOverlay(page, "4/7 Claude 세션 선택: 말풍선 왼쪽 위 provider 아이콘과 user/assistant/system/tool 메시지 표시");
     await check("Selecting a Claude session loads chat messages with provider icons", async () => {
       await page.getByRole("button", { name: /claude .*manual AI history|claude .*Claude QA prompt/i }).click({ timeout: 15000 });
       await waitForText(page, "Claude QA assistant answer");
@@ -723,7 +788,56 @@ async function main() {
     });
     await takeScreenshot(page, run, "claude-session-detail-messages", screenshots);
 
-    await setStepOverlay(page, "5/6 역할 필터: 시스템 입력만 선택하면 system 메시지만 남아야 함");
+    await setStepOverlay(page, "5/7 Markdown + Mermaid: heading/list/code/link/SVG 렌더링 및 sanitize 검증");
+    await check("Selected Claude detail renders Markdown and Mermaid safely", async () => {
+      await waitForText(page, "Markdown + Mermaid QA summary");
+      await waitForText(page, "Markdown bullet renders as a real list item.");
+      await waitForText(page, "const qaResult = 'markdown-rendered';");
+      await page.locator("[data-testid='ai-session-mermaid-diagram'] svg").first().waitFor({ state: "attached", timeout: 20000 });
+
+      const renderState = await page.locator("[data-testid='inline-ai-chat']").evaluate((root) => {
+        const textIncludes = (selector, value) => Array.from(root.querySelectorAll(selector)).some((node) => node.textContent?.includes(value));
+        const safeLink = Array.from(root.querySelectorAll(".ai-session-markdown a"))
+          .find((node) => node.textContent?.includes("Safe KanVibe link"));
+
+        return {
+          heading: textIncludes("h2", "Markdown + Mermaid QA summary"),
+          listItem: textIncludes("li", "Markdown bullet renders as a real list item."),
+          codeBlock: textIncludes("pre code", "const qaResult = 'markdown-rendered';"),
+          strongText: textIncludes("strong", "Strong text"),
+          mermaidSvg: Boolean(root.querySelector("[data-testid='ai-session-mermaid-diagram'] svg")),
+          mermaidFallback: Boolean(root.querySelector("[data-testid='ai-session-mermaid-fallback']")),
+          unsafeScript: Boolean(root.querySelector(".ai-session-markdown script")),
+          unsafeStyle: Boolean(root.querySelector(".ai-session-markdown [style]")),
+          unsafeJavascriptLink: Boolean(root.querySelector('.ai-session-markdown a[href^="javascript:"]')),
+          safeLinkTarget: safeLink?.getAttribute("target") || "",
+          safeLinkRel: safeLink?.getAttribute("rel") || "",
+          safeLinkHref: safeLink?.getAttribute("href") || "",
+        };
+      });
+
+      const failures = [];
+      if (!renderState.heading) failures.push("missing markdown h2");
+      if (!renderState.listItem) failures.push("missing markdown li");
+      if (!renderState.codeBlock) failures.push("missing fenced code block");
+      if (!renderState.strongText) failures.push("missing strong text");
+      if (!renderState.mermaidSvg) failures.push("missing Mermaid SVG");
+      if (renderState.mermaidFallback) failures.push("Mermaid fell back to raw pre/code");
+      if (renderState.unsafeScript) failures.push("script tag survived sanitizer");
+      if (renderState.unsafeStyle) failures.push("style attribute survived sanitizer");
+      if (renderState.unsafeJavascriptLink) failures.push("javascript: link survived sanitizer");
+      if (renderState.safeLinkTarget !== "_blank") failures.push(`safe link target=${renderState.safeLinkTarget || "missing"}`);
+      if (!renderState.safeLinkRel.includes("noopener") || !renderState.safeLinkRel.includes("noreferrer")) {
+        failures.push(`safe link rel=${renderState.safeLinkRel || "missing"}`);
+      }
+      if (renderState.safeLinkHref !== "https://example.com/kanvibe") failures.push(`safe link href=${renderState.safeLinkHref || "missing"}`);
+      if (failures.length > 0) throw new Error(failures.join("; "));
+
+      return "Markdown h2/li/strong/code/link rendered, Mermaid SVG attached, and unsafe script/style/javascript links were removed";
+    });
+    await takeScreenshot(page, run, "markdown-mermaid-rendered-and-sanitized", screenshots);
+
+    await setStepOverlay(page, "6/7 역할 필터: 시스템 입력만 선택하면 system 메시지만 남아야 함");
     await check("Role filter passes through and narrows detail to system messages", async () => {
       await page.getByRole("button", { name: "시스템 입력" }).click({ timeout: 15000 });
       await page.waitForTimeout(1000);
@@ -744,7 +858,7 @@ async function main() {
     });
     await takeScreenshot(page, run, "system-role-filter-applied", screenshots);
 
-    await setStepOverlay(page, "6/6 채팅 검색: 본문에만 있는 database migration 문구로 Claude 대화 검색");
+    await setStepOverlay(page, "7/7 채팅 검색: 본문에만 있는 database migration 문구로 Claude 대화 검색");
     await check("Chat search reloads history by message-body query and opens the matching conversation", async () => {
       const searchInput = page.locator("#ai-session-search");
       await searchInput.fill("database migration rollback");
@@ -792,6 +906,7 @@ async function main() {
     console.error(`[kanvibe-qa] AI session history flow failed:\n${detail}`);
     checks.push({ name: "AI session history Electron QA flow", ok: false, detail });
   } finally {
+    isExpectedShutdown = true;
     if (page && traceStarted) {
       await page.context().tracing.stop({ path: run.tracePath }).catch((error) => {
         checks.push({ name: "Playwright trace artifact", ok: false, detail: error instanceof Error ? error.message : String(error) });
@@ -834,7 +949,7 @@ async function main() {
 
   const result = {
     ok,
-    scope: "Electron UI QA for AI session history controls: manual history loading, provider icon rail OR filtering, message-level provider icons, body-text chat search across Claude/Codex/OpenCode/Gemini history, session detail rendering, and role filter narrowing",
+    scope: "Electron UI QA for AI session history controls: manual history loading, provider icon rail OR filtering, message-level provider icons, Markdown rendering, Mermaid SVG rendering, sanitizer behavior, body-text chat search across Claude/Codex/OpenCode/Gemini history, session detail rendering, and role filter narrowing",
     branch: gitValue(["branch", "--show-current"]),
     commit: gitValue(["rev-parse", "--short", "HEAD"]),
     checks,

--- a/qa/electron/flows/task-kind-filter.cjs
+++ b/qa/electron/flows/task-kind-filter.cjs
@@ -1,0 +1,414 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+const { createQaRun } = require("../lib/report.cjs");
+const { launchKanVibeElectron } = require("../lib/launchElectron.cjs");
+
+const TASK_KIND_FILTER_SCOPE = "Project/Task/All task-kind filter UI: seed an isolated project-root task plus branch/plain tasks, then verify the Board filter buttons hide/show the expected cards in Electron";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--run-dir") args.runDir = argv[++index];
+    else if (arg === "--run-id") args.runId = argv[++index];
+    else if (arg === "--output-root") args.outputRoot = argv[++index];
+  }
+  return args;
+}
+
+function gitValue(args) {
+  try {
+    return execFileSync("git", args, { encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function execGit(args, cwd) {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function renderReport(result) {
+  const lines = [];
+  lines.push("# KanVibe Task Kind Filter Electron QA Report");
+  lines.push("");
+  lines.push(`- Run ID: \`${result.runId}\``);
+  lines.push(`- Branch: \`${result.branch || "unknown"}\``);
+  lines.push(`- Commit: \`${result.commit || "unknown"}\``);
+  lines.push(`- Scope: ${result.scope}`);
+  lines.push(`- Status: **${result.ok ? "PASS" : "FAIL"}**`);
+  lines.push("");
+  lines.push("## Checks");
+  lines.push("");
+  for (const check of result.checks) {
+    lines.push(`- ${check.ok ? "✅" : "❌"} **${check.name}**${check.detail ? ` — ${check.detail}` : ""}`);
+  }
+  lines.push("");
+  lines.push("## Console / Runtime Errors");
+  lines.push("");
+  if (result.errors.length > 0) {
+    for (const error of result.errors) lines.push(`- ${error}`);
+  } else {
+    lines.push("No blocking console/runtime errors captured.");
+  }
+  lines.push("");
+  lines.push("## Evidence");
+  lines.push("");
+  for (const shot of result.screenshots) {
+    lines.push(`- ${shot.label}: \`${shot.path}\``);
+  }
+  if (result.videoPath) lines.push(`- Video: \`${result.videoPath}\``);
+  if (result.tracePath) lines.push(`- Playwright trace: \`${result.tracePath}\``);
+  lines.push("");
+  lines.push("## Notes");
+  lines.push("");
+  for (const note of result.notes) lines.push(`- ${note}`);
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeReport(run, result) {
+  const fullResult = { ...result, runId: run.runId };
+  writeJson(run.jsonPath, fullResult);
+  fs.writeFileSync(run.reportPath, renderReport(fullResult), "utf8");
+}
+
+async function optionalStep(checks, name, fn) {
+  try {
+    const detail = await fn();
+    checks.push({ name, ok: true, detail: detail || "ok" });
+    return detail;
+  } catch (error) {
+    checks.push({ name, ok: false, detail: error instanceof Error ? error.message : String(error) });
+    return null;
+  }
+}
+
+async function takeScreenshot(page, run, label, screenshots) {
+  const fileName = `${String(screenshots.length + 1).padStart(2, "0")}-${label}.png`;
+  const shotPath = path.join(run.screenshotsDir, fileName);
+  await page.screenshot({ path: shotPath, fullPage: true });
+  screenshots.push({ label, path: shotPath });
+}
+
+async function invokeDesktop(page, namespace, method, ...args) {
+  return page.evaluate(
+    async ({ namespace: serviceNamespace, method: serviceMethod, args: serviceArgs }) => (
+      window.kanvibeDesktop.invoke(serviceNamespace, serviceMethod, serviceArgs)
+    ),
+    { namespace, method, args },
+  );
+}
+
+async function dismissUpdateDialogIfPresent(page) {
+  const closeButton = page.getByRole("button", { name: /닫기|Close/i }).first();
+  try {
+    await closeButton.click({ timeout: 2500 });
+    await page.waitForTimeout(500);
+  } catch {
+    // Optional release/update dialog is not always present.
+  }
+}
+
+function createLocalFixtureRepository(run) {
+  const projectDir = path.join(run.runDir, "fixtures", `task-kind-filter-${run.runId}`);
+  const projectName = `Task Kind Filter QA ${run.runId}`;
+  const defaultBranch = "main";
+  fs.rmSync(projectDir, { recursive: true, force: true });
+  ensureDir(projectDir);
+
+  try {
+    execGit(["init", "--initial-branch", defaultBranch], projectDir);
+  } catch {
+    execGit(["init"], projectDir);
+    execGit(["checkout", "-B", defaultBranch], projectDir);
+  }
+  execGit(["config", "user.email", "qa@kanvibe.local"], projectDir);
+  execGit(["config", "user.name", "KanVibe QA"], projectDir);
+  fs.writeFileSync(path.join(projectDir, "README.md"), `# ${projectName}\n`, "utf8");
+  execGit(["add", "README.md"], projectDir);
+  execGit(["commit", "-m", "Initial QA fixture"], projectDir);
+
+  return { projectDir, projectName, defaultBranch };
+}
+
+function cardSelector(taskId) {
+  return `[data-kanban-task-card='true'][data-kanban-task-id='${taskId}']`;
+}
+
+async function expectCardVisible(page, taskId, label) {
+  const card = page.locator(cardSelector(taskId));
+  await card.waitFor({ state: "visible", timeout: 15000 });
+  await card.scrollIntoViewIfNeeded();
+  return `${label}:${taskId}`;
+}
+
+async function expectCardHidden(page, taskId, label) {
+  await page.waitForFunction(
+    (id) => !document.querySelector(`[data-kanban-task-card='true'][data-kanban-task-id='${id}']`),
+    taskId,
+    { timeout: 15000 },
+  );
+  return `${label}:${taskId}`;
+}
+
+async function expectVisibleAndHidden(page, visible, hidden) {
+  const visibleDetails = [];
+  for (const item of visible) {
+    visibleDetails.push(await expectCardVisible(page, item.id, item.label));
+  }
+  const hiddenDetails = [];
+  for (const item of hidden) {
+    hiddenDetails.push(await expectCardHidden(page, item.id, item.label));
+  }
+  return `visible=[${visibleDetails.join(", ")}], hidden=[${hiddenDetails.join(", ")}]`;
+}
+
+async function clickTaskKindFilter(page, name) {
+  await page.getByTestId("task-kind-filter").getByRole("button", { name }).click();
+  await page.waitForTimeout(900);
+}
+
+async function seedTaskKindFilterData(page, fixture, runId) {
+  const projectResult = await invokeDesktop(page, "project", "registerProject", fixture.projectName, fixture.projectDir);
+  if (!projectResult.success || !projectResult.project) {
+    throw new Error(projectResult.error || "QA project registration failed");
+  }
+
+  const project = projectResult.project;
+  const rootTaskId = await invokeDesktop(page, "kanban", "getTaskIdByProjectAndBranch", project.id, fixture.defaultBranch);
+  if (!rootTaskId) {
+    throw new Error("Project root task was not created for the fixture project");
+  }
+
+  const branchTask = await invokeDesktop(page, "kanban", "createTask", {
+    title: `qa-filter-branch-${runId}`,
+    description: "Electron QA branch task for the Project/Task/All filter.",
+    branchName: `qa/filter-${runId}`,
+    baseBranch: fixture.defaultBranch,
+    projectId: project.id,
+  });
+  const plainTask = await invokeDesktop(page, "kanban", "createTask", {
+    title: `qa-filter-plain-${runId}`,
+    description: "Electron QA plain task for the Project/Task/All filter.",
+    projectId: project.id,
+  });
+
+  await page.evaluate(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    window.location.hash = "#/ko";
+  });
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await dismissUpdateDialogIfPresent(page);
+
+  return {
+    project,
+    rootTask: { id: rootTaskId, label: "project-root" },
+    branchTask: { id: branchTask.id, label: "branch-task" },
+    plainTask: { id: plainTask.id, label: "plain-task" },
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv);
+  const run = createQaRun({ ...options, rootDir: process.cwd() });
+  const fixture = createLocalFixtureRepository(run);
+  const checks = [];
+  const screenshots = [];
+  const consoleErrors = [];
+  const notes = [];
+  let app = null;
+  let page = null;
+  let traceStarted = false;
+
+  try {
+    const launched = await launchKanVibeElectron({
+      rootDir: run.rootDir,
+      outputDir: run.runDir,
+      appDataDir: path.join(run.runDir, "app-data"),
+      viewport: { width: 1500, height: 950 },
+      actionTimeoutMs: 15000,
+    });
+    app = launched.app;
+    page = launched.page;
+
+    page.on("console", (message) => {
+      if (["error", "warning"].includes(message.type())) {
+        consoleErrors.push(`${message.type()}: ${message.text()}`);
+      }
+    });
+    page.on("pageerror", (error) => consoleErrors.push(`pageerror: ${error.message}`));
+    page.on("requestfailed", (request) => {
+      const failure = request.failure();
+      consoleErrors.push(`requestfailed: ${request.url()} ${failure?.errorText || "unknown"}`);
+    });
+
+    await page.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
+    traceStarted = true;
+
+    await optionalStep(checks, "Electron window opens on the KanVibe board", async () => {
+      await page.waitForLoadState("domcontentloaded");
+      await page.locator("body").waitFor({ state: "visible", timeout: 20000 });
+      await dismissUpdateDialogIfPresent(page);
+      return page.url();
+    });
+
+    let seeded = null;
+    await optionalStep(checks, "Seed isolated project-root, branch, and plain tasks through app IPC", async () => {
+      seeded = await seedTaskKindFilterData(page, fixture, run.runId);
+      return `project=${seeded.project.name}, root=${seeded.rootTask.id}, branch=${seeded.branchTask.id}, plain=${seeded.plainTask.id}`;
+    });
+    if (!seeded) throw new Error("QA seed failed; cannot continue task-kind filter flow");
+
+    await optionalStep(checks, "Task kind filter is left of the project selector with matching control sizing", async () => {
+      await page.getByTestId("task-kind-filter").waitFor({ state: "visible", timeout: 15000 });
+      await page.getByTestId("project-filter-control").waitFor({ state: "visible", timeout: 15000 });
+      const metrics = await page.evaluate(() => {
+        const filter = document.querySelector("[data-testid='task-kind-filter']");
+        const project = document.querySelector("[data-testid='project-filter-control']");
+        if (!filter || !project) return null;
+        const filterRect = filter.getBoundingClientRect();
+        const projectRect = project.getBoundingClientRect();
+        return {
+          filterLeft: filterRect.left,
+          filterRight: filterRect.right,
+          filterWidth: filterRect.width,
+          filterHeight: filterRect.height,
+          projectLeft: projectRect.left,
+          projectHeight: projectRect.height,
+          filterClassName: filter.className,
+        };
+      });
+      if (!metrics) throw new Error("filter/project selector controls were not found");
+      if (metrics.filterRight > metrics.projectLeft) {
+        throw new Error(`task-kind filter is not left of project selector: filterRight=${metrics.filterRight}, projectLeft=${metrics.projectLeft}`);
+      }
+      if (Math.abs(metrics.filterHeight - metrics.projectHeight) > 2) {
+        throw new Error(`control heights differ: filter=${metrics.filterHeight}, project=${metrics.projectHeight}`);
+      }
+      if (Math.abs(metrics.filterWidth - 180) > 2 || Math.abs(metrics.filterHeight - 34) > 2) {
+        throw new Error(`unexpected task-kind filter size: ${metrics.filterWidth}x${metrics.filterHeight}`);
+      }
+      if (!String(metrics.filterClassName).includes("bg-bg-page")) {
+        throw new Error(`task-kind filter is missing bg-bg-page styling: ${metrics.filterClassName}`);
+      }
+      return `filter=${Math.round(metrics.filterWidth)}x${Math.round(metrics.filterHeight)} left of project selector (${Math.round(metrics.filterRight)} <= ${Math.round(metrics.projectLeft)})`;
+    });
+
+    await optionalStep(checks, "All filter shows project root, branch task, and plain task", async () => {
+      await clickTaskKindFilter(page, "All");
+      const detail = await expectVisibleAndHidden(
+        page,
+        [seeded.rootTask, seeded.branchTask, seeded.plainTask],
+        [],
+      );
+      await takeScreenshot(page, run, "all-filter-shows-root-branch-plain", screenshots);
+      return detail;
+    });
+
+    await optionalStep(checks, "Project filter shows only the project-root task", async () => {
+      await clickTaskKindFilter(page, "Project");
+      const detail = await expectVisibleAndHidden(
+        page,
+        [seeded.rootTask],
+        [seeded.branchTask, seeded.plainTask],
+      );
+      await takeScreenshot(page, run, "project-filter-shows-root-only", screenshots);
+      return detail;
+    });
+
+    await optionalStep(checks, "Task filter hides project root and shows branch/plain tasks", async () => {
+      await clickTaskKindFilter(page, "Task");
+      const detail = await expectVisibleAndHidden(
+        page,
+        [seeded.branchTask, seeded.plainTask],
+        [seeded.rootTask],
+      );
+      await takeScreenshot(page, run, "task-filter-hides-root", screenshots);
+      return detail;
+    });
+
+    await optionalStep(checks, "Filter buttons keep their pressed state visible", async () => {
+      const taskPressed = await page.getByTestId("task-kind-filter").getByRole("button", { name: "Task" }).getAttribute("aria-pressed");
+      await clickTaskKindFilter(page, "All");
+      const allPressed = await page.getByTestId("task-kind-filter").getByRole("button", { name: "All" }).getAttribute("aria-pressed");
+      if (taskPressed !== "true" || allPressed !== "true") {
+        throw new Error(`unexpected pressed states: Task=${taskPressed}, All=${allPressed}`);
+      }
+      await takeScreenshot(page, run, "all-filter-restored", screenshots);
+      return "Task and All buttons expose aria-pressed=true when active";
+    });
+
+    await optionalStep(checks, "No blocking console errors", async () => {
+      const blocking = consoleErrors.filter((line) => !/favicon|DevTools|Electron Security Warning|Insecure Content-Security-Policy/i.test(line));
+      if (blocking.length > 0) throw new Error(blocking.join("\n"));
+      return "none";
+    });
+  } catch (error) {
+    checks.push({ name: "Electron task-kind filter QA flow", ok: false, detail: error instanceof Error ? error.stack || error.message : String(error) });
+  } finally {
+    if (page && traceStarted) {
+      await page.context().tracing.stop({ path: run.tracePath }).catch((error) => {
+        checks.push({ name: "Playwright trace artifact", ok: false, detail: error instanceof Error ? error.message : String(error) });
+      });
+    }
+    if (app) await app.close().catch(() => {});
+  }
+
+  await optionalStep(checks, "Playwright trace artifact written", async () => {
+    if (!fs.existsSync(run.tracePath) || fs.statSync(run.tracePath).size === 0) {
+      throw new Error(`trace missing or empty: ${run.tracePath}`);
+    }
+    return run.tracePath;
+  });
+
+  await optionalStep(checks, "Isolated app-data database written inside run directory", async () => {
+    const isolatedDatabasePath = path.join(run.runDir, "app-data", "kanvibe.db");
+    if (!fs.existsSync(isolatedDatabasePath) || fs.statSync(isolatedDatabasePath).size === 0) {
+      throw new Error(`isolated QA database missing or empty: ${isolatedDatabasePath}`);
+    }
+    return isolatedDatabasePath;
+  });
+
+  const ok = checks.every((check) => check.ok);
+  const videoExists = fs.existsSync(run.videoPath) && fs.statSync(run.videoPath).size > 0;
+  notes.push(`Fixture project: ${fixture.projectName} / ${fixture.projectDir}`);
+  notes.push("QA uses an isolated KANVIBE_APP_DATA_DIR inside the run directory, not the user's app database.");
+  notes.push(videoExists ? "Actual X11 screen recording captured with ffmpeg." : "No mp4 was present when flow finished; wrapper script can synthesize one from screenshots.");
+  notes.push(`Node: ${process.version}; platform: ${process.platform}/${process.arch}; tmp: ${os.tmpdir()}`);
+
+  const result = {
+    ok,
+    scope: TASK_KIND_FILTER_SCOPE,
+    branch: gitValue(["branch", "--show-current"]),
+    commit: gitValue(["rev-parse", "--short", "HEAD"]),
+    checks,
+    errors: consoleErrors,
+    screenshots,
+    videoPath: videoExists ? run.videoPath : null,
+    tracePath: fs.existsSync(run.tracePath) ? run.tracePath : null,
+    notes,
+  };
+
+  writeReport(run, result);
+  console.log(JSON.stringify({ ok, runDir: run.runDir, reportPath: run.reportPath, videoPath: run.videoPath }, null, 2));
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/qa-task-kind-filter-video.sh
+++ b/scripts/qa-task-kind-filter-video.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN_ID="${KANVIBE_QA_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+RUN_DIR="${KANVIBE_QA_RUN_DIR:-$ROOT_DIR/qa-output/$RUN_ID}"
+VIDEO_PATH="$RUN_DIR/run.mp4"
+LOG_PATH="$RUN_DIR/ffmpeg.log"
+NODE_BIN="${KANVIBE_QA_NODE_BIN:-${npm_node_execpath:-node}}"
+mkdir -p "$RUN_DIR"
+
+run_flow() {
+  "$NODE_BIN" qa/electron/flows/task-kind-filter.cjs --run-dir "$RUN_DIR" --run-id "$RUN_ID"
+}
+
+record_and_run() {
+  local ffmpeg_pid=""
+  if command -v ffmpeg >/dev/null 2>&1 && [[ -n "${DISPLAY:-}" ]]; then
+    ffmpeg -y \
+      -video_size "${KANVIBE_QA_VIDEO_SIZE:-1600x1000}" \
+      -framerate "${KANVIBE_QA_FRAMERATE:-15}" \
+      -f x11grab \
+      -i "${DISPLAY}" \
+      -pix_fmt yuv420p \
+      "$VIDEO_PATH" >"$LOG_PATH" 2>&1 &
+    ffmpeg_pid="$!"
+    sleep 1
+  fi
+
+  set +e
+  run_flow
+  local flow_status="$?"
+  set -e
+
+  if [[ -n "$ffmpeg_pid" ]]; then
+    kill -INT "$ffmpeg_pid" >/dev/null 2>&1 || true
+    wait "$ffmpeg_pid" >/dev/null 2>&1 || true
+  fi
+
+  if [[ ! -s "$VIDEO_PATH" ]] && command -v ffmpeg >/dev/null 2>&1; then
+    local first_shot
+    first_shot="$(find "$RUN_DIR/screenshots" -type f -name '*.png' | sort | head -n 1 || true)"
+    if [[ -n "$first_shot" ]]; then
+      ffmpeg -y -loop 1 -i "$first_shot" -t 5 -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" -pix_fmt yuv420p "$VIDEO_PATH" >>"$LOG_PATH" 2>&1 || true
+    fi
+  fi
+
+  exit "$flow_status"
+}
+
+cd "$ROOT_DIR"
+
+if [[ -z "${DISPLAY:-}" && -z "${WAYLAND_DISPLAY:-}" ]]; then
+  if ! command -v xvfb-run >/dev/null 2>&1; then
+    echo "[kanvibe-qa] xvfb-run is required for headless Electron QA. Install xvfb or run under a desktop DISPLAY." >&2
+    exit 127
+  fi
+  xvfb-run -a -s "-screen 0 ${KANVIBE_QA_VIDEO_SIZE:-1600x1000}x24" bash -lc "DISPLAY=\$DISPLAY KANVIBE_QA_RUN_ID='$RUN_ID' KANVIBE_QA_RUN_DIR='$RUN_DIR' KANVIBE_QA_NODE_BIN='$NODE_BIN' '$0' --inside-xvfb"
+  exit "$?"
+fi
+
+record_and_run

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -13,6 +13,7 @@ import TaskContextMenu from "./TaskContextMenu";
 import BranchTaskModal from "./BranchTaskModal";
 import DoneConfirmDialog from "./DoneConfirmDialog";
 import { reorderTasks, deleteTask, getMoreDoneTasks, moveTaskToColumn } from "@/desktop/renderer/actions/kanban";
+import { runBackgroundTaskSyncNow } from "@/desktop/renderer/actions/backgroundTaskSync";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
 import { navigateToTaskDetail } from "@/desktop/renderer/utils/taskNavigation";
@@ -67,6 +68,8 @@ const TASK_DELETE_SEQUENCE_KEY = "d";
 const TASK_DELETE_SEQUENCE_TIMEOUT_MS = 1_000;
 
 const VIM_MOVE_COMMAND_ALIASES = new Set(["move", "m"]);
+const VIM_SYNC_COMMAND_ALIASES = new Set(["sync", "s"]);
+const VIM_COMMAND_NAMES = ["move", "sync"] as const;
 const VIM_MOVE_STATUSES = [
   TaskStatus.TODO,
   TaskStatus.PROGRESS,
@@ -237,19 +240,32 @@ function getFocusedBoardTaskCard() {
     : null;
 }
 
-function parseVimMoveStatus(commandValue: string): TaskStatus | null {
-  const tokens = commandValue
+type ParsedVimCommand =
+  | { type: "move"; destinationStatus: TaskStatus }
+  | { type: "sync" };
+
+function parseVimCommandTokens(commandValue: string) {
+  return commandValue
     .trim()
     .replace(/^:/, "")
     .toLowerCase()
     .split(/\s+/)
     .filter(Boolean);
+}
 
-  if (tokens.length !== 2 || !VIM_MOVE_COMMAND_ALIASES.has(tokens[0])) {
-    return null;
+function parseVimCommand(commandValue: string): ParsedVimCommand | null {
+  const tokens = parseVimCommandTokens(commandValue);
+
+  if (tokens.length === 1 && VIM_SYNC_COMMAND_ALIASES.has(tokens[0])) {
+    return { type: "sync" };
   }
 
-  return VIM_STATUS_ALIASES[tokens[1]] ?? null;
+  if (tokens.length === 2 && VIM_MOVE_COMMAND_ALIASES.has(tokens[0])) {
+    const destinationStatus = VIM_STATUS_ALIASES[tokens[1]];
+    return destinationStatus ? { type: "move", destinationStatus } : null;
+  }
+
+  return null;
 }
 
 function getUniqueVimMoveStatusCompletion(statusPrefix: string): TaskStatus | null {
@@ -270,7 +286,15 @@ function getUniqueVimMoveStatusCompletion(statusPrefix: string): TaskStatus | nu
   return aliasMatches.size === 1 ? Array.from(aliasMatches)[0] : null;
 }
 
-function getVimMoveCommandAutocomplete(commandValue: string): string | null {
+function getUniqueVimCommandCompletion(commandPrefix: string) {
+  const normalizedPrefix = commandPrefix.toLowerCase();
+  if (!normalizedPrefix) return "move";
+
+  const matches = VIM_COMMAND_NAMES.filter((command) => command.startsWith(normalizedPrefix));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function getVimCommandAutocomplete(commandValue: string): string | null {
   const leadingWhitespace = commandValue.match(/^\s*/)?.[0] ?? "";
   const trimmedStartValue = commandValue.trimStart();
   const hasColonPrefix = trimmedStartValue.startsWith(":");
@@ -279,22 +303,25 @@ function getVimMoveCommandAutocomplete(commandValue: string): string | null {
   const tokens = valueWithoutColon.toLowerCase().split(/\s+/).filter(Boolean);
   const commandToken = tokens[0] ?? "";
 
-  const formatCompletion = (status?: TaskStatus) => {
-    const prefix = `${leadingWhitespace}${hasColonPrefix ? ":" : ""}move`;
+  const commandPrefix = `${leadingWhitespace}${hasColonPrefix ? ":" : ""}`;
+  const formatMoveCompletion = (status?: TaskStatus) => {
+    const prefix = `${commandPrefix}move`;
     return status ? `${prefix} ${status}` : `${prefix} `;
+  };
+  const formatCommandCompletion = (command: typeof VIM_COMMAND_NAMES[number]) => {
+    return command === "move" ? formatMoveCompletion() : `${commandPrefix}${command}`;
   };
 
   if (tokens.length === 0) {
-    return formatCompletion();
+    return formatMoveCompletion();
   }
 
   if (tokens.length === 1 && !hasTrailingWhitespace) {
-    if ("move".startsWith(commandToken) || commandToken === "m") {
-      const completion = formatCompletion();
-      return completion === commandValue ? null : completion;
-    }
+    const completedCommand = getUniqueVimCommandCompletion(commandToken);
+    if (!completedCommand) return null;
 
-    return null;
+    const completion = formatCommandCompletion(completedCommand);
+    return completion === commandValue ? null : completion;
   }
 
   if (!VIM_MOVE_COMMAND_ALIASES.has(commandToken) || tokens.length !== 2) {
@@ -304,7 +331,7 @@ function getVimMoveCommandAutocomplete(commandValue: string): string | null {
   const completedStatus = getUniqueVimMoveStatusCompletion(tokens[1]);
   if (!completedStatus) return null;
 
-  const completion = formatCompletion(completedStatus);
+  const completion = formatMoveCompletion(completedStatus);
   return completion === commandValue ? null : completion;
 }
 
@@ -530,7 +557,7 @@ export default function Board({
   const [currentDefaultSessionType, setCurrentDefaultSessionType] = useState<SessionType>(defaultSessionType);
   const [shouldUseMacTitlebarLayout, setShouldUseMacTitlebarLayout] = useState(false);
   const vimCommandCompletion = useMemo(
-    () => getVimMoveCommandAutocomplete(vimCommandValue),
+    () => getVimCommandAutocomplete(vimCommandValue),
     [vimCommandValue],
   );
   const [, startDragPersistenceTransition] = useTransition();
@@ -990,13 +1017,21 @@ export default function Board({
   }, []);
 
   const submitVimCommand = useCallback(() => {
-    const destinationStatus = parseVimMoveStatus(vimCommandValue);
-    if (!destinationStatus) {
+    const parsedCommand = parseVimCommand(vimCommandValue);
+    if (!parsedCommand) {
       setVimCommandError(t("vimCommand.errors.unknownCommand"));
       return;
     }
 
-    const moveResult = moveFocusedTaskToStatus(destinationStatus, vimCommandTaskId);
+    if (parsedCommand.type === "sync") {
+      closeVimCommand();
+      void runBackgroundTaskSyncNow().catch((error) => {
+        console.error("Failed to run background task sync", error);
+      });
+      return;
+    }
+
+    const moveResult = moveFocusedTaskToStatus(parsedCommand.destinationStatus, vimCommandTaskId);
     if (moveResult === "missing-focus") {
       setVimCommandError(t("vimCommand.errors.noFocusedTask"));
       return;
@@ -1216,7 +1251,7 @@ export default function Board({
               }}
               onKeyDown={(event) => {
                 if (event.key === "Tab" && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
-                  const completion = getVimMoveCommandAutocomplete(event.currentTarget.value);
+                  const completion = getVimCommandAutocomplete(event.currentTarget.value);
                   if (completion) {
                     event.preventDefault();
                     setVimCommandValue(completion);

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -21,6 +21,11 @@ import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask"
 import type { Project } from "@/entities/Project";
 import { useAutoRefresh } from "@/desktop/renderer/hooks/useAutoRefresh";
 import { useProjectFilterParams } from "@/desktop/renderer/hooks/useProjectFilterParams";
+import {
+  TASK_KIND_FILTER_VALUES,
+  useTaskKindFilterParams,
+  type TaskKindFilter,
+} from "@/desktop/renderer/hooks/useTaskKindFilterParams";
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from "@/desktop/renderer/utils/locales";
 import { computeProjectColor } from "@/lib/projectColor";
 import type { NotificationCenterButtonHandle } from "./NotificationCenterButton";
@@ -66,6 +71,8 @@ const VIM_NEW_TASK_KEY = "n";
 const VIM_COMMAND_KEY = ":";
 const TASK_DELETE_SEQUENCE_KEY = "d";
 const TASK_DELETE_SEQUENCE_TIMEOUT_MS = 1_000;
+
+type BoardTaskFilter = (task: KanbanTask) => boolean;
 
 const VIM_MOVE_COMMAND_ALIASES = new Set(["move", "m"]);
 const VIM_SYNC_COMMAND_ALIASES = new Set(["sync", "s"]);
@@ -388,6 +395,28 @@ function extractMainRepoPath(repoPath: string): string | null {
   return repoPath.slice(0, worktreeIndex);
 }
 
+function isProjectRootTask(task: KanbanTask, projectLookup: Map<string, Project>): boolean {
+  if (!task.projectId || !task.branchName) return false;
+
+  const project = projectLookup.get(task.projectId);
+  return Boolean(project && !project.isWorktree && task.branchName === project.defaultBranch);
+}
+
+function matchesTaskKindFilter(
+  task: KanbanTask,
+  taskKindFilter: TaskKindFilter,
+  projectLookup: Map<string, Project>,
+): boolean {
+  if (taskKindFilter === "all") return true;
+
+  const isRootTask = isProjectRootTask(task, projectLookup);
+  return taskKindFilter === "project" ? isRootTask : !isRootTask;
+}
+
+function matchesProjectFilter(task: KanbanTask, projectFilterSet: Set<string> | null): boolean {
+  return !projectFilterSet || Boolean(task.projectId && projectFilterSet.has(task.projectId));
+}
+
 function openSettingsPage() {
   window.location.hash = `#/${getCurrentBoardLocale()}/settings`;
 }
@@ -401,16 +430,16 @@ function insertAtFilteredIndex(
   fullArray: KanbanTask[],
   task: KanbanTask,
   filteredIndex: number,
-  filterSet: Set<string> | null
+  taskFilter: BoardTaskFilter | null
 ): KanbanTask[] {
   const arr = [...fullArray];
 
-  if (!filterSet) {
+  if (!taskFilter) {
     arr.splice(filteredIndex, 0, task);
     return arr;
   }
 
-  const filtered = arr.filter((t) => t.projectId && filterSet.has(t.projectId));
+  const filtered = arr.filter(taskFilter);
 
   if (filteredIndex < filtered.length) {
     const targetTask = filtered[filteredIndex];
@@ -439,7 +468,7 @@ interface DragMovePlan {
 function buildDragMovePlan(
   currentTasks: TasksByStatus,
   result: DropResult,
-  projectFilterSet: Set<string> | null,
+  taskFilter: BoardTaskFilter | null,
 ): DragMovePlan | null {
   const { source, destination, draggableId } = result;
   if (!destination) return null;
@@ -459,14 +488,12 @@ function buildDragMovePlan(
       newSource,
       movedTask,
       destination.index,
-      projectFilterSet,
+      taskFilter,
     );
 
     const orderedIds = (
-      projectFilterSet
-        ? updated[sourceStatus].filter(
-            (task) => task.projectId && projectFilterSet.has(task.projectId),
-          )
+      taskFilter
+        ? updated[sourceStatus].filter(taskFilter)
         : updated[sourceStatus]
     ).map((task) => task.id);
 
@@ -488,14 +515,12 @@ function buildDragMovePlan(
     updated[destStatus],
     updatedTask,
     destination.index,
-    projectFilterSet,
+    taskFilter,
   );
 
   const orderedIds = (
-    projectFilterSet
-      ? updated[destStatus].filter(
-          (task) => task.projectId && projectFilterSet.has(task.projectId),
-        )
+    taskFilter
+      ? updated[destStatus].filter(taskFilter)
       : updated[destStatus]
   ).map((task) => task.id);
 
@@ -549,6 +574,7 @@ export default function Board({
   const [selectedProjectIds, setSelectedProjectIds] = useProjectFilterParams(
     projects.map((p) => p.id),
   );
+  const [taskKindFilter, setTaskKindFilter] = useTaskKindFilterParams();
   const [doneTotal, setDoneTotal] = useState(initialDoneTotal);
   const [doneOffset, setDoneOffset] = useState(initialDoneLimit);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -615,6 +641,11 @@ export default function Board({
     return colorMap;
   }, [projectNameMap, projects]);
 
+  const projectLookup = useMemo(
+    () => new Map(projects.map((project) => [project.id, project])),
+    [projects],
+  );
+
   /** 필터 드롭다운에 표시할 메인 프로젝트 목록 (worktree 제외) */
   const filterableProjects = useMemo(
     () => projects.filter((p) => !p.isWorktree),
@@ -642,9 +673,15 @@ export default function Board({
     return matchingIds.size > 0 ? matchingIds : null;
   }, [selectedProjectIds, projects]);
 
-  /** 프로젝트 필터가 적용된 태스크 목록 */
+  /** 프로젝트 + task kind 필터가 적용된 태스크 목록 */
+  const hasActiveBoardTaskFilter = projectFilterSet !== null || taskKindFilter !== "all";
+  const boardTaskFilter = useCallback<BoardTaskFilter>((task) => (
+    matchesProjectFilter(task, projectFilterSet)
+    && matchesTaskKindFilter(task, taskKindFilter, projectLookup)
+  ), [projectFilterSet, projectLookup, taskKindFilter]);
+
   const filteredTasks = useMemo(() => {
-    if (!projectFilterSet) return tasks;
+    if (!hasActiveBoardTaskFilter) return tasks;
 
     const filtered: TasksByStatus = {
       [TaskStatus.TODO]: [],
@@ -655,13 +692,11 @@ export default function Board({
     };
 
     for (const status of Object.values(TaskStatus)) {
-      filtered[status] = tasks[status].filter(
-        (task) => task.projectId && projectFilterSet.has(task.projectId)
-      );
+      filtered[status] = tasks[status].filter(boardTaskFilter);
     }
 
     return filtered;
-  }, [tasks, projectFilterSet]);
+  }, [boardTaskFilter, hasActiveBoardTaskFilter, tasks]);
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     isOpen: false,
@@ -944,7 +979,11 @@ export default function Board({
   /** 드래그 결과를 받아 state 업데이트 + DB 반영을 수행한다 */
   const executeDragMove = useCallback(
     (result: DropResult) => {
-      const plan = buildDragMovePlan(tasks, result, projectFilterSet);
+      const plan = buildDragMovePlan(
+        tasks,
+        result,
+        hasActiveBoardTaskFilter ? boardTaskFilter : null,
+      );
       if (!plan) return;
 
       setTasks(plan.updatedTasks);
@@ -970,7 +1009,7 @@ export default function Board({
         );
       });
     },
-    [projectFilterSet, startDragPersistenceTransition, tasks]
+    [boardTaskFilter, hasActiveBoardTaskFilter, startDragPersistenceTransition, tasks]
   );
 
   const moveTaskToStatus = useCallback(
@@ -1137,7 +1176,33 @@ export default function Board({
       <BoardPageFindBar vimModeEnabled={vimModeEnabled} />
       <header className={headerClassName}>
         <div className="flex items-center gap-3 [-webkit-app-region:no-drag]">
-          <div className="w-64">
+          <div
+            role="group"
+            aria-label={t("taskKindFilter.label")}
+            className="flex h-[34px] w-[180px] shrink-0 items-stretch rounded-md border border-border-default bg-bg-page p-0.5"
+            data-testid="task-kind-filter"
+          >
+            {TASK_KIND_FILTER_VALUES.map((filter) => {
+              const isActive = taskKindFilter === filter;
+              return (
+                <button
+                  key={filter}
+                  type="button"
+                  aria-pressed={isActive}
+                  title={t(`taskKindFilter.descriptions.${filter}`)}
+                  onClick={() => setTaskKindFilter(filter)}
+                  className={`flex flex-1 items-center justify-center rounded text-sm font-medium transition-colors ${
+                    isActive
+                      ? "bg-brand-primary text-text-inverse shadow-sm"
+                      : "text-text-secondary hover:bg-bg-surface hover:text-text-primary"
+                  }`}
+                >
+                  {t(`taskKindFilter.options.${filter}`)}
+                </button>
+              );
+            })}
+          </div>
+          <div className="w-64" data-testid="project-filter-control">
             <ProjectSelector
               ref={projectSelectorRef}
               multiple

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 import Board from "../Board";
 import { deleteTask, moveTaskToColumn, reorderTasks } from "@/desktop/renderer/actions/kanban";
 import { runBackgroundTaskSyncNow } from "@/desktop/renderer/actions/backgroundTaskSync";
+import { useTaskKindFilterParams } from "@/desktop/renderer/hooks/useTaskKindFilterParams";
 import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
@@ -73,6 +74,11 @@ vi.mock("@/desktop/renderer/hooks/useAutoRefresh", () => ({
 
 vi.mock("@/desktop/renderer/hooks/useProjectFilterParams", () => ({
   useProjectFilterParams: vi.fn().mockReturnValue([[], vi.fn()]),
+}));
+
+vi.mock("@/desktop/renderer/hooks/useTaskKindFilterParams", () => ({
+  TASK_KIND_FILTER_VALUES: ["project", "task", "all"],
+  useTaskKindFilterParams: vi.fn().mockReturnValue(["all", vi.fn()]),
 }));
 
 vi.mock("../Column", () => ({
@@ -166,7 +172,7 @@ vi.mock("../CreateTaskModal", () => ({
   ) : null,
 }));
 
-function createProject(): Project {
+function createProject(overrides: Partial<Project> = {}): Project {
   return {
     id: "project-1",
     name: "kanvibe",
@@ -176,6 +182,28 @@ function createProject(): Project {
     isWorktree: false,
     color: null,
     createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function createTask(overrides: Partial<KanbanTask> & Pick<KanbanTask, "id" | "title" | "status">): KanbanTask {
+  return {
+    description: null,
+    branchName: null,
+    worktreePath: null,
+    sessionType: null,
+    sessionName: null,
+    sshHost: null,
+    agentType: null,
+    project: null,
+    projectId: "project-1",
+    baseBranch: null,
+    prUrl: null,
+    priority: null,
+    displayOrder: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
   };
 }
 
@@ -272,6 +300,65 @@ function createTasksWithTodoAndProgress(): TasksByStatus {
   };
 }
 
+function createTaskKindFilterTasks(): TasksByStatus {
+  return {
+    [TaskStatus.TODO]: [
+      createTask({
+        id: "project-root-task",
+        title: "Root Project Task",
+        status: TaskStatus.TODO,
+        branchName: "main",
+        baseBranch: "main",
+      }),
+      createTask({
+        id: "branch-worktree-task",
+        title: "Branch Worktree Task",
+        status: TaskStatus.TODO,
+        branchName: "feat/filter-ui",
+        baseBranch: "main",
+        worktreePath: "/repo/kanvibe__worktrees/feat-filter-ui",
+      }),
+      createTask({
+        id: "plain-task",
+        title: "Plain Task",
+        status: TaskStatus.TODO,
+      }),
+    ],
+    [TaskStatus.PROGRESS]: [],
+    [TaskStatus.PENDING]: [],
+    [TaskStatus.REVIEW]: [],
+    [TaskStatus.DONE]: [],
+  };
+}
+
+function renderBoardForTaskKindFilter() {
+  return render(
+    <Board
+      initialTasks={createTaskKindFilterTasks()}
+      initialDoneTotal={0}
+      initialDoneLimit={20}
+      sshHosts={[]}
+      projects={[createProject()]}
+      sidebarDefaultCollapsed={false}
+      doneAlertDismissed={false}
+      notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+      defaultSessionType={SessionType.TMUX}
+      taskSearchShortcut="Mod+Shift+O"
+    />,
+  );
+}
+
+function expectTaskKindFilterVisibleTasks(names: string[]) {
+  for (const name of ["Root Project Task", "Branch Worktree Task", "Plain Task"]) {
+    const assertion = expect(screen.queryByRole("link", { name }));
+    if (names.includes(name)) {
+      assertion.toBeTruthy();
+    } else {
+      assertion.toBeNull();
+    }
+  }
+}
+
 function BoardCommandRequester() {
   const boardCommands = useBoardCommands();
 
@@ -304,6 +391,7 @@ function BoardShortcutBlocker() {
 describe("Board defaultSessionType sync", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useTaskKindFilterParams).mockReturnValue(["all", vi.fn()] as const);
     delete window.kanvibeDesktop;
     mockNavigatorPlatform("Linux x86_64");
     mockWindowFind();
@@ -361,7 +449,7 @@ describe("Board defaultSessionType sync", () => {
     expect(window.location.hash).toBe("#/ko/settings");
   });
 
-  it("프로젝트 스캔 아이콘 버튼을 프로젝트 필터와 새 작업 버튼 사이에 렌더링한다", () => {
+  it("프로젝트/태스크 필터를 전체 프로젝트 필터 왼쪽에 같은 높이/포인트 컬러로 렌더링한다", () => {
     render(
       <Board
         initialTasks={createEmptyTasks()}
@@ -377,20 +465,66 @@ describe("Board defaultSessionType sync", () => {
       />,
     );
 
-    const projectSelectorContainer = screen.getByTestId("project-selector").parentElement;
+    const projectSelectorContainer = screen.getByTestId("project-filter-control");
+    const taskKindFilter = screen.getByTestId("task-kind-filter");
     const scanButton = screen.getByRole("button", { name: "scanTitle" });
     const newTaskButton = screen.getByRole("button", { name: "newTask" });
     const toolbarItems = Array.from(scanButton.parentElement?.children ?? []);
+    const allFilterButton = screen.getByRole("button", { name: "taskKindFilter.options.all" });
 
-    expect(projectSelectorContainer).toBeTruthy();
+    expect(taskKindFilter.getAttribute("aria-label")).toBe("taskKindFilter.label");
+    expect(taskKindFilter.className).toContain("h-[34px]");
+    expect(taskKindFilter.className).toContain("w-[180px]");
+    expect(allFilterButton.className).toContain("bg-brand-primary");
+    expect(allFilterButton.className).toContain("text-text-inverse");
+    expect(projectSelectorContainer.className).toContain("w-64");
     expect(scanButton.getAttribute("aria-label")).toBe("scanTitle");
     expect(scanButton.textContent).toBe("");
-    expect(toolbarItems.indexOf(projectSelectorContainer as Element)).toBeLessThan(toolbarItems.indexOf(scanButton));
+    expect(toolbarItems.indexOf(taskKindFilter)).toBeLessThan(toolbarItems.indexOf(projectSelectorContainer));
+    expect(toolbarItems.indexOf(projectSelectorContainer)).toBeLessThan(toolbarItems.indexOf(scanButton));
     expect(toolbarItems.indexOf(scanButton)).toBeLessThan(toolbarItems.indexOf(newTaskButton));
 
     fireEvent.click(scanButton);
 
     expect(screen.getByRole("dialog", { name: "scanTitle" })).toBeTruthy();
+  });
+
+  it("task kind filter 버튼을 프로젝트 필터 옆에 렌더링하고 선택 변경을 요청한다", () => {
+    const setTaskKindFilter = vi.fn();
+    vi.mocked(useTaskKindFilterParams).mockReturnValue(["all", setTaskKindFilter] as const);
+
+    renderBoardForTaskKindFilter();
+
+    expect(screen.getByRole("group", { name: "taskKindFilter.label" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "taskKindFilter.options.all" }).getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "taskKindFilter.options.project" }));
+
+    expect(setTaskKindFilter).toHaveBeenCalledWith("project");
+  });
+
+  it("Project 필터 선택 시 기본 브랜치 root task만 표시한다", () => {
+    vi.mocked(useTaskKindFilterParams).mockReturnValue(["project", vi.fn()] as const);
+
+    renderBoardForTaskKindFilter();
+
+    expectTaskKindFilterVisibleTasks(["Root Project Task"]);
+  });
+
+  it("Task 필터 선택 시 project root를 제외한 작업만 표시한다", () => {
+    vi.mocked(useTaskKindFilterParams).mockReturnValue(["task", vi.fn()] as const);
+
+    renderBoardForTaskKindFilter();
+
+    expectTaskKindFilterVisibleTasks(["Branch Worktree Task", "Plain Task"]);
+  });
+
+  it("All 필터 선택 시 project root와 일반 작업을 모두 표시한다", () => {
+    vi.mocked(useTaskKindFilterParams).mockReturnValue(["all", vi.fn()] as const);
+
+    renderBoardForTaskKindFilter();
+
+    expectTaskKindFilterVisibleTasks(["Root Project Task", "Branch Worktree Task", "Plain Task"]);
   });
 
   it("드래그 종료 시 reorder action을 이벤트 이후에 호출한다", async () => {

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -4,6 +4,7 @@ import { createEvent, fireEvent, render, screen, waitFor } from "@testing-librar
 import { MemoryRouter } from "react-router-dom";
 import Board from "../Board";
 import { deleteTask, moveTaskToColumn, reorderTasks } from "@/desktop/renderer/actions/kanban";
+import { runBackgroundTaskSyncNow } from "@/desktop/renderer/actions/backgroundTaskSync";
 import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
@@ -60,6 +61,10 @@ vi.mock("@/desktop/renderer/actions/kanban", () => ({
   deleteTask: vi.fn(),
   getMoreDoneTasks: vi.fn().mockResolvedValue({ tasks: [], doneTotal: 0 }),
   moveTaskToColumn: vi.fn(),
+}));
+
+vi.mock("@/desktop/renderer/actions/backgroundTaskSync", () => ({
+  runBackgroundTaskSyncNow: vi.fn().mockResolvedValue({ reviewNeeded: false, boardUpdated: false }),
 }));
 
 vi.mock("@/desktop/renderer/hooks/useAutoRefresh", () => ({
@@ -1004,6 +1009,68 @@ describe("Board defaultSessionType sync", () => {
 
     await waitFor(() => {
       expect(moveTaskToColumn).toHaveBeenCalledWith("task-1", TaskStatus.REVIEW, ["task-1"]);
+    });
+  });
+
+  it(":sync 명령으로 background task sync를 백그라운드 실행한다", async () => {
+    render(
+      <Board
+        initialTasks={createEmptyTasks()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
+      />,
+    );
+
+    const openCommandEvent = createEvent.keyDown(window, { key: ":" });
+    fireEvent(window, openCommandEvent);
+
+    expect(openCommandEvent.defaultPrevented).toBe(true);
+
+    const commandInput = await screen.findByRole("textbox", { name: "vimCommand.label" });
+    fireEvent.change(commandInput, { target: { value: "sync" } });
+    fireEvent.keyDown(commandInput, { key: "Enter" });
+
+    expect(runBackgroundTaskSyncNow).toHaveBeenCalledTimes(1);
+    expect(moveTaskToColumn).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox", { name: "vimCommand.label" })).toBeNull();
+    });
+  });
+
+  it(":sync 명령은 Tab 자동 완성으로 입력할 수 있다", async () => {
+    render(
+      <Board
+        initialTasks={createEmptyTasks()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: ":" });
+
+    const commandInput = await screen.findByRole("textbox", { name: "vimCommand.label" });
+    fireEvent.change(commandInput, { target: { value: "s" } });
+
+    const autocompleteEvent = createEvent.keyDown(commandInput, { key: "Tab" });
+    fireEvent(commandInput, autocompleteEvent);
+
+    expect(autocompleteEvent.defaultPrevented).toBe(true);
+    await waitFor(() => {
+      expect((commandInput as HTMLInputElement).value).toBe("sync");
     });
   });
 

--- a/src/desktop/main/serviceRegistry.ts
+++ b/src/desktop/main/serviceRegistry.ts
@@ -1,4 +1,5 @@
 import * as appSettings from "@/desktop/main/services/appSettingsService";
+import { runBackgroundTaskSyncNow } from "@/desktop/main/services/backgroundTaskSyncService";
 import * as diff from "@/desktop/main/services/diffService";
 import * as githubCliDependency from "@/desktop/main/services/githubCliDependencyService";
 import * as hooks from "@/desktop/main/services/hookService";
@@ -8,8 +9,11 @@ import * as project from "@/desktop/main/services/projectService";
 import * as releaseUpdates from "@/desktop/main/services/releaseUpdateService";
 import * as sessionDependency from "@/desktop/main/services/sessionDependencyService";
 
+const backgroundTaskSync = { runBackgroundTaskSyncNow };
+
 export const desktopServices = {
   appSettings,
+  backgroundTaskSync,
   diff,
   githubCliDependency,
   hooks,

--- a/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
+++ b/src/desktop/main/services/__tests__/backgroundTaskSyncService.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   broadcastBackgroundSyncReviewNeeded: vi.fn(),
   getBackgroundSyncEnabled: vi.fn().mockResolvedValue(true),
   getBackgroundSyncIntervalMs: vi.fn().mockResolvedValue(10 * 60_000),
+  registerBackgroundSyncIntervalChangedCallback: vi.fn(),
+  registerBackgroundSyncEnabledChangedCallback: vi.fn(),
 }));
 
 vi.mock("@/desktop/main/services/projectService", () => ({
@@ -27,8 +29,8 @@ vi.mock("@/lib/boardNotifier", () => ({
 vi.mock("@/desktop/main/services/appSettingsService", () => ({
   getBackgroundSyncEnabled: mocks.getBackgroundSyncEnabled,
   getBackgroundSyncIntervalMs: mocks.getBackgroundSyncIntervalMs,
-  registerBackgroundSyncIntervalChangedCallback: vi.fn(),
-  registerBackgroundSyncEnabledChangedCallback: vi.fn(),
+  registerBackgroundSyncIntervalChangedCallback: mocks.registerBackgroundSyncIntervalChangedCallback,
+  registerBackgroundSyncEnabledChangedCallback: mocks.registerBackgroundSyncEnabledChangedCallback,
 }));
 
 async function flushBackgroundSyncCycle() {
@@ -117,6 +119,60 @@ describe("backgroundTaskSyncService", () => {
       ],
       pulledTasks: [],
     });
+
+    stop();
+  });
+
+  it("manual background sync는 설정 비활성화와 무관하게 동일한 sync cycle을 실행한다", async () => {
+    mocks.getBackgroundSyncEnabled.mockResolvedValue(false);
+
+    const { runBackgroundTaskSyncNow } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    await runBackgroundTaskSyncNow();
+
+    expect(mocks.getBackgroundSyncEnabled).not.toHaveBeenCalled();
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
+  });
+
+  it("manual background sync는 진행 중인 scheduled cycle과 같은 in-flight 작업을 공유한다", async () => {
+    let resolveWorktreeSync: (result: {
+      worktreeTasks: string[];
+      registeredWorktrees: never[];
+      hooksSetup: never[];
+      errors: never[];
+      changed: boolean;
+    }) => void = () => {};
+    mocks.syncRegisteredProjectWorktrees.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveWorktreeSync = resolve;
+      }),
+    );
+
+    const { startBackgroundTaskSync, runBackgroundTaskSyncNow } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    const stop = startBackgroundTaskSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    const manualSync = runBackgroundTaskSyncNow();
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).not.toHaveBeenCalled();
+    expect(mocks.syncActiveTaskPulls).not.toHaveBeenCalled();
+
+    resolveWorktreeSync({
+      worktreeTasks: [],
+      registeredWorktrees: [],
+      hooksSetup: [],
+      errors: [],
+      changed: false,
+    });
+    await manualSync;
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPullRequests).toHaveBeenCalledTimes(1);
+    expect(mocks.syncActiveTaskPulls).toHaveBeenCalledTimes(1);
 
     stop();
   });
@@ -308,6 +364,49 @@ describe("backgroundTaskSyncService", () => {
       ],
     });
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
+  it("manual sync 진행 중에 주기가 바뀌면 새 주기로 다음 sync를 다시 예약한다", async () => {
+    const { startBackgroundTaskSync, runBackgroundTaskSyncNow } = await import("@/desktop/main/services/backgroundTaskSyncService");
+
+    const stop = startBackgroundTaskSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+    await flushBackgroundSyncCycle();
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(1);
+
+    let resolveManualWorktreeSync: () => void = () => {};
+    mocks.syncRegisteredProjectWorktrees.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveManualWorktreeSync = () => resolve({
+          worktreeTasks: [],
+          registeredWorktrees: [],
+          hooksSetup: [],
+          errors: [],
+          changed: false,
+        });
+      }),
+    );
+
+    const manualSync = runBackgroundTaskSyncNow();
+    await flushBackgroundSyncCycle();
+
+    const notifyIntervalChanged = mocks.registerBackgroundSyncIntervalChangedCallback.mock.calls[0][0];
+    mocks.getBackgroundSyncIntervalMs.mockResolvedValue(60_000);
+    notifyIntervalChanged(60_000);
+
+    resolveManualWorktreeSync();
+    await manualSync;
+    await flushBackgroundSyncCycle();
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flushBackgroundSyncCycle();
+
+    expect(mocks.syncRegisteredProjectWorktrees).toHaveBeenCalledTimes(3);
 
     stop();
   });

--- a/src/desktop/main/services/backgroundTaskSyncService.ts
+++ b/src/desktop/main/services/backgroundTaskSyncService.ts
@@ -21,6 +21,13 @@ const INITIAL_SYNC_DELAY_MS = 20_000;
 const FALLBACK_SYNC_INTERVAL_MS = 10 * 60_000;
 
 let activeBackgroundTaskSyncStop: (() => void) | null = null;
+let activeBackgroundTaskSyncCycle: Promise<BackgroundTaskSyncRunResult> | null = null;
+const emittedMergeEventKeys = new Set<string>();
+
+export interface BackgroundTaskSyncRunResult {
+  reviewNeeded: boolean;
+  boardUpdated: boolean;
+}
 
 interface BackgroundSyncStageResult<T> {
   result: T;
@@ -84,15 +91,100 @@ async function runBackgroundSyncStage<T>(
   }
 }
 
+async function executeBackgroundTaskSyncCycle(): Promise<BackgroundTaskSyncRunResult> {
+  const worktreeSync = await runBackgroundSyncStage(
+    "worktree sync",
+    syncRegisteredProjectWorktrees,
+    createEmptyWorktreeSyncResult,
+    (reason) => ({
+      operation: "worktree-sync",
+      target: "등록 프로젝트 worktree sync",
+      reason,
+    }),
+  );
+  const prSync = await runBackgroundSyncStage(
+    "pull request sync",
+    () => syncActiveTaskPullRequests(emittedMergeEventKeys),
+    createEmptyPullRequestSyncResult,
+    (reason) => ({
+      operation: "pull-request-sync",
+      target: "PR 상태 sync",
+      reason,
+    }),
+  );
+  const pullSync = await runBackgroundSyncStage(
+    "task pull sync",
+    syncActiveTaskPulls,
+    createEmptyTaskPullSyncResult,
+    (reason) => ({
+      operation: "task-pull-sync",
+      target: "active task pull sync",
+      reason,
+    }),
+  );
+  const worktreeSyncResult = worktreeSync.result;
+  const prSyncResult = prSync.result;
+  const pullSyncResult = pullSync.result;
+  const failures: BackgroundSyncFailurePayload[] = [
+    ...(worktreeSync.failure ? [worktreeSync.failure] : []),
+    ...worktreeSyncResult.errors.map((reason) => ({
+      operation: "worktree-sync" as const,
+      target: "등록 프로젝트 worktree sync",
+      reason,
+    })),
+    ...(prSync.failure ? [prSync.failure] : []),
+    ...(prSyncResult.failures ?? []),
+    ...(pullSync.failure ? [pullSync.failure] : []),
+  ];
+
+  const reviewNeeded = worktreeSyncResult.registeredWorktrees.length > 0
+    || prSyncResult.mergedPullRequests.length > 0
+    || pullSyncResult.pulledTasks.length > 0
+    || failures.length > 0;
+
+  if (reviewNeeded) {
+    broadcastBackgroundSyncReviewNeeded({
+      registeredWorktrees: worktreeSyncResult.registeredWorktrees,
+      mergedPullRequests: prSyncResult.mergedPullRequests,
+      pulledTasks: pullSyncResult.pulledTasks,
+      ...(failures.length > 0 ? { failures } : {}),
+    });
+  }
+
+  const hasUpdatedPulledTasks = pullSyncResult.pulledTasks.some((task) => task.status === "updated");
+  const boardUpdated = worktreeSyncResult.changed || prSyncResult.updatedTaskIds.length > 0 || hasUpdatedPulledTasks;
+  if (boardUpdated) {
+    broadcastBoardUpdate();
+  }
+
+  return { reviewNeeded, boardUpdated };
+}
+
+function runSharedBackgroundTaskSyncCycle(): Promise<BackgroundTaskSyncRunResult> {
+  if (activeBackgroundTaskSyncCycle) {
+    return activeBackgroundTaskSyncCycle;
+  }
+
+  activeBackgroundTaskSyncCycle = executeBackgroundTaskSyncCycle().finally(() => {
+    activeBackgroundTaskSyncCycle = null;
+  });
+  return activeBackgroundTaskSyncCycle;
+}
+
+export function runBackgroundTaskSyncNow(): Promise<BackgroundTaskSyncRunResult> {
+  return runSharedBackgroundTaskSyncCycle();
+}
+
 export function startBackgroundTaskSync() {
   if (activeBackgroundTaskSyncStop) {
     return activeBackgroundTaskSyncStop;
   }
 
   let disposed = false;
-  let running = false;
+  // 스케줄러가 직접 돌린 사이클만 표시한다. manual sync가 공유 사이클을 점유한 경우와 구분해야
+  // 재예약 책임이 finally 블록에 있는지 콜백에 있는지 판단할 수 있다.
+  let isSchedulerCycleRunning = false;
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-  const emittedMergeEventKeys = new Set<string>();
 
   function scheduleNext(delayMs: number) {
     if (disposed) {
@@ -109,92 +201,25 @@ export function startBackgroundTaskSync() {
       return;
     }
 
-    if (running) {
-      return;
-    }
-
-    running = true;
-
+    isSchedulerCycleRunning = true;
     try {
       const isEnabled = await getBackgroundSyncEnabled();
       if (isEnabled) {
-        const worktreeSync = await runBackgroundSyncStage(
-          "worktree sync",
-          syncRegisteredProjectWorktrees,
-          createEmptyWorktreeSyncResult,
-          (reason) => ({
-            operation: "worktree-sync",
-            target: "등록 프로젝트 worktree sync",
-            reason,
-          }),
-        );
-        const prSync = await runBackgroundSyncStage(
-          "pull request sync",
-          () => syncActiveTaskPullRequests(emittedMergeEventKeys),
-          createEmptyPullRequestSyncResult,
-          (reason) => ({
-            operation: "pull-request-sync",
-            target: "PR 상태 sync",
-            reason,
-          }),
-        );
-        const pullSync = await runBackgroundSyncStage(
-          "task pull sync",
-          syncActiveTaskPulls,
-          createEmptyTaskPullSyncResult,
-          (reason) => ({
-            operation: "task-pull-sync",
-            target: "active task pull sync",
-            reason,
-          }),
-        );
-        const worktreeSyncResult = worktreeSync.result;
-        const prSyncResult = prSync.result;
-        const pullSyncResult = pullSync.result;
-        const failures: BackgroundSyncFailurePayload[] = [
-          ...(worktreeSync.failure ? [worktreeSync.failure] : []),
-          ...worktreeSyncResult.errors.map((reason) => ({
-            operation: "worktree-sync" as const,
-            target: "등록 프로젝트 worktree sync",
-            reason,
-          })),
-          ...(prSync.failure ? [prSync.failure] : []),
-          ...(prSyncResult.failures ?? []),
-          ...(pullSync.failure ? [pullSync.failure] : []),
-        ];
-
-        if (
-          worktreeSyncResult.registeredWorktrees.length > 0
-          || prSyncResult.mergedPullRequests.length > 0
-          || pullSyncResult.pulledTasks.length > 0
-          || failures.length > 0
-        ) {
-          broadcastBackgroundSyncReviewNeeded({
-            registeredWorktrees: worktreeSyncResult.registeredWorktrees,
-            mergedPullRequests: prSyncResult.mergedPullRequests,
-            pulledTasks: pullSyncResult.pulledTasks,
-            ...(failures.length > 0 ? { failures } : {}),
-          });
-        }
-
-        const hasUpdatedPulledTasks = pullSyncResult.pulledTasks.some((task) => task.status === "updated");
-        if (worktreeSyncResult.changed || prSyncResult.updatedTaskIds.length > 0 || hasUpdatedPulledTasks) {
-          broadcastBoardUpdate();
-        }
+        await runSharedBackgroundTaskSyncCycle();
       }
     } catch (error) {
       console.error("[background-task-sync] sync failed:", error);
     } finally {
-      running = false;
       const intervalMs = await getBackgroundSyncIntervalMs().catch(() => FALLBACK_SYNC_INTERVAL_MS);
       scheduleNext(intervalMs);
+      isSchedulerCycleRunning = false;
     }
   }
 
   function reschedule(newIntervalMs: number) {
     if (disposed) return;
-    // 사이클 실행 중이면 건너뜀 — finally 블록이 최신 주기를 읽어 스케줄링함
-    if (running) return;
+    // 스케줄러 사이클 실행 중이면 건너뜀 — finally 블록이 최신 주기를 읽어 스케줄링함
+    if (isSchedulerCycleRunning) return;
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
       timeoutHandle = null;
@@ -205,7 +230,7 @@ export function startBackgroundTaskSync() {
   function rescheduleOnEnable(enabled: boolean) {
     if (!enabled) return; // 비활성화 시: 루프는 다음 웨이크업에서 작업을 건너뜀
     if (disposed) return;
-    if (running) return; // 사이클 진행 중: finally 블록이 이어서 스케줄링함
+    if (isSchedulerCycleRunning) return; // 스케줄러 사이클 진행 중: finally 블록이 이어서 스케줄링함
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
       timeoutHandle = null;

--- a/src/desktop/renderer/actions/backgroundTaskSync.ts
+++ b/src/desktop/renderer/actions/backgroundTaskSync.ts
@@ -1,0 +1,6 @@
+import { invokeDesktop } from "@/desktop/renderer/ipc";
+import type { BackgroundTaskSyncRunResult } from "@/desktop/main/services/backgroundTaskSyncService";
+
+export function runBackgroundTaskSyncNow(): Promise<BackgroundTaskSyncRunResult> {
+  return invokeDesktop("backgroundTaskSync", "runBackgroundTaskSyncNow");
+}

--- a/src/desktop/renderer/components/AiSessionMessageContent.tsx
+++ b/src/desktop/renderer/components/AiSessionMessageContent.tsx
@@ -1,0 +1,211 @@
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+import { useEffect, useId, useMemo, useState } from "react";
+
+const MERMAID_BLOCK_PATTERN = /```[ \t]*mermaid[^\r\n]*(?:\r?\n)([\s\S]*?)```/gi;
+const MARKDOWN_SANITIZE_CONFIG = {
+  ADD_ATTR: ["target", "rel", "loading", "referrerpolicy"],
+  FORBID_ATTR: ["style"],
+  FORBID_TAGS: ["style"],
+  USE_PROFILES: { html: true },
+};
+const MERMAID_SANITIZE_CONFIG = {
+  ADD_ATTR: ["data-testid"],
+};
+const MERMAID_THEME = "dark";
+
+interface AiSessionMessageContentProps {
+  text: string;
+  isUserMessage: boolean;
+}
+
+interface MarkdownSegment {
+  type: "markdown";
+  value: string;
+}
+
+interface MermaidSegment {
+  type: "mermaid";
+  value: string;
+}
+
+type MessageSegment = MarkdownSegment | MermaidSegment;
+
+function splitMarkdownAndMermaidBlocks(markdown: string): MessageSegment[] {
+  const segments: MessageSegment[] = [];
+  let cursor = 0;
+
+  for (const match of markdown.matchAll(MERMAID_BLOCK_PATTERN)) {
+    const blockStart = match.index ?? 0;
+    const markdownValue = markdown.slice(cursor, blockStart);
+    if (markdownValue.trim()) {
+      segments.push({ type: "markdown", value: markdownValue });
+    }
+
+    const diagramValue = match[1]?.trim();
+    if (diagramValue) {
+      segments.push({ type: "mermaid", value: diagramValue });
+    }
+
+    cursor = blockStart + match[0].length;
+  }
+
+  const remainingMarkdown = markdown.slice(cursor);
+  if (remainingMarkdown.trim()) {
+    segments.push({ type: "markdown", value: remainingMarkdown });
+  }
+
+  return segments.length > 0 ? segments : [{ type: "markdown", value: markdown }];
+}
+
+function addMarkdownElementAttributes(html: string) {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+
+  for (const link of template.content.querySelectorAll("a")) {
+    link.setAttribute("target", "_blank");
+    link.setAttribute("rel", "noopener noreferrer");
+  }
+
+  for (const image of template.content.querySelectorAll("img")) {
+    image.setAttribute("loading", "lazy");
+    image.setAttribute("referrerpolicy", "no-referrer");
+  }
+
+  return template.innerHTML;
+}
+
+function renderMarkdownHtml(markdown: string) {
+  const rawHtml = marked.parse(markdown, {
+    async: false,
+    breaks: true,
+    gfm: true,
+  }) as string;
+  const sanitizedHtml = DOMPurify.sanitize(rawHtml, MARKDOWN_SANITIZE_CONFIG);
+  return addMarkdownElementAttributes(sanitizedHtml);
+}
+
+function createMermaidElementId(definition: string, index: number, componentId: string) {
+  let hash = 0;
+  for (let charIndex = 0; charIndex < definition.length; charIndex += 1) {
+    hash = (hash * 31 + definition.charCodeAt(charIndex)) | 0;
+  }
+
+  const stableComponentId = componentId.replace(/[^a-zA-Z0-9_-]/g, "");
+  return `ai-session-mermaid-${stableComponentId}-${index}-${Math.abs(hash)}`;
+}
+
+function MarkdownContent({ markdown, isUserMessage }: { markdown: string; isUserMessage: boolean }) {
+  const html = useMemo(() => renderMarkdownHtml(markdown), [markdown]);
+
+  if (!html.trim()) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`ai-session-markdown text-sm leading-6 [&_*:first-child]:mt-0 [&_*:last-child]:mb-0 [&_a]:underline-offset-2 [&_a:hover]:underline [&_blockquote]:my-3 [&_blockquote]:border-l-2 [&_blockquote]:pl-3 [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.86em] [&_h1]:mb-3 [&_h1]:mt-5 [&_h1]:text-lg [&_h1]:font-semibold [&_h2]:mb-2 [&_h2]:mt-4 [&_h2]:text-base [&_h2]:font-semibold [&_h3]:mb-2 [&_h3]:mt-4 [&_h3]:text-sm [&_h3]:font-semibold [&_hr]:my-4 [&_li]:my-1 [&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:p-3 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_strong]:font-semibold [&_table]:my-3 [&_table]:w-full [&_table]:border-separate [&_table]:border-spacing-2 [&_td]:align-top [&_th]:align-top [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5 ${
+        isUserMessage
+          ? "[&_a]:text-white [&_blockquote]:border-white/35 [&_blockquote]:text-white/75 [&_code]:bg-white/15 [&_h1]:text-white [&_h2]:text-white [&_h3]:text-white [&_hr]:border-white/20 [&_pre]:border-white/20 [&_pre]:bg-black/20 [&_strong]:text-white"
+          : "[&_a]:text-brand-primary [&_blockquote]:border-border-default [&_blockquote]:text-text-muted [&_code]:bg-bg-page [&_h1]:text-text-primary [&_h2]:text-text-primary [&_h3]:text-text-primary [&_hr]:border-border-subtle [&_pre]:border-border-subtle [&_pre]:bg-bg-page [&_strong]:text-text-primary"
+      }`}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+function MermaidDiagram({ definition, index, isUserMessage }: { definition: string; index: number; isUserMessage: boolean }) {
+  const [svg, setSvg] = useState<string | null>(null);
+  const [hasError, setHasError] = useState(false);
+  const componentId = useId();
+  const elementId = useMemo(() => createMermaidElementId(definition, index, componentId), [definition, index, componentId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSvg(null);
+    setHasError(false);
+
+    async function renderDiagram() {
+      try {
+        const mermaidModule = await import("mermaid");
+        const mermaidApi = mermaidModule.default;
+        mermaidApi.initialize({
+          securityLevel: "strict",
+          startOnLoad: false,
+          theme: MERMAID_THEME,
+        });
+        const result = await mermaidApi.render(elementId, definition);
+        const sanitizedSvg = DOMPurify.sanitize(result.svg, MERMAID_SANITIZE_CONFIG);
+        if (!cancelled) {
+          setSvg(sanitizedSvg);
+        }
+      } catch {
+        if (!cancelled) {
+          setHasError(true);
+        }
+      }
+    }
+
+    void renderDiagram();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [definition, elementId]);
+
+  if (hasError) {
+    return (
+      <pre
+        data-testid="ai-session-mermaid-fallback"
+        className={`my-3 overflow-x-auto rounded-lg border p-3 font-mono text-xs ${
+          isUserMessage ? "border-white/20 bg-black/20 text-white" : "border-border-subtle bg-bg-page text-text-primary"
+        }`}
+      >
+        <code>{definition}</code>
+      </pre>
+    );
+  }
+
+  return (
+    <div
+      data-testid="ai-session-mermaid-diagram"
+      className={`my-3 overflow-x-auto rounded-lg border p-3 ${
+        isUserMessage ? "border-white/20 bg-white/10" : "border-border-subtle bg-bg-page"
+      }`}
+    >
+      {svg ? (
+        <div
+          className="min-w-max [&_svg]:h-auto [&_svg]:max-w-full"
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+      ) : (
+        <p className={isUserMessage ? "text-xs text-white/70" : "text-xs text-text-muted"}>Rendering diagram…</p>
+      )}
+    </div>
+  );
+}
+
+export function AiSessionMessageContent({ text, isUserMessage }: AiSessionMessageContentProps) {
+  const segments = useMemo(() => splitMarkdownAndMermaidBlocks(text), [text]);
+
+  return (
+    <div className="space-y-3 break-words">
+      {segments.map((segment, index) => (
+        segment.type === "mermaid" ? (
+          <MermaidDiagram
+            key={`mermaid-${index}`}
+            definition={segment.value}
+            index={index}
+            isUserMessage={isUserMessage}
+          />
+        ) : (
+          <MarkdownContent
+            key={`markdown-${index}`}
+            markdown={segment.value}
+            isUserMessage={isUserMessage}
+          />
+        )
+      ))}
+    </div>
+  );
+}

--- a/src/desktop/renderer/hooks/__tests__/useTaskKindFilterParams.test.tsx
+++ b/src/desktop/renderer/hooks/__tests__/useTaskKindFilterParams.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useSearchParams } from "react-router-dom";
+import { describe, expect, it, beforeEach } from "vitest";
+import { useTaskKindFilterParams } from "../useTaskKindFilterParams";
+
+function TaskKindFilterHarness() {
+  const [filter, setFilter] = useTaskKindFilterParams();
+  const [searchParams] = useSearchParams();
+
+  return (
+    <div>
+      <div data-testid="filter">{filter}</div>
+      <div data-testid="query">{searchParams.get("taskKind") ?? ""}</div>
+      <button type="button" onClick={() => setFilter("project")}>project</button>
+      <button type="button" onClick={() => setFilter("task")}>task</button>
+      <button type="button" onClick={() => setFilter("all")}>all</button>
+    </div>
+  );
+}
+
+function renderHarness(initialEntry = "/ko") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <TaskKindFilterHarness />
+    </MemoryRouter>,
+  );
+}
+
+describe("useTaskKindFilterParams", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("taskKind query가 없으면 All을 기본값으로 사용한다", () => {
+    renderHarness();
+
+    expect(screen.getByTestId("filter").textContent).toBe("all");
+    expect(screen.getByTestId("query").textContent).toBe("");
+  });
+
+  it("Project/Task 선택을 URL query와 sessionStorage에 반영하고 All 선택 시 query를 제거한다", async () => {
+    renderHarness();
+
+    fireEvent.click(screen.getByRole("button", { name: "project" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("project");
+      expect(screen.getByTestId("query").textContent).toBe("project");
+    });
+    expect(sessionStorage.getItem("kanvibe_task_kind_filter")).toBe("project");
+
+    fireEvent.click(screen.getByRole("button", { name: "task" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("task");
+      expect(screen.getByTestId("query").textContent).toBe("task");
+    });
+    expect(sessionStorage.getItem("kanvibe_task_kind_filter")).toBe("task");
+
+    fireEvent.click(screen.getByRole("button", { name: "all" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("all");
+      expect(screen.getByTestId("query").textContent).toBe("");
+    });
+    expect(sessionStorage.getItem("kanvibe_task_kind_filter")).toBeNull();
+  });
+
+  it("query가 없으면 sessionStorage에 저장된 필터를 복원한다", async () => {
+    sessionStorage.setItem("kanvibe_task_kind_filter", "task");
+
+    renderHarness();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("task");
+      expect(screen.getByTestId("query").textContent).toBe("task");
+    });
+  });
+
+  it("알 수 없는 query 값은 제거하고 기본값으로 되돌린다", async () => {
+    renderHarness("/ko?taskKind=unknown");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("all");
+      expect(screen.getByTestId("query").textContent).toBe("");
+    });
+  });
+
+  it("알 수 없는 query 값으로 진입하면 sessionStorage에 남은 필터도 함께 비운다", async () => {
+    sessionStorage.setItem("kanvibe_task_kind_filter", "project");
+
+    renderHarness("/ko?taskKind=unknown");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter").textContent).toBe("all");
+      expect(screen.getByTestId("query").textContent).toBe("");
+    });
+    expect(sessionStorage.getItem("kanvibe_task_kind_filter")).toBeNull();
+  });
+});

--- a/src/desktop/renderer/hooks/useTaskKindFilterParams.ts
+++ b/src/desktop/renderer/hooks/useTaskKindFilterParams.ts
@@ -1,0 +1,86 @@
+import { useEffect, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export const TASK_KIND_FILTER_VALUES = ["project", "task", "all"] as const;
+export type TaskKindFilter = typeof TASK_KIND_FILTER_VALUES[number];
+
+const QUERY_PARAM_KEY = "taskKind";
+const SESSION_STORAGE_KEY = "kanvibe_task_kind_filter";
+const DEFAULT_TASK_KIND_FILTER: TaskKindFilter = "all";
+
+function normalizeTaskKindFilter(value: string | null): TaskKindFilter {
+  if (value && TASK_KIND_FILTER_VALUES.includes(value as TaskKindFilter)) {
+    return value as TaskKindFilter;
+  }
+
+  return DEFAULT_TASK_KIND_FILTER;
+}
+
+function syncToSessionStorage(filter: TaskKindFilter) {
+  try {
+    if (filter === DEFAULT_TASK_KIND_FILTER) {
+      sessionStorage.removeItem(SESSION_STORAGE_KEY);
+    } else {
+      sessionStorage.setItem(SESSION_STORAGE_KEY, filter);
+    }
+  } catch {
+    /* sessionStorage 접근 불가 시 무시 */
+  }
+}
+
+function restoreFromSessionStorage(): TaskKindFilter {
+  try {
+    return normalizeTaskKindFilter(sessionStorage.getItem(SESSION_STORAGE_KEY));
+  } catch {
+    return DEFAULT_TASK_KIND_FILTER;
+  }
+}
+
+export function useTaskKindFilterParams() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const paramValue = searchParams.get(QUERY_PARAM_KEY);
+  const taskKindFilter = useMemo(
+    () => normalizeTaskKindFilter(paramValue),
+    [paramValue],
+  );
+
+  useEffect(() => {
+    if (paramValue) {
+      const normalizedParam = normalizeTaskKindFilter(paramValue);
+      if (normalizedParam !== paramValue) {
+        // 저장된 필터를 함께 기본값으로 되돌린다. 지우지 않으면 query를 제거한 다음 렌더에서
+        // 세션 복원이 일어나 잘못된 값으로 진입한 사용자가 이전 필터로 끌려간다.
+        syncToSessionStorage(normalizedParam);
+
+        const nextParams = new URLSearchParams(searchParams);
+        nextParams.delete(QUERY_PARAM_KEY);
+        setSearchParams(nextParams, { replace: true });
+        return;
+      }
+
+      syncToSessionStorage(normalizedParam);
+      return;
+    }
+
+    const restored = restoreFromSessionStorage();
+    if (restored !== DEFAULT_TASK_KIND_FILTER) {
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.set(QUERY_PARAM_KEY, restored);
+      setSearchParams(nextParams, { replace: true });
+    }
+  }, [paramValue, searchParams, setSearchParams]);
+
+  const setTaskKindFilter = (filter: TaskKindFilter) => {
+    syncToSessionStorage(filter);
+
+    const nextParams = new URLSearchParams(searchParams);
+    if (filter === DEFAULT_TASK_KIND_FILTER) {
+      nextParams.delete(QUERY_PARAM_KEY);
+    } else {
+      nextParams.set(QUERY_PARAM_KEY, filter);
+    }
+    setSearchParams(nextParams, { replace: true });
+  };
+
+  return [taskKindFilter, setTaskKindFilter] as const;
+}

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -28,6 +28,7 @@ import {
   getTaskOpenCodeHooksStatus,
   getAllProjects,
 } from "@/desktop/renderer/actions/project";
+import { AiSessionMessageContent } from "@/desktop/renderer/components/AiSessionMessageContent";
 import {
   useBoardCommands,
   useHasBoardShortcutBlocker,
@@ -785,7 +786,7 @@ function InlineAiChatMessage({ message, provider }: { message: AggregatedAiMessa
           <AiSessionProviderIcon provider={provider} testId={false} />
           <span>{message.role}</span>
         </div>
-        <p className="whitespace-pre-wrap break-words">{displayedText}</p>
+        <AiSessionMessageContent text={displayedText} isUserMessage={isUserMessage} />
       </div>
     </div>
   );

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -41,6 +41,10 @@ const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   back: vi.fn(),
   forward: vi.fn(),
+  mermaidInitialize: vi.fn(),
+  mermaidRender: vi.fn(async (_id: string, definition: string) => ({
+    svg: `<svg data-testid="rendered-mermaid-svg"><g onload="alert('svg')"><script>svg-xss</script><text>${definition}</text></g></svg>`,
+  })),
 }));
 
 function createDeferred<T>() {
@@ -90,6 +94,13 @@ vi.mock("@hugeicons/react", () => ({
 vi.mock("@hugeicons/core-free-icons", () => ({
   Chatting01Icon: { __iconName: "Chatting01Icon" },
   InformationCircleIcon: { __iconName: "InformationCircleIcon" },
+}));
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: mocks.mermaidInitialize,
+    render: mocks.mermaidRender,
+  },
 }));
 
 vi.mock("react-router-dom", () => ({
@@ -1617,6 +1628,96 @@ describe("TaskDetailRoute", () => {
       expect(mocks.getTaskAiSessions).toHaveBeenLastCalledWith("task-1", undefined, "20", 20);
     });
     expect(await screen.findByRole("button", { name: /Codex older/ })).toBeTruthy();
+  });
+
+  it("채팅 상세 메시지는 markdown과 mermaid 다이어그램을 렌더링하고 위험한 HTML은 제거한다", async () => {
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(true);
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/markdown-mermaid-ai-chat",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/markdown-mermaid-ai-chat",
+    });
+    mocks.getTaskAiSessions.mockResolvedValue({
+      isRemote: false,
+      targetPath: "/repo__worktrees/markdown-mermaid-ai-chat",
+      repoPath: "/repo",
+      sources: [],
+      nextCursor: null,
+      sessions: [
+        { id: "claude-1", provider: "claude", startedAt: null, updatedAt: "2026-01-01T00:03:00.000Z", matchedPath: "/repo", matchScope: "worktree", title: "Markdown diagram chat", firstUserPrompt: "Show diagram", messageCount: 1, sourceRef: "claude.jsonl" },
+      ],
+    });
+    mocks.getTaskAiSessionDetail.mockResolvedValue({
+      sessionId: "claude-1",
+      provider: "claude",
+      title: "Markdown diagram chat",
+      matchedPath: "/repo",
+      sourceRef: "claude.jsonl",
+      nextCursor: null,
+      messages: [
+        {
+          role: "assistant",
+          timestamp: "2026-01-01T00:03:00.000Z",
+          text: "markdown preview",
+          fullText: [
+            "## 작업 요약",
+            "",
+            "- 첫 번째 항목",
+            "",
+            "```ts",
+            "const value = 1;",
+            "```",
+            "",
+            "```mermaid",
+            "graph TD",
+            "  A[Start] --> B[Done]",
+            "```",
+            "",
+            '<script>alert("xss")</script>',
+            '<img src="x" style="color: red" onerror="alert(1)" alt="unsafe image">',
+            '[위험 링크](javascript:alert("link"))',
+            '<svg><script>markdown-svg-xss</script></svg>',
+          ].join("\n"),
+          isTruncated: false,
+        },
+      ],
+    });
+
+    render(<TaskDetailRoute />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "aiSessions.inlineChat" }));
+    fireEvent.click(await screen.findByRole("button", { name: /Markdown diagram chat/ }));
+
+    expect(await screen.findByRole("heading", { level: 2, name: "작업 요약" })).toBeTruthy();
+    expect(screen.getByText("첫 번째 항목").tagName).toBe("LI");
+    expect(screen.getByText("const value = 1;").closest("pre")).toBeTruthy();
+    expect(await screen.findByTestId("rendered-mermaid-svg")).toBeTruthy();
+    expect(screen.getByText(/graph TD/)).toBeTruthy();
+    expect(screen.queryByText(/alert\("xss"\)/)).toBeNull();
+    expect(screen.queryByText("markdown-svg-xss")).toBeNull();
+    expect(screen.queryByText("svg-xss")).toBeNull();
+    expect(document.querySelector('.ai-session-markdown a[href^="javascript:"]')).toBeNull();
+    expect(document.querySelector(".ai-session-markdown [style]")).toBeNull();
+    expect(document.querySelector(".ai-session-markdown [onerror]")).toBeNull();
+    expect(document.querySelector(".ai-session-markdown svg")).toBeNull();
+    expect(document.querySelector("[onload]")).toBeNull();
+    expect(mocks.mermaidInitialize).toHaveBeenCalledWith(expect.objectContaining({
+      securityLevel: "strict",
+      startOnLoad: false,
+      theme: "dark",
+    }));
+    expect(mocks.mermaidRender.mock.calls[0]?.[0]).toMatch(/^ai-session-mermaid-/);
   });
 
   it("채팅 상세 메시지는 최신순 페이지를 받고 더보기로 이전 메시지를 이어 붙인다", async () => {

--- a/src/lib/aiSessions/__tests__/readAiSessions.test.ts
+++ b/src/lib/aiSessions/__tests__/readAiSessions.test.ts
@@ -711,7 +711,10 @@ conn.close()
   });
 
   it("treats OpenCode body search wildcard characters as literal text", async () => {
-    const worktreePath = path.join(tempHome, "repo", "task");
+    // 세션 필터는 directory 값에도 부분 문자열 매칭을 하므로, OS 임시 경로에 우연히 `_`나 `%`가
+    // 들어 있으면 모든 행이 걸려 검증이 무의미해진다. macOS의 /var/folders/... 경로가 실제로
+    // 그렇기 때문에 이 테스트만 와일드카드 문자가 없는 고정 경로를 쓴다.
+    const worktreePath = "/kanvibe-opencode-fixture/repo/task";
     const rows = [
       {
         id: "literal-percent",

--- a/src/lib/aiSessions/__tests__/shared.test.ts
+++ b/src/lib/aiSessions/__tests__/shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mapWithConcurrency, normalizeText, sortMessagesDescending } from "@/lib/aiSessions/shared";
+import { extractPlainText, makePreviewMessage, mapWithConcurrency, normalizeText, sortMessagesDescending } from "@/lib/aiSessions/shared";
 
 describe("sortMessagesDescending", () => {
   it("should sort session detail messages from newest to oldest", () => {
@@ -18,6 +18,35 @@ describe("normalizeText", () => {
     const result = normalizeText(`Fix hook state\n[Pasted ~33 lines]\n[remote-ssh] command failed {\nsshHost: 'roky-home'\nerror: 'server exited unexpectedly'\n    at createSessionWithoutWorktree (/tmp/worktree.js:1:1)\nmain branch tmux session failed`);
 
     expect(result).toBe("Fix hook state main branch tmux session failed");
+  });
+});
+
+describe("AI session message text", () => {
+  it("should preserve markdown and mermaid line breaks for detail rendering while keeping a flat preview", () => {
+    const source = {
+      text: `## Markdown summary
+
+- **Strong** list item
+- Safe [link](https://example.com)
+
+\`\`\`ts
+const rendered = true;
+\`\`\`
+
+\`\`\`mermaid
+graph TD
+  A[AI history loaded] --> B[Markdown rendered]
+  B --> C[Mermaid SVG rendered]
+\`\`\``,
+    };
+
+    const fullText = extractPlainText(source);
+    const previewMessage = makePreviewMessage("assistant", "2026-01-01T00:00:00.000Z", fullText);
+
+    expect(fullText).toContain("## Markdown summary\n");
+    expect(fullText).toContain("```mermaid\ngraph TD");
+    expect(previewMessage?.text).toContain("## Markdown summary - **Strong** list item");
+    expect(previewMessage?.fullText).toBe(fullText);
   });
 });
 

--- a/src/lib/aiSessions/shared.ts
+++ b/src/lib/aiSessions/shared.ts
@@ -78,23 +78,32 @@ export function limitPreviewMessages(messages: AggregatedAiMessage[]): Aggregate
   return messages.slice(0, MAX_PREVIEW_MESSAGES);
 }
 
-export function normalizeText(value: string): string {
-  const sanitized = value
-    .replace(/\[Pasted ~\d+ lines\]/g, " ")
-    .split(/\r?\n/)
-    .filter((line) => {
-      const trimmed = line.trim();
-      if (!trimmed) return false;
+function isTransportNoiseLine(trimmedLine: string): boolean {
+  return [
+    /^\[(?:remote-ssh|터미널|terminal)\]/,
+    /^sshHost:/,
+    /^command:/,
+    /^sshArgs:/,
+    /^error:/,
+    /^at\s+.*:\d+:\d+\)?$/,
+  ].some((pattern) => pattern.test(trimmedLine));
+}
 
-      return ![
-        /^\[(?:remote-ssh|터미널|terminal)\]/,
-        /^sshHost:/,
-        /^command:/,
-        /^sshArgs:/,
-        /^error:/,
-        /^at\s+.*:\d+:\d+\)?$/,
-      ].some((pattern) => pattern.test(trimmed));
-    })
+export function preserveMessageText(value: string): string {
+  return value
+    .replace(/\[Pasted ~\d+ lines\]/g, "\n")
+    .split(/\r?\n/)
+    .filter((line) => !isTransportNoiseLine(line.trim()))
+    .join("\n")
+    .replace(/[ \t]+$/gm, "")
+    .trim();
+}
+
+export function normalizeText(value: string): string {
+  const sanitized = preserveMessageText(value)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
     .join(" ");
 
   return sanitized.replace(/\s+/g, " ").trim();
@@ -111,13 +120,13 @@ function createTruncatedText(value: string, maxLength = MAX_PREVIEW_TEXT_LENGTH)
   previewText: string;
   isTruncated: boolean;
 } {
-  const fullText = normalizeText(value);
+  const fullText = preserveMessageText(value);
   const previewText = truncateText(fullText, maxLength);
 
   return {
     fullText,
     previewText,
-    isTruncated: previewText.length < fullText.length,
+    isTruncated: previewText.length < normalizeText(fullText).length,
   };
 }
 
@@ -220,11 +229,11 @@ export function safeJsonParse<T>(value: string): T | null {
 
 export function extractPlainText(value: unknown): string {
   if (typeof value === "string") {
-    return normalizeText(value);
+    return preserveMessageText(value);
   }
 
   if (Array.isArray(value)) {
-    return normalizeText(value.map(extractPlainText).filter(Boolean).join(" "));
+    return preserveMessageText(value.map(extractPlainText).filter(Boolean).join("\n"));
   }
 
   if (!value || typeof value !== "object") {
@@ -236,7 +245,7 @@ export function extractPlainText(value: unknown): string {
   const directKeys = ["text", "input_text", "output_text", "display", "description", "subject", "output", "result"];
   for (const key of directKeys) {
     if (typeof record[key] === "string") {
-      return normalizeText(record[key] as string);
+      return preserveMessageText(record[key] as string);
     }
   }
 
@@ -251,7 +260,7 @@ export function extractPlainText(value: unknown): string {
   }
 
   if (record.title && typeof record.title === "string") {
-    return normalizeText(record.title);
+    return preserveMessageText(record.title);
   }
 
   return "";


### PR DESCRIPTION
Promote the pinned 1.0.4 release branch to main after the published DMG release and Homebrew cask update.

- Release: https://github.com/rookedsysc/kanvibe/releases/tag/1.0.4
- Pinned head SHA: `fe1c29363baafbf2516edf4dd59da0e700d8c4ad` (cut from `origin/dev` at `50845e0`)
- Homebrew cask: `rookedsysc/homebrew-kanvibe@22cb6e0`