### PR TITLE
fix(release): publish KanVibe 1.0.5 — app.asar 전이 의존성 누락 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",
@@ -104,6 +104,5 @@
     "typescript-eslint": "^8.33.1",
     "vite": "^7.1.10",
     "vitest": "^4.0.18"
-  },
-  "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e"
+  }
 }

--- a/scripts/dist-deploy.cjs
+++ b/scripts/dist-deploy.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const { execFileSync } = require("node:child_process");
-const { existsSync, readFileSync, readdirSync, statSync } = require("node:fs");
+const { closeSync, existsSync, openSync, readFileSync, readdirSync, readSync, statSync } = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
@@ -17,6 +17,12 @@ const notarizationEnvironmentKeys = [
   "APPLE_KEYCHAIN",
   "APPLE_KEYCHAIN_PROFILE",
 ];
+
+// electron-builder가 실행 환경에서 패키지 매니저를 추론할 때 참고하는 값들이다.
+const packageManagerHintKeys = ["npm_config_user_agent", "npm_execpath", "npm_lifecycle_event", "npm_lifecycle_script"];
+
+// 앱 기동에 필요하지만 잘못된 수집 경로에서 누락된 적이 있는 전이 의존성이다.
+const requiredPackagedModules = ["ms", "scheduler", "ansi-regex", "decimal.js", "string_decoder", "util-deprecate", "wrappy", "typeorm", "better-sqlite3"];
 
 function stripInlineComment(value) {
   const commentIndex = value.search(/\s#/);
@@ -175,6 +181,83 @@ function createBuildEnvironment() {
   return buildEnvironment;
 }
 
+/**
+ * electron-builder는 락 파일이 여러 개면 패키지 매니저를 판정하지 못하고 실행 환경 변수를 보고
+ * 결정한다. 이 저장소에는 pnpm-lock.yaml과 package-lock.json이 함께 있어, pnpm이 띄운 프로세스에서
+ * 패키징하면 pnpm 수집기가 선택되고 전이 의존성 일부가 asar에서 누락된다. 패키징에만 쓰는 환경에서
+ * 패키지 매니저 힌트를 지워 항상 같은 수집 경로를 타도록 고정한다.
+ *
+ * @param {NodeJS.ProcessEnv} buildEnvironment 빌드용 환경
+ * @returns {NodeJS.ProcessEnv} 패키지 매니저 힌트를 제거한 패키징 전용 환경
+ */
+function createPackagingEnvironment(buildEnvironment) {
+  const packagingEnvironment = { ...buildEnvironment };
+
+  for (const key of packageManagerHintKeys) {
+    delete packagingEnvironment[key];
+  }
+
+  return packagingEnvironment;
+}
+
+/**
+ * 패키징 결과물이 앱 실행에 필요한 의존성을 실제로 담고 있는지 검사한다. 서명·공증이 모두 성공해도
+ * 의존성이 빠진 채로 배포될 수 있어, 발행 전에 여기서 끊는다.
+ *
+ * @param {string} appBundlePath 검사할 앱 번들 경로
+ */
+function ensurePackagedDependencies(appBundlePath) {
+  const asarPath = path.join(appBundlePath, "Contents", "Resources", "app.asar");
+  const packaged = readAsarNodeModuleNames(asarPath);
+  const missing = requiredPackagedModules.filter((name) => !packaged.has(name));
+
+  if (missing.length > 0) {
+    throw new Error(
+      `packaged app.asar is missing required modules: ${missing.join(", ")}. ` +
+        "This usually means electron-builder collected dependencies with the wrong package manager."
+    );
+  }
+
+  console.log(`\n[kanvibe] packaged node_modules verified: ${packaged.size} packages`);
+}
+
+/**
+ * asar 헤더만 읽어 최상위 node_modules 패키지 이름을 모은다.
+ *
+ * @param {string} asarPath 대상 asar 경로
+ * @returns {Set<string>} 패키징된 최상위 패키지 이름 집합
+ */
+function readAsarNodeModuleNames(asarPath) {
+  const descriptor = openSync(asarPath, "r");
+
+  try {
+    const sizeBuffer = Buffer.alloc(16);
+    readSync(descriptor, sizeBuffer, 0, 16, 0);
+
+    const headerSize = sizeBuffer.readUInt32LE(12);
+    const headerBuffer = Buffer.alloc(headerSize);
+    readSync(descriptor, headerBuffer, 0, headerSize, 16);
+
+    const header = JSON.parse(headerBuffer.toString("utf8").replace(/\0+$/, ""));
+    const names = new Set();
+
+    for (const [name, entry] of Object.entries(header.files?.node_modules?.files ?? {})) {
+      if (name.startsWith("@")) {
+        for (const scoped of Object.keys(entry.files ?? {})) {
+          names.add(`${name}/${scoped}`);
+        }
+        continue;
+      }
+
+      names.add(name);
+    }
+
+    return names;
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
 function ensureBuildArtifacts(version) {
   const dmgPath = path.join(projectRoot, "dist", `KanVibe-${version}.dmg`);
   const appBundlePath = findAppBundle(path.join(projectRoot, "dist"));
@@ -222,10 +305,18 @@ function main() {
     const version = getPackageVersion();
     const buildEnvironment = createBuildEnvironment();
 
-    runCommand("pnpm", ["dist"], { env: buildEnvironment });
+    runCommand("pnpm", ["db:prepare"], { env: buildEnvironment });
+    runCommand("pnpm", ["build"], { env: buildEnvironment });
+    runCommand("pnpm", ["rebuild:native:electron"], { env: buildEnvironment });
+
+    // electron-builder는 pnpm이 띄운 프로세스에서 실행하면 전이 의존성을 누락시키므로 직접 호출한다.
+    runCommand(path.join(projectRoot, "node_modules", ".bin", "electron-builder"), ["--mac", "dmg"], {
+      env: createPackagingEnvironment(buildEnvironment),
+    });
 
     const { appBundlePath, dmgPath } = ensureBuildArtifacts(version);
 
+    ensurePackagedDependencies(appBundlePath);
     runCommand("codesign", ["--verify", "--deep", "--strict", "--verbose=2", appBundlePath]);
     submitDmgForNotarization(dmgPath);
     runCommand("xcrun", ["stapler", "staple", dmgPath]);


### PR DESCRIPTION
## Summary

1.0.4 배포본이 실행 즉시 `Cannot find module 'ms'`로 죽는 문제를 수정하고 1.0.5를 발행한다.

electron-builder는 락 파일이 둘 이상이면 패키지 매니저를 판정하지 못하고 실행 환경 변수로 결정한다. 이 저장소에는 `pnpm-lock.yaml`과 `package-lock.json`이 함께 있어 `pnpm run`으로 빌드하면 pnpm 수집기가 선택됐고, 그 경로가 hoisted 레이아웃의 전이 의존성을 따라가지 못해 7개 패키지가 asar에서 빠졌다: `ms`, `scheduler`, `ansi-regex`, `decimal.js`, `string_decoder`, `util-deprecate`, `wrappy`.

## Changes

- `packageManager` 필드 제거 — 이 필드가 있으면 환경 변수보다 먼저 pnpm으로 판정된다. pnpm 버전 고정은 CI의 `pnpm/action-setup` `version: 10` 입력으로 되돌렸다.
- `scripts/dist-deploy.cjs`가 electron-builder를 pnpm 경유가 아니라 직접 호출하고, 패키지 매니저 힌트(`npm_config_user_agent` 등)를 지운 환경을 넘겨 수집 경로를 고정한다.
- 패키징 직후 asar에 필수 모듈이 실제로 담겼는지 검사하는 가드를 추가했다. 서명·공증이 통과해도 기동 불가능한 번들이 나갈 수 있었던 구멍을 막는다.

## Verification

- 수집기: `searching for node modules pm=npm` (고정 확인)
- 가드: `packaged node_modules verified: 278 packages` (1.0.4는 271개)
- 공증: submission `9e6dd781-4c6f-4ed3-b33d-c33d566ca22c`, `Accepted`, staple validate 통과
- Gatekeeper: 마운트된 DMG 내부 앱 `accepted / source=Notarized Developer ID`
- **실행 검증**: DMG에서 꺼낸 앱 기동 성공 — 모듈 오류 0건, IPC 24건 성공
- 발행 에셋 다운로드 해시 = 로컬 DMG 해시 일치 (`d77f6389…`)
- Homebrew: `brew fetch --cask rookedsysc/kanvibe/kanvibe` → `✔︎ Cask kanvibe (1.0.5)`

## Release

- https://github.com/rookedsysc/kanvibe/releases/tag/1.0.5
- Cask: `rookedsysc/homebrew-kanvibe@81525ad`