### PR TITLE
modify: .kanvibe 상태 client 단위 공유 및 GitHub repo 아이콘 표시

### DIFF
--- a/qa/electron/flows/docs-board-capture.cjs
+++ b/qa/electron/flows/docs-board-capture.cjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports */
+/**
+ * docs용 보드 스크린샷 캡처 플로우.
+ * GitHub remote가 있는 저장소(아이콘)와 없는 저장소(이니셜 배지)를 함께 시드해
+ * 프로젝트 마커 두 종류가 한 화면에 나오게 한다.
+ */
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+const { launchKanVibeElectron } = require("../lib/launchElectron.cjs");
+
+const ROOT_DIR = process.env.KANVIBE_ROOT_DIR;
+const BOARD_VIEWPORT = { width: 1680, height: 1040 };
+/** docs 이미지는 Retina 화면에서도 선명하도록 2배 밀도로 촬영한다 */
+const DEVICE_SCALE_FACTOR = 2;
+const OUT_DIR = process.env.CAPTURE_OUT_DIR;
+
+/** owner가 있으면 GitHub remote를 붙여 아이콘을 받고, 없으면 이니셜 배지로 그려진다 */
+const PROJECT_FIXTURES = [
+  { name: "kanvibe", owner: "rookedsysc" },
+  { name: "techtaurant-be", owner: "rookedsysc" },
+  { name: "techtaurant-fe", owner: "rookedsysc" },
+  { name: "prompt", owner: "rookedsysc" },
+  { name: "llm-wiki-mcp", owner: "rookedsysc" },
+  { name: "portfolio", owner: "rookedsysc" },
+  { name: "nvim", owner: null },
+  { name: "timelabs-mobile", owner: null },
+  { name: "dotfiles", owner: null },
+];
+
+const TASK_FIXTURES = [
+  { project: "kanvibe", title: "feat/project-icon", status: "progress", description: "보드 카드 프로젝트 마커를 아이콘으로 교체" },
+  { project: "kanvibe", title: "modify/state-sync", status: "review", description: ".kanvibe 상태를 client 단위로 공유" },
+  { project: "kanvibe", title: "fix/kanban-task-move", status: "done" },
+  { project: "kanvibe", title: "feat/task-detail-dock-shortcut", status: "done" },
+  { project: "techtaurant-be", title: "refactor/auth-detail", status: "review" },
+  { project: "techtaurant-be", title: "modify/prepare-ssg-isr", status: "done", description: "ssg isr 위한 api 분리 작업" },
+  { project: "techtaurant-fe", title: "feat/setting-redirect", status: "progress" },
+  { project: "techtaurant-fe", title: "feat/comment-thread", status: "todo" },
+  { project: "prompt", title: "feat/roky-harness", status: "todo" },
+  { project: "llm-wiki-mcp", title: "feat/vault-push", status: "pending" },
+  { project: "portfolio", title: "chore/deploy", status: "todo" },
+  { project: "nvim", title: "feat/lsp-config", status: "todo" },
+  { project: "timelabs-mobile", title: "feat/timesystem", status: "progress" },
+  { project: "timelabs-mobile", title: "feat/project-screen", status: "pending" },
+  { project: "dotfiles", title: "chore/zsh-plugins", status: "todo" },
+];
+
+function execGit(args, cwd) {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function createLocalRepository(fixturesRoot, fixture) {
+  const projectDir = path.join(fixturesRoot, fixture.name);
+  fs.mkdirSync(projectDir, { recursive: true });
+
+  execGit(["init", "--initial-branch=main"], projectDir);
+  execGit(["config", "user.email", "qa@kanvibe.local"], projectDir);
+  execGit(["config", "user.name", "KanVibe QA"], projectDir);
+  fs.writeFileSync(path.join(projectDir, "README.md"), `# ${fixture.name}\n`, "utf8");
+  execGit(["add", "."], projectDir);
+  execGit(["commit", "-m", "chore: init"], projectDir);
+
+  if (fixture.owner) {
+    execGit(["remote", "add", "origin", `https://github.com/${fixture.owner}/${fixture.name}.git`], projectDir);
+  }
+
+  return projectDir;
+}
+
+/**
+ * Playwright의 setViewportSize는 deviceScaleFactor를 1로 고정해 Retina 배율을 죽인다.
+ * docs용 이미지는 2배 밀도가 필요하므로 CDP로 배율을 직접 지정한 뒤 촬영한다.
+ */
+async function captureRetinaScreenshot(app, page, shotPath) {
+  const devicePixelRatio = await page.evaluate(() => window.devicePixelRatio);
+  const encodedPng = await app.evaluate(async ({ BrowserWindow, screen }) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    const image = await win.webContents.capturePage();
+    return {
+      png: image.toPNG().toString("base64"),
+      scaleFactor: screen.getPrimaryDisplay().scaleFactor,
+    };
+  });
+
+  fs.writeFileSync(shotPath, Buffer.from(encodedPng.png, "base64"));
+  return { devicePixelRatio, scaleFactor: encodedPng.scaleFactor };
+}
+
+async function invokeDesktop(page, namespace, method, ...args) {
+  return page.evaluate(
+    async ({ namespace, method, args }) => window.kanvibeDesktop.invoke(namespace, method, args),
+    { namespace, method, args },
+  );
+}
+
+async function dismissDialogIfPresent(page) {
+  try {
+    await page.getByRole("button", { name: "닫기" }).first().click({ timeout: 2500 });
+    await page.waitForTimeout(500);
+  } catch {
+    // 릴리스 노트 다이얼로그는 없을 수도 있다.
+  }
+}
+
+async function main() {
+  const fixturesRoot = path.join(OUT_DIR, "fixtures");
+  const appDataDir = path.join(OUT_DIR, "app-data");
+  fs.rmSync(fixturesRoot, { recursive: true, force: true });
+  fs.rmSync(appDataDir, { recursive: true, force: true });
+  fs.mkdirSync(fixturesRoot, { recursive: true });
+  fs.mkdirSync(appDataDir, { recursive: true });
+
+  const projectDirs = new Map();
+  for (const fixture of PROJECT_FIXTURES) {
+    projectDirs.set(fixture.name, createLocalRepository(fixturesRoot, fixture));
+  }
+  console.log(`[capture] created ${projectDirs.size} fixture repositories`);
+
+  const { app, page } = await launchKanVibeElectron({
+    rootDir: ROOT_DIR,
+    appDataDir,
+    viewport: BOARD_VIEWPORT,
+    timeoutMs: 60000,
+    actionTimeoutMs: 30000,
+  });
+
+  try {
+    await page.waitForLoadState("domcontentloaded");
+    await page.waitForTimeout(2500);
+    await page.screenshot({ path: path.join(OUT_DIR, "00-launched.png") });
+    await dismissDialogIfPresent(page);
+
+    const projectIds = new Map();
+    for (const fixture of PROJECT_FIXTURES) {
+      const result = await invokeDesktop(page, "project", "registerProject", fixture.name, projectDirs.get(fixture.name));
+      if (!result?.success || !result.project) {
+        console.log(`[capture] register failed: ${fixture.name} -> ${result?.error}`);
+        continue;
+      }
+      projectIds.set(fixture.name, result.project.id);
+      console.log(`[capture] registered ${fixture.name} icon=${result.project.iconDataUrl ? "yes" : "no"} color=${result.project.color}`);
+    }
+
+    for (const task of TASK_FIXTURES) {
+      const projectId = projectIds.get(task.project);
+      if (!projectId) continue;
+
+      const created = await invokeDesktop(page, "kanban", "createTask", {
+        title: task.title,
+        description: task.description ?? "",
+        projectId,
+      });
+      if (task.status !== "todo" && created?.id) {
+        await invokeDesktop(page, "kanban", "moveTaskToColumn", created.id, task.status, [created.id]);
+      }
+    }
+    console.log(`[capture] seeded ${TASK_FIXTURES.length} tasks`);
+
+    await page.reload();
+    await page.waitForLoadState("domcontentloaded");
+    await page.waitForTimeout(4000);
+    await dismissDialogIfPresent(page);
+
+    const shotPath = path.join(OUT_DIR, "board.png");
+    const density = await captureRetinaScreenshot(app, page, shotPath);
+    console.log(JSON.stringify({ ok: true, screenshot: shotPath, ...density }));
+  } catch (error) {
+    console.error("[capture] electron output:\n" + (typeof app.output === "function" ? app.output() : ""));
+    throw error;
+  } finally {
+    await app.close().catch(() => {});
+  }
+}
+
+main().catch((error) => {
+  console.error("[capture] failed:", error);
+  process.exit(1);
+});

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -623,23 +623,32 @@ export default function Board({
     return nameMap;
   }, [projects]);
 
-  /** 프로젝트명 → hex 색상 매핑. DB color 우선, 없으면 해시 기반 프리셋 할당 */
-  const projectColorMap = useMemo(() => {
-    const colorMap: Record<string, string> = {};
-
+  /** 프로젝트명 → 해당 이름의 메인 프로젝트(worktree 제외) 매핑 */
+  const mainProjectByName = useMemo(() => {
     const uniqueNames = new Set(Object.values(projectNameMap));
+    const mainProjects = new Map<string, Project>();
+
     for (const name of uniqueNames) {
       const mainProject = projects.find(
         (p) => p.name === name && !extractMainRepoPath(p.repoPath)
       );
-      if (mainProject?.color) {
-        colorMap[name] = mainProject.color;
-      } else {
-        colorMap[name] = computeProjectColor(name);
+      if (mainProject) {
+        mainProjects.set(name, mainProject);
       }
     }
-    return colorMap;
+
+    return mainProjects;
   }, [projectNameMap, projects]);
+
+  /** 프로젝트명 → hex 색상 매핑. DB color 우선, 없으면 해시 기반 프리셋 할당 */
+  const projectColorMap = useMemo(() => {
+    const colorMap: Record<string, string> = {};
+
+    for (const name of new Set(Object.values(projectNameMap))) {
+      colorMap[name] = mainProjectByName.get(name)?.color || computeProjectColor(name);
+    }
+    return colorMap;
+  }, [projectNameMap, mainProjectByName]);
 
   const projectLookup = useMemo(
     () => new Map(projects.map((project) => [project.id, project])),

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -650,6 +650,19 @@ export default function Board({
     return colorMap;
   }, [projectNameMap, mainProjectByName]);
 
+  /** 프로젝트명 → GitHub 아이콘 data URL 매핑. 아이콘이 없는 프로젝트는 항목을 만들지 않는다 */
+  const projectIconMap = useMemo(() => {
+    const iconMap: Record<string, string> = {};
+
+    for (const name of new Set(Object.values(projectNameMap))) {
+      const iconDataUrl = mainProjectByName.get(name)?.iconDataUrl;
+      if (iconDataUrl) {
+        iconMap[name] = iconDataUrl;
+      }
+    }
+    return iconMap;
+  }, [projectNameMap, mainProjectByName]);
+
   const projectLookup = useMemo(
     () => new Map(projects.map((project) => [project.id, project])),
     [projects],
@@ -1280,6 +1293,7 @@ export default function Board({
                   onContextMenu={handleContextMenu}
                   projectNameMap={projectNameMap}
                   projectColorMap={projectColorMap}
+                  projectIconMap={projectIconMap}
                   vimModeEnabled={vimModeEnabled}
                   {...(col.status === TaskStatus.DONE && {
                     totalCount: doneTotal,

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -15,6 +15,7 @@ interface ColumnProps {
   onContextMenu: (task: KanbanTask, position: { x: number; y: number }) => void;
   projectNameMap: Record<string, string>;
   projectColorMap: Record<string, string>;
+  projectIconMap: Record<string, string>;
   totalCount?: number;
   hasMore?: boolean;
   onLoadMore?: () => void;
@@ -77,6 +78,7 @@ export default function Column({
   onContextMenu,
   projectNameMap,
   projectColorMap,
+  projectIconMap,
   totalCount,
   hasMore,
   onLoadMore,
@@ -151,6 +153,7 @@ export default function Column({
               }
 
               const color = projectColorMap[group.projectName] ?? "#93C5FD";
+              const iconDataUrl = projectIconMap[group.projectName] ?? null;
 
               return (
                 <ProjectTaskGroup
@@ -164,6 +167,7 @@ export default function Column({
                       onContextMenu={onContextMenu}
                       projectName={group.projectName ?? undefined}
                       projectColor={color}
+                      projectIconDataUrl={iconDataUrl}
                       isBaseProject={
                         !!task.worktreePath &&
                         !task.worktreePath.includes("__worktrees")

--- a/src/components/ProjectIcon.tsx
+++ b/src/components/ProjectIcon.tsx
@@ -1,31 +1,55 @@
 "use client";
 
+import { getReadableTextColor } from "@/lib/projectColor";
+
 interface ProjectIconProps {
   projectName: string;
   /** 프로젝트 등록 시 받아둔 GitHub repo/org 아이콘 data URL */
   iconDataUrl?: string | null;
+  /** 아이콘이 없을 때 이니셜 배지를 칠할 프로젝트 색상. 색상이 없으면 배지를 그리지 않는다 */
+  color?: string | null;
   sizeClassName?: string;
 }
 
+function getProjectInitial(projectName: string): string {
+  return [...projectName.trim()][0] ?? "";
+}
+
 /**
- * 프로젝트 제목 앞에 붙는 GitHub repo/org 아이콘.
- * GitHub 저장소가 아니거나 아이콘을 받지 못한 프로젝트에서는 아무것도 그리지 않는다.
+ * 프로젝트 제목 앞에 붙는 마커.
+ * GitHub 아이콘을 받아둔 프로젝트는 아이콘을, 아이콘이 없는 프로젝트는 프로젝트 색상의
+ * 이니셜 배지를 그린다. 바로 옆에 프로젝트명이 그대로 나오므로 배지는 스크린 리더에서 숨긴다.
  */
 export default function ProjectIcon({
   projectName,
   iconDataUrl,
+  color,
   sizeClassName = "h-3.5 w-3.5",
 }: ProjectIconProps) {
-  if (!iconDataUrl) {
+  if (iconDataUrl) {
+    return (
+      <img
+        src={iconDataUrl}
+        alt={`${projectName} icon`}
+        className={`${sizeClassName} shrink-0 rounded-sm object-cover`}
+        data-testid="project-github-icon"
+      />
+    );
+  }
+
+  const initial = getProjectInitial(projectName);
+  if (!color || !initial) {
     return null;
   }
 
   return (
-    <img
-      src={iconDataUrl}
-      alt={`${projectName} icon`}
-      className={`${sizeClassName} shrink-0 rounded-sm object-cover`}
-      data-testid="project-github-icon"
-    />
+    <span
+      className={`${sizeClassName} inline-flex shrink-0 items-center justify-center rounded-sm text-[9px] font-bold uppercase leading-none`}
+      style={{ backgroundColor: color, color: getReadableTextColor(color) }}
+      aria-hidden="true"
+      data-testid="project-initial-icon"
+    >
+      {initial}
+    </span>
   );
 }

--- a/src/components/ProjectIcon.tsx
+++ b/src/components/ProjectIcon.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+interface ProjectIconProps {
+  projectName: string;
+  /** 프로젝트 등록 시 받아둔 GitHub repo/org 아이콘 data URL */
+  iconDataUrl?: string | null;
+  sizeClassName?: string;
+}
+
+/**
+ * 프로젝트 제목 앞에 붙는 GitHub repo/org 아이콘.
+ * GitHub 저장소가 아니거나 아이콘을 받지 못한 프로젝트에서는 아무것도 그리지 않는다.
+ */
+export default function ProjectIcon({
+  projectName,
+  iconDataUrl,
+  sizeClassName = "h-3.5 w-3.5",
+}: ProjectIconProps) {
+  if (!iconDataUrl) {
+    return null;
+  }
+
+  return (
+    <img
+      src={iconDataUrl}
+      alt={`${projectName} icon`}
+      className={`${sizeClassName} shrink-0 rounded-sm object-cover`}
+      data-testid="project-github-icon"
+    />
+  );
+}

--- a/src/components/ProjectRegistryDialog.tsx
+++ b/src/components/ProjectRegistryDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
 import type { Project } from "@/entities/Project";
 import FolderSearchInput from "@/components/FolderSearchInput";
+import ProjectIcon from "@/components/ProjectIcon";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 interface ProjectRegistryDialogProps {
@@ -200,7 +201,8 @@ export default function ProjectRegistryDialog({
                   >
                     <div className="flex items-center justify-between gap-3">
                       <div className="min-w-0">
-                        <p className="truncate text-sm font-medium text-text-primary">
+                        <p className="flex items-center gap-1.5 truncate text-sm font-medium text-text-primary">
+                          <ProjectIcon projectName={project.name} iconDataUrl={project.iconDataUrl} />
                           {project.name}
                         </p>
                         <p className="truncate font-mono text-xs text-text-muted">

--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -2,6 +2,7 @@
 
 import { forwardRef, useState, useEffect, useRef, useCallback, useImperativeHandle, useMemo } from "react";
 import type { Project } from "@/entities/Project";
+import ProjectIcon from "@/components/ProjectIcon";
 
 const MAX_VISIBLE_CHIPS = 2;
 const EMPTY_SELECTED_PROJECT_IDS: string[] = [];
@@ -388,6 +389,7 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
                           </svg>
                         )}
                       </span>
+                      <ProjectIcon projectName={project.name} iconDataUrl={project.iconDataUrl} />
                       <span className="truncate">
                         {project.name}
                         {project.sshHost && (
@@ -546,18 +548,21 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
                       handleToggle(project.id);
                     }}
                     onMouseEnter={() => setHighlightedIndex(itemIndex)}
-                    className={`px-3 py-2 text-sm cursor-pointer transition-colors ${
+                    className={`flex items-center gap-2 px-3 py-2 text-sm cursor-pointer transition-colors ${
                       itemIndex === normalizedHighlightedIndex
                         ? "bg-brand-primary/10 text-text-primary"
                         : "text-text-primary hover:bg-bg-page"
                     } ${project.id === selectedProjectId ? "font-medium" : ""}`}
                   >
-                    {project.name}
-                    {project.sshHost && (
-                      <span className="text-text-muted ml-1">
-                        ({project.sshHost})
-                      </span>
-                    )}
+                    <ProjectIcon projectName={project.name} iconDataUrl={project.iconDataUrl} />
+                    <span className="truncate">
+                      {project.name}
+                      {project.sshHost && (
+                        <span className="text-text-muted ml-1">
+                          ({project.sshHost})
+                        </span>
+                      )}
+                    </span>
                   </li>
                 );
               })

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/desktop/renderer/utils/taskNavigation";
 import { TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import { TaskPriority } from "@/entities/TaskPriority";
+import ProjectIcon from "@/components/ProjectIcon";
 
 interface ContextMenuPosition {
   x: number;
@@ -21,6 +22,7 @@ interface TaskCardProps {
   onContextMenu: (task: KanbanTask, position: ContextMenuPosition) => void;
   projectName?: string;
   projectColor?: string;
+  projectIconDataUrl?: string | null;
   isBaseProject?: boolean;
   vimModeEnabled?: boolean;
 }
@@ -156,6 +158,7 @@ export default function TaskCard({
   onContextMenu,
   projectName,
   projectColor,
+  projectIconDataUrl,
   isBaseProject,
   vimModeEnabled = true,
 }: TaskCardProps) {
@@ -270,11 +273,18 @@ export default function TaskCard({
                 className="h-1.5 w-1.5 shrink-0 rounded-full"
                 style={{ backgroundColor: projectColor }}
               />
-              <span
-                className="truncate text-xs font-semibold leading-4"
-                style={{ color: projectColor }}
-              >
-                {projectName}
+              <span className="flex min-w-0 items-center gap-1.5">
+                <ProjectIcon
+                  projectName={projectName}
+                  iconDataUrl={projectIconDataUrl}
+                  sizeClassName="h-3.5 w-3.5"
+                />
+                <span
+                  className="truncate text-xs font-semibold leading-4"
+                  style={{ color: projectColor }}
+                >
+                  {projectName}
+                </span>
               </span>
             </div>
           )}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -40,6 +40,8 @@ const priorityConfig: Record<TaskPriority, { label: string; colorClass: string }
 };
 
 const badgeClassName = "inline-flex items-center rounded border border-border-subtle px-1.5 py-0.5 text-[10px]";
+/** 프로젝트 마커 열 + 본문 열. 마커 폭은 ProjectIcon 기본 크기(h-3.5 w-3.5 = 14px)와 맞춘다 */
+const PROJECT_MARKER_GRID_COLUMNS = "grid-cols-[14px_minmax(0,1fr)]";
 
 const KANBAN_STATUS_ORDER = [
   TaskStatus.TODO,
@@ -268,28 +270,22 @@ export default function TaskCard({
           )}
 
           {projectName && (
-            <div className="mb-1 grid grid-cols-[6px_minmax(0,1fr)] items-center gap-2">
-              <span
-                className="h-1.5 w-1.5 shrink-0 rounded-full"
-                style={{ backgroundColor: projectColor }}
+            <div className={`mb-1 grid ${PROJECT_MARKER_GRID_COLUMNS} items-center gap-2`}>
+              <ProjectIcon
+                projectName={projectName}
+                iconDataUrl={projectIconDataUrl}
+                color={projectColor}
               />
-              <span className="flex min-w-0 items-center gap-1.5">
-                <ProjectIcon
-                  projectName={projectName}
-                  iconDataUrl={projectIconDataUrl}
-                  sizeClassName="h-3.5 w-3.5"
-                />
-                <span
-                  className="truncate text-xs font-semibold leading-4"
-                  style={{ color: projectColor }}
-                >
-                  {projectName}
-                </span>
+              <span
+                className="truncate text-xs font-semibold leading-4"
+                style={{ color: projectColor }}
+              >
+                {projectName}
               </span>
             </div>
           )}
 
-          <div className={projectName ? "grid grid-cols-[6px_minmax(0,1fr)] items-start gap-2" : "block"}>
+          <div className={projectName ? `grid ${PROJECT_MARKER_GRID_COLUMNS} items-start gap-2` : "block"}>
             {projectName ? <span aria-hidden="true" /> : null}
             <div className="min-w-0">
               <h3 className="truncate text-[13px] font-medium leading-5 text-text-primary">

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -181,6 +181,7 @@ function createProject(overrides: Partial<Project> = {}): Project {
     sshHost: null,
     isWorktree: false,
     color: null,
+    iconDataUrl: null,
     createdAt: new Date(),
     ...overrides,
   };

--- a/src/components/__tests__/BranchTaskModal.test.tsx
+++ b/src/components/__tests__/BranchTaskModal.test.tsx
@@ -41,6 +41,7 @@ function createProject(overrides?: Partial<Project>): Project {
     sshHost: "remote-box",
     isWorktree: false,
     color: null,
+    iconDataUrl: null,
     createdAt: new Date(),
     ...overrides,
   };

--- a/src/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/components/__tests__/CreateTaskModal.test.tsx
@@ -65,6 +65,7 @@ function createProject(overrides?: Partial<Project>): Project {
     sshHost: "remote-box",
     isWorktree: false,
     color: null,
+    iconDataUrl: null,
     createdAt: new Date(),
     ...overrides,
   };

--- a/src/components/__tests__/ProjectIcon.test.tsx
+++ b/src/components/__tests__/ProjectIcon.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ProjectIcon from "@/components/ProjectIcon";
+
+const ICON_DATA_URL = "data:image/png;base64,iVBORw0KGgo=";
+
+describe("ProjectIcon", () => {
+  it("GitHub 아이콘이 있으면 프로젝트명 앞 아이콘으로 그린다", () => {
+    render(<ProjectIcon projectName="kanvibe" iconDataUrl={ICON_DATA_URL} />);
+
+    const icon = screen.getByAltText("kanvibe icon");
+    expect(icon.getAttribute("src")).toBe(ICON_DATA_URL);
+  });
+
+  it("아이콘이 없는 프로젝트는 아무것도 그리지 않는다", () => {
+    const { container } = render(<ProjectIcon projectName="kanvibe" iconDataUrl={null} />);
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/src/components/__tests__/ProjectIcon.test.tsx
+++ b/src/components/__tests__/ProjectIcon.test.tsx
@@ -12,7 +12,29 @@ describe("ProjectIcon", () => {
     expect(icon.getAttribute("src")).toBe(ICON_DATA_URL);
   });
 
-  it("아이콘이 없는 프로젝트는 아무것도 그리지 않는다", () => {
+  it("아이콘이 없으면 프로젝트 색상의 이니셜 배지를 그린다", () => {
+    render(<ProjectIcon projectName="internal-tool" iconDataUrl={null} color="#86EFAC" />);
+
+    const badge = screen.getByTestId("project-initial-icon");
+    expect(badge.textContent).toBe("i");
+    expect(badge.style.backgroundColor).toBe("rgb(134, 239, 172)");
+    /** 파스텔 배경 위에서는 어두운 글자로 대비를 확보한다 */
+    expect(badge.style.color).toBe("rgb(17, 24, 39)");
+  });
+
+  it("어두운 프로젝트 색상에서는 이니셜을 흰색으로 그린다", () => {
+    render(<ProjectIcon projectName="kanvibe" iconDataUrl={null} color="#0064FF" />);
+
+    expect(screen.getByTestId("project-initial-icon").style.color).toBe("rgb(255, 255, 255)");
+  });
+
+  it("아이콘이 있으면 색상이 있어도 이니셜 배지를 그리지 않는다", () => {
+    render(<ProjectIcon projectName="kanvibe" iconDataUrl={ICON_DATA_URL} color="#86EFAC" />);
+
+    expect(screen.queryByTestId("project-initial-icon")).toBeNull();
+  });
+
+  it("색상이 없으면 아무것도 그리지 않는다", () => {
     const { container } = render(<ProjectIcon projectName="kanvibe" iconDataUrl={null} />);
 
     expect(container.innerHTML).toBe("");

--- a/src/components/__tests__/ProjectRegistryDialog.test.tsx
+++ b/src/components/__tests__/ProjectRegistryDialog.test.tsx
@@ -51,6 +51,7 @@ function createProject(): Project {
     sshHost: null,
     isWorktree: false,
     color: null,
+    iconDataUrl: null,
     createdAt: new Date(),
   };
 }

--- a/src/components/__tests__/ProjectSelector.test.tsx
+++ b/src/components/__tests__/ProjectSelector.test.tsx
@@ -24,6 +24,7 @@ function createProject(id: string, name: string): Project {
     sshHost: null,
     isWorktree: false,
     color: null,
+    iconDataUrl: null,
     createdAt: new Date(),
   };
 }

--- a/src/components/__tests__/ProjectSettings.test.tsx
+++ b/src/components/__tests__/ProjectSettings.test.tsx
@@ -74,6 +74,7 @@ function createProject(): Project {
     sshHost: null,
     isWorktree: false,
     color: null,
+    iconDataUrl: null,
     createdAt: new Date(),
   };
 }

--- a/src/components/__tests__/TaskDetailInfoCard.test.tsx
+++ b/src/components/__tests__/TaskDetailInfoCard.test.tsx
@@ -56,6 +56,7 @@ function createTask(overrides: Partial<KanbanTask> = {}): KanbanTask {
       sshHost: null,
       isWorktree: false,
       color: null,
+      iconDataUrl: null,
       createdAt: new Date(),
     },
     projectId: "project-1",
@@ -157,6 +158,7 @@ describe("TaskDetailInfoCard - Project Badge Color", () => {
         sshHost: null,
         isWorktree: false,
         color: "#FF0000",
+        iconDataUrl: null,
         createdAt: new Date(),
       },
     });

--- a/src/components/__tests__/TaskDetailTitleCard.test.tsx
+++ b/src/components/__tests__/TaskDetailTitleCard.test.tsx
@@ -68,6 +68,7 @@ function createTask(overrides: Partial<KanbanTask> = {}): KanbanTask {
       sshHost: null,
       isWorktree: false,
       color: null,
+      iconDataUrl: null,
       createdAt: new Date(),
     },
     projectId: "project-1",

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
     find: vi.fn(),
     findOneBy: vi.fn(),
     save: vi.fn(),
+    update: vi.fn(),
   },
   execFile: vi.fn(),
   createWorktreeWithSession: vi.fn(),
@@ -1109,7 +1110,7 @@ describe("kanbanService.createTask", () => {
     };
     mocks.projectRepo.findOneBy.mockResolvedValue(project);
     mocks.projectRepo.find.mockResolvedValue([]);
-    mocks.projectRepo.save.mockImplementation(async (value) => value);
+    mocks.projectRepo.update.mockResolvedValue({ affected: 1 });
 
     const { updateProjectColor } = await import("@/desktop/main/services/kanbanService");
 
@@ -1117,11 +1118,41 @@ describe("kanbanService.createTask", () => {
     await updateProjectColor("project-1", "#93C5FD");
 
     // Then
-    expect(mocks.projectRepo.save).toHaveBeenCalledWith(expect.objectContaining({
-      id: "project-1",
-      color: "#93C5FD",
-    }));
+    expect(mocks.projectRepo.update).toHaveBeenCalledWith(
+      expect.anything(),
+      { color: "#93C5FD" },
+    );
     expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("프로젝트 색상 수정은 DB보다 권위 파일인 .kanvibe 상태를 먼저 기록한다", async () => {
+    // Given
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      color: "#65D08A",
+    });
+    mocks.projectRepo.find.mockResolvedValue([]);
+    mocks.projectRepo.update.mockResolvedValue({ affected: 1 });
+
+    const writeOrder: string[] = [];
+    mocks.writeTextFile.mockImplementation(async () => {
+      writeOrder.push("kanvibe-state");
+    });
+    mocks.projectRepo.update.mockImplementation(async () => {
+      writeOrder.push("database");
+      return { affected: 1 };
+    });
+
+    const { updateProjectColor } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    await updateProjectColor("project-1", "#0064FF");
+
+    // Then
+    /** DB가 먼저 바뀌면 그 사이 도는 background sync가 아직 낡은 공유 파일을 읽어 색을 되돌린다 */
+    expect(writeOrder.indexOf("kanvibe-state")).toBeGreaterThanOrEqual(0);
+    expect(writeOrder.indexOf("kanvibe-state")).toBeLessThan(writeOrder.indexOf("database"));
   });
 
   it("컬럼 내 task 순서 변경 후 board update를 브로드캐스트한다", async () => {

--- a/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
+++ b/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
@@ -24,9 +24,9 @@ vi.mock("@/lib/kanvibeProjectState", async (importOriginal) => ({
 
 import type { Project } from "@/entities/Project";
 import {
-  applySharedProjectColor,
   persistProjectColorToKanvibeState,
   readSharedProjectColor,
+  syncProjectColorWithKanvibeState,
 } from "@/desktop/main/services/kanvibeProjectColorService";
 
 function createProject(overrides: Partial<Project> = {}): Project {
@@ -89,19 +89,29 @@ describe("kanvibeProjectColorService", () => {
     mocks.readKanvibeProjectColor.mockResolvedValue("#0064FF");
     const project = createProject();
 
-    await expect(applySharedProjectColor(project)).resolves.toBe(true);
+    await expect(syncProjectColorWithKanvibeState(project)).resolves.toBe(true);
     expect(project.color).toBe("#0064FF");
 
     mocks.readKanvibeProjectColor.mockResolvedValue("#0064FF");
-    await expect(applySharedProjectColor(project)).resolves.toBe(false);
+    await expect(syncProjectColorWithKanvibeState(project)).resolves.toBe(false);
   });
 
-  it("공유 색상이 없으면 기존 색상을 유지한다", async () => {
+  it("공유 색상이 반영되거나 이미 같으면 공유 파일을 다시 쓰지 않는다", async () => {
+    mocks.readKanvibeProjectColor.mockResolvedValue("#65D08A");
+
+    await expect(syncProjectColorWithKanvibeState(createProject())).resolves.toBe(false);
+
+    expect(mocks.writeKanvibeProjectColor).not.toHaveBeenCalled();
+  });
+
+  it("공유 색상이 없으면 기존 색상을 유지한 채 씨앗으로 기록한다", async () => {
     mocks.readKanvibeProjectColor.mockResolvedValue(null);
     const project = createProject();
 
-    await expect(applySharedProjectColor(project)).resolves.toBe(false);
+    await expect(syncProjectColorWithKanvibeState(project)).resolves.toBe(false);
+
     expect(project.color).toBe("#65D08A");
+    expect(mocks.writeKanvibeProjectColor).toHaveBeenCalledWith("/workspace/kanvibe", "#65D08A", null);
   });
 
   it("색상 읽기 실패는 등록 흐름을 막지 않는다", async () => {

--- a/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
+++ b/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
@@ -2,14 +2,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   taskRepo: { findBy: vi.fn() },
+  projectRepo: { findOneBy: vi.fn() },
   getTaskRepository: vi.fn(),
+  getProjectRepository: vi.fn(),
   addAiToolPatternsToGitExclude: vi.fn(),
   readKanvibeProjectColor: vi.fn(),
   writeKanvibeProjectColor: vi.fn(),
+  writeKanvibeProjectColorIfAbsent: vi.fn(),
 }));
 
 vi.mock("@/lib/database", () => ({
   getTaskRepository: mocks.getTaskRepository,
+  getProjectRepository: mocks.getProjectRepository,
 }));
 
 vi.mock("@/lib/gitExclude", () => ({
@@ -20,6 +24,7 @@ vi.mock("@/lib/kanvibeProjectState", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/kanvibeProjectState")>()),
   readKanvibeProjectColor: mocks.readKanvibeProjectColor,
   writeKanvibeProjectColor: mocks.writeKanvibeProjectColor,
+  writeKanvibeProjectColorIfAbsent: mocks.writeKanvibeProjectColorIfAbsent,
 }));
 
 import type { Project } from "@/entities/Project";
@@ -48,9 +53,12 @@ describe("kanvibeProjectColorService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getTaskRepository.mockResolvedValue(mocks.taskRepo);
+    mocks.getProjectRepository.mockResolvedValue(mocks.projectRepo);
     mocks.taskRepo.findBy.mockResolvedValue([]);
+    mocks.projectRepo.findOneBy.mockResolvedValue(null);
     mocks.addAiToolPatternsToGitExclude.mockResolvedValue(undefined);
     mocks.writeKanvibeProjectColor.mockResolvedValue(undefined);
+    mocks.writeKanvibeProjectColorIfAbsent.mockResolvedValue(undefined);
     vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
@@ -85,15 +93,23 @@ describe("kanvibeProjectColorService", () => {
     expect(mocks.writeKanvibeProjectColor).toHaveBeenCalledTimes(2);
   });
 
-  it("다른 client가 바꾼 색상만 프로젝트에 반영한다", async () => {
+  it("다른 client가 바꾼 색상만 DB 반영 대상으로 돌려준다", async () => {
     mocks.readKanvibeProjectColor.mockResolvedValue("#0064FF");
     const project = createProject();
 
-    await expect(syncProjectColorWithKanvibeState(project)).resolves.toBe(true);
-    expect(project.color).toBe("#0064FF");
+    await expect(syncProjectColorWithKanvibeState(project)).resolves.toBe("#0064FF");
 
     mocks.readKanvibeProjectColor.mockResolvedValue("#0064FF");
-    await expect(syncProjectColorWithKanvibeState(project)).resolves.toBe(false);
+    await expect(syncProjectColorWithKanvibeState(createProject({ color: "#0064FF" }))).resolves.toBeNull();
+  });
+
+  it("프로젝트 색상을 직접 바꾸지 않아 호출한 쪽이 반영 여부를 판단할 수 있다", async () => {
+    mocks.readKanvibeProjectColor.mockResolvedValue("#0064FF");
+    const project = createProject();
+
+    await syncProjectColorWithKanvibeState(project);
+
+    expect(project.color).toBe("#65D08A");
   });
 
   it("이미 같은 색상이 기록된 경로는 다시 쓰지 않는다", async () => {
@@ -102,7 +118,7 @@ describe("kanvibeProjectColorService", () => {
     ]);
     mocks.readKanvibeProjectColor.mockResolvedValue("#65D08A");
 
-    await expect(syncProjectColorWithKanvibeState(createProject())).resolves.toBe(false);
+    await expect(syncProjectColorWithKanvibeState(createProject())).resolves.toBeNull();
 
     expect(mocks.writeKanvibeProjectColor).not.toHaveBeenCalled();
     expect(mocks.addAiToolPatternsToGitExclude).not.toHaveBeenCalled();
@@ -117,7 +133,7 @@ describe("kanvibeProjectColorService", () => {
       repoPath === "/workspace/kanvibe" ? "#65D08A" : null,
     );
 
-    await expect(syncProjectColorWithKanvibeState(createProject())).resolves.toBe(false);
+    await expect(syncProjectColorWithKanvibeState(createProject())).resolves.toBeNull();
 
     expect(mocks.writeKanvibeProjectColor.mock.calls).toEqual([
       ["/workspace/kanvibe__worktrees/feature", "#65D08A", null],
@@ -133,10 +149,9 @@ describe("kanvibeProjectColorService", () => {
     /** 메모리의 project.color는 sync 시작 시점의 낡은 값 */
     const project = createProject({ color: "#65D08A" });
 
-    await expect(syncProjectColorWithKanvibeState(project)).resolves.toBe(true);
+    await expect(syncProjectColorWithKanvibeState(project)).resolves.toBe("#0064FF");
 
     expect(mocks.writeKanvibeProjectColor).not.toHaveBeenCalled();
-    expect(project.color).toBe("#0064FF");
   });
 
   it("프로젝트 루트 색상 파일은 sync 전파 대상에서 제외한다", async () => {
@@ -158,12 +173,48 @@ describe("kanvibeProjectColorService", () => {
 
   it("공유 색상이 없으면 기존 색상을 유지한 채 씨앗으로 기록한다", async () => {
     mocks.readKanvibeProjectColor.mockResolvedValue(null);
+    mocks.projectRepo.findOneBy.mockResolvedValue({ color: "#65D08A" });
     const project = createProject();
 
-    await expect(syncProjectColorWithKanvibeState(project)).resolves.toBe(false);
+    await expect(syncProjectColorWithKanvibeState(project)).resolves.toBeNull();
 
     expect(project.color).toBe("#65D08A");
-    expect(mocks.writeKanvibeProjectColor).toHaveBeenCalledWith("/workspace/kanvibe", "#65D08A", null);
+    expect(mocks.writeKanvibeProjectColorIfAbsent)
+      .toHaveBeenCalledWith("/workspace/kanvibe", "#65D08A", null);
+  });
+
+  it("씨앗은 sync 시작 시점의 낡은 색이 아니라 DB의 현재 색을 기록한다", async () => {
+    mocks.readKanvibeProjectColor.mockResolvedValue(null);
+    /** sync가 시작된 뒤 사용자가 #0064FF로 바꿔 DB에는 이미 새 색이 저장된 상태 */
+    mocks.projectRepo.findOneBy.mockResolvedValue({ color: "#0064FF" });
+
+    await syncProjectColorWithKanvibeState(createProject({ color: "#65D08A" }));
+
+    expect(mocks.writeKanvibeProjectColorIfAbsent)
+      .toHaveBeenCalledWith("/workspace/kanvibe", "#0064FF", null);
+  });
+
+  it("씨앗은 권위 파일인 루트에만 기록하고 worktree는 전파에 맡긴다", async () => {
+    mocks.readKanvibeProjectColor.mockResolvedValue(null);
+    mocks.projectRepo.findOneBy.mockResolvedValue({ color: "#65D08A" });
+    mocks.taskRepo.findBy.mockResolvedValue([
+      { worktreePath: "/workspace/kanvibe__worktrees/feature" },
+    ]);
+
+    await syncProjectColorWithKanvibeState(createProject());
+
+    expect(mocks.writeKanvibeProjectColorIfAbsent.mock.calls).toEqual([
+      ["/workspace/kanvibe", "#65D08A", null],
+    ]);
+    expect(mocks.writeKanvibeProjectColor).not.toHaveBeenCalled();
+  });
+
+  it("씨앗 기록이 실패해도 sync 흐름을 막지 않는다", async () => {
+    mocks.readKanvibeProjectColor.mockResolvedValue(null);
+    mocks.projectRepo.findOneBy.mockResolvedValue({ color: "#65D08A" });
+    mocks.writeKanvibeProjectColorIfAbsent.mockRejectedValue(new Error("read-only"));
+
+    await expect(syncProjectColorWithKanvibeState(createProject())).resolves.toBeNull();
   });
 
   it("색상 읽기 실패는 등록 흐름을 막지 않는다", async () => {

--- a/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
+++ b/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  taskRepo: { findBy: vi.fn() },
+  getTaskRepository: vi.fn(),
+  addAiToolPatternsToGitExclude: vi.fn(),
+  readKanvibeProjectColor: vi.fn(),
+  writeKanvibeProjectColor: vi.fn(),
+}));
+
+vi.mock("@/lib/database", () => ({
+  getTaskRepository: mocks.getTaskRepository,
+}));
+
+vi.mock("@/lib/gitExclude", () => ({
+  addAiToolPatternsToGitExclude: mocks.addAiToolPatternsToGitExclude,
+}));
+
+vi.mock("@/lib/kanvibeProjectState", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/kanvibeProjectState")>()),
+  readKanvibeProjectColor: mocks.readKanvibeProjectColor,
+  writeKanvibeProjectColor: mocks.writeKanvibeProjectColor,
+}));
+
+import type { Project } from "@/entities/Project";
+import {
+  applySharedProjectColor,
+  persistProjectColorToKanvibeState,
+  readSharedProjectColor,
+} from "@/desktop/main/services/kanvibeProjectColorService";
+
+function createProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "project-1",
+    name: "kanvibe",
+    repoPath: "/workspace/kanvibe",
+    defaultBranch: "main",
+    sshHost: null,
+    isWorktree: false,
+    color: "#65D08A",
+    iconDataUrl: null,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("kanvibeProjectColorService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getTaskRepository.mockResolvedValue(mocks.taskRepo);
+    mocks.taskRepo.findBy.mockResolvedValue([]);
+    mocks.addAiToolPatternsToGitExclude.mockResolvedValue(undefined);
+    mocks.writeKanvibeProjectColor.mockResolvedValue(undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("프로젝트 루트와 소속 task worktree에 모두 색상을 기록한다", async () => {
+    mocks.taskRepo.findBy.mockResolvedValue([
+      { worktreePath: "/workspace/kanvibe__worktrees/feature" },
+      { worktreePath: null },
+      { worktreePath: "/workspace/kanvibe__worktrees/feature" },
+    ]);
+
+    await persistProjectColorToKanvibeState(createProject({ sshHost: "remote-host" }));
+
+    expect(mocks.writeKanvibeProjectColor.mock.calls).toEqual([
+      ["/workspace/kanvibe", "#65D08A", "remote-host"],
+      ["/workspace/kanvibe__worktrees/feature", "#65D08A", "remote-host"],
+    ]);
+  });
+
+  it("색상이 없거나 형식이 어긋나면 기록하지 않는다", async () => {
+    await persistProjectColorToKanvibeState(createProject({ color: null }));
+    await persistProjectColorToKanvibeState(createProject({ color: "not-a-color" }));
+
+    expect(mocks.writeKanvibeProjectColor).not.toHaveBeenCalled();
+  });
+
+  it("일부 경로 기록이 실패해도 나머지 경로 기록을 계속한다", async () => {
+    mocks.taskRepo.findBy.mockResolvedValue([{ worktreePath: "/workspace/kanvibe__worktrees/feature" }]);
+    mocks.writeKanvibeProjectColor.mockRejectedValueOnce(new Error("read-only"));
+
+    await expect(persistProjectColorToKanvibeState(createProject())).resolves.toBeUndefined();
+
+    expect(mocks.writeKanvibeProjectColor).toHaveBeenCalledTimes(2);
+  });
+
+  it("다른 client가 바꾼 색상만 프로젝트에 반영한다", async () => {
+    mocks.readKanvibeProjectColor.mockResolvedValue("#0064FF");
+    const project = createProject();
+
+    await expect(applySharedProjectColor(project)).resolves.toBe(true);
+    expect(project.color).toBe("#0064FF");
+
+    mocks.readKanvibeProjectColor.mockResolvedValue("#0064FF");
+    await expect(applySharedProjectColor(project)).resolves.toBe(false);
+  });
+
+  it("공유 색상이 없으면 기존 색상을 유지한다", async () => {
+    mocks.readKanvibeProjectColor.mockResolvedValue(null);
+    const project = createProject();
+
+    await expect(applySharedProjectColor(project)).resolves.toBe(false);
+    expect(project.color).toBe("#65D08A");
+  });
+
+  it("색상 읽기 실패는 등록 흐름을 막지 않는다", async () => {
+    mocks.readKanvibeProjectColor.mockRejectedValue(new Error("permission denied"));
+
+    await expect(readSharedProjectColor("/workspace/kanvibe", null)).resolves.toBeNull();
+  });
+});

--- a/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
+++ b/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
@@ -96,12 +96,28 @@ describe("kanvibeProjectColorService", () => {
     await expect(syncProjectColorWithKanvibeState(project)).resolves.toBe(false);
   });
 
-  it("공유 색상이 반영되거나 이미 같으면 공유 파일을 다시 쓰지 않는다", async () => {
+  it("이미 같은 색상이 기록된 경로는 다시 쓰지 않는다", async () => {
     mocks.readKanvibeProjectColor.mockResolvedValue("#65D08A");
 
     await expect(syncProjectColorWithKanvibeState(createProject())).resolves.toBe(false);
 
     expect(mocks.writeKanvibeProjectColor).not.toHaveBeenCalled();
+  });
+
+  it("색상 확정 이후 생긴 worktree에도 공유 색상을 뒤늦게 기록한다", async () => {
+    mocks.taskRepo.findBy.mockResolvedValue([
+      { worktreePath: "/workspace/kanvibe__worktrees/feature" },
+    ]);
+    /** 프로젝트 루트에는 색상이 있지만 나중에 생긴 worktree에는 아직 없다 */
+    mocks.readKanvibeProjectColor.mockImplementation(async (repoPath: string) =>
+      repoPath === "/workspace/kanvibe" ? "#65D08A" : null,
+    );
+
+    await expect(syncProjectColorWithKanvibeState(createProject())).resolves.toBe(false);
+
+    expect(mocks.writeKanvibeProjectColor.mock.calls).toEqual([
+      ["/workspace/kanvibe__worktrees/feature", "#65D08A", null],
+    ]);
   });
 
   it("공유 색상이 없으면 기존 색상을 유지한 채 씨앗으로 기록한다", async () => {

--- a/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
+++ b/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
@@ -97,11 +97,15 @@ describe("kanvibeProjectColorService", () => {
   });
 
   it("이미 같은 색상이 기록된 경로는 다시 쓰지 않는다", async () => {
+    mocks.taskRepo.findBy.mockResolvedValue([
+      { worktreePath: "/workspace/kanvibe__worktrees/feature" },
+    ]);
     mocks.readKanvibeProjectColor.mockResolvedValue("#65D08A");
 
     await expect(syncProjectColorWithKanvibeState(createProject())).resolves.toBe(false);
 
     expect(mocks.writeKanvibeProjectColor).not.toHaveBeenCalled();
+    expect(mocks.addAiToolPatternsToGitExclude).not.toHaveBeenCalled();
   });
 
   it("색상 확정 이후 생긴 worktree에도 공유 색상을 뒤늦게 기록한다", async () => {
@@ -117,6 +121,38 @@ describe("kanvibeProjectColorService", () => {
 
     expect(mocks.writeKanvibeProjectColor.mock.calls).toEqual([
       ["/workspace/kanvibe__worktrees/feature", "#65D08A", null],
+    ]);
+  });
+
+  it("sync 중 사용자가 색을 바꾸면 낡은 색이 아니라 루트의 새 색상을 퍼뜨린다", async () => {
+    mocks.taskRepo.findBy.mockResolvedValue([
+      { worktreePath: "/workspace/kanvibe__worktrees/feature" },
+    ]);
+    /** sync가 시작된 뒤 사용자가 #0064FF로 바꿔 루트와 worktree에 이미 기록된 상태 */
+    mocks.readKanvibeProjectColor.mockResolvedValue("#0064FF");
+    /** 메모리의 project.color는 sync 시작 시점의 낡은 값 */
+    const project = createProject({ color: "#65D08A" });
+
+    await expect(syncProjectColorWithKanvibeState(project)).resolves.toBe(true);
+
+    expect(mocks.writeKanvibeProjectColor).not.toHaveBeenCalled();
+    expect(project.color).toBe("#0064FF");
+  });
+
+  it("프로젝트 루트 색상 파일은 sync 전파 대상에서 제외한다", async () => {
+    mocks.taskRepo.findBy.mockResolvedValue([
+      { worktreePath: "/workspace/kanvibe" },
+      { worktreePath: "/workspace/kanvibe__worktrees/feature" },
+    ]);
+    /** 루트는 새 색상, worktree는 아직 옛 색상인 전파 직전 상태 */
+    mocks.readKanvibeProjectColor.mockImplementation(async (repoPath: string) =>
+      repoPath === "/workspace/kanvibe" ? "#0064FF" : "#65D08A",
+    );
+
+    await syncProjectColorWithKanvibeState(createProject({ color: "#0064FF" }));
+
+    expect(mocks.writeKanvibeProjectColor.mock.calls).toEqual([
+      ["/workspace/kanvibe__worktrees/feature", "#0064FF", null],
     ]);
   });
 

--- a/src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts
+++ b/src/desktop/main/services/__tests__/kanvibeTaskStateService.test.ts
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   },
   getProjectRepository: vi.fn(),
   readKanvibeTaskState: vi.fn(),
-  writeKanvibeTaskState: vi.fn(),
+  writeKanvibeTaskStatus: vi.fn(),
   addAiToolPatternsToGitExclude: vi.fn(),
 }));
 
@@ -28,7 +28,7 @@ vi.mock("@/lib/database", () => ({
 
 vi.mock("@/lib/kanvibeProjectState", () => ({
   readKanvibeTaskState: mocks.readKanvibeTaskState,
-  writeKanvibeTaskState: mocks.writeKanvibeTaskState,
+  writeKanvibeTaskStatus: mocks.writeKanvibeTaskStatus,
 }));
 
 vi.mock("@/lib/gitExclude", () => ({
@@ -44,7 +44,7 @@ describe("kanvibeTaskStateService", () => {
     mocks.getProjectRepository.mockReset();
     mocks.projectRepo.findOneBy.mockReset();
     mocks.readKanvibeTaskState.mockReset();
-    mocks.writeKanvibeTaskState.mockReset();
+    mocks.writeKanvibeTaskStatus.mockReset();
     mocks.addAiToolPatternsToGitExclude.mockReset();
     mocks.getProjectRepository.mockResolvedValue(mocks.projectRepo);
   });
@@ -54,7 +54,7 @@ describe("kanvibeTaskStateService", () => {
 
     await persistTaskStateAtPath(null, { id: "task-1", status: TaskStatus.PROGRESS }, "ssh-host");
 
-    expect(mocks.writeKanvibeTaskState).not.toHaveBeenCalled();
+    expect(mocks.writeKanvibeTaskStatus).not.toHaveBeenCalled();
     expect(mocks.addAiToolPatternsToGitExclude).not.toHaveBeenCalled();
   });
 
@@ -72,11 +72,11 @@ describe("kanvibeTaskStateService", () => {
       "remote-host",
     );
     expect(mocks.addAiToolPatternsToGitExclude.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.writeKanvibeTaskState.mock.invocationCallOrder[0],
+      mocks.writeKanvibeTaskStatus.mock.invocationCallOrder[0],
     );
-    expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
+    expect(mocks.writeKanvibeTaskStatus).toHaveBeenCalledWith(
       "/remote/repo__worktrees/feature-task",
-      { status: TaskStatus.REVIEW },
+      TaskStatus.REVIEW,
       "remote-host",
     );
   });
@@ -92,9 +92,9 @@ describe("kanvibeTaskStateService", () => {
       null,
     )).resolves.toBeUndefined();
 
-    expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
+    expect(mocks.writeKanvibeTaskStatus).toHaveBeenCalledWith(
       "/workspace/repo",
-      { status: TaskStatus.PROGRESS },
+      TaskStatus.PROGRESS,
       null,
     );
     expect(consoleWarn).toHaveBeenCalledWith(
@@ -110,7 +110,7 @@ describe("kanvibeTaskStateService", () => {
 
   it("path 기반 task 상태 저장은 실패해도 호출자 흐름을 막지 않는다", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    mocks.writeKanvibeTaskState.mockRejectedValue(new Error("disk full"));
+    mocks.writeKanvibeTaskStatus.mockRejectedValue(new Error("disk full"));
     const { persistTaskStateAtPath } = await import("@/desktop/main/services/kanvibeTaskStateService");
 
     await expect(persistTaskStateAtPath(
@@ -119,9 +119,9 @@ describe("kanvibeTaskStateService", () => {
       "ssh-host",
     )).resolves.toBeUndefined();
 
-    expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
+    expect(mocks.writeKanvibeTaskStatus).toHaveBeenCalledWith(
       "/workspace/repo",
-      { status: TaskStatus.REVIEW },
+      TaskStatus.REVIEW,
       "ssh-host",
     );
     expect(consoleError).toHaveBeenCalledWith(
@@ -150,9 +150,9 @@ describe("kanvibeTaskStateService", () => {
     });
 
     expect(mocks.getProjectRepository).not.toHaveBeenCalled();
-    expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
+    expect(mocks.writeKanvibeTaskStatus).toHaveBeenCalledWith(
       "/workspace/repo__worktrees/task-1",
-      { status: TaskStatus.PENDING },
+      TaskStatus.PENDING,
       "ssh-host",
     );
   });
@@ -176,9 +176,9 @@ describe("kanvibeTaskStateService", () => {
     });
 
     expect(mocks.projectRepo.findOneBy).toHaveBeenCalledWith({ id: "project-1" });
-    expect(mocks.writeKanvibeTaskState).toHaveBeenCalledWith(
+    expect(mocks.writeKanvibeTaskStatus).toHaveBeenCalledWith(
       "/workspace/repo",
-      { status: TaskStatus.TODO },
+      TaskStatus.TODO,
       "project-ssh",
     );
   });
@@ -202,7 +202,7 @@ describe("kanvibeTaskStateService", () => {
     });
 
     expect(mocks.projectRepo.findOneBy).toHaveBeenCalledWith({ id: "project-1" });
-    expect(mocks.writeKanvibeTaskState).not.toHaveBeenCalled();
+    expect(mocks.writeKanvibeTaskStatus).not.toHaveBeenCalled();
   });
 
   it("저장된 task 상태만 읽어 반환한다", async () => {

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -555,6 +555,57 @@ describe("projectService remote registration flow", () => {
       error: "이미 등록된 프로젝트입니다.",
     });
   });
+
+  it("프로젝트 등록은 GitHub 아이콘 조회를 기다리지 않고 저장을 마친 뒤 백그라운드로 아이콘을 채운다", async () => {
+    // Given
+    mocks.validateGitRepo.mockResolvedValue(true);
+    mocks.getDefaultBranch.mockResolvedValue("main");
+    mocks.createSessionWithoutWorktree.mockResolvedValue({ sessionName: "api-main" });
+
+    let releaseIconGate: (() => void) | undefined;
+    const iconGate = new Promise<void>((resolve) => {
+      releaseIconGate = resolve;
+    });
+    mocks.resolveProjectIconDataUrl.mockImplementation(async () => {
+      await iconGate;
+      return "data:image/png;base64,icon";
+    });
+
+    const projectSave = vi.fn(async (value) => ({ id: "project-1", ...value }));
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([]),
+      create: vi.fn((value) => value),
+      save: projectSave,
+      remove: vi.fn(),
+    });
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn().mockResolvedValue(null),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => ({ id: "task-1", ...value })),
+    });
+
+    try {
+      const { registerProject } = await import("@/desktop/main/services/projectService");
+
+      // When
+      const result = await registerProject("api", "/workspace/api");
+
+      // Then
+      /** 아이콘 조회가 아직 끝나지 않아도 등록과 DB 저장은 완료된다 */
+      expect(result.success).toBe(true);
+      expect(projectSave).toHaveBeenCalledTimes(1);
+      expect(projectSave.mock.calls[0][0].iconDataUrl).toBeUndefined();
+
+      releaseIconGate?.();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(projectSave).toHaveBeenLastCalledWith(expect.objectContaining({
+        iconDataUrl: "data:image/png;base64,icon",
+      }));
+    } finally {
+      mocks.resolveProjectIconDataUrl.mockImplementation(async () => null);
+    }
+  });
 });
 
 describe("projectService local hook installation", () => {

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -572,10 +572,12 @@ describe("projectService remote registration flow", () => {
     });
 
     const projectSave = vi.fn(async (value) => ({ id: "project-1", ...value }));
+    const projectUpdate = vi.fn(async () => ({ affected: 1 }));
     mocks.getProjectRepository.mockResolvedValue({
       find: vi.fn().mockResolvedValue([]),
       create: vi.fn((value) => value),
       save: projectSave,
+      update: projectUpdate,
       remove: vi.fn(),
     });
     mocks.getTaskRepository.mockResolvedValue({
@@ -599,9 +601,50 @@ describe("projectService remote registration flow", () => {
       releaseIconGate?.();
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(projectSave).toHaveBeenLastCalledWith(expect.objectContaining({
-        iconDataUrl: "data:image/png;base64,icon",
-      }));
+      /** 아이콘은 이미 존재하는 행에만 반영해 조회 중 삭제된 프로젝트가 되살아나지 않게 한다 */
+      expect(projectSave).toHaveBeenCalledTimes(1);
+      expect(projectUpdate).toHaveBeenCalledWith(
+        { id: "project-1" },
+        { iconDataUrl: "data:image/png;base64,icon" },
+      );
+    } finally {
+      mocks.resolveProjectIconDataUrl.mockImplementation(async () => null);
+    }
+  });
+
+  it("아이콘 조회 도중 프로젝트가 삭제되면 아이콘을 다시 저장하지 않는다", async () => {
+    // Given
+    mocks.validateGitRepo.mockResolvedValue(true);
+    mocks.getDefaultBranch.mockResolvedValue("main");
+    mocks.createSessionWithoutWorktree.mockResolvedValue({ sessionName: "api-main" });
+    mocks.resolveProjectIconDataUrl.mockImplementation(async () => "data:image/png;base64,icon");
+
+    /** 삭제된 프로젝트라 조건부 update가 어떤 행도 건드리지 못한 상황 */
+    const projectUpdate = vi.fn(async () => ({ affected: 0 }));
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([]),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => ({ id: "project-1", ...value })),
+      update: projectUpdate,
+      remove: vi.fn(),
+    });
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn().mockResolvedValue(null),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => ({ id: "task-1", ...value })),
+    });
+
+    try {
+      const { registerProject } = await import("@/desktop/main/services/projectService");
+
+      // When
+      await registerProject("api", "/workspace/api");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Then
+      expect(projectUpdate).toHaveBeenCalledTimes(1);
+      /** 등록 직후 1회만 갱신되고, 반영되지 못한 아이콘으로 보드를 다시 갱신하지 않는다 */
+      expect(mocks.broadcastBoardUpdate).toHaveBeenCalledTimes(1);
     } finally {
       mocks.resolveProjectIconDataUrl.mockImplementation(async () => null);
     }
@@ -2214,8 +2257,8 @@ describe("projectService local hook installation", () => {
       return `data:image/png;base64,${repoPath}`;
     });
 
-    const projectSave = vi.fn(async (value) => value);
-    mocks.getProjectRepository.mockResolvedValue({ save: projectSave });
+    const projectUpdate = vi.fn(async () => ({ affected: 1 }));
+    mocks.getProjectRepository.mockResolvedValue({ save: vi.fn(async (value) => value), update: projectUpdate });
     mocks.getTaskRepository.mockResolvedValue({
       findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => ({
         id: `task-${criteria.projectId}`,
@@ -2252,7 +2295,11 @@ describe("projectService local hook installation", () => {
 
       expect(result.changed).toBe(true);
       expect(projects[2].iconDataUrl).toBe("data:image/png;base64,kept");
-      expect(projectSave).toHaveBeenCalledTimes(2);
+      /** 아이콘은 이미 존재하는 행에만 조건부로 반영한다 */
+      expect(projectUpdate.mock.calls).toEqual([
+        [{ id: "project-a" }, { iconDataUrl: "data:image/png;base64,/workspace/api-a" }],
+        [{ id: "project-b" }, { iconDataUrl: "data:image/png;base64,/workspace/api-b" }],
+      ]);
     } finally {
       mocks.resolveProjectIconDataUrl.mockImplementation(async () => null);
     }

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   isSessionAlive: vi.fn(),
   formatSessionName: vi.fn(),
   computeProjectColor: vi.fn(() => "blue"),
+  resolveProjectIconDataUrl: vi.fn<(repoPath: string, sshHost?: string | null) => Promise<string | null>>(async () => null),
   getDefaultSessionType: vi.fn(),
   setupClaudeHooks: vi.fn(),
   getClaudeHooksStatus: vi.fn(),
@@ -117,6 +118,10 @@ vi.mock("os", () => ({
 
 vi.mock("@/lib/projectColor", () => ({
   computeProjectColor: mocks.computeProjectColor,
+}));
+
+vi.mock("@/lib/githubProjectIcon", () => ({
+  resolveProjectIconDataUrl: mocks.resolveProjectIconDataUrl,
 }));
 
 vi.mock("@/lib/boardNotifier", () => ({
@@ -2140,6 +2145,66 @@ describe("projectService local hook installation", () => {
     await syncPromise;
 
     expect(Array.from(firstCalls).filter((repoPath) => repoPath.startsWith("/workspace/api-"))).toEqual(["/workspace/api-a", "/workspace/api-b"]);
+  });
+
+  it("등록된 프로젝트 background sync는 아이콘 backfill을 순차 worktree 스캔과 분리해 병렬로 실행한다", async () => {
+    // Given
+    mocks.isSessionAlive.mockResolvedValue(false);
+    mocks.listWorktrees.mockResolvedValue([]);
+
+    const iconLookupPaths: string[] = [];
+    let releaseIconGate: (() => void) | undefined;
+    const iconGate = new Promise<void>((resolve) => {
+      releaseIconGate = resolve;
+    });
+    mocks.resolveProjectIconDataUrl.mockImplementation(async (repoPath: string) => {
+      iconLookupPaths.push(repoPath);
+      await iconGate;
+      return `data:image/png;base64,${repoPath}`;
+    });
+
+    const projectSave = vi.fn(async (value) => value);
+    mocks.getProjectRepository.mockResolvedValue({ save: projectSave });
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => ({
+        id: `task-${criteria.projectId}`,
+        branchName: criteria.branchName,
+        projectId: criteria.projectId,
+        baseBranch: criteria.branchName,
+        worktreePath: null,
+        sshHost: null,
+      })),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => value),
+    });
+
+    const projects = [
+      { id: "project-a", name: "api-a", repoPath: "/workspace/api-a", defaultBranch: "main", sshHost: null, iconDataUrl: null },
+      { id: "project-b", name: "api-b", repoPath: "/workspace/api-b", defaultBranch: "main", sshHost: null, iconDataUrl: null },
+      { id: "project-c", name: "api-c", repoPath: "/workspace/api-c", defaultBranch: "main", sshHost: null, iconDataUrl: "data:image/png;base64,kept" },
+    ];
+
+    try {
+      const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+      // When
+      const syncPromise = syncRegisteredProjectWorktrees(projects as never);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Then
+      /** 아이콘이 없는 두 프로젝트의 조회가 서로를 기다리지 않고 동시에 진행된다 */
+      expect(iconLookupPaths).toEqual(["/workspace/api-a", "/workspace/api-b"]);
+      expect(mocks.listWorktrees).not.toHaveBeenCalled();
+
+      releaseIconGate?.();
+      const result = await syncPromise;
+
+      expect(result.changed).toBe(true);
+      expect(projects[2].iconDataUrl).toBe("data:image/png;base64,kept");
+      expect(projectSave).toHaveBeenCalledTimes(2);
+    } finally {
+      mocks.resolveProjectIconDataUrl.mockImplementation(async () => null);
+    }
   });
 });
 

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   broadcastBoardUpdate: vi.fn(),
   readTextFile: vi.fn(),
   writeTextFile: vi.fn(),
+  writeTextFileIfAbsent: vi.fn(),
   quoteShellArgument: vi.fn((value: string) => `'${value}'`),
 }));
 
@@ -149,6 +150,7 @@ vi.mock("@/lib/kanvibeHooksInstaller", () => ({
 vi.mock("@/lib/hostFileAccess", () => ({
   readTextFile: mocks.readTextFile,
   writeTextFile: mocks.writeTextFile,
+  writeTextFileIfAbsent: mocks.writeTextFileIfAbsent,
   quoteShellArgument: mocks.quoteShellArgument,
 }));
 
@@ -655,6 +657,8 @@ describe("projectService local hook installation", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    /** 파일 읽기 구현은 테스트마다 다르므로 이전 테스트의 구현이 남지 않도록 되돌린다 */
+    mocks.readTextFile.mockReset();
     mocks.execGit.mockResolvedValue("");
     mocks.getDefaultSessionType.mockResolvedValue("tmux");
     mocks.getClaudeHooksStatus.mockResolvedValue({ installed: false });
@@ -1587,6 +1591,100 @@ describe("projectService local hook installation", () => {
     expect(mocks.getCodexHooksStatus).not.toHaveBeenCalled();
     expect(mocks.getOpenCodeHooksStatus).not.toHaveBeenCalled();
     expect(mocks.installKanvibeHooks).not.toHaveBeenCalled();
+  });
+
+  /**
+   * 공유 색상 파일을 읽는 동안 사용자가 색을 바꿀 수 있으므로, sync가 읽어둔 색상이 아직 DB에
+   * 남아 있을 때만 덮어써야 방금 고른 색이 되돌아가지 않는다.
+   */
+  function mockProjectColorSyncRepositories(
+    project: { id: string; color: string },
+    update: ReturnType<typeof vi.fn>,
+  ): void {
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([project]),
+      findOneBy: vi.fn().mockResolvedValue(project),
+      update,
+    });
+
+    mocks.getTaskRepository.mockResolvedValue({
+      findBy: vi.fn().mockResolvedValue([]),
+      findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => (
+        criteria.projectId === project.id && criteria.branchName === "main"
+          ? {
+            id: "task-main",
+            branchName: "main",
+            projectId: project.id,
+            baseBranch: "main",
+            worktreePath: "/workspace/api",
+            sshHost: null,
+          }
+          : null
+      )),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => value),
+    });
+  }
+
+  function mockSharedProjectColorFile(sharedColor: string): void {
+    mocks.listWorktrees.mockResolvedValue([
+      { path: "/workspace/api", branch: "main", isBare: false },
+    ]);
+    mocks.readTextFile.mockImplementation(async (filePath: string) => (
+      filePath === "/workspace/api/.kanvibe/project.json"
+        ? JSON.stringify({ schemaVersion: 1, projectColor: sharedColor })
+        : ""
+    ));
+  }
+
+  it("공유 색상을 DB에 반영하는 사이 사용자가 색을 바꾸면 그 값을 덮지 않는다", async () => {
+    // Given
+    mockSharedProjectColorFile("#0064FF");
+    const project = {
+      id: "project-1",
+      name: "api",
+      repoPath: "/workspace/api",
+      defaultBranch: "main",
+      sshHost: null,
+      color: "#65D08A",
+    };
+    /** affected 0은 sync가 읽어둔 색상이 더 이상 DB에 없다는 뜻, 즉 사용자 편집이 먼저 반영된 상태다 */
+    const update = vi.fn().mockResolvedValue({ affected: 0 });
+    mockProjectColorSyncRepositories(project, update);
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const result = await syncRegisteredProjectWorktrees();
+
+    // Then
+    expect(update).toHaveBeenCalledWith({ id: "project-1", color: "#65D08A" }, { color: "#0064FF" });
+    expect(result.changed).toBe(false);
+    expect(project.color).toBe("#65D08A");
+  });
+
+  it("공유 색상이 그대로 남아 있으면 DB와 보드에 반영한다", async () => {
+    // Given
+    mockSharedProjectColorFile("#0064FF");
+    const project = {
+      id: "project-1",
+      name: "api",
+      repoPath: "/workspace/api",
+      defaultBranch: "main",
+      sshHost: null,
+      color: "#65D08A",
+    };
+    const update = vi.fn().mockResolvedValue({ affected: 1 });
+    mockProjectColorSyncRepositories(project, update);
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const result = await syncRegisteredProjectWorktrees();
+
+    // Then
+    expect(result.changed).toBe(true);
+    expect(project.color).toBe("#0064FF");
   });
 
   it("등록된 원격 프로젝트 background sync는 기존 root hook 복구를 예약하지 않는다", async () => {

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -620,7 +620,7 @@ export async function updateTask(
 
 /**
  * 프로젝트의 color(hex)를 변경하고, 같은 repo의 worktree 프로젝트에도 동일하게 반영한다.
- * 변경된 색상은 `.kanvibe/status.json`에도 기록되어 같은 저장소를 보는 다른 client와 동기화된다.
+ * 변경된 색상은 `.kanvibe/project.json`에도 기록되어 같은 저장소를 보는 다른 client와 동기화된다.
  */
 export async function updateProjectColor(
   projectId: string,

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -20,6 +20,7 @@ import {
 import { execGit, pullCurrentBranch, remoteBranchExists } from "@/lib/gitOperations";
 import { detachSession } from "@/lib/terminal";
 import { persistTaskStateForTask as persistTaskState } from "@/desktop/main/services/kanvibeTaskStateService";
+import { persistProjectColorToKanvibeState } from "@/desktop/main/services/kanvibeProjectColorService";
 
 export type TasksByStatus = Record<TaskStatus, KanbanTask[]>;
 
@@ -617,7 +618,10 @@ export async function updateTask(
   return serialize(saved);
 }
 
-/** 프로젝트의 color(hex)를 변경하고, 같은 repo의 worktree 프로젝트에도 동일하게 반영한다 */
+/**
+ * 프로젝트의 color(hex)를 변경하고, 같은 repo의 worktree 프로젝트에도 동일하게 반영한다.
+ * 변경된 색상은 `.kanvibe/status.json`에도 기록되어 같은 저장소를 보는 다른 client와 동기화된다.
+ */
 export async function updateProjectColor(
   projectId: string,
   color: string
@@ -638,10 +642,16 @@ export async function updateProjectColor(
     where: { repoPath: Like(`${mainRepoPath}%`) },
   });
 
+  const recoloredProjects = [project];
   for (const related of relatedProjects) {
     if (related.id === projectId) continue;
     related.color = color;
     await repo.save(related);
+    recoloredProjects.push(related);
+  }
+
+  for (const recolored of recoloredProjects) {
+    await persistProjectColorToKanvibeState(recolored);
   }
 
   broadcastBoardUpdate();

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -2,6 +2,7 @@ import { execFile } from "child_process";
 import { In, Not, Like } from "typeorm";
 import { getTaskRepository } from "@/lib/database";
 import { KanbanTask, TaskStatus, SessionType } from "@/entities/KanbanTask";
+import type { Project } from "@/entities/Project";
 import { TaskPriority } from "@/entities/TaskPriority";
 import { createWorktreeWithSession, removeWorktreeAndBranch, createSessionWithoutWorktree, removeSessionOnly, formatProjectBranchSessionName } from "@/lib/worktree";
 import { getProjectRepository } from "@/lib/database";
@@ -621,6 +622,9 @@ export async function updateTask(
 /**
  * 프로젝트의 color(hex)를 변경하고, 같은 repo의 worktree 프로젝트에도 동일하게 반영한다.
  * 변경된 색상은 `.kanvibe/project.json`에도 기록되어 같은 저장소를 보는 다른 client와 동기화된다.
+ *
+ * 색상의 권위는 프로젝트 루트의 `.kanvibe/project.json`이므로 DB보다 먼저 기록한다. 순서가 뒤집히면
+ * 그 사이 도는 background sync가 아직 이전 색상인 공유 파일을 읽어 방금 고른 색을 DB에서 되돌린다.
  */
 export async function updateProjectColor(
   projectId: string,
@@ -629,9 +633,6 @@ export async function updateProjectColor(
   const repo = await getProjectRepository();
   const project = await repo.findOneBy({ id: projectId });
   if (!project) return;
-
-  project.color = color;
-  await repo.save(project);
 
   // worktree 프로젝트들의 color도 함께 업데이트한다
   const mainRepoPath = project.repoPath.includes("__worktrees")
@@ -642,19 +643,35 @@ export async function updateProjectColor(
     where: { repoPath: Like(`${mainRepoPath}%`) },
   });
 
-  const recoloredProjects = [project];
-  for (const related of relatedProjects) {
-    if (related.id === projectId) continue;
-    related.color = color;
-    await repo.save(related);
-    recoloredProjects.push(related);
-  }
+  const recoloredProjects = orderProjectRepoRootFirst(
+    [project, ...relatedProjects.filter((related) => related.id !== projectId)],
+    mainRepoPath,
+  );
 
   for (const recolored of recoloredProjects) {
+    recolored.color = color;
     await persistProjectColorToKanvibeState(recolored);
   }
 
+  await repo.update({ id: In(recoloredProjects.map((recolored) => recolored.id)) }, { color });
+
   broadcastBoardUpdate();
+}
+
+/**
+ * 저장소 루트를 보는 프로젝트를 맨 앞으로 옮긴다.
+ * 색상의 권위 파일은 루트에 있으므로 사용자가 worktree 프로젝트에서 색을 바꿨더라도 루트부터 확정해야 한다.
+ */
+function orderProjectRepoRootFirst(projects: Project[], mainRepoPath: string): Project[] {
+  const rootIndex = projects.findIndex((project) => project.repoPath === mainRepoPath);
+  if (rootIndex <= 0) {
+    return projects;
+  }
+
+  return [
+    projects[rootIndex],
+    ...projects.filter((_, index) => index !== rootIndex),
+  ];
 }
 
 /** 작업에 연결된 worktree, 세션, 브랜치를 정리한다. task 레코드는 삭제하지 않는다 */

--- a/src/desktop/main/services/kanvibeProjectColorService.ts
+++ b/src/desktop/main/services/kanvibeProjectColorService.ts
@@ -1,7 +1,21 @@
 import type { Project } from "@/entities/Project";
-import { getTaskRepository } from "@/lib/database";
+import { getProjectRepository, getTaskRepository } from "@/lib/database";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
-import { parseProjectColor, readKanvibeProjectColor, writeKanvibeProjectColor } from "@/lib/kanvibeProjectState";
+import {
+  parseProjectColor,
+  readKanvibeProjectColor,
+  writeKanvibeProjectColor,
+  writeKanvibeProjectColorIfAbsent,
+} from "@/lib/kanvibeProjectState";
+
+/**
+ * 프로젝트 색상의 권위는 프로젝트 루트의 `.kanvibe/project.json` 하나뿐이다.
+ *
+ * 루트 파일을 쓰는 주체는 사용자 색상 편집과, 파일이 아직 없을 때의 씨앗 기록 둘로 한정한다.
+ * background sync는 루트를 읽기만 하고 worktree 전파와 DB 반영만 담당한다.
+ * sync가 루트를 쓰게 두면 sync 시작 시점에 읽은 낡은 색상이 그 사이의 사용자 편집을 되돌리고,
+ * 되돌아간 루트 값이 다음 sync에서 다시 DB로 내려가 색이 왕복하게 된다.
+ */
 
 type ColorSyncProject = Pick<Project, "id" | "repoPath" | "sshHost" | "color">;
 
@@ -10,8 +24,8 @@ function getErrorMessage(error: unknown): string {
 }
 
 /**
- * 프로젝트 색상을 `.kanvibe/project.json`에 기록해 같은 저장소를 보는 다른 KanVibe client와 공유한다.
- * 프로젝트 루트와 소속 task의 worktree에 모두 기록해 어느 경로로 열어도 같은 색상을 읽게 한다.
+ * 사용자가 고른 색상을 `.kanvibe/project.json`에 기록해 같은 저장소를 보는 다른 KanVibe client와 공유한다.
+ * 권위인 프로젝트 루트를 먼저 확정한 뒤 소속 task worktree에 퍼뜨려, 어느 경로로 열어도 같은 색상을 읽게 한다.
  */
 export async function persistProjectColorToKanvibeState(project: ColorSyncProject): Promise<void> {
   const projectColor = parseProjectColor(project.color);
@@ -22,10 +36,12 @@ export async function persistProjectColorToKanvibeState(project: ColorSyncProjec
   /** worktree들은 git common dir의 info/exclude를 공유하므로 exclude 갱신은 저장소당 한 번이면 된다 */
   await excludeKanvibeStateDirectory(project);
 
+  await writeProjectColorQuietly(project.repoPath, projectColor, project.sshHost);
+
+  const worktreePaths = (await resolveProjectColorRepoPaths(project))
+    .filter((repoPath) => repoPath !== project.repoPath);
   await Promise.all(
-    (await resolveProjectColorRepoPaths(project)).map(
-      (repoPath) => writeProjectColorQuietly(repoPath, projectColor, project.sshHost),
-    ),
+    worktreePaths.map((repoPath) => writeProjectColorQuietly(repoPath, projectColor, project.sshHost)),
   );
 }
 
@@ -79,27 +95,67 @@ export async function readSharedProjectColor(
 }
 
 /**
- * 프로젝트 색상을 `.kanvibe/project.json`과 양방향으로 맞춘다.
- * 공유 색상이 있으면 그 값을 프로젝트에 반영하고, 공유 파일이 아직 없으면 현재 색상을 씨앗으로 기록한다.
- * 씨앗 기록이 없으면 이 기능 이전에 등록된 프로젝트끼리는 서로 다른 DB 색상을 계속 유지하게 된다.
- * 색상이 이미 확정된 뒤에 생긴 worktree도 sync를 거치면 같은 색상 파일을 갖게 된다.
- * @returns 색상이 실제로 바뀌어 DB에 저장해야 하면 true
+ * 권위인 프로젝트 루트의 공유 색상을 읽어 worktree에 퍼뜨리고, DB에 반영할 값을 돌려준다.
+ * 공유 파일이 아직 없으면 현재 색상을 씨앗으로 기록한다. 씨앗이 없으면 이 기능 이전에 등록된
+ * 프로젝트끼리는 서로 다른 DB 색상을 계속 유지하게 된다.
+ *
+ * 프로젝트 색상을 여기서 직접 바꾸지 않고 값만 돌려주는 이유는, 호출한 쪽이 DB에 쓸 때
+ * 자신이 읽어둔 색상이 아직 최신인지 확인(compare-and-set)할 수 있어야 하기 때문이다.
+ * @returns DB에 반영해야 할 공유 색상. 반영할 변경이 없으면 null
  */
-export async function syncProjectColorWithKanvibeState(project: Project): Promise<boolean> {
+export async function syncProjectColorWithKanvibeState(project: Project): Promise<string | null> {
   const sharedColor = await readSharedProjectColor(project.repoPath, project.sshHost);
   if (!sharedColor) {
-    await persistProjectColorToKanvibeState(project);
-    return false;
+    await seedSharedProjectColor(project);
+    return null;
   }
 
   await propagateSharedProjectColorToWorktrees(project, sharedColor);
 
-  if (sharedColor === project.color) {
-    return false;
+  return sharedColor === project.color ? null : sharedColor;
+}
+
+/**
+ * 공유 색상 파일이 없는 프로젝트에 현재 색상을 씨앗으로 남긴다.
+ *
+ * 기록할 색상은 sync가 시작될 때 읽은 메모리 값이 아니라 DB의 현재 값이다. 그 사이 사용자가
+ * 색을 바꿨다면 메모리 값은 이미 낡았고, 그 낡은 값이 권위 파일의 초기값으로 굳으면
+ * 다음 sync가 방금 고른 색을 되돌린다.
+ *
+ * 기록 자체도 파일이 없을 때만 이뤄져야 한다. 존재 검사와 기록 사이에 사용자 편집이
+ * 루트 파일을 만들 수 있으므로, 원자적 쓰기로 이미 만들어진 권위 파일을 덮지 않는다.
+ */
+async function seedSharedProjectColor(project: ColorSyncProject): Promise<void> {
+  const projectColor = parseProjectColor(await readCurrentProjectColor(project.id) ?? project.color);
+  if (!projectColor) {
+    return;
   }
 
-  project.color = sharedColor;
-  return true;
+  await excludeKanvibeStateDirectory(project);
+
+  try {
+    await writeKanvibeProjectColorIfAbsent(project.repoPath, projectColor, project.sshHost);
+  } catch (error) {
+    console.warn("[project-color] .kanvibe 색상 씨앗 기록 실패", {
+      repoPath: project.repoPath,
+      sshHost: project.sshHost ?? null,
+      error: getErrorMessage(error),
+    });
+  }
+}
+
+/** 씨앗으로 남길 색상은 sync 시작 시점의 스냅샷이 아니라 DB에 저장된 현재 값이어야 한다 */
+async function readCurrentProjectColor(projectId: string): Promise<string | null> {
+  try {
+    const projectRepo = await getProjectRepository();
+    return (await projectRepo.findOneBy({ id: projectId }))?.color ?? null;
+  } catch (error) {
+    console.warn("[project-color] 프로젝트 색상 조회 실패", {
+      projectId,
+      error: getErrorMessage(error),
+    });
+    return null;
+  }
 }
 
 /**

--- a/src/desktop/main/services/kanvibeProjectColorService.ts
+++ b/src/desktop/main/services/kanvibeProjectColorService.ts
@@ -10,7 +10,7 @@ function getErrorMessage(error: unknown): string {
 }
 
 /**
- * 프로젝트 색상을 `.kanvibe/status.json`에 기록해 같은 저장소를 보는 다른 KanVibe client와 공유한다.
+ * 프로젝트 색상을 `.kanvibe/project.json`에 기록해 같은 저장소를 보는 다른 KanVibe client와 공유한다.
  * 프로젝트 루트와 소속 task의 worktree에 모두 기록해 어느 경로로 열어도 같은 색상을 읽게 한다.
  */
 export async function persistProjectColorToKanvibeState(project: ColorSyncProject): Promise<void> {
@@ -19,22 +19,38 @@ export async function persistProjectColorToKanvibeState(project: ColorSyncProjec
     return;
   }
 
-  for (const repoPath of await resolveProjectColorRepoPaths(project)) {
-    try {
-      await addAiToolPatternsToGitExclude(repoPath, project.sshHost);
-      await writeKanvibeProjectColor(repoPath, projectColor, project.sshHost);
-    } catch (error) {
-      console.warn("[project-color] .kanvibe 색상 기록 실패", {
-        repoPath,
-        sshHost: project.sshHost ?? null,
-        error: getErrorMessage(error),
-      });
-    }
+  /** worktree들은 git common dir의 info/exclude를 공유하므로 exclude 갱신은 저장소당 한 번이면 된다 */
+  await excludeKanvibeStateDirectory(project);
+
+  await Promise.all(
+    (await resolveProjectColorRepoPaths(project)).map(async (repoPath) => {
+      try {
+        await writeKanvibeProjectColor(repoPath, projectColor, project.sshHost);
+      } catch (error) {
+        console.warn("[project-color] .kanvibe 색상 기록 실패", {
+          repoPath,
+          sshHost: project.sshHost ?? null,
+          error: getErrorMessage(error),
+        });
+      }
+    }),
+  );
+}
+
+async function excludeKanvibeStateDirectory(project: ColorSyncProject): Promise<void> {
+  try {
+    await addAiToolPatternsToGitExclude(project.repoPath, project.sshHost);
+  } catch (error) {
+    console.warn("[project-color] git exclude 패턴 추가 실패", {
+      repoPath: project.repoPath,
+      sshHost: project.sshHost ?? null,
+      error: getErrorMessage(error),
+    });
   }
 }
 
 /**
- * 다른 client가 `.kanvibe/status.json`에 남긴 프로젝트 색상을 읽는다.
+ * 다른 client가 `.kanvibe/project.json`에 남긴 프로젝트 색상을 읽는다.
  * 프로젝트를 새로 등록할 때 기존 client가 정한 색상을 그대로 이어받기 위해 사용한다.
  */
 export async function readSharedProjectColor(

--- a/src/desktop/main/services/kanvibeProjectColorService.ts
+++ b/src/desktop/main/services/kanvibeProjectColorService.ts
@@ -1,0 +1,90 @@
+import type { Project } from "@/entities/Project";
+import { getTaskRepository } from "@/lib/database";
+import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import { parseProjectColor, readKanvibeProjectColor, writeKanvibeProjectColor } from "@/lib/kanvibeProjectState";
+
+type ColorSyncProject = Pick<Project, "id" | "repoPath" | "sshHost" | "color">;
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * 프로젝트 색상을 `.kanvibe/status.json`에 기록해 같은 저장소를 보는 다른 KanVibe client와 공유한다.
+ * 프로젝트 루트와 소속 task의 worktree에 모두 기록해 어느 경로로 열어도 같은 색상을 읽게 한다.
+ */
+export async function persistProjectColorToKanvibeState(project: ColorSyncProject): Promise<void> {
+  const projectColor = parseProjectColor(project.color);
+  if (!projectColor) {
+    return;
+  }
+
+  for (const repoPath of await resolveProjectColorRepoPaths(project)) {
+    try {
+      await addAiToolPatternsToGitExclude(repoPath, project.sshHost);
+      await writeKanvibeProjectColor(repoPath, projectColor, project.sshHost);
+    } catch (error) {
+      console.warn("[project-color] .kanvibe 색상 기록 실패", {
+        repoPath,
+        sshHost: project.sshHost ?? null,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+}
+
+/**
+ * 다른 client가 `.kanvibe/status.json`에 남긴 프로젝트 색상을 읽는다.
+ * 프로젝트를 새로 등록할 때 기존 client가 정한 색상을 그대로 이어받기 위해 사용한다.
+ */
+export async function readSharedProjectColor(
+  repoPath: string,
+  sshHost?: string | null,
+): Promise<string | null> {
+  try {
+    return await readKanvibeProjectColor(repoPath, sshHost);
+  } catch (error) {
+    console.warn("[project-color] .kanvibe 색상 읽기 실패", {
+      repoPath,
+      sshHost: sshHost ?? null,
+      error: getErrorMessage(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * 다른 client가 바꾼 색상을 프로젝트에 반영한다.
+ * @returns 색상이 실제로 바뀌었으면 true
+ */
+export async function applySharedProjectColor(project: Project): Promise<boolean> {
+  const sharedColor = await readSharedProjectColor(project.repoPath, project.sshHost);
+  if (!sharedColor || sharedColor === project.color) {
+    return false;
+  }
+
+  project.color = sharedColor;
+  return true;
+}
+
+/** 색상을 기록할 저장소 경로 목록. 프로젝트 루트와 소속 task worktree를 포함한다 */
+async function resolveProjectColorRepoPaths(project: ColorSyncProject): Promise<string[]> {
+  const repoPaths = new Set<string>([project.repoPath]);
+
+  try {
+    const taskRepo = await getTaskRepository();
+    const tasks = await taskRepo.findBy({ projectId: project.id });
+    for (const task of tasks) {
+      if (task.worktreePath) {
+        repoPaths.add(task.worktreePath);
+      }
+    }
+  } catch (error) {
+    console.warn("[project-color] worktree 경로 조회 실패", {
+      projectId: project.id,
+      error: getErrorMessage(error),
+    });
+  }
+
+  return [...repoPaths];
+}

--- a/src/desktop/main/services/kanvibeProjectColorService.ts
+++ b/src/desktop/main/services/kanvibeProjectColorService.ts
@@ -23,23 +23,27 @@ export async function persistProjectColorToKanvibeState(project: ColorSyncProjec
   await excludeKanvibeStateDirectory(project);
 
   await Promise.all(
-    (await resolveProjectColorRepoPaths(project)).map(async (repoPath) => {
-      /** 이미 같은 색상이 기록된 경로는 건너뛰어 sync 주기마다 파일이 다시 쓰이지 않게 한다 */
-      if (await readSharedProjectColor(repoPath, project.sshHost) === projectColor) {
-        return;
-      }
-
-      try {
-        await writeKanvibeProjectColor(repoPath, projectColor, project.sshHost);
-      } catch (error) {
-        console.warn("[project-color] .kanvibe 색상 기록 실패", {
-          repoPath,
-          sshHost: project.sshHost ?? null,
-          error: getErrorMessage(error),
-        });
-      }
-    }),
+    (await resolveProjectColorRepoPaths(project)).map(
+      (repoPath) => writeProjectColorQuietly(repoPath, projectColor, project.sshHost),
+    ),
   );
+}
+
+/** 한 경로의 색상 기록 실패가 나머지 경로 기록을 막지 않도록 경고만 남긴다 */
+async function writeProjectColorQuietly(
+  repoPath: string,
+  projectColor: string,
+  sshHost?: string | null,
+): Promise<void> {
+  try {
+    await writeKanvibeProjectColor(repoPath, projectColor, sshHost);
+  } catch (error) {
+    console.warn("[project-color] .kanvibe 색상 기록 실패", {
+      repoPath,
+      sshHost: sshHost ?? null,
+      error: getErrorMessage(error),
+    });
+  }
 }
 
 async function excludeKanvibeStateDirectory(project: ColorSyncProject): Promise<void> {
@@ -83,13 +87,52 @@ export async function readSharedProjectColor(
  */
 export async function syncProjectColorWithKanvibeState(project: Project): Promise<boolean> {
   const sharedColor = await readSharedProjectColor(project.repoPath, project.sshHost);
-  const hasAdoptedSharedColor = Boolean(sharedColor) && sharedColor !== project.color;
-  if (hasAdoptedSharedColor) {
-    project.color = sharedColor;
+  if (!sharedColor) {
+    await persistProjectColorToKanvibeState(project);
+    return false;
   }
 
-  await persistProjectColorToKanvibeState(project);
-  return hasAdoptedSharedColor;
+  await propagateSharedProjectColorToWorktrees(project, sharedColor);
+
+  if (sharedColor === project.color) {
+    return false;
+  }
+
+  project.color = sharedColor;
+  return true;
+}
+
+/**
+ * 프로젝트 루트에 기록된 공유 색상을 소속 worktree들에 퍼뜨린다.
+ * 색상이 확정된 뒤에 생긴 worktree는 공유 파일을 받지 못한 채 남아, 그 경로를 직접 등록한
+ * 다른 client가 다른 색상을 계산하게 된다.
+ *
+ * 기록하는 값은 방금 루트에서 읽은 색상이다. 메모리의 프로젝트 색상은 sync가 시작될 때 읽은
+ * 값이라 그 사이 사용자가 색을 바꿨으면 이미 낡았고, 그 낡은 값을 퍼뜨리면 방금 고른 색이 밀린다.
+ * 루트 파일은 사용자 편집과 씨앗 기록만 쓰는 권위 경로이므로 여기서는 건드리지 않는다.
+ */
+async function propagateSharedProjectColorToWorktrees(
+  project: ColorSyncProject,
+  sharedColor: string,
+): Promise<void> {
+  const worktreePaths = (await resolveProjectColorRepoPaths(project))
+    .filter((repoPath) => repoPath !== project.repoPath);
+
+  const outdatedPaths = (await Promise.all(
+    worktreePaths.map(async (repoPath) => (
+      await readSharedProjectColor(repoPath, project.sshHost) === sharedColor ? null : repoPath
+    )),
+  )).filter((repoPath): repoPath is string => repoPath !== null);
+
+  /** 이미 같은 색상인 경로만 남으면 sync 주기마다 파일을 다시 쓰지 않는다 */
+  if (outdatedPaths.length === 0) {
+    return;
+  }
+
+  await excludeKanvibeStateDirectory(project);
+  await Promise.all(
+    outdatedPaths.map((repoPath) => writeProjectColorQuietly(repoPath, sharedColor, project.sshHost)),
+  );
 }
 
 /** 색상을 기록할 저장소 경로 목록. 프로젝트 루트와 소속 task worktree를 포함한다 */

--- a/src/desktop/main/services/kanvibeProjectColorService.ts
+++ b/src/desktop/main/services/kanvibeProjectColorService.ts
@@ -24,6 +24,11 @@ export async function persistProjectColorToKanvibeState(project: ColorSyncProjec
 
   await Promise.all(
     (await resolveProjectColorRepoPaths(project)).map(async (repoPath) => {
+      /** 이미 같은 색상이 기록된 경로는 건너뛰어 sync 주기마다 파일이 다시 쓰이지 않게 한다 */
+      if (await readSharedProjectColor(repoPath, project.sshHost) === projectColor) {
+        return;
+      }
+
       try {
         await writeKanvibeProjectColor(repoPath, projectColor, project.sshHost);
       } catch (error) {
@@ -73,21 +78,18 @@ export async function readSharedProjectColor(
  * 프로젝트 색상을 `.kanvibe/project.json`과 양방향으로 맞춘다.
  * 공유 색상이 있으면 그 값을 프로젝트에 반영하고, 공유 파일이 아직 없으면 현재 색상을 씨앗으로 기록한다.
  * 씨앗 기록이 없으면 이 기능 이전에 등록된 프로젝트끼리는 서로 다른 DB 색상을 계속 유지하게 된다.
+ * 색상이 이미 확정된 뒤에 생긴 worktree도 sync를 거치면 같은 색상 파일을 갖게 된다.
  * @returns 색상이 실제로 바뀌어 DB에 저장해야 하면 true
  */
 export async function syncProjectColorWithKanvibeState(project: Project): Promise<boolean> {
   const sharedColor = await readSharedProjectColor(project.repoPath, project.sshHost);
-  if (!sharedColor) {
-    await persistProjectColorToKanvibeState(project);
-    return false;
+  const hasAdoptedSharedColor = Boolean(sharedColor) && sharedColor !== project.color;
+  if (hasAdoptedSharedColor) {
+    project.color = sharedColor;
   }
 
-  if (sharedColor === project.color) {
-    return false;
-  }
-
-  project.color = sharedColor;
-  return true;
+  await persistProjectColorToKanvibeState(project);
+  return hasAdoptedSharedColor;
 }
 
 /** 색상을 기록할 저장소 경로 목록. 프로젝트 루트와 소속 task worktree를 포함한다 */

--- a/src/desktop/main/services/kanvibeProjectColorService.ts
+++ b/src/desktop/main/services/kanvibeProjectColorService.ts
@@ -70,12 +70,19 @@ export async function readSharedProjectColor(
 }
 
 /**
- * 다른 client가 바꾼 색상을 프로젝트에 반영한다.
- * @returns 색상이 실제로 바뀌었으면 true
+ * 프로젝트 색상을 `.kanvibe/project.json`과 양방향으로 맞춘다.
+ * 공유 색상이 있으면 그 값을 프로젝트에 반영하고, 공유 파일이 아직 없으면 현재 색상을 씨앗으로 기록한다.
+ * 씨앗 기록이 없으면 이 기능 이전에 등록된 프로젝트끼리는 서로 다른 DB 색상을 계속 유지하게 된다.
+ * @returns 색상이 실제로 바뀌어 DB에 저장해야 하면 true
  */
-export async function applySharedProjectColor(project: Project): Promise<boolean> {
+export async function syncProjectColorWithKanvibeState(project: Project): Promise<boolean> {
   const sharedColor = await readSharedProjectColor(project.repoPath, project.sshHost);
-  if (!sharedColor || sharedColor === project.color) {
+  if (!sharedColor) {
+    await persistProjectColorToKanvibeState(project);
+    return false;
+  }
+
+  if (sharedColor === project.color) {
     return false;
   }
 

--- a/src/desktop/main/services/kanvibeTaskStateService.ts
+++ b/src/desktop/main/services/kanvibeTaskStateService.ts
@@ -1,7 +1,7 @@
 import type { KanbanTask, TaskStatus } from "@/entities/KanbanTask";
 import { getProjectRepository } from "@/lib/database";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
-import { readKanvibeTaskState, writeKanvibeTaskState } from "@/lib/kanvibeProjectState";
+import { readKanvibeTaskState, writeKanvibeTaskStatus } from "@/lib/kanvibeProjectState";
 
 type TaskStateTask = Pick<KanbanTask, "id" | "status">;
 
@@ -42,7 +42,7 @@ export async function persistTaskStateAtPath(
 
   try {
     await ensureKanvibeStateDirectoryExcluded(repoPath, sshHost);
-    await writeKanvibeTaskState(repoPath, { status: task.status }, sshHost);
+    await writeKanvibeTaskStatus(repoPath, task.status, sshHost);
   } catch (error) {
     console.error(".kanvibe task 상태 저장 실패:", {
       repoPath,

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -13,6 +13,7 @@ import type { AggregatedAiSessionDetail, AggregatedAiSessionsResult, AiMessageRo
 import { homedir } from "os";
 import path from "path";
 import { computeProjectColor } from "@/lib/projectColor";
+import { resolveProjectIconDataUrl } from "@/lib/githubProjectIcon";
 import { broadcastBoardUpdate } from "@/lib/boardNotifier";
 import { getAvailableHosts as readAvailableHosts } from "@/lib/sshConfig";
 import { getDefaultSessionType } from "@/desktop/main/services/appSettingsService";
@@ -498,6 +499,7 @@ export async function registerProject(
     defaultBranch,
     sshHost: sshHost || null,
     color: await resolveProjectColor(normalizedRepoPath, projectName, sshHost || null),
+    iconDataUrl: await resolveProjectIconDataUrl(normalizedRepoPath, sshHost || null),
   });
 
   const saved = await repo.save(project);
@@ -845,6 +847,7 @@ export async function scanAndRegisterProjects(
         defaultBranch,
         sshHost: sshHost || null,
         color: await resolveProjectColor(repoPath, projectName, sshHost || null),
+        iconDataUrl: await resolveProjectIconDataUrl(repoPath, sshHost || null),
       });
 
       const saved = await repo.save(project);

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -23,10 +23,14 @@ import {
   readPersistedTaskStatusAtPath as readPersistedTaskStatus,
 } from "@/desktop/main/services/kanvibeTaskStateService";
 import {
-  applySharedProjectColor,
   persistProjectColorToKanvibeState,
   readSharedProjectColor,
+  syncProjectColorWithKanvibeState,
 } from "@/desktop/main/services/kanvibeProjectColorService";
+import { mapWithConcurrency } from "@/lib/aiSessions/shared";
+
+/** 아이콘 backfill 동시 실행 수. GitHub에 과도한 동시 요청을 보내지 않으면서 순차 대기를 줄이는 값 */
+const PROJECT_ICON_BACKFILL_CONCURRENCY = 8;
 
 /**
  * 프로젝트 색상을 결정한다.
@@ -598,7 +602,7 @@ function mergeRegisteredProjectWorktreeSyncResult(
  * @returns 색상이 실제로 바뀌어 보드를 갱신해야 하면 true
  */
 async function syncSharedProjectColor(project: Project): Promise<boolean> {
-  if (!await applySharedProjectColor(project)) {
+  if (!await syncProjectColorWithKanvibeState(project)) {
     return false;
   }
 
@@ -629,6 +633,23 @@ async function syncMissingProjectIcon(project: Project): Promise<boolean> {
   return true;
 }
 
+/**
+ * 아이콘이 없는 프로젝트들의 아이콘 확보를 병렬로 처리한다.
+ * 아이콘 조회는 GitHub 네트워크 요청이라 느리거나 끊긴 회선에서는 프로젝트마다 타임아웃을 기다리게 되므로,
+ * worktree 스캔의 순차 루프 안에서 프로젝트 수만큼 대기 시간이 누적되지 않도록 분리해서 실행한다.
+ * @returns 아이콘을 새로 확보한 프로젝트가 있어 보드를 갱신해야 하면 true
+ */
+async function backfillMissingProjectIcons(projects: Project[]): Promise<boolean> {
+  const projectsWithoutIcon = projects.filter((project) => !project.iconDataUrl);
+  const iconResults = await mapWithConcurrency(
+    projectsWithoutIcon,
+    PROJECT_ICON_BACKFILL_CONCURRENCY,
+    (project) => syncMissingProjectIcon(project),
+  );
+
+  return iconResults.some(Boolean);
+}
+
 async function syncProjectWorktrees(
   project: Project,
   taskRepo: Awaited<ReturnType<typeof getTaskRepository>>,
@@ -643,7 +664,6 @@ async function syncProjectWorktrees(
 
   try {
     result.changed = await syncSharedProjectColor(project) || result.changed;
-    result.changed = await syncMissingProjectIcon(project) || result.changed;
 
     const { repaired } = await ensureProjectRootTask(project, {
       repairHooks: false,
@@ -798,6 +818,8 @@ export async function syncRegisteredProjectWorktrees(
     errors: [],
     changed: false,
   };
+
+  mergedResult.changed = await backfillMissingProjectIcons(projects);
 
   const projectResults: RegisteredProjectWorktreeSyncResult[] = [];
   for (const project of projects) {

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -599,14 +599,23 @@ function mergeRegisteredProjectWorktreeSyncResult(
 
 /**
  * 다른 KanVibe client가 `.kanvibe/project.json`에 기록한 프로젝트 색상을 DB에 반영한다.
+ *
+ * 공유 파일을 읽는 동안 사용자가 색을 바꿨을 수 있으므로, 읽어둔 색상이 아직 DB에 남아 있을 때만
+ * 덮어쓴다. 조건 없이 쓰면 방금 고른 색이 공유 파일에서 읽은 이전 색으로 되돌아간다.
  * @returns 색상이 실제로 바뀌어 보드를 갱신해야 하면 true
  */
 async function syncSharedProjectColor(project: Project): Promise<boolean> {
-  if (!await syncProjectColorWithKanvibeState(project)) {
+  const sharedColor = await syncProjectColorWithKanvibeState(project);
+  if (!sharedColor) {
     return false;
   }
 
-  return await updateExistingProject(project.id, { color: project.color });
+  if (!await updateExistingProject(project.id, { color: sharedColor }, { color: project.color })) {
+    return false;
+  }
+
+  project.color = sharedColor;
+  return true;
 }
 
 /**
@@ -637,14 +646,22 @@ async function syncMissingProjectIcon(project: Project): Promise<boolean> {
  * 이미 존재하는 프로젝트 행에만 변경분을 반영한다.
  * sync/backfill은 오래 걸리는 git·GitHub 요청을 기다리는 동안 프로젝트가 삭제될 수 있는데,
  * `save`는 사라진 행을 원래 id 그대로 다시 insert해 task 없는 프로젝트를 되살리므로 조건부 update를 쓴다.
+ * @param expectedColor 이 색상이 아직 DB에 남아 있을 때만 갱신한다. 그 사이 들어온 사용자 편집을 덮지 않기 위한 조건
  * @returns 실제로 갱신된 행이 있어 보드를 갱신해야 하면 true
  */
 async function updateExistingProject(
   projectId: string,
   changes: Partial<Pick<Project, "color" | "iconDataUrl">>,
+  expected: { color?: string | null } = {},
 ): Promise<boolean> {
   const projectRepo = await getProjectRepository();
-  const { affected } = await projectRepo.update({ id: projectId }, changes);
+  const { affected } = await projectRepo.update(
+    {
+      id: projectId,
+      ...("color" in expected ? { color: expected.color ?? IsNull() } : {}),
+    },
+    changes,
+  );
   return affected !== 0;
 }
 

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -21,6 +21,24 @@ import {
   persistTaskStateAtPath as persistTaskState,
   readPersistedTaskStatusAtPath as readPersistedTaskStatus,
 } from "@/desktop/main/services/kanvibeTaskStateService";
+import {
+  applySharedProjectColor,
+  persistProjectColorToKanvibeState,
+  readSharedProjectColor,
+} from "@/desktop/main/services/kanvibeProjectColorService";
+
+/**
+ * 프로젝트 색상을 결정한다.
+ * 같은 저장소를 이미 보고 있는 다른 KanVibe client가 정한 색상이 있으면 이어받고,
+ * 없으면 프로젝트명 기반 색상을 새로 계산한다.
+ */
+async function resolveProjectColor(
+  repoPath: string,
+  projectName: string,
+  sshHost?: string | null,
+): Promise<string> {
+  return await readSharedProjectColor(repoPath, sshHost) ?? computeProjectColor(projectName);
+}
 
 function matchesTaskLocation(task: { worktreePath?: string | null; sshHost?: string | null }, expectedPath: string, sshHost?: string | null): boolean {
   return task.worktreePath === expectedPath && (task.sshHost || null) === (sshHost || null);
@@ -479,10 +497,11 @@ export async function registerProject(
     repoPath: normalizedRepoPath,
     defaultBranch,
     sshHost: sshHost || null,
-    color: computeProjectColor(projectName),
+    color: await resolveProjectColor(normalizedRepoPath, projectName, sshHost || null),
   });
 
   const saved = await repo.save(project);
+  await persistProjectColorToKanvibeState(saved);
   try {
     await ensureProjectRootTask(saved, {
       repairHooks: !saved.sshHost,
@@ -572,6 +591,20 @@ function mergeRegisteredProjectWorktreeSyncResult(
   target.hooksSetup.push(...next.hooksSetup.filter((name) => !target.hooksSetup.includes(name)));
 }
 
+/**
+ * 다른 KanVibe client가 `.kanvibe/status.json`에 기록한 프로젝트 색상을 DB에 반영한다.
+ * @returns 색상이 실제로 바뀌어 보드를 갱신해야 하면 true
+ */
+async function syncSharedProjectColor(project: Project): Promise<boolean> {
+  if (!await applySharedProjectColor(project)) {
+    return false;
+  }
+
+  const projectRepo = await getProjectRepository();
+  await projectRepo.save(project);
+  return true;
+}
+
 async function syncProjectWorktrees(
   project: Project,
   taskRepo: Awaited<ReturnType<typeof getTaskRepository>>,
@@ -585,6 +618,8 @@ async function syncProjectWorktrees(
   };
 
   try {
+    result.changed = await syncSharedProjectColor(project) || result.changed;
+
     const { repaired } = await ensureProjectRootTask(project, {
       repairHooks: false,
       throwOnHookRepairFailure: false,
@@ -809,10 +844,11 @@ export async function scanAndRegisterProjects(
         repoPath,
         defaultBranch,
         sshHost: sshHost || null,
-        color: computeProjectColor(projectName),
+        color: await resolveProjectColor(repoPath, projectName, sshHost || null),
       });
 
       const saved = await repo.save(project);
+      await persistProjectColorToKanvibeState(saved);
       existingPaths.add(pathKey);
       result.registered.push(projectName);
 

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -594,7 +594,7 @@ function mergeRegisteredProjectWorktreeSyncResult(
 }
 
 /**
- * 다른 KanVibe client가 `.kanvibe/status.json`에 기록한 프로젝트 색상을 DB에 반영한다.
+ * 다른 KanVibe client가 `.kanvibe/project.json`에 기록한 프로젝트 색상을 DB에 반영한다.
  * @returns 색상이 실제로 바뀌어 보드를 갱신해야 하면 true
  */
 async function syncSharedProjectColor(project: Project): Promise<boolean> {
@@ -602,6 +602,28 @@ async function syncSharedProjectColor(project: Project): Promise<boolean> {
     return false;
   }
 
+  const projectRepo = await getProjectRepository();
+  await projectRepo.save(project);
+  return true;
+}
+
+/**
+ * 아직 아이콘이 없는 프로젝트의 GitHub 아이콘을 뒤늦게 채운다.
+ * 이전 버전에서 등록됐거나, 등록 시점에 오프라인이었거나, GitHub remote가 나중에 추가된
+ * 프로젝트도 sync를 거치면 아이콘을 갖게 된다.
+ * @returns 아이콘을 새로 확보해 보드를 갱신해야 하면 true
+ */
+async function syncMissingProjectIcon(project: Project): Promise<boolean> {
+  if (project.iconDataUrl) {
+    return false;
+  }
+
+  const iconDataUrl = await resolveProjectIconDataUrl(project.repoPath, project.sshHost);
+  if (!iconDataUrl) {
+    return false;
+  }
+
+  project.iconDataUrl = iconDataUrl;
   const projectRepo = await getProjectRepository();
   await projectRepo.save(project);
   return true;
@@ -621,6 +643,7 @@ async function syncProjectWorktrees(
 
   try {
     result.changed = await syncSharedProjectColor(project) || result.changed;
+    result.changed = await syncMissingProjectIcon(project) || result.changed;
 
     const { repaired } = await ensureProjectRootTask(project, {
       repairHooks: false,
@@ -847,7 +870,6 @@ export async function scanAndRegisterProjects(
         defaultBranch,
         sshHost: sshHost || null,
         color: await resolveProjectColor(repoPath, projectName, sshHost || null),
-        iconDataUrl: await resolveProjectIconDataUrl(repoPath, sshHost || null),
       });
 
       const saved = await repo.save(project);

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -503,7 +503,6 @@ export async function registerProject(
     defaultBranch,
     sshHost: sshHost || null,
     color: await resolveProjectColor(normalizedRepoPath, projectName, sshHost || null),
-    iconDataUrl: await resolveProjectIconDataUrl(normalizedRepoPath, sshHost || null),
   });
 
   const saved = await repo.save(project);
@@ -521,6 +520,7 @@ export async function registerProject(
     };
   }
 
+  scheduleProjectIconBackfill(saved);
   broadcastBoardUpdate();
   return { success: true, project: serialize(saved) };
 }
@@ -631,6 +631,25 @@ async function syncMissingProjectIcon(project: Project): Promise<boolean> {
   const projectRepo = await getProjectRepository();
   await projectRepo.save(project);
   return true;
+}
+
+/**
+ * 새로 등록한 프로젝트의 GitHub 아이콘 확보를 백그라운드로 넘긴다.
+ * 아이콘 조회는 GitHub 네트워크 요청이라 느리거나 끊긴 회선에서는 타임아웃까지 대기하게 되므로,
+ * 프로젝트 저장과 등록 응답이 그 시간만큼 막히지 않도록 저장이 끝난 뒤에 따로 실행한다.
+ */
+function scheduleProjectIconBackfill(project: Project): void {
+  void (async () => {
+    try {
+      if (await syncMissingProjectIcon(project)) {
+        broadcastBoardUpdate();
+      }
+    } catch (error) {
+      if (!isRemoteConnectionError(error)) {
+        console.warn(`${project.name} 아이콘 백그라운드 확보 실패:`, error);
+      }
+    }
+  })();
 }
 
 /**

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -606,9 +606,7 @@ async function syncSharedProjectColor(project: Project): Promise<boolean> {
     return false;
   }
 
-  const projectRepo = await getProjectRepository();
-  await projectRepo.save(project);
-  return true;
+  return await updateExistingProject(project.id, { color: project.color });
 }
 
 /**
@@ -627,10 +625,27 @@ async function syncMissingProjectIcon(project: Project): Promise<boolean> {
     return false;
   }
 
+  if (!await updateExistingProject(project.id, { iconDataUrl })) {
+    return false;
+  }
+
   project.iconDataUrl = iconDataUrl;
-  const projectRepo = await getProjectRepository();
-  await projectRepo.save(project);
   return true;
+}
+
+/**
+ * 이미 존재하는 프로젝트 행에만 변경분을 반영한다.
+ * sync/backfill은 오래 걸리는 git·GitHub 요청을 기다리는 동안 프로젝트가 삭제될 수 있는데,
+ * `save`는 사라진 행을 원래 id 그대로 다시 insert해 task 없는 프로젝트를 되살리므로 조건부 update를 쓴다.
+ * @returns 실제로 갱신된 행이 있어 보드를 갱신해야 하면 true
+ */
+async function updateExistingProject(
+  projectId: string,
+  changes: Partial<Pick<Project, "color" | "iconDataUrl">>,
+): Promise<boolean> {
+  const projectRepo = await getProjectRepository();
+  const { affected } = await projectRepo.update({ id: projectId }, changes);
+  return affected !== 0;
 }
 
 /**

--- a/src/desktop/renderer/routes/BoardRoute.tsx
+++ b/src/desktop/renderer/routes/BoardRoute.tsx
@@ -63,8 +63,8 @@ function createEmptyBoardData(): BoardData {
 function BoardTaskCardSkeleton({ index }: { index: number }) {
   return (
     <div className="rounded-md border border-border-subtle px-2.5 py-2">
-      <div className="mb-2 grid grid-cols-[6px_minmax(0,1fr)] items-center gap-2">
-        <div className="h-1.5 w-1.5 rounded-full bg-border-strong" />
+      <div className="mb-2 grid grid-cols-[14px_minmax(0,1fr)] items-center gap-2">
+        <div className="h-3.5 w-3.5 rounded-sm bg-border-strong" />
         <div className="h-3 w-24 rounded bg-border-subtle" />
       </div>
       <div className={`h-3.5 rounded bg-border-default ${BOARD_SKELETON_TITLE_WIDTHS[index % BOARD_SKELETON_TITLE_WIDTHS.length]}`} />

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -820,6 +820,7 @@ export default function TaskDetailRoute() {
   const [mainView, setMainView] = useState<MainView>("terminal");
   const notificationCenterRef = useRef<NotificationCenterButtonHandle>(null);
   const currentTaskIdRef = useRef(id);
+  const dockItemsRef = useRef<TaskDetailDockItem[]>([]);
   const commonTranslationsRef = useRef(tc);
   const hasTerminal = !!(state?.task.sessionType && state.task.sessionName);
   const shortcutPlatform = getCurrentShortcutPlatform();
@@ -918,19 +919,23 @@ export default function TaskDetailRoute() {
     return items;
   }, [mainView, state, statusPanelLabel, t, toggleChatView, toggleDetailPanel, visiblePanel]);
 
+  // dock 항목을 렌더 시점에 ref로 넘겨두면 shortcut 구독을 다시 등록하지 않아도 항상 최신 dock을 실행한다.
+  // 구독을 dock 변경마다 재등록하면 커밋과 effect flush 사이에 들어온 shortcut이 이전 dock(빈 배열)을 보고 무시된다.
+  dockItemsRef.current = dockItems;
+
   const activateDockItem = useCallback((shortcutIndex: number) => {
     if (!Number.isInteger(shortcutIndex)) {
       return false;
     }
 
-    const item = dockItems[shortcutIndex - 1];
+    const item = dockItemsRef.current[shortcutIndex - 1];
     if (!item) {
       return false;
     }
 
     item.onActivate();
     return true;
-  }, [dockItems]);
+  }, []);
 
   useEffect(() => {
     if (id) {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -852,6 +852,49 @@ describe("TaskDetailRoute", () => {
     expect(await screen.findByTestId("hooks-status-card")).toBeTruthy();
   });
 
+  it("최초 등록된 Electron dock shortcut 구독은 task 로드 이후에도 최신 dock 항목을 실행한다", async () => {
+    const dockShortcutListeners: ((index: number) => void)[] = [];
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      onTaskDetailDockShortcut(listener: (index: number) => void) {
+        dockShortcutListeners.push(listener);
+        return () => {};
+      },
+    };
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(true);
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(
+      <BoardCommandProvider>
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    await screen.findByLabelText("terminal input");
+
+    const [initialDockShortcutListener] = dockShortcutListeners;
+    act(() => {
+      initialDockShortcutListener?.(2);
+    });
+
+    expect(await screen.findByTestId("hooks-status-card")).toBeTruthy();
+  });
+
   it("Electron dock shortcut 3은 수동 히스토리 버튼 없이 AI 채팅 첫 페이지를 로드한다", async () => {
     let dockShortcutListener: ((index: number) => void) | null = null;
     window.kanvibeDesktop = {

--- a/src/entities/Project.ts
+++ b/src/entities/Project.ts
@@ -33,6 +33,10 @@ export class Project {
   @Column({ name: "color", type: "varchar", length: 7, nullable: true, default: null })
   color!: string | null;
 
+  /** 프로젝트 제목 앞에 표시할 GitHub repo/org 아이콘. 오프라인에서도 쓰도록 data URL로 보관한다 */
+  @Column({ name: "icon_data_url", type: "text", nullable: true, default: null })
+  iconDataUrl!: string | null;
+
   @CreateDateColumn({ name: "created_at" })
   createdAt!: Date;
 }

--- a/src/lib/__tests__/claudeHooksSetup.test.ts
+++ b/src/lib/__tests__/claudeHooksSetup.test.ts
@@ -130,7 +130,7 @@ describe("claudeHooksSetup", () => {
     vi.unstubAllGlobals();
   });
 
-  it("현재 task id와 다른 Claude hook은 설치된 것으로 보지 않는다", async () => {
+  it("targets.json에 등록되지 않은 task는 설치된 것으로 보지 않는다", async () => {
     const repoPath = tempDir;
 
     await setupClaudeHooks(repoPath, "task-1", "http://localhost:9736");
@@ -138,7 +138,22 @@ describe("claudeHooksSetup", () => {
 
     expect(status.installed).toBe(false);
     expect(status.hasTaskIdBinding).toBe(true);
-    expect(status.hasExpectedTaskId).toBe(false);
+    expect(status.hasRegisteredHookTarget).toBe(false);
     expect(status.boundTaskId).toBe("task-1");
+  });
+
+  it("다른 client가 hook script를 덮어써도 targets.json에 등록된 client는 설치 상태를 유지한다", async () => {
+    const repoPath = tempDir;
+
+    await setupClaudeHooks(repoPath, "task-1", "http://localhost:9736");
+    /** 같은 worktree를 보는 다른 client가 자기 URL과 task로 hook script를 다시 기록한다 */
+    await setupClaudeHooks(repoPath, "task-9", "http://10.0.0.5:9736");
+
+    const status = await getClaudeHooksStatus(repoPath, "task-1");
+
+    expect(status.installed).toBe(true);
+    expect(status.hasRegisteredHookTarget).toBe(true);
+    expect(status.registeredHookTargetUrl).toBe("http://localhost:9736");
+    expect(status.boundTaskId).toBe("task-9");
   });
 });

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -121,7 +121,7 @@ describe("codexHooksSetup", () => {
       expect(promptHookContent).toContain('TASK_ID="task-1"');
       expect(promptHookContent).toContain("taskId");
       expect(promptHookContent).toContain("status.json");
-      expect(promptHookContent).toContain('"schemaVersion":1');
+      expect(promptHookContent).toContain('\\"schemaVersion\\":1');
 
       const configContent = await readFile(join(repoPath, ".codex", "config.toml"), "utf-8");
       expect(configContent).toContain("[features]");
@@ -230,13 +230,16 @@ describe("codexHooksSetup", () => {
         hasHookEntries: true,
         hasConfigEntry: true,
         hasTaskIdBinding: true,
-        hasExpectedTaskId: true,
+        hasRegisteredHookTarget: true,
         hasStatusMappings: true,
         hasStatusJsonPersistence: true,
+        hasProjectColorPersistence: true,
         hasTargetFanout: true,
+        hasParallelTargetFanout: true,
         hasExpectedHookServerUrl: true,
         hasReachableHookServer: true,
         boundTaskId: "task-1",
+        registeredHookTargetUrl: null,
         configuredHookServerUrl: "http://localhost:3000",
         expectedHookServerUrl: null,
       });
@@ -257,7 +260,7 @@ describe("codexHooksSetup", () => {
       vi.unstubAllGlobals();
     });
 
-    it("현재 task id와 다른 Codex hook은 설치된 것으로 보지 않는다", async () => {
+    it("targets.json에 등록되지 않은 task는 설치된 것으로 보지 않는다", async () => {
       const repoPath = tempDir;
       await setupCodexHooks(repoPath, "task-1", "http://localhost:9736");
 
@@ -265,7 +268,7 @@ describe("codexHooksSetup", () => {
 
       expect(status.installed).toBe(false);
       expect(status.hasTaskIdBinding).toBe(true);
-      expect(status.hasExpectedTaskId).toBe(false);
+      expect(status.hasRegisteredHookTarget).toBe(false);
       expect(status.boundTaskId).toBe("task-1");
     });
   });

--- a/src/lib/__tests__/codexHooksSetup.test.ts
+++ b/src/lib/__tests__/codexHooksSetup.test.ts
@@ -233,7 +233,7 @@ describe("codexHooksSetup", () => {
         hasRegisteredHookTarget: true,
         hasStatusMappings: true,
         hasStatusJsonPersistence: true,
-        hasProjectColorPersistence: true,
+        hasBoundedNotifyTimeout: true,
         hasTargetFanout: true,
         hasParallelTargetFanout: true,
         hasExpectedHookServerUrl: true,

--- a/src/lib/__tests__/databaseMigrations.test.ts
+++ b/src/lib/__tests__/databaseMigrations.test.ts
@@ -119,7 +119,7 @@ describe("database migrations", () => {
         { id: "task-1", branch_name: "main", display_order: 0 },
         { id: "task-2", branch_name: "main", display_order: 1 },
       ]);
-      expect(migrations).toHaveLength(12);
+      expect(migrations).toHaveLength(13);
       expect(migrations[0]).toEqual({ name: "InitialSchema1770854400000" });
     } finally {
       await dataSource.destroy();
@@ -158,7 +158,7 @@ describe("database migrations", () => {
           display_order: 0,
         },
       ]);
-      expect(migrations).toHaveLength(12);
+      expect(migrations).toHaveLength(13);
     } finally {
       await dataSource.destroy();
     }
@@ -188,7 +188,7 @@ describe("database migrations", () => {
       expect(indexes.map((row: { name: string }) => row.name)).not.toContain(
         "UQ_kanban_tasks_branch_name",
       );
-      expect(migrations).toHaveLength(12);
+      expect(migrations).toHaveLength(13);
     } finally {
       await dataSource.destroy();
     }

--- a/src/lib/__tests__/geminiHooksSetup.test.ts
+++ b/src/lib/__tests__/geminiHooksSetup.test.ts
@@ -34,7 +34,7 @@ describe("geminiHooksSetup", () => {
       expect(promptScript).toContain(taskId);
       expect(promptScript).toContain("taskId");
       expect(promptScript).toContain("status.json");
-      expect(promptScript).toContain('"schemaVersion":1');
+      expect(promptScript).toContain('\\"schemaVersion\\":1');
       expect(promptScript).toContain("echo '{}'");
 
       expect(stopScript).toContain("#!/bin/bash");
@@ -181,14 +181,14 @@ describe("geminiHooksSetup", () => {
       expect(status.installed).toBe(false);
     });
 
-    it("현재 task id와 다른 Gemini hook은 설치된 것으로 보지 않는다", async () => {
+    it("targets.json에 등록되지 않은 task는 설치된 것으로 보지 않는다", async () => {
       await setupGeminiHooks(tmpDir, "task-1", "http://localhost:9736");
 
       const status = await getGeminiHooksStatus(tmpDir, "task-2");
 
       expect(status.installed).toBe(false);
       expect(status.hasTaskIdBinding).toBe(true);
-      expect(status.hasExpectedTaskId).toBe(false);
+      expect(status.hasRegisteredHookTarget).toBe(false);
       expect(status.boundTaskId).toBe("task-1");
     });
   });

--- a/src/lib/__tests__/githubProjectIcon.test.ts
+++ b/src/lib/__tests__/githubProjectIcon.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/gitOperations", () => ({
 }));
 
 import {
+  clearGitHubOwnerIconCache,
   fetchGitHubOwnerIconDataUrl,
   parseGitHubRepositoryReference,
   resolveProjectIconDataUrl,
@@ -23,6 +24,7 @@ function createIconResponse(contentType: string, bytes: Uint8Array): Response {
 describe("githubProjectIcon", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearGitHubOwnerIconCache();
     vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
@@ -89,5 +91,32 @@ describe("githubProjectIcon", () => {
       "git -C '/remote/repo' config --get remote.origin.url",
       "remote-host",
     );
+  });
+
+  it("같은 owner의 아바타는 한 번만 내려받는다", async () => {
+    const iconFetch = vi.fn().mockResolvedValue(
+      createIconResponse("image/png", new Uint8Array([1, 2, 3])),
+    );
+    vi.stubGlobal("fetch", iconFetch);
+
+    const [first, second] = await Promise.all([
+      fetchGitHubOwnerIconDataUrl("shared-owner"),
+      fetchGitHubOwnerIconDataUrl("shared-owner"),
+    ]);
+    await fetchGitHubOwnerIconDataUrl("shared-owner");
+
+    expect(first).toBe(second);
+    expect(iconFetch).toHaveBeenCalledTimes(1);
+  });
+
+  /** 오프라인에서 저장소마다 5초 타임아웃을 다시 기다리지 않도록 실패도 캐싱한다 */
+  it("아이콘 확보 실패도 owner 단위로 캐싱한다", async () => {
+    const iconFetch = vi.fn().mockRejectedValue(new Error("offline"));
+    vi.stubGlobal("fetch", iconFetch);
+
+    await expect(fetchGitHubOwnerIconDataUrl("offline-owner")).resolves.toBeNull();
+    await expect(fetchGitHubOwnerIconDataUrl("offline-owner")).resolves.toBeNull();
+
+    expect(iconFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/__tests__/githubProjectIcon.test.ts
+++ b/src/lib/__tests__/githubProjectIcon.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockExecGit } = vi.hoisted(() => ({ mockExecGit: vi.fn() }));
+
+vi.mock("@/lib/gitOperations", () => ({
+  execGit: (...args: unknown[]) => mockExecGit(...args),
+}));
+
+import {
+  fetchGitHubOwnerIconDataUrl,
+  parseGitHubRepositoryReference,
+  resolveProjectIconDataUrl,
+} from "@/lib/githubProjectIcon";
+
+function createIconResponse(contentType: string, bytes: Uint8Array): Response {
+  return {
+    ok: true,
+    headers: { get: () => contentType },
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  } as unknown as Response;
+}
+
+describe("githubProjectIcon", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("여러 형식의 GitHub remote URL에서 owner/repository를 읽어낸다", () => {
+    expect(parseGitHubRepositoryReference("https://github.com/rookedsysc/kanvibe.git"))
+      .toEqual({ owner: "rookedsysc", repository: "kanvibe" });
+    expect(parseGitHubRepositoryReference("git@github.com:rookedsysc/kanvibe.git\n"))
+      .toEqual({ owner: "rookedsysc", repository: "kanvibe" });
+    expect(parseGitHubRepositoryReference("ssh://git@github.com/rookedsysc/kanvibe"))
+      .toEqual({ owner: "rookedsysc", repository: "kanvibe" });
+    expect(parseGitHubRepositoryReference("https://github.com/rookedsysc/kanvibe/"))
+      .toEqual({ owner: "rookedsysc", repository: "kanvibe" });
+  });
+
+  it("GitHub이 아니거나 owner 형식이 어긋나는 remote는 아이콘 대상이 아니다", () => {
+    expect(parseGitHubRepositoryReference("https://gitlab.com/team/app.git")).toBeNull();
+    expect(parseGitHubRepositoryReference("")).toBeNull();
+    expect(parseGitHubRepositoryReference("https://github.com/-bad-owner/app.git")).toBeNull();
+    expect(parseGitHubRepositoryReference("https://github.com/own er/app.git")).toBeNull();
+  });
+
+  it("GitHub 아바타를 data URL로 변환한다", async () => {
+    const iconBytes = new Uint8Array([137, 80, 78, 71]);
+    const mockFetch = vi.fn().mockResolvedValue(createIconResponse("image/png", iconBytes));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await expect(fetchGitHubOwnerIconDataUrl("rookedsysc")).resolves.toBe(
+      `data:image/png;base64,${Buffer.from(iconBytes).toString("base64")}`,
+    );
+    expect(mockFetch.mock.calls[0][0]).toContain("https://github.com/rookedsysc.png");
+  });
+
+  it("이미지가 아닌 응답이나 네트워크 실패는 아이콘 없음으로 처리한다", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(createIconResponse("text/html", new Uint8Array([1]))));
+    await expect(fetchGitHubOwnerIconDataUrl("rookedsysc")).resolves.toBeNull();
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    await expect(fetchGitHubOwnerIconDataUrl("rookedsysc")).resolves.toBeNull();
+  });
+
+  it("remote가 없는 저장소는 아이콘 없이 등록되게 한다", async () => {
+    mockExecGit.mockRejectedValue(new Error("no origin"));
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    await expect(resolveProjectIconDataUrl("/repo", null)).resolves.toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("origin remote를 읽어 아이콘 data URL을 확보한다", async () => {
+    mockExecGit.mockResolvedValue("git@github.com:rookedsysc/kanvibe.git\n");
+    const iconBytes = new Uint8Array([1, 2, 3]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(createIconResponse("image/png", iconBytes)));
+
+    await expect(resolveProjectIconDataUrl("/remote/repo", "remote-host")).resolves.toBe(
+      `data:image/png;base64,${Buffer.from(iconBytes).toString("base64")}`,
+    );
+    expect(mockExecGit).toHaveBeenCalledWith(
+      "git -C '/remote/repo' config --get remote.origin.url",
+      "remote-host",
+    );
+  });
+});

--- a/src/lib/__tests__/hookTargetRegistration.test.ts
+++ b/src/lib/__tests__/hookTargetRegistration.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { verifyHookTargetRegistration } from "@/lib/hookTargetRegistration";
+
+const TARGETS_CONTENT = JSON.stringify({
+  schemaVersion: 1,
+  targets: [
+    { url: "http://127.0.0.1:9736", taskId: "task-local" },
+    { url: "http://10.0.0.5:9736", taskId: "task-remote" },
+  ],
+});
+
+describe("hookTargetRegistration", () => {
+  it("현재 client url과 taskId가 모두 등록되어야 설치된 것으로 본다", () => {
+    expect(verifyHookTargetRegistration(TARGETS_CONTENT, "task-local", "http://127.0.0.1:9736")).toEqual({
+      hasRegisteredHookTarget: true,
+      registeredHookTargetUrl: "http://127.0.0.1:9736",
+    });
+  });
+
+  it("다른 client가 같은 task를 등록했더라도 내 client url이 없으면 미설치로 본다", () => {
+    expect(verifyHookTargetRegistration(TARGETS_CONTENT, "task-remote", "http://127.0.0.1:9736")).toEqual({
+      hasRegisteredHookTarget: false,
+      registeredHookTargetUrl: "http://10.0.0.5:9736",
+    });
+  });
+
+  it("등록되지 않은 task는 미설치로 본다", () => {
+    expect(verifyHookTargetRegistration(TARGETS_CONTENT, "task-unknown", "http://127.0.0.1:9736")).toEqual({
+      hasRegisteredHookTarget: false,
+      registeredHookTargetUrl: null,
+    });
+  });
+
+  it("hook 서버 주소를 확정하지 못하면 taskId 등록 여부만으로 판정한다", () => {
+    expect(verifyHookTargetRegistration(TARGETS_CONTENT, "task-remote", null)).toEqual({
+      hasRegisteredHookTarget: true,
+      registeredHookTargetUrl: "http://10.0.0.5:9736",
+    });
+    expect(verifyHookTargetRegistration(TARGETS_CONTENT, "task-unknown", null)).toEqual({
+      hasRegisteredHookTarget: false,
+      registeredHookTargetUrl: null,
+    });
+  });
+
+  it("확인할 task가 없으면 등록 여부를 판정하지 않는다", () => {
+    expect(verifyHookTargetRegistration("", undefined, "http://127.0.0.1:9736")).toEqual({
+      hasRegisteredHookTarget: true,
+      registeredHookTargetUrl: null,
+    });
+  });
+});

--- a/src/lib/__tests__/hostFileAccess.test.ts
+++ b/src/lib/__tests__/hostFileAccess.test.ts
@@ -105,3 +105,62 @@ describe("hostFileAccess.readTextFiles", () => {
     expect(files.get(finalFilePath)).toEqual({ exists: true, content: finalContent });
   });
 });
+
+describe("hostFileAccess.writeTextFileIfAbsent", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "kanvibe-write-if-absent-"));
+    mocks.execGit.mockReset();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("파일이 없으면 상위 디렉터리까지 만들어 기록한다", async () => {
+    // Given
+    const targetPath = path.join(tempDir, "nested", "project.json");
+    const { writeTextFileIfAbsent } = await import("@/lib/hostFileAccess");
+
+    // When
+    await writeTextFileIfAbsent(targetPath, "seed\n");
+
+    // Then
+    await expect(readFile(targetPath, "utf-8")).resolves.toBe("seed\n");
+  });
+
+  /** 이미 만들어진 값은 다른 주체가 확정한 권위 값이므로 씨앗 기록이 덮으면 안 된다 */
+  it("이미 있는 파일은 덮지 않는다", async () => {
+    // Given
+    const targetPath = path.join(tempDir, "project.json");
+    await writeFile(targetPath, "authoritative\n", "utf-8");
+    const { writeTextFileIfAbsent } = await import("@/lib/hostFileAccess");
+
+    // When
+    await writeTextFileIfAbsent(targetPath, "seed\n");
+
+    // Then
+    await expect(readFile(targetPath, "utf-8")).resolves.toBe("authoritative\n");
+  });
+
+  it("원격 기록 명령은 POSIX sh에서 실행 가능하고 기존 파일을 덮지 않는다", async () => {
+    // Given
+    const createdPath = path.join(tempDir, "created's file.json");
+    const existingPath = path.join(tempDir, "existing.json");
+    await writeFile(existingPath, "authoritative\n", "utf-8");
+    mocks.execGit.mockImplementation(async (command: string) => {
+      const { stdout } = await execFileAsync("sh", ["-lc", wrapLikeRemoteExecGit(command)]);
+      return stdout;
+    });
+    const { writeTextFileIfAbsent } = await import("@/lib/hostFileAccess");
+
+    // When
+    await writeTextFileIfAbsent(createdPath, "seed\n", "remote-host");
+    await writeTextFileIfAbsent(existingPath, "seed\n", "remote-host");
+
+    // Then
+    await expect(readFile(createdPath, "utf-8")).resolves.toBe("seed\n");
+    await expect(readFile(existingPath, "utf-8")).resolves.toBe("authoritative\n");
+  });
+});

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -63,10 +63,18 @@ function buildReadResults(files: Record<string, string> = {}): Map<string, TextF
   return new Map(Object.entries(files).map(([filePath, content]) => [filePath, { exists: true, content }]));
 }
 
-/** 마지막 쓰기 배치에서 특정 경로의 파일 내용을 찾는다 */
+/** 쓰기는 provider 단위로 격리되므로 한 번의 설치는 provider 수만큼의 쓰기 배치를 만든다 */
+const HOOK_PROVIDER_COUNT = 4;
+
+/** 마지막 설치가 기록한 파일 전체를 provider 배치들에서 모은다 */
+function getLastInstallWrittenFiles(): ShellHookProviderFile[] {
+  return mockWriteHookProviderFiles.mock.calls
+    .slice(-HOOK_PROVIDER_COUNT)
+    .flatMap((call) => (call[0] ?? []) as ShellHookProviderFile[]);
+}
+
 function findWrittenContent(filePath: string): string {
-  const writtenFiles = mockWriteHookProviderFiles.mock.calls.at(-1)?.[0] as ShellHookProviderFile[];
-  const file = writtenFiles?.find((candidate) => candidate.filePath === filePath);
+  const file = getLastInstallWrittenFiles().find((candidate) => candidate.filePath === filePath);
   if (!file) {
     throw new Error(`write payload not found for ${filePath}`);
   }
@@ -75,8 +83,14 @@ function findWrittenContent(filePath: string): string {
 }
 
 function getWrittenFilePaths(): string[] {
-  const writtenFiles = mockWriteHookProviderFiles.mock.calls.at(-1)?.[0] as ShellHookProviderFile[];
-  return (writtenFiles ?? []).map((file) => file.filePath);
+  return getLastInstallWrittenFiles().map((file) => file.filePath);
+}
+
+/** provider별 쓰기가 모두 시작될 때까지 microtask queue를 비운다 */
+async function flushMicrotasks(): Promise<void> {
+  for (let tick = 0; tick < 20; tick += 1) {
+    await Promise.resolve();
+  }
 }
 
 describe("kanvibeHooksInstaller", () => {
@@ -100,7 +114,7 @@ describe("kanvibeHooksInstaller", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
-  it("전체 설치는 모든 provider hook 파일을 한 번의 쓰기 배치로 기록한다", async () => {
+  it("전체 설치는 provider별 쓰기 배치로 모든 hook 파일을 기록한다", async () => {
     // Given
     const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
 
@@ -108,7 +122,7 @@ describe("kanvibeHooksInstaller", () => {
     await installKanvibeHooks("/repo", "task-1", null);
 
     // Then
-    expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(1);
+    expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(HOOK_PROVIDER_COUNT);
     expect(mockWriteHookProviderFiles).toHaveBeenCalledWith(expect.any(Array), null);
     expect(getWrittenFilePaths()).toEqual(expect.arrayContaining([
       "/repo/.claude/hooks/kanvibe-prompt-hook.sh",
@@ -255,7 +269,7 @@ describe("kanvibeHooksInstaller", () => {
     await installKanvibeHookFiles("/repo", "task-1", null);
 
     // Then
-    expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(1);
+    expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(HOOK_PROVIDER_COUNT);
     expect(mockGetClaudeHooksStatus).not.toHaveBeenCalled();
     expect(mockGetGeminiHooksStatus).not.toHaveBeenCalled();
     expect(mockGetCodexHooksStatus).not.toHaveBeenCalled();
@@ -462,7 +476,7 @@ describe("kanvibeHooksInstaller", () => {
 
       // Then
       await result;
-      expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(2);
+      expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(HOOK_PROVIDER_COUNT * 2);
     } finally {
       vi.useRealTimers();
     }
@@ -482,7 +496,7 @@ describe("kanvibeHooksInstaller", () => {
 
       // Then
       await result;
-      expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(3);
+      expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(HOOK_PROVIDER_COUNT * 3);
     } finally {
       vi.useRealTimers();
     }
@@ -490,22 +504,22 @@ describe("kanvibeHooksInstaller", () => {
 
   it("같은 target/task/host 동시 설치 요청은 하나의 설치 작업을 공유한다", async () => {
     // Given
-    let resolveHookFileWrite: (() => void) | undefined;
+    const pendingHookFileWrites: (() => void)[] = [];
     mockWriteHookProviderFiles.mockImplementation(() => new Promise<void>((resolve) => {
-      resolveHookFileWrite = resolve;
+      pendingHookFileWrites.push(resolve);
     }));
     const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
 
     // When
     const firstInstall = installKanvibeHooks("/repo", "task-1", null);
     const secondInstall = installKanvibeHooks("/repo", "task-1", null);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushMicrotasks();
 
     // Then
-    expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(1);
-    resolveHookFileWrite?.();
+    expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(HOOK_PROVIDER_COUNT);
+    for (const resolveHookFileWrite of pendingHookFileWrites) {
+      resolveHookFileWrite();
+    }
     await expect(Promise.all([firstInstall, secondInstall])).resolves.toEqual([undefined, undefined]);
   });
 
@@ -524,7 +538,7 @@ describe("kanvibeHooksInstaller", () => {
       await vi.runAllTimersAsync();
 
       // Then
-      expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(1);
+      expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(HOOK_PROVIDER_COUNT);
       expect(onSuccessA).toHaveBeenCalledTimes(1);
       expect(onSuccessB).toHaveBeenCalledTimes(1);
     } finally {

--- a/src/lib/__tests__/kanvibeHooksInstaller.test.ts
+++ b/src/lib/__tests__/kanvibeHooksInstaller.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TextFileReadResult } from "@/lib/hostFileAccess";
+import type { ShellHookProviderFile } from "@/lib/shellHookProvider";
 
 const mockSetupClaudeHooks = vi.fn();
 const mockSetupGeminiHooks = vi.fn();
@@ -8,117 +10,87 @@ const mockGetClaudeHooksStatus = vi.fn();
 const mockGetGeminiHooksStatus = vi.fn();
 const mockGetCodexHooksStatus = vi.fn();
 const mockGetOpenCodeHooksStatus = vi.fn();
-const mockExecGit = vi.fn();
 const mockGetHookServerUrl = vi.fn();
-const mockAddAiToolPatternsToGitExclude = vi.fn();
-const mockUpsertKanvibeHookTarget = vi.fn();
+const mockRegisterKanvibeHookTarget = vi.fn();
+const mockReadTextFiles = vi.fn();
+const mockWriteHookProviderFiles = vi.fn();
 
-vi.mock("@/lib/claudeHooksSetup", () => ({
+vi.mock("@/lib/claudeHooksSetup", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/claudeHooksSetup")>()),
   setupClaudeHooks: (...args: unknown[]) => mockSetupClaudeHooks(...args),
   getClaudeHooksStatus: (...args: unknown[]) => mockGetClaudeHooksStatus(...args),
-  generatePromptHookScript: vi.fn(() => "claude prompt"),
-  generateStopHookScript: vi.fn(() => "claude stop"),
-  generateQuestionHookScript: vi.fn(() => "claude question"),
 }));
 
-vi.mock("@/lib/geminiHooksSetup", () => ({
+vi.mock("@/lib/geminiHooksSetup", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/geminiHooksSetup")>()),
   setupGeminiHooks: (...args: unknown[]) => mockSetupGeminiHooks(...args),
   getGeminiHooksStatus: (...args: unknown[]) => mockGetGeminiHooksStatus(...args),
-  generatePromptHookScript: vi.fn(() => "gemini prompt"),
-  generateStopHookScript: vi.fn(() => "gemini stop"),
 }));
 
-vi.mock("@/lib/codexHooksSetup", () => ({
+vi.mock("@/lib/codexHooksSetup", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/codexHooksSetup")>()),
   setupCodexHooks: (...args: unknown[]) => mockSetupCodexHooks(...args),
   getCodexHooksStatus: (...args: unknown[]) => mockGetCodexHooksStatus(...args),
-  generatePromptHookScript: vi.fn(() => "codex prompt"),
-  generatePermissionHookScript: vi.fn(() => "codex permission"),
-  generatePreToolHookScript: vi.fn(() => "codex pre tool"),
-  generateStopHookScript: vi.fn(() => "codex stop"),
-  upsertCodexConfigToml: vi.fn((content: string) => `${content.trimEnd()}\n[features]\nhooks = true\n`),
-  upsertCodexHooksJson: vi.fn(() => JSON.stringify({ hooks: { UserPromptSubmit: [{}], PermissionRequest: [{}], PreToolUse: [{}], Stop: [{}] } }, null, 2)),
-  PROMPT_HOOK_SCRIPT_NAME: "kanvibe-prompt-hook.sh",
-  PERMISSION_HOOK_SCRIPT_NAME: "kanvibe-permission-hook.sh",
-  PRE_TOOL_HOOK_SCRIPT_NAME: "kanvibe-pre-tool-hook.sh",
-  STOP_HOOK_SCRIPT_NAME: "kanvibe-stop-hook.sh",
-  HOOKS_FILE_NAME: "hooks.json",
-  CONFIG_FILE_NAME: "config.toml",
 }));
 
-vi.mock("@/lib/openCodeHooksSetup", () => ({
+vi.mock("@/lib/openCodeHooksSetup", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/openCodeHooksSetup")>()),
   setupOpenCodeHooks: (...args: unknown[]) => mockSetupOpenCodeHooks(...args),
   getOpenCodeHooksStatus: (...args: unknown[]) => mockGetOpenCodeHooksStatus(...args),
-  generatePluginScript: vi.fn(() => "open code plugin"),
-  PLUGIN_DIR_NAME: "plugins",
-  PLUGIN_FILE_NAME: "kanvibe-plugin.ts",
-}));
-
-vi.mock("@/lib/gitOperations", () => ({
-  execGit: (...args: unknown[]) => mockExecGit(...args),
 }));
 
 vi.mock("@/lib/hookEndpoint", () => ({
   getHookServerUrl: (...args: unknown[]) => mockGetHookServerUrl(...args),
 }));
 
-vi.mock("@/lib/gitExclude", () => ({
-  addAiToolPatternsToGitExclude: (...args: unknown[]) => mockAddAiToolPatternsToGitExclude(...args),
+vi.mock("@/lib/hookTargetRegistration", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hookTargetRegistration")>()),
+  registerKanvibeHookTarget: (...args: unknown[]) => mockRegisterKanvibeHookTarget(...args),
 }));
 
-vi.mock("@/lib/kanvibeProjectState", () => ({
-  upsertKanvibeHookTarget: (...args: unknown[]) => mockUpsertKanvibeHookTarget(...args),
+vi.mock("@/lib/hookFileWriter", () => ({
+  writeHookProviderFiles: (...args: unknown[]) => mockWriteHookProviderFiles(...args),
 }));
 
-function extractWrittenContent(calls: unknown[][], filePath: string): string {
-  const targetCall = calls.find(([command]) => typeof command === "string"
-    && (command.includes(`> "${filePath}"`) || command.includes(`> '${filePath}'`)));
-  if (!targetCall) {
-    throw new Error(`write command not found for ${filePath}`);
-  }
+vi.mock("@/lib/hostFileAccess", () => ({
+  readTextFile: vi.fn(async () => ""),
+  readTextFiles: (...args: unknown[]) => mockReadTextFiles(...args),
+  writeTextFile: vi.fn(async () => undefined),
+  quoteShellArgument: (value: string) => `'${value}'`,
+}));
 
-  const command = targetCall[0] as string;
-  const escapedFilePath = filePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const encodedMatch = command.match(new RegExp(
-    `printf '%s' ['"]([^'"]+)['"] \\| \\(base64 -d 2>/dev/null \\|\\| base64 -D\\) > ['"]${escapedFilePath}['"]`,
-  ));
-  if (!encodedMatch) {
-    throw new Error(`base64 payload not found for ${filePath}`);
-  }
-
-  return Buffer.from(encodedMatch[1], "base64").toString("utf-8");
+function buildReadResults(files: Record<string, string> = {}): Map<string, TextFileReadResult> {
+  return new Map(Object.entries(files).map(([filePath, content]) => [filePath, { exists: true, content }]));
 }
 
-function buildRemoteTextFileRecords(files: Record<string, string>): string {
-  return Object.entries(files)
-    .map(([filePath, content]) => [
-      "__KANVIBE_FILE_RECORD__",
-      filePath,
-      "1",
-      Buffer.from(content, "utf-8").toString("base64"),
-    ].join("\t"))
-    .join("\n");
+/** 마지막 쓰기 배치에서 특정 경로의 파일 내용을 찾는다 */
+function findWrittenContent(filePath: string): string {
+  const writtenFiles = mockWriteHookProviderFiles.mock.calls.at(-1)?.[0] as ShellHookProviderFile[];
+  const file = writtenFiles?.find((candidate) => candidate.filePath === filePath);
+  if (!file) {
+    throw new Error(`write payload not found for ${filePath}`);
+  }
+
+  return file.content;
+}
+
+function getWrittenFilePaths(): string[] {
+  const writtenFiles = mockWriteHookProviderFiles.mock.calls.at(-1)?.[0] as ShellHookProviderFile[];
+  return (writtenFiles ?? []).map((file) => file.filePath);
 }
 
 describe("kanvibeHooksInstaller", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    mockSetupClaudeHooks.mockReset();
-    mockSetupGeminiHooks.mockReset();
-    mockSetupCodexHooks.mockReset();
-    mockSetupOpenCodeHooks.mockReset();
-    mockExecGit.mockReset();
-    mockGetHookServerUrl.mockReset();
-    mockAddAiToolPatternsToGitExclude.mockReset();
-    mockUpsertKanvibeHookTarget.mockReset();
     mockSetupClaudeHooks.mockResolvedValue(undefined);
     mockSetupGeminiHooks.mockResolvedValue(undefined);
     mockSetupCodexHooks.mockResolvedValue(undefined);
     mockSetupOpenCodeHooks.mockResolvedValue(undefined);
-    mockGetHookServerUrl.mockReturnValue("http://192.168.0.8:9736");
-    mockUpsertKanvibeHookTarget.mockResolvedValue(undefined);
-    mockExecGit.mockResolvedValue("");
-    mockAddAiToolPatternsToGitExclude.mockResolvedValue(undefined);
+    mockGetHookServerUrl.mockResolvedValue("http://192.168.0.8:9736");
+    mockRegisterKanvibeHookTarget.mockResolvedValue(undefined);
+    mockReadTextFiles.mockResolvedValue(buildReadResults());
+    mockWriteHookProviderFiles.mockResolvedValue(undefined);
     mockGetClaudeHooksStatus.mockResolvedValue({ installed: true });
     mockGetGeminiHooksStatus.mockResolvedValue({ installed: true });
     mockGetCodexHooksStatus.mockResolvedValue({ installed: true });
@@ -128,7 +100,7 @@ describe("kanvibeHooksInstaller", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
-  it("로컬 프로젝트면 기존 hook setup 함수들에 서버 URL을 전달한다", async () => {
+  it("전체 설치는 모든 provider hook 파일을 한 번의 쓰기 배치로 기록한다", async () => {
     // Given
     const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
 
@@ -136,16 +108,143 @@ describe("kanvibeHooksInstaller", () => {
     await installKanvibeHooks("/repo", "task-1", null);
 
     // Then
-    expect(mockSetupClaudeHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
-    expect(mockSetupGeminiHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
-    expect(mockSetupCodexHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
-    expect(mockSetupOpenCodeHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
-    expect(mockUpsertKanvibeHookTarget).toHaveBeenCalledWith(
+    expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(1);
+    expect(mockWriteHookProviderFiles).toHaveBeenCalledWith(expect.any(Array), null);
+    expect(getWrittenFilePaths()).toEqual(expect.arrayContaining([
+      "/repo/.claude/hooks/kanvibe-prompt-hook.sh",
+      "/repo/.claude/settings.json",
+      "/repo/.gemini/hooks/kanvibe-stop-hook.sh",
+      "/repo/.gemini/settings.json",
+      "/repo/.codex/hooks/kanvibe-permission-hook.sh",
+      "/repo/.codex/hooks.json",
+      "/repo/.codex/config.toml",
+      "/repo/.opencode/plugins/kanvibe-plugin.ts",
+    ]));
+  });
+
+  it("설치는 현재 client를 알림 대상으로 먼저 등록한다", async () => {
+    // Given
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    await installKanvibeHooks("/repo", "task-1", null);
+
+    // Then
+    expect(mockRegisterKanvibeHookTarget).toHaveBeenCalledWith(
       "/repo",
-      { url: "http://192.168.0.8:9736", taskId: "task-1" },
+      "task-1",
+      "http://192.168.0.8:9736",
       null,
     );
-    expect(mockExecGit).not.toHaveBeenCalled();
+    expect(mockRegisterKanvibeHookTarget.mock.invocationCallOrder[0]).toBeLessThan(
+      mockWriteHookProviderFiles.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("원격 설치도 같은 경로로 동작하며 sshHost를 쓰기 계층에 전달한다", async () => {
+    // Given
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
+
+    // Then
+    expect(mockGetHookServerUrl).toHaveBeenCalledWith("remote-host");
+    expect(mockWriteHookProviderFiles).toHaveBeenCalledWith(expect.any(Array), "remote-host");
+    expect(getWrittenFilePaths()).toContain("/remote/repo/.claude/settings.json");
+  });
+
+  it("기존 설정 파일은 provider별로 나눠 읽지 않고 한 번에 읽는다", async () => {
+    // Given
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
+
+    // Then
+    expect(mockReadTextFiles).toHaveBeenCalledTimes(1);
+    expect(mockReadTextFiles).toHaveBeenCalledWith([
+      "/remote/repo/.claude/settings.json",
+      "/remote/repo/.gemini/settings.json",
+      "/remote/repo/.codex/config.toml",
+      "/remote/repo/.codex/hooks.json",
+    ], "remote-host");
+  });
+
+  it("설치는 제거된 .kanvibe/hooks-targets.json을 읽거나 쓰지 않는다", async () => {
+    // Given
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
+
+    // Then
+    const readPaths = (mockReadTextFiles.mock.calls[0]?.[0] ?? []) as string[];
+    expect([...readPaths, ...getWrittenFilePaths()].join("\n")).not.toContain("hooks-targets.json");
+  });
+
+  it("stale한 Claude/Gemini hook entry는 재설치 시 현재 project 경로로 덮어쓴다", async () => {
+    // Given
+    mockReadTextFiles.mockResolvedValue(buildReadResults({
+      "/remote/repo/.claude/settings.json": JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [{ hooks: [{ type: "command", command: '"/tmp/old/.claude/hooks/kanvibe-prompt-hook.sh"', timeout: 10 }] }],
+          PreToolUse: [{ matcher: "AskUserQuestion", hooks: [{ type: "command", command: '"/tmp/old/.claude/hooks/kanvibe-question-hook.sh"', timeout: 10 }] }],
+          PostToolUse: [{ matcher: "AskUserQuestion", hooks: [{ type: "command", command: '"/tmp/old/.claude/hooks/kanvibe-prompt-hook.sh"', timeout: 10 }] }],
+          Stop: [{ hooks: [{ type: "command", command: '"/tmp/old/.claude/hooks/kanvibe-stop-hook.sh"', timeout: 10 }] }],
+        },
+      }),
+      "/remote/repo/.gemini/settings.json": JSON.stringify({
+        hooks: {
+          BeforeAgent: [{ matcher: "*", hooks: [{ type: "command", command: '"/tmp/old/.gemini/hooks/kanvibe-prompt-hook.sh"', timeout: 10000 }] }],
+          AfterAgent: [{ matcher: "*", hooks: [{ type: "command", command: '"/tmp/old/.gemini/hooks/kanvibe-stop-hook.sh"', timeout: 10000 }] }],
+        },
+      }),
+    }));
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
+
+    // Then
+    const claudeSettings = JSON.parse(findWrittenContent("/remote/repo/.claude/settings.json"));
+    expect(claudeSettings.hooks.UserPromptSubmit).toHaveLength(1);
+    expect(claudeSettings.hooks.UserPromptSubmit[0].hooks[0].command).toBe('"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh');
+    expect(claudeSettings.hooks.PreToolUse).toHaveLength(1);
+    expect(claudeSettings.hooks.PreToolUse[0].hooks[0].command).toBe('"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-question-hook.sh');
+    expect(claudeSettings.hooks.Stop).toHaveLength(1);
+    expect(claudeSettings.hooks.Stop[0].hooks[0].command).toBe('"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-stop-hook.sh');
+
+    const geminiSettings = JSON.parse(findWrittenContent("/remote/repo/.gemini/settings.json"));
+    expect(geminiSettings.hooks.BeforeAgent).toHaveLength(1);
+    expect(geminiSettings.hooks.BeforeAgent[0].hooks[0].command).toBe('"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-prompt-hook.sh');
+    expect(geminiSettings.hooks.AfterAgent).toHaveLength(1);
+    expect(geminiSettings.hooks.AfterAgent[0].hooks[0].command).toBe('"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-stop-hook.sh');
+  });
+
+  it("Codex 재설치는 기존 설정을 보존하면서 최신 hooks.json/config.toml 구조로 갱신한다", async () => {
+    // Given
+    mockReadTextFiles.mockResolvedValue(buildReadResults({
+      "/remote/repo/.codex/config.toml": 'model = "gpt-5"\nnotify = ["other-notify.sh"]\n',
+      "/remote/repo/.codex/hooks.json": JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: "command", command: "old-stop" }] }] } }),
+    }));
+    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+    // When
+    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
+
+    // Then
+    const configContent = findWrittenContent("/remote/repo/.codex/config.toml");
+    expect(configContent).toContain('model = "gpt-5"');
+    expect(configContent).toContain("[features]");
+    expect(configContent).toMatch(/^hooks = true$/m);
+    expect(configContent).not.toMatch(/^codex_hooks\s*=/m);
+
+    const hooksContent = findWrittenContent("/remote/repo/.codex/hooks.json");
+    expect(hooksContent).toContain("UserPromptSubmit");
+    expect(hooksContent).toContain("PermissionRequest");
+    expect(hooksContent).toContain("PreToolUse");
+    expect(hooksContent).toContain("Stop");
   });
 
   it("hook 파일 설치 API는 provider 검증을 기다리지 않는다", async () => {
@@ -156,15 +255,7 @@ describe("kanvibeHooksInstaller", () => {
     await installKanvibeHookFiles("/repo", "task-1", null);
 
     // Then
-    expect(mockSetupClaudeHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
-    expect(mockSetupGeminiHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
-    expect(mockSetupCodexHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
-    expect(mockSetupOpenCodeHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
-    expect(mockUpsertKanvibeHookTarget).toHaveBeenCalledWith(
-      "/repo",
-      { url: "http://192.168.0.8:9736", taskId: "task-1" },
-      null,
-    );
+    expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(1);
     expect(mockGetClaudeHooksStatus).not.toHaveBeenCalled();
     expect(mockGetGeminiHooksStatus).not.toHaveBeenCalled();
     expect(mockGetCodexHooksStatus).not.toHaveBeenCalled();
@@ -193,7 +284,6 @@ describe("kanvibeHooksInstaller", () => {
 
       // Then
       expect(mockGetClaudeHooksStatus).not.toHaveBeenCalled();
-      expect(mockSetupClaudeHooks).not.toHaveBeenCalled();
 
       await vi.runAllTimersAsync();
 
@@ -201,10 +291,7 @@ describe("kanvibeHooksInstaller", () => {
       expect(mockGetGeminiHooksStatus).toHaveBeenCalledWith("/remote/repo", "task-2", "remote-host");
       expect(mockGetCodexHooksStatus).toHaveBeenCalledWith("/remote/repo", "task-2", "remote-host");
       expect(mockGetOpenCodeHooksStatus).toHaveBeenCalledWith("/remote/repo", "task-2", "remote-host");
-      expect(mockSetupClaudeHooks).not.toHaveBeenCalled();
-      expect(mockSetupGeminiHooks).not.toHaveBeenCalled();
-      expect(mockSetupCodexHooks).not.toHaveBeenCalled();
-      expect(mockSetupOpenCodeHooks).not.toHaveBeenCalled();
+      expect(mockWriteHookProviderFiles).not.toHaveBeenCalled();
       expect(onSuccess).toHaveBeenCalledTimes(1);
       expect(onFailure).not.toHaveBeenCalled();
     } finally {
@@ -233,17 +320,16 @@ describe("kanvibeHooksInstaller", () => {
       // Then
       expect(onSuccess).not.toHaveBeenCalled();
       expect(onFailure).toHaveBeenCalledTimes(1);
-      expect(onFailure.mock.calls[0][0]).toEqual(expect.any(Error));
       expect((onFailure.mock.calls[0][0] as Error).message).toContain(
         "hooks 검증 실패: Codex(hasConfigEntry)",
       );
-      expect(mockSetupCodexHooks).not.toHaveBeenCalled();
+      expect(mockWriteHookProviderFiles).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("provider별 설치는 선택한 provider setup만 기다리고 다른 provider는 실행하지 않는다", async () => {
+  it("provider별 설치는 선택한 provider setup만 실행한다", async () => {
     // Given
     const { installKanvibeHookProvider } = await import("@/lib/kanvibeHooksInstaller");
 
@@ -251,15 +337,11 @@ describe("kanvibeHooksInstaller", () => {
     await installKanvibeHookProvider("/repo", "task-1", "codex", null);
 
     // Then
-    expect(mockSetupCodexHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736");
-    expect(mockUpsertKanvibeHookTarget).toHaveBeenCalledWith(
-      "/repo",
-      { url: "http://192.168.0.8:9736", taskId: "task-1" },
-      null,
-    );
+    expect(mockSetupCodexHooks).toHaveBeenCalledWith("/repo", "task-1", "http://192.168.0.8:9736", null);
     expect(mockSetupClaudeHooks).not.toHaveBeenCalled();
     expect(mockSetupGeminiHooks).not.toHaveBeenCalled();
     expect(mockSetupOpenCodeHooks).not.toHaveBeenCalled();
+    expect(mockWriteHookProviderFiles).not.toHaveBeenCalled();
   });
 
   it("OpenCode 등록만 누락된 상태는 전체 hook 설치 실패로 처리하지 않는다", async () => {
@@ -272,19 +354,17 @@ describe("kanvibeHooksInstaller", () => {
       hasPlugin: true,
       hasRegisteredPlugin: false,
       hasTaskIdBinding: true,
-      hasExpectedTaskId: true,
+      hasRegisteredHookTarget: true,
       hasStatusEndpoint: true,
       hasEventMappings: true,
       hasMainSessionGuard: true,
       hasDuplicateProgressGuard: true,
-      hasExpectedHookServerUrl: true,
     });
 
     const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
 
     // When & Then
     await expect(installKanvibeHooks("/repo", "task-1", null)).resolves.toBeUndefined();
-    expect(mockSetupOpenCodeHooks).toHaveBeenCalledTimes(1);
     expect(mockGetOpenCodeHooksStatus).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith("[hooks] OpenCode verification", expect.objectContaining({
       failedChecks: ["hasRegisteredPlugin"],
@@ -300,12 +380,11 @@ describe("kanvibeHooksInstaller", () => {
       hasPlugin: true,
       hasRegisteredPlugin: false,
       hasTaskIdBinding: true,
-      hasExpectedTaskId: true,
+      hasRegisteredHookTarget: true,
       hasStatusEndpoint: true,
       hasEventMappings: true,
       hasMainSessionGuard: true,
       hasDuplicateProgressGuard: true,
-      hasExpectedHookServerUrl: true,
     });
 
     const { installKanvibeHookProvider } = await import("@/lib/kanvibeHooksInstaller");
@@ -367,14 +446,14 @@ describe("kanvibeHooksInstaller", () => {
     }
   });
 
-  it("로컬 hook 설치가 일시적으로 실패하면 재시도 후 성공한다", async () => {
+  it("hook 파일 쓰기가 일시적으로 실패하면 재시도 후 성공한다", async () => {
     vi.useFakeTimers();
 
     try {
       // Given
-      mockSetupOpenCodeHooks
-        .mockRejectedValueOnce(new Error("open code busy"))
-        .mockResolvedValueOnce(undefined);
+      mockWriteHookProviderFiles
+        .mockRejectedValueOnce(new Error("remote host busy"))
+        .mockResolvedValue(undefined);
       const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
 
       // When
@@ -383,7 +462,27 @@ describe("kanvibeHooksInstaller", () => {
 
       // Then
       await result;
-      expect(mockSetupOpenCodeHooks).toHaveBeenCalledTimes(2);
+      expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("hook 파일 쓰기가 계속 실패하면 재시도 후 예외를 전파한다", async () => {
+    vi.useFakeTimers();
+
+    try {
+      // Given
+      mockWriteHookProviderFiles.mockRejectedValue(new Error("remote host unavailable"));
+      const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
+
+      // When
+      const result = expect(installKanvibeHooks("/remote/repo", "task-2", "remote-host")).rejects.toThrow("remote host unavailable");
+      await vi.runAllTimersAsync();
+
+      // Then
+      await result;
+      expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(3);
     } finally {
       vi.useRealTimers();
     }
@@ -391,9 +490,9 @@ describe("kanvibeHooksInstaller", () => {
 
   it("같은 target/task/host 동시 설치 요청은 하나의 설치 작업을 공유한다", async () => {
     // Given
-    let resolveClaudeInstall: (() => void) | undefined;
-    mockSetupClaudeHooks.mockImplementation(() => new Promise<void>((resolve) => {
-      resolveClaudeInstall = resolve;
+    let resolveHookFileWrite: (() => void) | undefined;
+    mockWriteHookProviderFiles.mockImplementation(() => new Promise<void>((resolve) => {
+      resolveHookFileWrite = resolve;
     }));
     const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
 
@@ -402,10 +501,11 @@ describe("kanvibeHooksInstaller", () => {
     const secondInstall = installKanvibeHooks("/repo", "task-1", null);
     await Promise.resolve();
     await Promise.resolve();
+    await Promise.resolve();
 
     // Then
-    expect(mockSetupClaudeHooks).toHaveBeenCalledTimes(1);
-    resolveClaudeInstall?.();
+    expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(1);
+    resolveHookFileWrite?.();
     await expect(Promise.all([firstInstall, secondInstall])).resolves.toEqual([undefined, undefined]);
   });
 
@@ -424,7 +524,7 @@ describe("kanvibeHooksInstaller", () => {
       await vi.runAllTimersAsync();
 
       // Then
-      expect(mockSetupClaudeHooks).toHaveBeenCalledTimes(1);
+      expect(mockWriteHookProviderFiles).toHaveBeenCalledTimes(1);
       expect(onSuccessA).toHaveBeenCalledTimes(1);
       expect(onSuccessB).toHaveBeenCalledTimes(1);
     } finally {
@@ -432,229 +532,8 @@ describe("kanvibeHooksInstaller", () => {
     }
   });
 
-  it("원격 프로젝트면 SSH 명령으로 hook 파일을 설치한다", async () => {
-    // Given
-    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
-
-    // When
-    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
-
-    // Then
-    expect(mockSetupClaudeHooks).not.toHaveBeenCalled();
-    expect(mockExecGit).toHaveBeenCalled();
-    expect(mockGetHookServerUrl).toHaveBeenCalledWith("remote-host");
-    expect(mockAddAiToolPatternsToGitExclude).toHaveBeenCalledWith("/remote/repo", "remote-host");
-  });
-
-  it("원격 프로젝트면 hooks 파일 설치 전에 git exclude도 함께 갱신한다", async () => {
-    // Given
-    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
-
-    // When
-    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
-
-    // Then
-    expect(mockAddAiToolPatternsToGitExclude).toHaveBeenCalledWith("/remote/repo", "remote-host");
-    expect(mockAddAiToolPatternsToGitExclude.mock.invocationCallOrder[0]).toBeLessThan(
-      mockExecGit.mock.invocationCallOrder[0],
-    );
-  });
-
-  it("원격 hook 설치는 제거된 .kanvibe/hooks-targets.json을 읽거나 쓰지 않는다", async () => {
-    // Given
-    mockExecGit.mockImplementation(async (command: string) => {
-      if (command.includes("__KANVIBE_FILE_RECORD__")) {
-        return buildRemoteTextFileRecords({
-          "/remote/repo/.kanvibe/hooks-targets.json": JSON.stringify({
-            version: 1,
-            targets: [
-              { url: "http://10.0.0.5:9736", taskId: "other-client-task" },
-            ],
-          }),
-        });
-      }
-
-      return "";
-    });
-    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
-
-    // When
-    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
-
-    // Then
-    const commands = mockExecGit.mock.calls.map(([command]) => String(command));
-    expect(commands.join("\n")).not.toContain("/remote/repo/.kanvibe/hooks-targets.json");
-  });
-
-  it.each([
-    ["claude", "/remote/repo/.claude/settings.json", "/remote/repo/.gemini/settings.json"],
-    ["gemini", "/remote/repo/.gemini/settings.json", "/remote/repo/.claude/settings.json"],
-    ["codex", "/remote/repo/.codex/hooks.json", "/remote/repo/.opencode/plugins/kanvibe-plugin.ts"],
-    ["openCode", "/remote/repo/.opencode/plugins/kanvibe-plugin.ts", "/remote/repo/.codex/hooks.json"],
-  ] as const)("원격 %s 단독 hook 설치도 target registry를 갱신하고 provider 파일만 쓴다", async (provider, expectedProviderFile, unexpectedProviderFile) => {
-    // Given
-    const { installKanvibeHookProvider } = await import("@/lib/kanvibeHooksInstaller");
-
-    // When
-    await installKanvibeHookProvider("/remote/repo", "task-2", provider, "remote-host");
-
-    // Then
-    const writeCommands = mockExecGit.mock.calls
-      .map(([command]) => String(command))
-      .filter((command) => command.includes("printf '%s'") && command.includes(" > "));
-    expect(writeCommands.join("\n")).toContain(expectedProviderFile);
-    expect(writeCommands.join("\n")).not.toContain(unexpectedProviderFile);
-    expect(writeCommands.join("\n")).not.toContain("/remote/repo/.kanvibe/hooks-targets.json");
-    expect(mockUpsertKanvibeHookTarget).toHaveBeenCalledWith(
-      "/remote/repo",
-      { url: "http://192.168.0.8:9736", taskId: "task-2" },
-      "remote-host",
-    );
-  });
-
-  it("원격 전체 hook 설치는 기존 설정 파일을 한 번의 SSH 명령으로 읽는다", async () => {
-    // Given
-    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
-
-    // When
-    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
-
-    // Then
-    const batchReadCommands = mockExecGit.mock.calls.filter(([command]) => typeof command === "string"
-      && command.includes("__KANVIBE_FILE_RECORD__"));
-    const individualReadCommands = mockExecGit.mock.calls.filter(([command]) => typeof command === "string"
-      && command.includes(" cat "));
-    const writeCommands = mockExecGit.mock.calls.filter(([command]) => typeof command === "string"
-      && command.includes("printf '%s'")
-      && command.includes(" > "));
-
-    expect(batchReadCommands).toHaveLength(1);
-    expect(individualReadCommands).toHaveLength(0);
-    expect(writeCommands).toHaveLength(4);
-  });
-
-  it("원격 Claude/Gemini stale hook entry도 재설치 시 현재 project 경로로 덮어쓴다", async () => {
-    mockExecGit.mockImplementation(async (command: string) => {
-      if (command.includes("__KANVIBE_FILE_RECORD__")) {
-        return buildRemoteTextFileRecords({
-          "/remote/repo/.claude/settings.json": JSON.stringify({
-            hooks: {
-              UserPromptSubmit: [{ hooks: [{ type: "command", command: '"/tmp/old/.claude/hooks/kanvibe-prompt-hook.sh"', timeout: 10 }] }],
-              PreToolUse: [{ matcher: "AskUserQuestion", hooks: [{ type: "command", command: '"/tmp/old/.claude/hooks/kanvibe-question-hook.sh"', timeout: 10 }] }],
-              PostToolUse: [{ matcher: "AskUserQuestion", hooks: [{ type: "command", command: '"/tmp/old/.claude/hooks/kanvibe-prompt-hook.sh"', timeout: 10 }] }],
-              Stop: [{ hooks: [{ type: "command", command: '"/tmp/old/.claude/hooks/kanvibe-stop-hook.sh"', timeout: 10 }] }],
-            },
-          }),
-          "/remote/repo/.gemini/settings.json": JSON.stringify({
-            hooks: {
-              BeforeAgent: [{ matcher: "*", hooks: [{ type: "command", command: '"/tmp/old/.gemini/hooks/kanvibe-prompt-hook.sh"', timeout: 10000 }] }],
-              AfterAgent: [{ matcher: "*", hooks: [{ type: "command", command: '"/tmp/old/.gemini/hooks/kanvibe-stop-hook.sh"', timeout: 10000 }] }],
-            },
-          }),
-        });
-      }
-
-      return "";
-    });
-
-    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
-
-    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
-
-    const claudeSettings = JSON.parse(extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.claude/settings.json"));
-    expect(claudeSettings.hooks.UserPromptSubmit).toHaveLength(1);
-    expect(claudeSettings.hooks.UserPromptSubmit[0].hooks[0].command).toBe('"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh');
-    expect(claudeSettings.hooks.PreToolUse).toHaveLength(1);
-    expect(claudeSettings.hooks.PreToolUse[0].hooks[0].command).toBe('"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-question-hook.sh');
-    expect(claudeSettings.hooks.Stop).toHaveLength(1);
-    expect(claudeSettings.hooks.Stop[0].hooks[0].command).toBe('"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-stop-hook.sh');
-
-    const geminiSettings = JSON.parse(extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.gemini/settings.json"));
-    expect(geminiSettings.hooks.BeforeAgent).toHaveLength(1);
-    expect(geminiSettings.hooks.BeforeAgent[0].hooks[0].command).toBe('"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-prompt-hook.sh');
-    expect(geminiSettings.hooks.AfterAgent).toHaveLength(1);
-    expect(geminiSettings.hooks.AfterAgent[0].hooks[0].command).toBe('"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-stop-hook.sh');
-  });
-
-  it("원격 Codex 재설치는 최신 hooks.json/config.toml 구조로 갱신한다", async () => {
-    mockExecGit.mockImplementation(async (command: string) => {
-      if (command.includes("__KANVIBE_FILE_RECORD__")) {
-        return buildRemoteTextFileRecords({
-          "/remote/repo/.codex/config.toml": 'model = "gpt-5"\nnotify = ["other-notify.sh"]\n',
-          "/remote/repo/.codex/hooks.json": JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: "command", command: "old-stop" }] }] } }),
-        });
-      }
-
-      return "";
-    });
-
-    const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
-
-    await installKanvibeHooks("/remote/repo", "task-2", "remote-host");
-
-    const configContent = extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.codex/config.toml");
-    expect(configContent).toContain('model = "gpt-5"');
-    expect(configContent).toContain("[features]");
-    expect(configContent).toMatch(/^hooks = true$/m);
-    expect(configContent).not.toMatch(/^codex_hooks\s*=/m);
-
-    const hooksContent = extractWrittenContent(mockExecGit.mock.calls, "/remote/repo/.codex/hooks.json");
-    expect(hooksContent).toContain("UserPromptSubmit");
-    expect(hooksContent).toContain("PermissionRequest");
-    expect(hooksContent).toContain("PreToolUse");
-    expect(hooksContent).toContain("Stop");
-  });
-
-  it("원격 hook 설치 중 SSH 쓰기가 계속 실패해도 모든 provider 쓰기를 시도한 뒤 예외를 전파한다", async () => {
-    vi.useFakeTimers();
-
-    try {
-      // Given
-      mockExecGit.mockImplementation(async (command: string) => {
-        if (command.includes("printf '%s'") && command.includes(" > ")) {
-          throw new Error("remote host unavailable");
-        }
-
-        return "";
-      });
-      const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
-
-      // When
-      const result = expect(installKanvibeHooks("/remote/repo", "task-2", "remote-host")).rejects.toThrow("remote host unavailable");
-      await vi.runAllTimersAsync();
-
-      // Then
-      await result;
-      const writeCommands = mockExecGit.mock.calls.filter(([command]) => typeof command === "string"
-        && command.includes("printf '%s'")
-        && command.includes(" > "));
-      expect(writeCommands).toHaveLength(12);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("로컬 hook 설치 중 하나라도 실패하면 예외를 전파한다", async () => {
-    vi.useFakeTimers();
-
-    try {
-      // Given
-      mockSetupOpenCodeHooks.mockRejectedValue(new Error("open code failed"));
-      const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
-
-      // When
-      const result = expect(installKanvibeHooks("/repo", "task-3", null)).rejects.toThrow("open code failed");
-      await vi.runAllTimersAsync();
-
-      // Then
-      await result;
-      expect(mockSetupOpenCodeHooks).toHaveBeenCalledTimes(3);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it("설치 후 provider별 검증 결과를 로그로 남긴다", async () => {
+    // Given
     mockGetClaudeHooksStatus.mockResolvedValue({ installed: true, hasSettingsEntry: true });
     mockGetGeminiHooksStatus.mockResolvedValue({ installed: true, hasSettingsEntry: true });
     mockGetCodexHooksStatus.mockResolvedValue({ installed: true, hasConfigEntry: true });
@@ -662,12 +541,11 @@ describe("kanvibeHooksInstaller", () => {
 
     const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
 
+    // When
     await installKanvibeHooks("/repo", "task-1", null);
 
+    // Then
     expect(mockGetClaudeHooksStatus).toHaveBeenCalledWith("/repo", "task-1", null);
-    expect(mockGetGeminiHooksStatus).toHaveBeenCalledWith("/repo", "task-1", null);
-    expect(mockGetCodexHooksStatus).toHaveBeenCalledWith("/repo", "task-1", null);
-    expect(mockGetOpenCodeHooksStatus).toHaveBeenCalledWith("/repo", "task-1", null);
     expect(console.log).toHaveBeenCalledWith("[hooks] Claude verification", expect.objectContaining({
       installed: true,
       targetPath: "/repo",
@@ -679,15 +557,18 @@ describe("kanvibeHooksInstaller", () => {
     vi.useFakeTimers();
 
     try {
+      // Given
       mockGetCodexHooksStatus.mockResolvedValue({ installed: false, hasConfigEntry: false });
 
       const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
 
+      // When
       const result = expect(installKanvibeHooks("/repo", "task-1", null)).rejects.toThrow(
         "hooks 검증 실패: Codex(hasConfigEntry)",
       );
       await vi.runAllTimersAsync();
 
+      // Then
       await result;
       expect(mockGetCodexHooksStatus).toHaveBeenCalledTimes(3);
       expect(console.warn).toHaveBeenCalledWith("[hooks] Codex verification", expect.objectContaining({
@@ -700,30 +581,27 @@ describe("kanvibeHooksInstaller", () => {
     }
   });
 
-  it("원격 설치는 SSH 기반 검증 로그를 기다린 뒤 반환한다", async () => {
-    let resolveClaudeVerification: (value: { installed: true; hasSettingsEntry: true }) => void = () => {};
+  it("원격 설치는 provider 검증이 끝난 뒤에 반환한다", async () => {
+    // Given
+    let resolveClaudeVerification: (value: { installed: true }) => void = () => {};
     mockGetClaudeHooksStatus.mockReturnValue(new Promise((resolve) => {
       resolveClaudeVerification = resolve;
     }));
-    mockGetGeminiHooksStatus.mockResolvedValue({ installed: true, hasSettingsEntry: true });
-    mockGetCodexHooksStatus.mockResolvedValue({ installed: true, hasConfigEntry: true });
-    mockGetOpenCodeHooksStatus.mockResolvedValue({ installed: true, hasRegisteredPlugin: true });
 
     const { installKanvibeHooks } = await import("@/lib/kanvibeHooksInstaller");
 
+    // When
     let resolved = false;
     const installPromise = installKanvibeHooks("/remote/repo", "task-2", "remote-host").then(() => {
       resolved = true;
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
+    // Then
     expect(mockGetClaudeHooksStatus).toHaveBeenCalledWith("/remote/repo", "task-2", "remote-host");
-    expect(mockGetGeminiHooksStatus).toHaveBeenCalledWith("/remote/repo", "task-2", "remote-host");
-    expect(mockGetCodexHooksStatus).toHaveBeenCalledWith("/remote/repo", "task-2", "remote-host");
-    expect(mockGetOpenCodeHooksStatus).toHaveBeenCalledWith("/remote/repo", "task-2", "remote-host");
     expect(resolved).toBe(false);
 
-    resolveClaudeVerification({ installed: true, hasSettingsEntry: true });
+    resolveClaudeVerification({ installed: true });
     await installPromise;
     expect(resolved).toBe(true);
   });

--- a/src/lib/__tests__/kanvibeProjectState.test.ts
+++ b/src/lib/__tests__/kanvibeProjectState.test.ts
@@ -16,13 +16,21 @@ import {
   buildKanvibeTaskStateContent,
   getKanvibeTargetsPath,
   getKanvibeTaskStatePath,
+  hasKanvibeHookTarget,
   parseKanvibeTargets,
   parseKanvibeTaskState,
+  parseProjectColor,
   parseTaskStatus,
+  readKanvibeProjectColor,
   readKanvibeTaskState,
   upsertKanvibeHookTarget,
-  writeKanvibeTaskState,
+  writeKanvibeProjectColor,
+  writeKanvibeTaskStatus,
 } from "@/lib/kanvibeProjectState";
+
+function getLastWrittenContent(): string {
+  return mockWriteTextFile.mock.calls.at(-1)?.[1] as string;
+}
 
 describe("kanvibeProjectState", () => {
   beforeEach(() => {
@@ -48,6 +56,29 @@ describe("kanvibeProjectState", () => {
     expect(content).not.toContain("url");
   });
 
+  it("status.json에 프로젝트 색상을 함께 담는다", () => {
+    const content = buildKanvibeTaskStateContent({
+      status: TaskStatus.PROGRESS,
+      projectColor: "#65D08A",
+    });
+
+    expect(JSON.parse(content)).toEqual({
+      schemaVersion: 1,
+      status: TaskStatus.PROGRESS,
+      updatedAt: expect.any(String),
+      projectColor: "#65D08A",
+    });
+  });
+
+  it("`#RRGGBB` 형태의 색상만 통과시킨다", () => {
+    expect(parseProjectColor("#65D08A")).toBe("#65D08A");
+    expect(parseProjectColor("  #65d08a  ")).toBe("#65d08a");
+    expect(parseProjectColor("65D08A")).toBeNull();
+    expect(parseProjectColor("#65D08")).toBeNull();
+    expect(parseProjectColor('#65D08A" ; rm -rf /')).toBeNull();
+    expect(parseProjectColor(42)).toBeNull();
+  });
+
   it("normalizes valid persisted task statuses and rejects unusable state files", () => {
     expect(parseTaskStatus("PROGRESS")).toBe(TaskStatus.PROGRESS);
     expect(parseTaskStatus(TaskStatus.PENDING)).toBe(TaskStatus.PENDING);
@@ -61,6 +92,11 @@ describe("kanvibeProjectState", () => {
       status: TaskStatus.REVIEW,
       updatedAt: "2026-06-03T00:00:00.000Z",
     });
+    expect(parseKanvibeTaskState(JSON.stringify({ schemaVersion: 1, status: "review", projectColor: "#65D08A" }))).toEqual({
+      schemaVersion: 1,
+      status: TaskStatus.REVIEW,
+      projectColor: "#65D08A",
+    });
     expect(parseKanvibeTaskState("DONE\n")).toEqual({
       schemaVersion: 1,
       status: TaskStatus.DONE,
@@ -72,20 +108,20 @@ describe("kanvibeProjectState", () => {
   });
 
   it("uses host-aware .kanvibe/status.json paths when reading and writing project status", async () => {
-    mockReadTextFile.mockResolvedValueOnce(JSON.stringify({ schemaVersion: 1, status: "pending" }));
+    mockReadTextFile.mockResolvedValue(JSON.stringify({ schemaVersion: 1, status: "pending" }));
     await expect(readKanvibeTaskState("/remote/repo", "ssh-host")).resolves.toEqual({
       schemaVersion: 1,
       status: TaskStatus.PENDING,
     });
     expect(mockReadTextFile).toHaveBeenCalledWith("/remote/repo/.kanvibe/status.json", "ssh-host");
 
-    await writeKanvibeTaskState("/remote/repo", { status: TaskStatus.DONE }, "ssh-host");
+    await writeKanvibeTaskStatus("/remote/repo", TaskStatus.DONE, "ssh-host");
     expect(mockWriteTextFile).toHaveBeenLastCalledWith(
       "/remote/repo/.kanvibe/status.json",
       expect.stringContaining('"status": "done"'),
       "ssh-host",
     );
-    const writtenContent = mockWriteTextFile.mock.calls.at(-1)?.[1] as string;
+    const writtenContent = getLastWrittenContent();
     expect(JSON.parse(writtenContent)).toEqual({
       schemaVersion: 1,
       status: TaskStatus.DONE,
@@ -98,19 +134,73 @@ describe("kanvibeProjectState", () => {
     expect(getKanvibeTaskStatePath("/local/repo")).toBe("/local/repo/.kanvibe/status.json");
   });
 
-  it("builds and parses .kanvibe/targets.json as url to task id mappings", () => {
+  it("상태를 갱신해도 다른 client가 기록한 프로젝트 색상은 보존한다", async () => {
+    mockReadTextFile.mockResolvedValue(JSON.stringify({
+      schemaVersion: 1,
+      status: "todo",
+      projectColor: "#65D08A",
+    }));
+
+    await writeKanvibeTaskStatus("/local/repo", TaskStatus.REVIEW);
+
+    expect(JSON.parse(getLastWrittenContent())).toEqual({
+      schemaVersion: 1,
+      status: TaskStatus.REVIEW,
+      updatedAt: expect.any(String),
+      projectColor: "#65D08A",
+    });
+  });
+
+  it("프로젝트 색상만 갱신할 때 기존 task 상태를 보존한다", async () => {
+    mockReadTextFile.mockResolvedValue(JSON.stringify({
+      schemaVersion: 1,
+      status: "progress",
+      projectColor: "#65D08A",
+    }));
+
+    await writeKanvibeProjectColor("/local/repo", "#0064FF");
+
+    expect(JSON.parse(getLastWrittenContent())).toEqual({
+      schemaVersion: 1,
+      status: TaskStatus.PROGRESS,
+      updatedAt: expect.any(String),
+      projectColor: "#0064FF",
+    });
+  });
+
+  it("status가 없는 status.json에서도 색상만 읽고 쓸 수 있다", async () => {
+    mockReadTextFile.mockResolvedValue("");
+    await writeKanvibeProjectColor("/local/repo", "#0064FF");
+    expect(JSON.parse(getLastWrittenContent())).toEqual({
+      schemaVersion: 1,
+      updatedAt: expect.any(String),
+      projectColor: "#0064FF",
+    });
+
+    mockReadTextFile.mockResolvedValue(JSON.stringify({ schemaVersion: 1, projectColor: "#0064FF" }));
+    await expect(readKanvibeProjectColor("/local/repo")).resolves.toBe("#0064FF");
+  });
+
+  it("형식이 잘못된 색상은 기록하지 않는다", async () => {
+    await writeKanvibeProjectColor("/local/repo", "not-a-color");
+
+    expect(mockWriteTextFile).not.toHaveBeenCalled();
+  });
+
+  it("builds and parses .kanvibe/targets.json as client url to task id mappings", () => {
     const content = buildKanvibeTargetsContent([
       { url: "http://127.0.0.1:19736/", taskId: "task-local" },
       { url: "http://127.0.0.1:19736", taskId: "task-dev" },
-      { url: "http://10.0.0.5:19736", taskId: "task-local" },
+      { url: "http://10.0.0.5:19736", taskId: "task-remote" },
     ]);
     const parsed = JSON.parse(content) as { schemaVersion?: unknown; targets?: unknown; updatedAt?: unknown };
 
+    /** 같은 client(url)는 하나로 합치고, 다른 client는 그대로 남긴다 */
     expect(parsed).toEqual({
       schemaVersion: 1,
       targets: [
         { url: "http://127.0.0.1:19736", taskId: "task-local" },
-        { url: "http://127.0.0.1:19736", taskId: "task-dev" },
+        { url: "http://10.0.0.5:19736", taskId: "task-remote" },
       ],
       updatedAt: expect.any(String),
     });
@@ -118,36 +208,60 @@ describe("kanvibeProjectState", () => {
     expect(parseKanvibeTargets("not-json")).toEqual({ schemaVersion: 1, targets: [] });
   });
 
-  it("upserts the current KanVibe hook target without dropping other clients", async () => {
-    mockReadTextFile.mockResolvedValueOnce(JSON.stringify({
+  it("같은 task를 보는 다른 client도 알림 대상으로 함께 남긴다", async () => {
+    mockReadTextFile.mockResolvedValue(JSON.stringify({
       schemaVersion: 1,
-      targets: [
-        { url: "http://127.0.0.1:19736", taskId: "origin-task" },
-        { url: "http://10.0.0.5:19736", taskId: "current-task" },
-      ],
+      targets: [{ url: "http://10.0.0.5:19736", taskId: "shared-task" }],
     }));
 
     await upsertKanvibeHookTarget(
       "/remote/repo",
-      { url: "http://127.0.0.1:19736/", taskId: "current-task" },
+      { url: "http://127.0.0.1:19736/", taskId: "shared-task" },
       "ssh-host",
     );
 
     expect(mockReadTextFile).toHaveBeenCalledWith("/remote/repo/.kanvibe/targets.json", "ssh-host");
-    expect(mockWriteTextFile).toHaveBeenCalledWith(
-      "/remote/repo/.kanvibe/targets.json",
-      expect.any(String),
-      "ssh-host",
-    );
-    const writtenContent = mockWriteTextFile.mock.calls.at(-1)?.[1] as string;
-    expect(JSON.parse(writtenContent)).toEqual({
+    expect(JSON.parse(getLastWrittenContent())).toEqual({
       schemaVersion: 1,
       targets: [
-        { url: "http://127.0.0.1:19736", taskId: "origin-task" },
-        { url: "http://127.0.0.1:19736", taskId: "current-task" },
+        { url: "http://10.0.0.5:19736", taskId: "shared-task" },
+        { url: "http://127.0.0.1:19736", taskId: "shared-task" },
+      ],
+      updatedAt: expect.any(String),
+    });
+  });
+
+  it("같은 client가 다른 task로 재설치하면 taskId만 교체한다", async () => {
+    mockReadTextFile.mockResolvedValue(JSON.stringify({
+      schemaVersion: 1,
+      targets: [
+        { url: "http://127.0.0.1:19736", taskId: "old-task" },
+        { url: "http://10.0.0.5:19736", taskId: "other-client-task" },
+      ],
+    }));
+
+    await upsertKanvibeHookTarget("/local/repo", { url: "http://127.0.0.1:19736", taskId: "new-task" });
+
+    expect(JSON.parse(getLastWrittenContent())).toEqual({
+      schemaVersion: 1,
+      targets: [
+        { url: "http://127.0.0.1:19736", taskId: "new-task" },
+        { url: "http://10.0.0.5:19736", taskId: "other-client-task" },
       ],
       updatedAt: expect.any(String),
     });
     expect(getKanvibeTargetsPath("/local/repo")).toBe("/local/repo/.kanvibe/targets.json");
+  });
+
+  it("client url과 taskId 쌍이 모두 맞아야 등록된 대상으로 본다", () => {
+    const content = JSON.stringify({
+      schemaVersion: 1,
+      targets: [{ url: "http://127.0.0.1:19736", taskId: "task-1" }],
+    });
+
+    expect(hasKanvibeHookTarget(content, { url: "http://127.0.0.1:19736/", taskId: "task-1" })).toBe(true);
+    expect(hasKanvibeHookTarget(content, { url: "http://127.0.0.1:19736", taskId: "task-2" })).toBe(false);
+    expect(hasKanvibeHookTarget(content, { url: "http://10.0.0.5:19736", taskId: "task-1" })).toBe(false);
+    expect(hasKanvibeHookTarget("", { url: "http://127.0.0.1:19736", taskId: "task-1" })).toBe(false);
   });
 });

--- a/src/lib/__tests__/kanvibeProjectState.test.ts
+++ b/src/lib/__tests__/kanvibeProjectState.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { TaskStatus } from "@/entities/KanbanTask";
 
-const { mockReadTextFile, mockWriteTextFile } = vi.hoisted(() => ({
+const { mockReadTextFile, mockWriteTextFile, mockWriteTextFileIfAbsent } = vi.hoisted(() => ({
   mockReadTextFile: vi.fn(),
   mockWriteTextFile: vi.fn(),
+  mockWriteTextFileIfAbsent: vi.fn(),
 }));
 
 vi.mock("@/lib/hostFileAccess", () => ({
   readTextFile: (...args: unknown[]) => mockReadTextFile(...args),
   writeTextFile: (...args: unknown[]) => mockWriteTextFile(...args),
+  writeTextFileIfAbsent: (...args: unknown[]) => mockWriteTextFileIfAbsent(...args),
 }));
 
 import {
@@ -27,6 +29,7 @@ import {
   readKanvibeTaskState,
   upsertKanvibeHookTarget,
   writeKanvibeProjectColor,
+  writeKanvibeProjectColorIfAbsent,
   writeKanvibeTaskStatus,
 } from "@/lib/kanvibeProjectState";
 
@@ -173,6 +176,24 @@ describe("kanvibeProjectState", () => {
     await writeKanvibeProjectColor("/local/repo", "not-a-color");
 
     expect(mockWriteTextFile).not.toHaveBeenCalled();
+  });
+
+  /** 씨앗 기록은 권위 파일을 만드는 것이지 이미 있는 값을 바꾸는 것이 아니다 */
+  it("씨앗 색상은 파일이 없을 때만 기록하는 경로로 쓴다", async () => {
+    await writeKanvibeProjectColorIfAbsent("/local/repo", "#0064FF");
+
+    expect(mockWriteTextFileIfAbsent).toHaveBeenLastCalledWith(
+      "/local/repo/.kanvibe/project.json",
+      expect.stringContaining("#0064FF"),
+      undefined,
+    );
+    expect(mockWriteTextFile).not.toHaveBeenCalled();
+  });
+
+  it("형식이 어긋난 씨앗 색상은 기록하지 않는다", async () => {
+    await writeKanvibeProjectColorIfAbsent("/local/repo", "not-a-color");
+
+    expect(mockWriteTextFileIfAbsent).not.toHaveBeenCalled();
   });
 
   it("builds and parses .kanvibe/targets.json as client url to task id mappings", () => {

--- a/src/lib/__tests__/kanvibeProjectState.test.ts
+++ b/src/lib/__tests__/kanvibeProjectState.test.ts
@@ -12,8 +12,10 @@ vi.mock("@/lib/hostFileAccess", () => ({
 }));
 
 import {
+  buildKanvibeProjectStateContent,
   buildKanvibeTargetsContent,
   buildKanvibeTaskStateContent,
+  getKanvibeProjectStatePath,
   getKanvibeTargetsPath,
   getKanvibeTaskStatePath,
   hasKanvibeHookTarget,
@@ -56,17 +58,17 @@ describe("kanvibeProjectState", () => {
     expect(content).not.toContain("url");
   });
 
-  it("status.json에 프로젝트 색상을 함께 담는다", () => {
-    const content = buildKanvibeTaskStateContent({
-      status: TaskStatus.PROGRESS,
-      projectColor: "#65D08A",
-    });
-
-    expect(JSON.parse(content)).toEqual({
+  it("프로젝트 색상은 status.json이 아니라 project.json에 담는다", () => {
+    expect(JSON.parse(buildKanvibeTaskStateContent({ status: TaskStatus.PROGRESS }))).toEqual({
       schemaVersion: 1,
       status: TaskStatus.PROGRESS,
       updatedAt: expect.any(String),
+    });
+
+    expect(JSON.parse(buildKanvibeProjectStateContent("#65D08A"))).toEqual({
+      schemaVersion: 1,
       projectColor: "#65D08A",
+      updatedAt: expect.any(String),
     });
   });
 
@@ -91,11 +93,6 @@ describe("kanvibeProjectState", () => {
       schemaVersion: 1,
       status: TaskStatus.REVIEW,
       updatedAt: "2026-06-03T00:00:00.000Z",
-    });
-    expect(parseKanvibeTaskState(JSON.stringify({ schemaVersion: 1, status: "review", projectColor: "#65D08A" }))).toEqual({
-      schemaVersion: 1,
-      status: TaskStatus.REVIEW,
-      projectColor: "#65D08A",
     });
     expect(parseKanvibeTaskState("DONE\n")).toEqual({
       schemaVersion: 1,
@@ -134,51 +131,42 @@ describe("kanvibeProjectState", () => {
     expect(getKanvibeTaskStatePath("/local/repo")).toBe("/local/repo/.kanvibe/status.json");
   });
 
-  it("상태를 갱신해도 다른 client가 기록한 프로젝트 색상은 보존한다", async () => {
-    mockReadTextFile.mockResolvedValue(JSON.stringify({
-      schemaVersion: 1,
-      status: "todo",
-      projectColor: "#65D08A",
-    }));
+  it("상태 기록과 색상 기록이 서로 다른 파일을 쓴다", async () => {
+    await writeKanvibeTaskStatus("/local/repo", TaskStatus.REVIEW);
+    expect(mockWriteTextFile).toHaveBeenLastCalledWith(
+      "/local/repo/.kanvibe/status.json",
+      expect.any(String),
+      undefined,
+    );
+    expect(getLastWrittenContent()).not.toContain("projectColor");
 
+    await writeKanvibeProjectColor("/local/repo", "#0064FF");
+    expect(mockWriteTextFile).toHaveBeenLastCalledWith(
+      "/local/repo/.kanvibe/project.json",
+      expect.any(String),
+      undefined,
+    );
+    expect(getLastWrittenContent()).not.toContain("status");
+  });
+
+  /** 상태 기록은 색상 파일을 읽지도 쓰지도 않으므로 동시 갱신이 서로를 되돌릴 수 없다 */
+  it("상태 기록은 읽기 없이 status.json만 덮어쓴다", async () => {
     await writeKanvibeTaskStatus("/local/repo", TaskStatus.REVIEW);
 
+    expect(mockReadTextFile).not.toHaveBeenCalled();
     expect(JSON.parse(getLastWrittenContent())).toEqual({
       schemaVersion: 1,
       status: TaskStatus.REVIEW,
       updatedAt: expect.any(String),
-      projectColor: "#65D08A",
     });
   });
 
-  it("프로젝트 색상만 갱신할 때 기존 task 상태를 보존한다", async () => {
-    mockReadTextFile.mockResolvedValue(JSON.stringify({
-      schemaVersion: 1,
-      status: "progress",
-      projectColor: "#65D08A",
-    }));
-
-    await writeKanvibeProjectColor("/local/repo", "#0064FF");
-
-    expect(JSON.parse(getLastWrittenContent())).toEqual({
-      schemaVersion: 1,
-      status: TaskStatus.PROGRESS,
-      updatedAt: expect.any(String),
-      projectColor: "#0064FF",
-    });
-  });
-
-  it("status가 없는 status.json에서도 색상만 읽고 쓸 수 있다", async () => {
-    mockReadTextFile.mockResolvedValue("");
-    await writeKanvibeProjectColor("/local/repo", "#0064FF");
-    expect(JSON.parse(getLastWrittenContent())).toEqual({
-      schemaVersion: 1,
-      updatedAt: expect.any(String),
-      projectColor: "#0064FF",
-    });
-
+  it("색상은 host 별 project.json 경로에서 읽고 쓴다", async () => {
     mockReadTextFile.mockResolvedValue(JSON.stringify({ schemaVersion: 1, projectColor: "#0064FF" }));
-    await expect(readKanvibeProjectColor("/local/repo")).resolves.toBe("#0064FF");
+    await expect(readKanvibeProjectColor("/remote/repo", "ssh-host")).resolves.toBe("#0064FF");
+    expect(mockReadTextFile).toHaveBeenCalledWith("/remote/repo/.kanvibe/project.json", "ssh-host");
+
+    expect(getKanvibeProjectStatePath("/local/repo")).toBe("/local/repo/.kanvibe/project.json");
   });
 
   it("형식이 잘못된 색상은 기록하지 않는다", async () => {

--- a/src/lib/__tests__/openCodeHooksSetup.test.ts
+++ b/src/lib/__tests__/openCodeHooksSetup.test.ts
@@ -57,7 +57,7 @@ describe("openCodeHooksSetup", () => {
       expect(pluginContent).toContain("status.json");
       expect(pluginContent).toContain("targets.json");
       expect(pluginContent).toContain("readKanvibeTargets");
-      expect(pluginContent).toContain("seenTaskIds");
+      expect(pluginContent).toContain("seenUrls");
       expect(pluginContent).not.toContain("hooks-targets.json");
       expect(pluginContent).not.toContain("task-state.json");
       expect(pluginContent).toContain("--git-common-dir");
@@ -302,7 +302,7 @@ export const KanvibePlugin: Plugin = async ({ $ }) => {
       expect(status.registeredPluginUrls).toHaveLength(2);
     });
 
-    it("현재 task id와 다른 OpenCode hook은 설치된 것으로 보지 않는다", async () => {
+    it("targets.json에 등록되지 않은 task는 설치된 것으로 보지 않는다", async () => {
       // Given
       const repoPath = tempDir;
       await setupOpenCodeHooks(repoPath, "task-1", "http://localhost:9736");
@@ -313,7 +313,7 @@ export const KanvibePlugin: Plugin = async ({ $ }) => {
       // Then
       expect(status.installed).toBe(false);
       expect(status.hasTaskIdBinding).toBe(true);
-      expect(status.hasExpectedTaskId).toBe(false);
+      expect(status.hasRegisteredHookTarget).toBe(false);
       expect(status.boundTaskId).toBe("task-1");
     });
   });

--- a/src/lib/__tests__/projectColor.test.ts
+++ b/src/lib/__tests__/projectColor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeProjectColor } from "@/lib/projectColor";
+import { computeProjectColor, getReadableTextColor } from "@/lib/projectColor";
 
 describe("computeProjectColor", () => {
   it("should return a valid hex color string", () => {
@@ -82,5 +82,39 @@ describe("computeProjectColor", () => {
 
     // Then
     expect(presetColors).toContain(result);
+  });
+});
+
+describe("getReadableTextColor", () => {
+  it("파스텔 프리셋 색상 위에서는 어두운 글자를 고른다", () => {
+    // Given
+    const presetColors = [
+      "#F9A8D4", "#93C5FD", "#86EFAC", "#C4B5FD",
+      "#FDBA74", "#FDE047", "#5EEAD4", "#A5B4FC",
+    ];
+
+    // When / Then
+    for (const color of presetColors) {
+      expect(getReadableTextColor(color)).toBe("#111827");
+    }
+  });
+
+  it("어두운 색상 위에서는 흰 글자를 고른다", () => {
+    // Given / When / Then
+    expect(getReadableTextColor("#0064FF")).toBe("#FFFFFF");
+    expect(getReadableTextColor("#000000")).toBe("#FFFFFF");
+    expect(getReadableTextColor("#202632")).toBe("#FFFFFF");
+  });
+
+  it("형식이 잘못된 색상은 어두운 글자로 처리한다", () => {
+    // Given / When / Then
+    expect(getReadableTextColor("not-a-color")).toBe("#111827");
+    expect(getReadableTextColor("#FFF")).toBe("#111827");
+    expect(getReadableTextColor("")).toBe("#111827");
+  });
+
+  it("앞뒤 공백이 있어도 배경 휘도를 그대로 판정한다", () => {
+    // Given / When / Then
+    expect(getReadableTextColor("  #000000  ")).toBe("#FFFFFF");
   });
 });

--- a/src/lib/__tests__/shellHookScript.test.ts
+++ b/src/lib/__tests__/shellHookScript.test.ts
@@ -11,7 +11,7 @@ import {
   extractShellTaskId,
   getShellTaskIdBindingStatus,
   hasShellKanvibeParallelTargetFanout,
-  hasShellKanvibeProjectColorPersistence,
+  hasShellKanvibeBoundedNotifyTimeout,
   hasShellKanvibeStatusJsonPersistence,
   hasShellKanvibeTargetFanout,
 } from "@/lib/shellHookScript";
@@ -127,12 +127,20 @@ describe("shellHookScript", () => {
     expect(hasShellKanvibeParallelTargetFanout(sequentialUpdater)).toBe(false);
   });
 
-  it("프로젝트 색상 보존 판정은 색상을 다시 쓰지 않는 hook을 거부한다", () => {
+  it("통보 타임아웃 판정은 상한 없는 curl hook을 거부한다", () => {
     const updater = buildShellKanvibeStatusUpdater("review");
-    const updaterWithoutColor = updater.replace(/\nKANVIBE_PROJECT_COLOR=[\s\S]*?esac\n/, "\n");
+    const unboundedUpdater = updater.replace("--max-time 3 ", "");
 
-    expect(hasShellKanvibeProjectColorPersistence(updater)).toBe(true);
-    expect(hasShellKanvibeProjectColorPersistence(updaterWithoutColor)).toBe(false);
+    expect(hasShellKanvibeBoundedNotifyTimeout(updater)).toBe(true);
+    expect(hasShellKanvibeBoundedNotifyTimeout(unboundedUpdater)).toBe(false);
+  });
+
+  /** hook은 색상 파일을 읽지도 쓰지도 않아 client의 색상 갱신과 경합하지 않는다 */
+  it("status 갱신 shell 조각은 프로젝트 색상을 건드리지 않는다", () => {
+    const updater = buildShellKanvibeStatusUpdater("review");
+
+    expect(updater).not.toContain("projectColor");
+    expect(updater).not.toContain("project.json");
   });
 
   it("node·user env 없이도 targets.json의 모든 client에 병렬로 status를 fan-out 한다", async () => {
@@ -158,7 +166,12 @@ describe("shellHookScript", () => {
       );
       await writeFile(
         join(repoPath, ".kanvibe", "status.json"),
-        JSON.stringify({ schemaVersion: 1, status: "todo", projectColor: "#65D08A" }),
+        JSON.stringify({ schemaVersion: 1, status: "todo" }),
+        "utf8",
+      );
+      await writeFile(
+        join(repoPath, ".kanvibe", "project.json"),
+        JSON.stringify({ schemaVersion: 1, projectColor: "#65D08A" }),
         "utf8",
       );
 
@@ -218,8 +231,13 @@ describe("shellHookScript", () => {
         await readFile(join(repoPath, ".kanvibe", "status.json"), "utf8"),
       ) as { status?: string; projectColor?: string };
       expect(status.status).toBe("review");
-      /** 다른 client가 정한 프로젝트 색상은 상태를 덮어써도 남아 있어야 한다 */
-      expect(status.projectColor).toBe("#65D08A");
+      expect(status.projectColor).toBeUndefined();
+
+      /** 색상은 별도 파일이므로 hook의 상태 기록이 건드리지 않는다 */
+      const projectState = JSON.parse(
+        await readFile(join(repoPath, ".kanvibe", "project.json"), "utf8"),
+      ) as { projectColor?: string };
+      expect(projectState.projectColor).toBe("#65D08A");
 
       const curlCalls = (await readFile(curlLogPath, "utf8"))
         .trim()

--- a/src/lib/__tests__/shellHookScript.test.ts
+++ b/src/lib/__tests__/shellHookScript.test.ts
@@ -10,9 +10,11 @@ import {
   buildShellTaskIdResolver,
   extractShellTaskId,
   getShellTaskIdBindingStatus,
+  hasShellKanvibeParallelTargetFanout,
+  hasShellKanvibeProjectColorPersistence,
   hasShellKanvibeStatusJsonPersistence,
   hasShellKanvibeTargetFanout,
-} from "@/lib/hookTaskBinding";
+} from "@/lib/shellHookScript";
 
 const execFileAsync = promisify(execFile);
 
@@ -47,7 +49,7 @@ function resolveRealBinary(name: string): string | null {
   return null;
 }
 
-describe("hookTaskBinding", () => {
+describe("shellHookScript", () => {
   it("shell resolver는 hook 파일 안에 task id를 직접 고정한다", () => {
     // Given
 
@@ -98,9 +100,9 @@ describe("hookTaskBinding", () => {
     expect(updater).toContain("/info/exclude");
     expect(updater).toContain(".kanvibe/");
     expect(updater).toContain("grep -qxF");
-    expect(updater).toContain('"schemaVersion":1');
-    expect(updater).toContain('"status":"%s"');
-    expect(updater).toContain('"updatedAt":"%s"');
+    expect(updater).toContain('\\"schemaVersion\\":1');
+    expect(updater).toContain('\\"status\\":\\"${KANVIBE_STATUS}\\"');
+    expect(updater).toContain('\\"updatedAt\\":\\"${KANVIBE_UPDATED_AT}\\"');
     expect(updater).toContain("${KANVIBE_TASK_STATE_FILE}");
     expect(updater).toContain("KANVIBE_TARGET_URL");
     expect(updater).toContain("KANVIBE_TARGET_TASK_ID");
@@ -117,7 +119,23 @@ describe("hookTaskBinding", () => {
     expect(hasShellKanvibeTargetFanout(updaterWithoutTargets)).toBe(false);
   });
 
-  it("node·user env 없이도 targets.json 대상별 task id로 status를 fan-out 한다", async () => {
+  it("병렬 fan-out 판정은 순차 curl 루프 hook을 거부한다", () => {
+    const updater = buildShellKanvibeStatusUpdater("review");
+    const sequentialUpdater = updater.replace("> /dev/null 2>&1 &", "> /dev/null 2>&1 || true");
+
+    expect(hasShellKanvibeParallelTargetFanout(updater)).toBe(true);
+    expect(hasShellKanvibeParallelTargetFanout(sequentialUpdater)).toBe(false);
+  });
+
+  it("프로젝트 색상 보존 판정은 색상을 다시 쓰지 않는 hook을 거부한다", () => {
+    const updater = buildShellKanvibeStatusUpdater("review");
+    const updaterWithoutColor = updater.replace(/\nKANVIBE_PROJECT_COLOR=[\s\S]*?esac\n/, "\n");
+
+    expect(hasShellKanvibeProjectColorPersistence(updater)).toBe(true);
+    expect(hasShellKanvibeProjectColorPersistence(updaterWithoutColor)).toBe(false);
+  });
+
+  it("node·user env 없이도 targets.json의 모든 client에 병렬로 status를 fan-out 한다", async () => {
     const repoPath = await mkdtemp(join(tmpdir(), "kanvibe-hook-nonode-"));
 
     try {
@@ -133,9 +151,14 @@ describe("hookTaskBinding", () => {
           schemaVersion: 1,
           targets: [
             { url: "http://127.0.0.1:9736/", taskId: "local-task" },
-            { url: "http://127.0.0.1:9736", taskId: "dev-task" },
+            { url: "http://10.0.0.5:9736", taskId: "dev-task" },
           ],
         }),
+        "utf8",
+      );
+      await writeFile(
+        join(repoPath, ".kanvibe", "status.json"),
+        JSON.stringify({ schemaVersion: 1, status: "todo", projectColor: "#65D08A" }),
         "utf8",
       );
 
@@ -193,28 +216,25 @@ describe("hookTaskBinding", () => {
 
       const status = JSON.parse(
         await readFile(join(repoPath, ".kanvibe", "status.json"), "utf8"),
-      ) as { status?: string };
+      ) as { status?: string; projectColor?: string };
       expect(status.status).toBe("review");
+      /** 다른 client가 정한 프로젝트 색상은 상태를 덮어써도 남아 있어야 한다 */
+      expect(status.projectColor).toBe("#65D08A");
 
       const curlCalls = (await readFile(curlLogPath, "utf8"))
         .trim()
         .split("\n")
         .filter((line) => line.length > 0);
-      const postedEndpoints = curlCalls.map((line) =>
-        line.split(/\s+/).find((token) => token.endsWith("/api/hooks/status")),
-      );
-      const payloads = curlCalls.map((line) => ({
+      /** 병렬 실행이므로 도착 순서는 보장되지 않는다. 집합으로 비교한다 */
+      const deliveries = curlCalls.map((line) => ({
+        endpoint: line.split(/\s+/).find((token) => token.endsWith("/api/hooks/status")),
         taskId: line.match(/"taskId":\s*"([^"]+)"/)?.[1],
         status: line.match(/"status":\s*"([^"]+)"/)?.[1],
-      }));
+      })).sort((left, right) => (left.taskId ?? "").localeCompare(right.taskId ?? ""));
 
-      expect(postedEndpoints).toEqual([
-        "http://127.0.0.1:9736/api/hooks/status",
-        "http://127.0.0.1:9736/api/hooks/status",
-      ]);
-      expect(payloads).toEqual([
-        { taskId: "local-task", status: "review" },
-        { taskId: "dev-task", status: "review" },
+      expect(deliveries).toEqual([
+        { endpoint: "http://10.0.0.5:9736/api/hooks/status", taskId: "dev-task", status: "review" },
+        { endpoint: "http://127.0.0.1:9736/api/hooks/status", taskId: "local-task", status: "review" },
       ]);
     } finally {
       await rm(repoPath, { recursive: true, force: true });
@@ -239,7 +259,7 @@ describe("hookTaskBinding", () => {
     expect(hasShellKanvibeStatusJsonPersistence(updaterWithoutCommonExclude)).toBe(false);
   });
 
-  it("모든 shell hook이 같은 현재 task id를 가리키는지 판정한다", () => {
+  it("모든 shell hook이 같은 fallback task id를 고정하는지 판정한다", () => {
     // Given
     const scripts = [
       ['TASK_ID="task-123"', 'curl -d "{\\"taskId\\": \\"${TASK_ID}\\"}"'].join("\n"),
@@ -247,36 +267,11 @@ describe("hookTaskBinding", () => {
     ];
 
     // When
-    const status = getShellTaskIdBindingStatus(scripts, "task-123");
-    const statusWithoutExpectedTask = getShellTaskIdBindingStatus(scripts);
+    const status = getShellTaskIdBindingStatus(scripts);
 
     // Then
     expect(status).toEqual({
       hasTaskIdBinding: true,
-      hasExpectedTaskId: true,
-      boundTaskId: "task-123",
-    });
-    expect(statusWithoutExpectedTask).toEqual({
-      hasTaskIdBinding: true,
-      hasExpectedTaskId: true,
-      boundTaskId: "task-123",
-    });
-  });
-
-  it("shell hook의 task id가 현재 task와 다르면 expected 판정을 실패시킨다", () => {
-    // Given
-    const scripts = [
-      ['TASK_ID="task-123"', 'curl -d "{\\"taskId\\": \\"${TASK_ID}\\"}"'].join("\n"),
-      ['TASK_ID="task-123"', 'curl -d "{\\"taskId\\": \\"${TASK_ID}\\"}"'].join("\n"),
-    ];
-
-    // When
-    const status = getShellTaskIdBindingStatus(scripts, "task-999");
-
-    // Then
-    expect(status).toEqual({
-      hasTaskIdBinding: true,
-      hasExpectedTaskId: false,
       boundTaskId: "task-123",
     });
   });
@@ -289,18 +284,16 @@ describe("hookTaskBinding", () => {
     ];
 
     // When
-    const status = getShellTaskIdBindingStatus(scripts, "task-123");
-    const emptyStatus = getShellTaskIdBindingStatus([], "task-123");
+    const status = getShellTaskIdBindingStatus(scripts);
+    const emptyStatus = getShellTaskIdBindingStatus([]);
 
     // Then
     expect(status).toEqual({
       hasTaskIdBinding: false,
-      hasExpectedTaskId: false,
       boundTaskId: null,
     });
     expect(emptyStatus).toEqual({
       hasTaskIdBinding: false,
-      hasExpectedTaskId: false,
       boundTaskId: null,
     });
   });

--- a/src/lib/claudeHooksSetup.ts
+++ b/src/lib/claudeHooksSetup.ts
@@ -1,305 +1,194 @@
-import { writeFile, mkdir, chmod } from "fs/promises";
-import path from "path";
-import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
-import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
-import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
+import { registerKanvibeHookTarget } from "@/lib/hookTargetRegistration";
+import { readTextFiles } from "@/lib/hostFileAccess";
+import { writeHookProviderFiles } from "@/lib/hookFileWriter";
 import {
-  buildShellKanvibeStatusUpdater,
-  buildShellTaskIdResolver,
-  getShellTaskIdBindingStatus,
-  hasShellKanvibeStatusJsonPersistence,
-  hasShellKanvibeTargetFanout,
-} from "@/lib/hookTaskBinding";
+  buildCommandHookEntry,
+  buildMatcherCommandHookEntry,
+  ensureJsonHookBuckets,
+  hasCommandHookEntry,
+  hasMatcherCommandHookEntry,
+  parseJsonHookSettings,
+  serializeJsonHookSettings,
+  upsertJsonHookEntries,
+} from "@/lib/jsonHookSettings";
+import {
+  buildShellHookScriptFiles,
+  generateShellHookScript,
+  isShellHookProviderInstalled,
+  readShellHookProviderState,
+  resolvePathModule,
+  type ShellHookProviderFile,
+  type ShellHookScriptDefinition,
+  type ShellHookScriptsStatus,
+} from "@/lib/shellHookProvider";
 
-/** UserPromptSubmit hook bash 스크립트를 생성한다 */
-export function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
-  return `#!/bin/bash
+const AGENT_LABEL = "Claude Code";
+const CONFIG_DIR_NAME = ".claude";
+const SETTINGS_FILE_NAME = "settings.json";
+const HOOK_TIMEOUT_SECONDS = 10;
+const ASK_USER_QUESTION_MATCHER = "AskUserQuestion";
 
-# KanVibe Claude Code Hook: UserPromptSubmit
-# 사용자가 prompt를 입력하면 현재 task를 PROGRESS로 변경한다.
+export const PROMPT_HOOK_SCRIPT_NAME = "kanvibe-prompt-hook.sh";
+export const STOP_HOOK_SCRIPT_NAME = "kanvibe-stop-hook.sh";
+export const QUESTION_HOOK_SCRIPT_NAME = "kanvibe-question-hook.sh";
 
-KANVIBE_URL="${kanvibeUrl}"
-${buildShellTaskIdResolver(taskId)}
-${buildShellKanvibeStatusUpdater("progress")}
+const CLAUDE_PROMPT_COMMAND = `"$CLAUDE_PROJECT_DIR"/${CONFIG_DIR_NAME}/hooks/${PROMPT_HOOK_SCRIPT_NAME}`;
+const CLAUDE_STOP_COMMAND = `"$CLAUDE_PROJECT_DIR"/${CONFIG_DIR_NAME}/hooks/${STOP_HOOK_SCRIPT_NAME}`;
+const CLAUDE_QUESTION_COMMAND = `"$CLAUDE_PROJECT_DIR"/${CONFIG_DIR_NAME}/hooks/${QUESTION_HOOK_SCRIPT_NAME}`;
 
-exit 0
-`;
-}
+const CLAUDE_HOOK_SCRIPTS: ShellHookScriptDefinition[] = [
+  {
+    fileName: PROMPT_HOOK_SCRIPT_NAME,
+    eventLabel: "UserPromptSubmit",
+    description: "사용자가 prompt를 입력하면 현재 task를 PROGRESS로 변경한다.",
+    status: "progress",
+  },
+  {
+    fileName: STOP_HOOK_SCRIPT_NAME,
+    eventLabel: "Stop",
+    description: "AI 응답이 완료되면 현재 task를 REVIEW로 변경한다.",
+    status: "review",
+  },
+  {
+    fileName: QUESTION_HOOK_SCRIPT_NAME,
+    eventLabel: `PreToolUse (${ASK_USER_QUESTION_MATCHER})`,
+    description: "Claude가 사용자에게 질문할 때 현재 task를 PENDING으로 변경한다.",
+    status: "pending",
+  },
+];
 
-/** Stop hook bash 스크립트를 생성한다 */
-export function generateStopHookScript(kanvibeUrl: string, taskId: string): string {
-  return `#!/bin/bash
-
-# KanVibe Claude Code Hook: Stop
-# AI 응답이 완료되면 현재 task를 REVIEW로 변경한다.
-
-KANVIBE_URL="${kanvibeUrl}"
-${buildShellTaskIdResolver(taskId)}
-${buildShellKanvibeStatusUpdater("review")}
-
-exit 0
-`;
-}
-
-/** PreToolUse(AskUserQuestion) hook bash 스크립트를 생성한다 */
-export function generateQuestionHookScript(kanvibeUrl: string, taskId: string): string {
-  return `#!/bin/bash
-
-# KanVibe Claude Code Hook: PreToolUse (AskUserQuestion)
-# Claude가 사용자에게 질문할 때 현재 task를 PENDING으로 변경한다.
-
-KANVIBE_URL="${kanvibeUrl}"
-${buildShellTaskIdResolver(taskId)}
-${buildShellKanvibeStatusUpdater("pending")}
-
-exit 0
-`;
-}
-
-interface ClaudeSettings {
-  hooks?: Record<string, unknown[]>;
-  [key: string]: unknown;
-}
-
-interface HookEntry {
-  hooks: { type: string; command: string; timeout: number }[];
-}
-
-interface MatcherHookEntry extends HookEntry {
-  matcher: string;
-}
-
-const CLAUDE_PROMPT_COMMAND = '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh';
-const CLAUDE_STOP_COMMAND = '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-stop-hook.sh';
-const CLAUDE_QUESTION_COMMAND = '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-question-hook.sh';
-
-/** 기존 settings.json을 읽거나 빈 객체를 반환한다 */
-async function readSettingsJson(settingsPath: string, sshHost?: string | null): Promise<ClaudeSettings> {
-  return parseSettingsJson(await readTextFile(settingsPath, sshHost));
-}
-
-function parseSettingsJson(content: string): ClaudeSettings {
-  if (!content) {
-    return {};
-  }
-
-  try {
-    return JSON.parse(content);
-  } catch {
-    return {};
-  }
-}
-
-/** 현재 bucket에 원하는 command hook이 정확히 등록되어 있는지 확인한다 */
-function hasCommandHook(hookEntries: unknown[], command: string): boolean {
-  if (!Array.isArray(hookEntries)) return false;
-  return hookEntries.some((entry) => {
-    const typed = entry as HookEntry;
-    return typed.hooks?.some((hook) => hook.type === "command" && hook.command === command);
-  });
-}
-
-function hasMatcherCommandHook(hookEntries: unknown[], matcher: string, command: string): boolean {
-  if (!Array.isArray(hookEntries)) return false;
-  return hookEntries.some((entry) => {
-    const typed = entry as MatcherHookEntry;
-    return typed.matcher === matcher && typed.hooks?.some((hook) => hook.type === "command" && hook.command === command);
-  });
-}
-
-function referencesScriptName(entry: unknown, scriptName: string): boolean {
-  return JSON.stringify(entry).includes(scriptName);
-}
-
-function upsertHookEntries<T>(hookEntries: unknown[] | undefined, scriptName: string, nextEntry: T): T[] {
-  const preservedEntries = Array.isArray(hookEntries)
-    ? hookEntries.filter((entry) => !referencesScriptName(entry, scriptName)) as T[]
-    : [];
-  preservedEntries.push(nextEntry);
-  return preservedEntries;
-}
-
-/**
- * 지정된 repo에 Claude Code hooks를 설정한다.
- * 기존 settings.json이 있으면 kanvibe hooks만 추가하고 나머지는 보존한다.
- */
-export async function setupClaudeHooks(
-  repoPath: string,
-  taskId: string,
-  kanvibeUrl: string,
-): Promise<void> {
-  const claudeDir = path.join(repoPath, ".claude");
-  const hooksDir = path.join(claudeDir, "hooks");
-  const settingsPath = path.join(claudeDir, "settings.json");
-
-  await mkdir(hooksDir, { recursive: true });
-
-  const promptScriptPath = path.join(hooksDir, "kanvibe-prompt-hook.sh");
-  const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
-  const questionScriptPath = path.join(hooksDir, "kanvibe-question-hook.sh");
-
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId), "utf-8");
-  await writeFile(questionScriptPath, generateQuestionHookScript(kanvibeUrl, taskId), "utf-8");
-  await chmod(promptScriptPath, 0o755);
-  await chmod(stopScriptPath, 0o755);
-  await chmod(questionScriptPath, 0o755);
-
-  const settings = await readSettingsJson(settingsPath);
-  if (!settings.hooks) {
-    settings.hooks = {};
-  }
-
-  const hooks = settings.hooks as Record<string, unknown[]>;
-
-  hooks.UserPromptSubmit = upsertHookEntries<HookEntry>(hooks.UserPromptSubmit, "kanvibe-prompt-hook.sh", {
-    hooks: [
-      {
-        type: "command",
-        command: CLAUDE_PROMPT_COMMAND,
-        timeout: 10,
-      },
-    ],
-  });
-
-  hooks.PreToolUse = upsertHookEntries<MatcherHookEntry>(hooks.PreToolUse, "kanvibe-question-hook.sh", {
-    matcher: "AskUserQuestion",
-    hooks: [
-      {
-        type: "command",
-        command: CLAUDE_QUESTION_COMMAND,
-        timeout: 10,
-      },
-    ],
-  });
-
-  hooks.PostToolUse = upsertHookEntries<MatcherHookEntry>(hooks.PostToolUse, "kanvibe-prompt-hook.sh", {
-    matcher: "AskUserQuestion",
-    hooks: [
-      {
-        type: "command",
-        command: CLAUDE_PROMPT_COMMAND,
-        timeout: 10,
-      },
-    ],
-  });
-
-  hooks.Stop = upsertHookEntries<HookEntry>(hooks.Stop, "kanvibe-stop-hook.sh", {
-    hooks: [
-      {
-        type: "command",
-        command: CLAUDE_STOP_COMMAND,
-        timeout: 10,
-      },
-    ],
-  });
-
-  await writeFile(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
-
-  try {
-    await addAiToolPatternsToGitExclude(repoPath);
-  } catch (error) {
-    console.error("git exclude 패턴 추가 실패:", error);
-  }
-}
-
-export interface ClaudeHooksStatus {
+export interface ClaudeHooksStatus extends Partial<ShellHookScriptsStatus> {
   installed: boolean;
   hasPromptHook: boolean;
   hasStopHook: boolean;
   hasQuestionHook: boolean;
   hasSettingsEntry: boolean;
-  hasTaskIdBinding?: boolean;
-  hasExpectedTaskId?: boolean;
-  hasStatusMappings?: boolean;
-  hasStatusJsonPersistence?: boolean;
-  hasTargetFanout?: boolean;
-  hasExpectedHookServerUrl?: boolean;
-  hasReachableHookServer?: boolean;
-  boundTaskId?: string | null;
-  configuredHookServerUrl?: string | null;
-  expectedHookServerUrl?: string | null;
+}
+
+/** UserPromptSubmit hook bash 스크립트를 생성한다 */
+export function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
+  return generateShellHookScript(AGENT_LABEL, CLAUDE_HOOK_SCRIPTS[0], kanvibeUrl, taskId);
+}
+
+/** Stop hook bash 스크립트를 생성한다 */
+export function generateStopHookScript(kanvibeUrl: string, taskId: string): string {
+  return generateShellHookScript(AGENT_LABEL, CLAUDE_HOOK_SCRIPTS[1], kanvibeUrl, taskId);
+}
+
+/** PreToolUse(AskUserQuestion) hook bash 스크립트를 생성한다 */
+export function generateQuestionHookScript(kanvibeUrl: string, taskId: string): string {
+  return generateShellHookScript(AGENT_LABEL, CLAUDE_HOOK_SCRIPTS[2], kanvibeUrl, taskId);
+}
+
+/** 설치 파일을 만들기 전에 읽어야 하는 기존 설정 파일 경로 */
+export function getClaudeHookInstallInputPaths(repoPath: string, sshHost?: string | null): string[] {
+  return [getClaudeSettingsPath(repoPath, sshHost)];
+}
+
+/**
+ * Claude Code hooks 설치 산출물을 만든다.
+ * 기존 settings.json이 있으면 kanvibe hooks 항목만 갱신하고 나머지는 보존한다.
+ */
+export function buildClaudeHookFiles(
+  repoPath: string,
+  taskId: string,
+  kanvibeUrl: string,
+  settingsContent: string,
+  sshHost?: string | null,
+): ShellHookProviderFile[] {
+  const pathModule = resolvePathModule(sshHost);
+  const hooksDir = pathModule.join(repoPath, CONFIG_DIR_NAME, "hooks");
+  const settings = parseJsonHookSettings(settingsContent);
+  const hooks = ensureJsonHookBuckets(settings);
+
+  hooks.UserPromptSubmit = upsertJsonHookEntries(
+    hooks.UserPromptSubmit,
+    PROMPT_HOOK_SCRIPT_NAME,
+    buildCommandHookEntry(CLAUDE_PROMPT_COMMAND, HOOK_TIMEOUT_SECONDS),
+  );
+  hooks.PreToolUse = upsertJsonHookEntries(
+    hooks.PreToolUse,
+    QUESTION_HOOK_SCRIPT_NAME,
+    buildMatcherCommandHookEntry(ASK_USER_QUESTION_MATCHER, CLAUDE_QUESTION_COMMAND, HOOK_TIMEOUT_SECONDS),
+  );
+  hooks.PostToolUse = upsertJsonHookEntries(
+    hooks.PostToolUse,
+    PROMPT_HOOK_SCRIPT_NAME,
+    buildMatcherCommandHookEntry(ASK_USER_QUESTION_MATCHER, CLAUDE_PROMPT_COMMAND, HOOK_TIMEOUT_SECONDS),
+  );
+  hooks.Stop = upsertJsonHookEntries(
+    hooks.Stop,
+    STOP_HOOK_SCRIPT_NAME,
+    buildCommandHookEntry(CLAUDE_STOP_COMMAND, HOOK_TIMEOUT_SECONDS),
+  );
+
+  return [
+    ...buildShellHookScriptFiles(hooksDir, AGENT_LABEL, CLAUDE_HOOK_SCRIPTS, kanvibeUrl, taskId, sshHost),
+    {
+      filePath: getClaudeSettingsPath(repoPath, sshHost),
+      content: serializeJsonHookSettings(settings),
+    },
+  ];
+}
+
+/** 지정된 repo에 Claude Code hooks를 설정한다. 로컬과 원격 repo 모두 같은 산출물을 기록한다 */
+export async function setupClaudeHooks(
+  repoPath: string,
+  taskId: string,
+  kanvibeUrl: string,
+  sshHost?: string | null,
+): Promise<void> {
+  const settingsPath = getClaudeSettingsPath(repoPath, sshHost);
+  const existingFiles = await readTextFiles([settingsPath], sshHost);
+
+  await writeHookProviderFiles(
+    buildClaudeHookFiles(repoPath, taskId, kanvibeUrl, existingFiles.get(settingsPath)?.content ?? "", sshHost),
+    sshHost,
+  );
+
+  await registerKanvibeHookTarget(repoPath, taskId, kanvibeUrl, sshHost);
 }
 
 /** 지정된 repo의 Claude Code hooks 설치 상태를 확인한다 */
-export async function getClaudeHooksStatus(repoPath: string, taskId?: string, sshHost?: string | null): Promise<ClaudeHooksStatus> {
-  const pathModule = sshHost ? path.posix : path;
-  const claudeDir = pathModule.join(repoPath, ".claude");
-  const hooksDir = pathModule.join(claudeDir, "hooks");
-  const settingsPath = pathModule.join(claudeDir, "settings.json");
-  const promptScriptPath = pathModule.join(hooksDir, "kanvibe-prompt-hook.sh");
-  const stopScriptPath = pathModule.join(hooksDir, "kanvibe-stop-hook.sh");
-  const questionScriptPath = pathModule.join(hooksDir, "kanvibe-question-hook.sh");
-
-  const files = await readTextFiles([
-    promptScriptPath,
-    stopScriptPath,
-    questionScriptPath,
-    settingsPath,
-  ], sshHost);
-  const promptScript = files.get(promptScriptPath) ?? { exists: false, content: "" };
-  const stopScript = files.get(stopScriptPath) ?? { exists: false, content: "" };
-  const questionScript = files.get(questionScriptPath) ?? { exists: false, content: "" };
-  const settingsFile = files.get(settingsPath) ?? { exists: false, content: "" };
-  const promptContent = promptScript.content;
-  const stopContent = stopScript.content;
-  const questionContent = questionScript.content;
-
-  const scriptContents = [promptContent, stopContent, questionContent];
-  const { boundTaskId, hasTaskIdBinding, hasExpectedTaskId } = getShellTaskIdBindingStatus(scriptContents, taskId);
-  const hookServerValidation = await validateHookServerConfiguration(
-    scriptContents.map(extractShellHookServerUrl),
-    Boolean(taskId),
+export async function getClaudeHooksStatus(
+  repoPath: string,
+  taskId?: string,
+  sshHost?: string | null,
+): Promise<ClaudeHooksStatus> {
+  const settingsPath = getClaudeSettingsPath(repoPath, sshHost);
+  const state = await readShellHookProviderState({
+    repoPath,
+    hooksDir: resolvePathModule(sshHost).join(repoPath, CONFIG_DIR_NAME, "hooks"),
+    definitions: CLAUDE_HOOK_SCRIPTS,
+    extraFilePaths: [settingsPath],
+    taskId,
     sshHost,
-  );
-  const hasStatusMappings =
-    promptContent.includes('\\\"status\\\": \\\"progress\\\"') &&
-    stopContent.includes('\\\"status\\\": \\\"review\\\"') &&
-    questionContent.includes('\\\"status\\\": \\\"pending\\\"');
-  const hasStatusJsonPersistence = scriptContents.every(hasShellKanvibeStatusJsonPersistence);
-  const hasTargetFanout = scriptContents.every(hasShellKanvibeTargetFanout);
-
-  let hasSettingsEntry = false;
-  try {
-    const settings = parseSettingsJson(settingsFile.content);
-    const hooks = settings.hooks as Record<string, unknown[]> | undefined;
-    if (hooks) {
-      const hasPrompt = hasCommandHook(hooks.UserPromptSubmit || [], CLAUDE_PROMPT_COMMAND);
-      const hasStop = hasCommandHook(hooks.Stop || [], CLAUDE_STOP_COMMAND);
-      const hasQuestion = hasMatcherCommandHook(hooks.PreToolUse || [], "AskUserQuestion", CLAUDE_QUESTION_COMMAND);
-      const hasAnswerResume = hasMatcherCommandHook(hooks.PostToolUse || [], "AskUserQuestion", CLAUDE_PROMPT_COMMAND);
-      hasSettingsEntry = hasPrompt && hasStop && hasQuestion && hasAnswerResume;
-    }
-  } catch {
-    /* settings.json 없음 */
-  }
-
-  const installed = promptScript.exists
-    && stopScript.exists
-    && questionScript.exists
-    && hasSettingsEntry
-    && hasTaskIdBinding
-    && hasExpectedTaskId
-    && hasStatusMappings
-    && hasStatusJsonPersistence
-    && hasTargetFanout
-    && hookServerValidation.hasExpectedHookServerUrl;
+  });
+  const [promptScript, stopScript, questionScript] = state.scriptFiles;
+  const hasSettingsEntry = hasClaudeSettingsEntry(state.files.get(settingsPath)?.content ?? "");
 
   return {
-    installed,
+    installed: isShellHookProviderInstalled(state, [hasSettingsEntry]),
     hasPromptHook: promptScript.exists,
     hasStopHook: stopScript.exists,
     hasQuestionHook: questionScript.exists,
     hasSettingsEntry,
-    hasTaskIdBinding,
-    hasExpectedTaskId,
-    hasStatusMappings,
-    hasStatusJsonPersistence,
-    hasTargetFanout,
-    hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
-    hasReachableHookServer: hookServerValidation.hasReachableHookServer,
-    boundTaskId,
-    configuredHookServerUrl: hookServerValidation.configuredHookServerUrl,
-    expectedHookServerUrl: hookServerValidation.expectedHookServerUrl,
+    ...state.status,
   };
+}
+
+function hasClaudeSettingsEntry(settingsContent: string): boolean {
+  const hooks = parseJsonHookSettings(settingsContent).hooks;
+  if (!hooks) {
+    return false;
+  }
+
+  return hasCommandHookEntry(hooks.UserPromptSubmit || [], CLAUDE_PROMPT_COMMAND)
+    && hasCommandHookEntry(hooks.Stop || [], CLAUDE_STOP_COMMAND)
+    && hasMatcherCommandHookEntry(hooks.PreToolUse || [], ASK_USER_QUESTION_MATCHER, CLAUDE_QUESTION_COMMAND)
+    && hasMatcherCommandHookEntry(hooks.PostToolUse || [], ASK_USER_QUESTION_MATCHER, CLAUDE_PROMPT_COMMAND);
+}
+
+function getClaudeSettingsPath(repoPath: string, sshHost?: string | null): string {
+  return resolvePathModule(sshHost).join(repoPath, CONFIG_DIR_NAME, SETTINGS_FILE_NAME);
 }

--- a/src/lib/codexHooksSetup.ts
+++ b/src/lib/codexHooksSetup.ts
@@ -1,33 +1,36 @@
-import { writeFile, mkdir, chmod } from "fs/promises";
-import path from "path";
-import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
-import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
-import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
+import { registerKanvibeHookTarget } from "@/lib/hookTargetRegistration";
+import { readTextFiles } from "@/lib/hostFileAccess";
+import { writeHookProviderFiles } from "@/lib/hookFileWriter";
 import {
-  buildShellKanvibeStatusUpdater,
-  buildShellTaskIdResolver,
-  getShellTaskIdBindingStatus,
-  hasShellKanvibeStatusJsonPersistence,
-  hasShellKanvibeTargetFanout,
-} from "@/lib/hookTaskBinding";
+  buildCommandHookEntry,
+  buildMatcherCommandHookEntry,
+  ensureJsonHookBuckets,
+  hasCommandHookEntry,
+  hasMatcherCommandHookEntry,
+  parseJsonHookSettings,
+  serializeJsonHookSettings,
+  upsertJsonHookEntries,
+} from "@/lib/jsonHookSettings";
+import {
+  buildShellHookScriptFiles,
+  generateShellHookScript,
+  isShellHookProviderInstalled,
+  readShellHookProviderState,
+  resolvePathModule,
+  type ShellHookProviderFile,
+  type ShellHookScriptDefinition,
+  type ShellHookScriptsStatus,
+} from "@/lib/shellHookProvider";
 
 /**
  * Codex CLI 최신 hooks 설정은 `.codex/config.toml`의 hooks feature flag와
  * `.codex/hooks.json` 조합을 사용한다.
  */
-
-interface CodexHooksFile {
-  hooks?: Record<string, unknown[]>;
-  [key: string]: unknown;
-}
-
-interface HookEntry {
-  hooks: { type: string; command: string; timeout: number }[];
-}
-
-interface MatcherHookEntry extends HookEntry {
-  matcher: string;
-}
+const AGENT_LABEL = "Codex";
+const CONFIG_DIR_NAME = ".codex";
+const HOOK_TIMEOUT_SECONDS = 10;
+const BASH_MATCHER = "Bash";
+const CODEX_HOOKS_FEATURE_FLAG = "hooks";
 
 export const CONFIG_FILE_NAME = "config.toml";
 export const HOOKS_FILE_NAME = "hooks.json";
@@ -36,114 +39,209 @@ export const PERMISSION_HOOK_SCRIPT_NAME = "kanvibe-permission-hook.sh";
 export const PRE_TOOL_HOOK_SCRIPT_NAME = "kanvibe-pre-tool-hook.sh";
 export const STOP_HOOK_SCRIPT_NAME = "kanvibe-stop-hook.sh";
 
-const CODEX_PROMPT_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hooks/${PROMPT_HOOK_SCRIPT_NAME}"`;
-const CODEX_PERMISSION_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hooks/${PERMISSION_HOOK_SCRIPT_NAME}"`;
-const CODEX_PRE_TOOL_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hooks/${PRE_TOOL_HOOK_SCRIPT_NAME}"`;
-const CODEX_STOP_COMMAND = `bash "$(git rev-parse --show-toplevel)/.codex/hooks/${STOP_HOOK_SCRIPT_NAME}"`;
-const CODEX_HOOKS_FEATURE_FLAG = "hooks";
+const CODEX_PROMPT_COMMAND = buildCodexHookCommand(PROMPT_HOOK_SCRIPT_NAME);
+const CODEX_PERMISSION_COMMAND = buildCodexHookCommand(PERMISSION_HOOK_SCRIPT_NAME);
+const CODEX_PRE_TOOL_COMMAND = buildCodexHookCommand(PRE_TOOL_HOOK_SCRIPT_NAME);
+const CODEX_STOP_COMMAND = buildCodexHookCommand(STOP_HOOK_SCRIPT_NAME);
 
-function generateStatusHookScript(
-  eventLabel: string,
-  description: string,
-  status: "progress" | "pending" | "review",
-  kanvibeUrl: string,
-  taskId: string,
-): string {
-  return `#!/bin/bash
+const CODEX_HOOK_SCRIPTS: ShellHookScriptDefinition[] = [
+  {
+    fileName: PROMPT_HOOK_SCRIPT_NAME,
+    eventLabel: "UserPromptSubmit",
+    description: "사용자가 prompt를 입력하면 현재 task를 PROGRESS로 변경한다.",
+    status: "progress",
+  },
+  {
+    fileName: PERMISSION_HOOK_SCRIPT_NAME,
+    eventLabel: `PermissionRequest(${BASH_MATCHER})`,
+    description: "Codex가 Bash 실행 승인을 요청하면 현재 task를 PENDING으로 변경한다.",
+    status: "pending",
+  },
+  {
+    fileName: PRE_TOOL_HOOK_SCRIPT_NAME,
+    eventLabel: `PreToolUse(${BASH_MATCHER})`,
+    description: "Codex가 Bash 실행을 재개하면 현재 task를 PROGRESS로 변경한다.",
+    status: "progress",
+  },
+  {
+    fileName: STOP_HOOK_SCRIPT_NAME,
+    eventLabel: "Stop",
+    description: "Codex 응답이 완료되면 현재 task를 REVIEW로 변경한다.",
+    status: "review",
+  },
+];
 
-# KanVibe Codex Hook: ${eventLabel}
-# ${description}
-
-KANVIBE_URL="${kanvibeUrl}"
-${buildShellTaskIdResolver(taskId)}
-${buildShellKanvibeStatusUpdater(status)}
-
-exit 0
-`;
+export interface CodexHooksStatus extends Partial<ShellHookScriptsStatus> {
+  installed: boolean;
+  hasPromptHook: boolean;
+  hasPermissionHook: boolean;
+  hasPreToolHook: boolean;
+  hasStopHook: boolean;
+  hasHooksFile: boolean;
+  hasHookEntries: boolean;
+  hasConfigEntry: boolean;
 }
 
 /** UserPromptSubmit hook bash 스크립트를 생성한다 */
 export function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
-  return generateStatusHookScript(
-    "UserPromptSubmit",
-    "사용자가 prompt를 입력하면 현재 task를 PROGRESS로 변경한다.",
-    "progress",
-    kanvibeUrl,
-    taskId,
-  );
+  return generateShellHookScript(AGENT_LABEL, CODEX_HOOK_SCRIPTS[0], kanvibeUrl, taskId);
 }
 
 /** PermissionRequest(Bash) hook bash 스크립트를 생성한다 */
 export function generatePermissionHookScript(kanvibeUrl: string, taskId: string): string {
-  return generateStatusHookScript(
-    "PermissionRequest(Bash)",
-    "Codex가 Bash 실행 승인을 요청하면 현재 task를 PENDING으로 변경한다.",
-    "pending",
-    kanvibeUrl,
-    taskId,
-  );
+  return generateShellHookScript(AGENT_LABEL, CODEX_HOOK_SCRIPTS[1], kanvibeUrl, taskId);
 }
 
 /** PreToolUse(Bash) hook bash 스크립트를 생성한다 */
 export function generatePreToolHookScript(kanvibeUrl: string, taskId: string): string {
-  return generateStatusHookScript(
-    "PreToolUse(Bash)",
-    "Codex가 Bash 실행을 재개하면 현재 task를 PROGRESS로 변경한다.",
-    "progress",
-    kanvibeUrl,
-    taskId,
-  );
+  return generateShellHookScript(AGENT_LABEL, CODEX_HOOK_SCRIPTS[2], kanvibeUrl, taskId);
 }
 
 /** Stop hook bash 스크립트를 생성한다 */
 export function generateStopHookScript(kanvibeUrl: string, taskId: string): string {
-  return generateStatusHookScript(
-    "Stop",
-    "Codex 응답이 완료되면 현재 task를 REVIEW로 변경한다.",
-    "review",
-    kanvibeUrl,
-    taskId,
+  return generateShellHookScript(AGENT_LABEL, CODEX_HOOK_SCRIPTS[3], kanvibeUrl, taskId);
+}
+
+/** 설치 파일을 만들기 전에 읽어야 하는 기존 설정 파일 경로 */
+export function getCodexHookInstallInputPaths(repoPath: string, sshHost?: string | null): string[] {
+  return [getCodexConfigPath(repoPath, sshHost), getCodexHooksPath(repoPath, sshHost)];
+}
+
+/**
+ * Codex CLI hooks 설치 산출물을 만든다.
+ * 기존 config.toml / hooks.json이 있으면 KanVibe 관련 항목만 갱신하고 나머지는 보존한다.
+ */
+export function buildCodexHookFiles(
+  repoPath: string,
+  taskId: string,
+  kanvibeUrl: string,
+  configContent: string,
+  hooksContent: string,
+  sshHost?: string | null,
+): ShellHookProviderFile[] {
+  const pathModule = resolvePathModule(sshHost);
+  const hooksDir = pathModule.join(repoPath, CONFIG_DIR_NAME, "hooks");
+
+  return [
+    ...buildShellHookScriptFiles(hooksDir, AGENT_LABEL, CODEX_HOOK_SCRIPTS, kanvibeUrl, taskId, sshHost),
+    {
+      filePath: getCodexConfigPath(repoPath, sshHost),
+      content: upsertCodexConfigToml(configContent),
+    },
+    {
+      filePath: getCodexHooksPath(repoPath, sshHost),
+      content: upsertCodexHooksJson(hooksContent),
+    },
+  ];
+}
+
+export function upsertCodexHooksJson(hooksContent: string): string {
+  const settings = parseJsonHookSettings(hooksContent);
+  const hooks = ensureJsonHookBuckets(settings);
+
+  hooks.UserPromptSubmit = upsertJsonHookEntries(
+    hooks.UserPromptSubmit,
+    PROMPT_HOOK_SCRIPT_NAME,
+    buildCommandHookEntry(CODEX_PROMPT_COMMAND, HOOK_TIMEOUT_SECONDS),
   );
+  hooks.PermissionRequest = upsertJsonHookEntries(
+    hooks.PermissionRequest,
+    PERMISSION_HOOK_SCRIPT_NAME,
+    buildMatcherCommandHookEntry(BASH_MATCHER, CODEX_PERMISSION_COMMAND, HOOK_TIMEOUT_SECONDS),
+  );
+  hooks.PreToolUse = upsertJsonHookEntries(
+    hooks.PreToolUse,
+    PRE_TOOL_HOOK_SCRIPT_NAME,
+    buildMatcherCommandHookEntry(BASH_MATCHER, CODEX_PRE_TOOL_COMMAND, HOOK_TIMEOUT_SECONDS),
+  );
+  hooks.Stop = upsertJsonHookEntries(
+    hooks.Stop,
+    STOP_HOOK_SCRIPT_NAME,
+    buildCommandHookEntry(CODEX_STOP_COMMAND, HOOK_TIMEOUT_SECONDS),
+  );
+
+  return serializeJsonHookSettings(settings);
 }
 
-function parseHooksJson(content: string): CodexHooksFile {
-  if (!content) {
-    return {};
-  }
+/** 지정된 repo에 Codex CLI hooks를 설정한다. 로컬과 원격 repo 모두 같은 산출물을 기록한다 */
+export async function setupCodexHooks(
+  repoPath: string,
+  taskId: string,
+  kanvibeUrl: string,
+  sshHost?: string | null,
+): Promise<void> {
+  const configPath = getCodexConfigPath(repoPath, sshHost);
+  const hooksPath = getCodexHooksPath(repoPath, sshHost);
+  const existingFiles = await readTextFiles([configPath, hooksPath], sshHost);
 
-  try {
-    return JSON.parse(content) as CodexHooksFile;
-  } catch {
-    return {};
-  }
+  await writeHookProviderFiles(
+    buildCodexHookFiles(
+      repoPath,
+      taskId,
+      kanvibeUrl,
+      existingFiles.get(configPath)?.content ?? "",
+      existingFiles.get(hooksPath)?.content ?? "",
+      sshHost,
+    ),
+    sshHost,
+  );
+
+  await registerKanvibeHookTarget(repoPath, taskId, kanvibeUrl, sshHost);
 }
 
-function hasCommandHook(hookEntries: unknown[], command: string): boolean {
-  if (!Array.isArray(hookEntries)) return false;
-  return hookEntries.some((entry) => {
-    const typed = entry as HookEntry;
-    return typed.hooks?.some((hook) => hook.type === "command" && hook.command === command);
+/** 지정된 repo의 Codex CLI hooks 설치 상태를 확인한다 */
+export async function getCodexHooksStatus(
+  repoPath: string,
+  taskId?: string,
+  sshHost?: string | null,
+): Promise<CodexHooksStatus> {
+  const configPath = getCodexConfigPath(repoPath, sshHost);
+  const hooksPath = getCodexHooksPath(repoPath, sshHost);
+  const state = await readShellHookProviderState({
+    repoPath,
+    hooksDir: resolvePathModule(sshHost).join(repoPath, CONFIG_DIR_NAME, "hooks"),
+    definitions: CODEX_HOOK_SCRIPTS,
+    extraFilePaths: [configPath, hooksPath],
+    taskId,
+    sshHost,
   });
+  const [promptScript, permissionScript, preToolScript, stopScript] = state.scriptFiles;
+  const hooksFile = state.files.get(hooksPath) ?? { exists: false, content: "" };
+  const hasHookEntries = hasCodexHookEntries(hooksFile.content);
+  const hasConfigEntry = hasCodexFeatureFlag(state.files.get(configPath)?.content ?? "");
+
+  return {
+    installed: isShellHookProviderInstalled(state, [hooksFile.exists, hasHookEntries, hasConfigEntry]),
+    hasPromptHook: promptScript.exists,
+    hasPermissionHook: permissionScript.exists,
+    hasPreToolHook: preToolScript.exists,
+    hasStopHook: stopScript.exists,
+    hasHooksFile: hooksFile.exists,
+    hasHookEntries,
+    hasConfigEntry,
+    ...state.status,
+  };
 }
 
-function hasMatcherCommandHook(hookEntries: unknown[], matcher: string, command: string): boolean {
-  if (!Array.isArray(hookEntries)) return false;
-  return hookEntries.some((entry) => {
-    const typed = entry as MatcherHookEntry;
-    return typed.matcher === matcher && typed.hooks?.some((hook) => hook.type === "command" && hook.command === command);
-  });
+function hasCodexHookEntries(hooksContent: string): boolean {
+  const hooks = parseJsonHookSettings(hooksContent).hooks || {};
+
+  return hasCommandHookEntry(hooks.UserPromptSubmit || [], CODEX_PROMPT_COMMAND)
+    && hasMatcherCommandHookEntry(hooks.PermissionRequest || [], BASH_MATCHER, CODEX_PERMISSION_COMMAND)
+    && hasMatcherCommandHookEntry(hooks.PreToolUse || [], BASH_MATCHER, CODEX_PRE_TOOL_COMMAND)
+    && hasCommandHookEntry(hooks.Stop || [], CODEX_STOP_COMMAND);
 }
 
-function referencesScriptName(entry: unknown, scriptName: string): boolean {
-  return JSON.stringify(entry).includes(scriptName);
+function buildCodexHookCommand(scriptName: string): string {
+  return `bash "$(git rev-parse --show-toplevel)/${CONFIG_DIR_NAME}/hooks/${scriptName}"`;
 }
 
-function upsertHookEntries<T>(hookEntries: unknown[] | undefined, scriptName: string, nextEntry: T): T[] {
-  const preservedEntries = Array.isArray(hookEntries)
-    ? hookEntries.filter((entry) => !referencesScriptName(entry, scriptName)) as T[]
-    : [];
-  preservedEntries.push(nextEntry);
-  return preservedEntries;
+function getCodexConfigPath(repoPath: string, sshHost?: string | null): string {
+  return resolvePathModule(sshHost).join(repoPath, CONFIG_DIR_NAME, CONFIG_FILE_NAME);
+}
+
+function getCodexHooksPath(repoPath: string, sshHost?: string | null): string {
+  return resolvePathModule(sshHost).join(repoPath, CONFIG_DIR_NAME, HOOKS_FILE_NAME);
 }
 
 function isSectionHeader(line: string): boolean {
@@ -227,212 +325,4 @@ function hasCodexFeatureFlag(configContent: string): boolean {
       && index < featuresSection.end
       && /^\s*hooks\s*=\s*true\s*$/.test(line),
   );
-}
-
-export function upsertCodexHooksJson(hooksContent: string): string {
-  const settings = parseHooksJson(hooksContent);
-  if (!settings.hooks) {
-    settings.hooks = {};
-  }
-
-  const hooks = settings.hooks as Record<string, unknown[]>;
-
-  hooks.UserPromptSubmit = upsertHookEntries<HookEntry>(hooks.UserPromptSubmit, PROMPT_HOOK_SCRIPT_NAME, {
-    hooks: [
-      {
-        type: "command",
-        command: CODEX_PROMPT_COMMAND,
-        timeout: 10,
-      },
-    ],
-  });
-
-  hooks.PermissionRequest = upsertHookEntries<MatcherHookEntry>(hooks.PermissionRequest, PERMISSION_HOOK_SCRIPT_NAME, {
-    matcher: "Bash",
-    hooks: [
-      {
-        type: "command",
-        command: CODEX_PERMISSION_COMMAND,
-        timeout: 10,
-      },
-    ],
-  });
-
-  hooks.PreToolUse = upsertHookEntries<MatcherHookEntry>(hooks.PreToolUse, PRE_TOOL_HOOK_SCRIPT_NAME, {
-    matcher: "Bash",
-    hooks: [
-      {
-        type: "command",
-        command: CODEX_PRE_TOOL_COMMAND,
-        timeout: 10,
-      },
-    ],
-  });
-
-  hooks.Stop = upsertHookEntries<HookEntry>(hooks.Stop, STOP_HOOK_SCRIPT_NAME, {
-    hooks: [
-      {
-        type: "command",
-        command: CODEX_STOP_COMMAND,
-        timeout: 10,
-      },
-    ],
-  });
-
-  return `${JSON.stringify(settings, null, 2)}\n`;
-}
-
-/**
- * 지정된 repo에 Codex CLI hooks를 설정한다.
- * 기존 config.toml / hooks.json이 있으면 KanVibe 관련 항목만 갱신하고 나머지는 보존한다.
- */
-export async function setupCodexHooks(
-  repoPath: string,
-  taskId: string,
-  kanvibeUrl: string,
-): Promise<void> {
-  const codexDir = path.join(repoPath, ".codex");
-  const hooksDir = path.join(codexDir, "hooks");
-  const configPath = path.join(codexDir, CONFIG_FILE_NAME);
-  const hooksFilePath = path.join(codexDir, HOOKS_FILE_NAME);
-
-  await mkdir(hooksDir, { recursive: true });
-
-  const promptScriptPath = path.join(hooksDir, PROMPT_HOOK_SCRIPT_NAME);
-  const permissionScriptPath = path.join(hooksDir, PERMISSION_HOOK_SCRIPT_NAME);
-  const preToolScriptPath = path.join(hooksDir, PRE_TOOL_HOOK_SCRIPT_NAME);
-  const stopScriptPath = path.join(hooksDir, STOP_HOOK_SCRIPT_NAME);
-
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId), "utf-8");
-  await writeFile(permissionScriptPath, generatePermissionHookScript(kanvibeUrl, taskId), "utf-8");
-  await writeFile(preToolScriptPath, generatePreToolHookScript(kanvibeUrl, taskId), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId), "utf-8");
-  await chmod(promptScriptPath, 0o755);
-  await chmod(permissionScriptPath, 0o755);
-  await chmod(preToolScriptPath, 0o755);
-  await chmod(stopScriptPath, 0o755);
-
-  const configContent = await readTextFile(configPath);
-  await writeFile(configPath, upsertCodexConfigToml(configContent), "utf-8");
-
-  const hooksContent = await readTextFile(hooksFilePath);
-  await writeFile(hooksFilePath, upsertCodexHooksJson(hooksContent), "utf-8");
-
-  try {
-    await addAiToolPatternsToGitExclude(repoPath);
-  } catch (error) {
-    console.error("git exclude 패턴 추가 실패:", error);
-  }
-}
-
-export interface CodexHooksStatus {
-  installed: boolean;
-  hasPromptHook: boolean;
-  hasPermissionHook: boolean;
-  hasPreToolHook: boolean;
-  hasStopHook: boolean;
-  hasHooksFile: boolean;
-  hasHookEntries: boolean;
-  hasConfigEntry: boolean;
-  hasTaskIdBinding?: boolean;
-  hasExpectedTaskId?: boolean;
-  hasStatusMappings?: boolean;
-  hasStatusJsonPersistence?: boolean;
-  hasTargetFanout?: boolean;
-  hasExpectedHookServerUrl?: boolean;
-  hasReachableHookServer?: boolean;
-  boundTaskId?: string | null;
-  configuredHookServerUrl?: string | null;
-  expectedHookServerUrl?: string | null;
-}
-
-/** 지정된 repo의 Codex CLI hooks 설치 상태를 확인한다 */
-export async function getCodexHooksStatus(repoPath: string, taskId?: string, sshHost?: string | null): Promise<CodexHooksStatus> {
-  const pathModule = sshHost ? path.posix : path;
-  const codexDir = pathModule.join(repoPath, ".codex");
-  const hooksDir = pathModule.join(codexDir, "hooks");
-  const configPath = pathModule.join(codexDir, CONFIG_FILE_NAME);
-  const hooksFilePath = pathModule.join(codexDir, HOOKS_FILE_NAME);
-  const promptScriptPath = pathModule.join(hooksDir, PROMPT_HOOK_SCRIPT_NAME);
-  const permissionScriptPath = pathModule.join(hooksDir, PERMISSION_HOOK_SCRIPT_NAME);
-  const preToolScriptPath = pathModule.join(hooksDir, PRE_TOOL_HOOK_SCRIPT_NAME);
-  const stopScriptPath = pathModule.join(hooksDir, STOP_HOOK_SCRIPT_NAME);
-
-  const files = await readTextFiles([
-    promptScriptPath,
-    permissionScriptPath,
-    preToolScriptPath,
-    stopScriptPath,
-    hooksFilePath,
-    configPath,
-  ], sshHost);
-  const promptScript = files.get(promptScriptPath) ?? { exists: false, content: "" };
-  const permissionScript = files.get(permissionScriptPath) ?? { exists: false, content: "" };
-  const preToolScript = files.get(preToolScriptPath) ?? { exists: false, content: "" };
-  const stopScript = files.get(stopScriptPath) ?? { exists: false, content: "" };
-  const hooksFile = files.get(hooksFilePath) ?? { exists: false, content: "" };
-  const configFile = files.get(configPath) ?? { exists: false, content: "" };
-  const promptContent = promptScript.content;
-  const permissionContent = permissionScript.content;
-  const preToolContent = preToolScript.content;
-  const stopContent = stopScript.content;
-  const hooksContent = hooksFile.content;
-  const configContent = configFile.content;
-
-  const hookScripts = [promptContent, permissionContent, preToolContent, stopContent];
-  const { boundTaskId, hasTaskIdBinding, hasExpectedTaskId } = getShellTaskIdBindingStatus(hookScripts, taskId);
-  const hasStatusMappings = promptContent.includes('\\\"status\\\": \\\"progress\\\"')
-    && permissionContent.includes('\\\"status\\\": \\\"pending\\\"')
-    && preToolContent.includes('\\\"status\\\": \\\"progress\\\"')
-    && stopContent.includes('\\\"status\\\": \\\"review\\\"');
-  const hasStatusJsonPersistence = hookScripts.every(hasShellKanvibeStatusJsonPersistence);
-  const hasTargetFanout = hookScripts.every(hasShellKanvibeTargetFanout);
-  const hookServerValidation = await validateHookServerConfiguration(
-    hookScripts.map((content) => extractShellHookServerUrl(content)),
-    Boolean(taskId),
-    sshHost,
-  );
-
-  const settings = parseHooksJson(hooksContent);
-  const hooks = settings.hooks || {};
-  const hasHookEntries = hasCommandHook(hooks.UserPromptSubmit || [], CODEX_PROMPT_COMMAND)
-    && hasMatcherCommandHook(hooks.PermissionRequest || [], "Bash", CODEX_PERMISSION_COMMAND)
-    && hasMatcherCommandHook(hooks.PreToolUse || [], "Bash", CODEX_PRE_TOOL_COMMAND)
-    && hasCommandHook(hooks.Stop || [], CODEX_STOP_COMMAND);
-  const hasConfigEntry = hasCodexFeatureFlag(configContent);
-
-  const installed = promptScript.exists
-    && permissionScript.exists
-    && preToolScript.exists
-    && stopScript.exists
-    && hooksFile.exists
-    && hasHookEntries
-    && hasConfigEntry
-    && hasTaskIdBinding
-    && hasExpectedTaskId
-    && hasStatusMappings
-    && hasStatusJsonPersistence
-    && hasTargetFanout
-    && hookServerValidation.hasExpectedHookServerUrl;
-
-  return {
-    installed,
-    hasPromptHook: promptScript.exists,
-    hasPermissionHook: permissionScript.exists,
-    hasPreToolHook: preToolScript.exists,
-    hasStopHook: stopScript.exists,
-    hasHooksFile: hooksFile.exists,
-    hasHookEntries,
-    hasConfigEntry,
-    hasTaskIdBinding,
-    hasExpectedTaskId,
-    hasStatusMappings,
-    hasStatusJsonPersistence,
-    hasTargetFanout,
-    hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
-    hasReachableHookServer: hookServerValidation.hasReachableHookServer,
-    boundTaskId,
-    configuredHookServerUrl: hookServerValidation.configuredHookServerUrl,
-    expectedHookServerUrl: hookServerValidation.expectedHookServerUrl,
-  };
 }

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -19,6 +19,7 @@ import { AddColorIndexToProjects1771343199455 } from "@/migrations/1771343199455
 import { AddPriorityToKanbanTasks1771344000000 } from "@/migrations/1771344000000-AddPriorityToKanbanTasks";
 import { ReplaceColorIndexWithColor1771388085809 } from "@/migrations/1771388085809-ReplaceColorIndexWithColor";
 import { FillEmptyBaseBranch1771400000000 } from "@/migrations/1771400000000-FillEmptyBaseBranch";
+import { AddIconDataUrlToProjects1771500000000 } from "@/migrations/1771500000000-AddIconDataUrlToProjects";
 
 /** TypeORM DataSource 싱글턴. Vite HMR 시 재연결을 방지하기 위해 globalThis에 캐싱한다. */
 const globalForDb = globalThis as unknown as {
@@ -38,6 +39,7 @@ const MIGRATIONS = [
   AddPriorityToKanbanTasks1771344000000,
   ReplaceColorIndexWithColor1771388085809,
   FillEmptyBaseBranch1771400000000,
+  AddIconDataUrlToProjects1771500000000,
 ];
 
 interface MigrationRecord {

--- a/src/lib/geminiHooksSetup.ts
+++ b/src/lib/geminiHooksSetup.ts
@@ -1,262 +1,175 @@
-import { writeFile, mkdir, chmod } from "fs/promises";
-import path from "path";
-import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
-import { readTextFile, readTextFiles } from "@/lib/hostFileAccess";
-import { extractShellHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
+import { registerKanvibeHookTarget } from "@/lib/hookTargetRegistration";
+import { readTextFiles } from "@/lib/hostFileAccess";
+import { writeHookProviderFiles } from "@/lib/hookFileWriter";
 import {
-  buildShellKanvibeStatusUpdater,
-  buildShellTaskIdResolver,
-  getShellTaskIdBindingStatus,
-  hasShellKanvibeStatusJsonPersistence,
-  hasShellKanvibeTargetFanout,
-} from "@/lib/hookTaskBinding";
+  buildMatcherCommandHookEntry,
+  ensureJsonHookBuckets,
+  hasMatcherCommandHookEntry,
+  parseJsonHookSettings,
+  serializeJsonHookSettings,
+  upsertJsonHookEntries,
+} from "@/lib/jsonHookSettings";
+import {
+  buildShellHookScriptFiles,
+  generateShellHookScript,
+  isShellHookProviderInstalled,
+  readShellHookProviderState,
+  resolvePathModule,
+  type ShellHookProviderFile,
+  type ShellHookScriptDefinition,
+  type ShellHookScriptsStatus,
+} from "@/lib/shellHookProvider";
 
 /**
  * Gemini CLI hooks는 stdout에 반드시 JSON만 출력해야 한다.
  * curl 결과는 /dev/null로 보내고, 마지막에 '{}' JSON을 출력한다.
  */
+const AGENT_LABEL = "Gemini CLI";
+const CONFIG_DIR_NAME = ".gemini";
+const SETTINGS_FILE_NAME = "settings.json";
+const HOOK_TIMEOUT_MS = 10000;
+const ALL_EVENTS_MATCHER = "*";
+const JSON_ONLY_STDOUT_NOTE = "Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.";
+const EMPTY_JSON_OUTPUT = "echo '{}'";
 
-/** BeforeAgent hook bash 스크립트를 생성한다 */
-export function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
-  return `#!/bin/bash
+export const PROMPT_HOOK_SCRIPT_NAME = "kanvibe-prompt-hook.sh";
+export const STOP_HOOK_SCRIPT_NAME = "kanvibe-stop-hook.sh";
 
-# KanVibe Gemini CLI Hook: BeforeAgent
-# 사용자가 prompt를 입력하면 현재 task를 PROGRESS로 변경한다.
-# Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
+const GEMINI_PROMPT_COMMAND = `"$GEMINI_PROJECT_DIR"/${CONFIG_DIR_NAME}/hooks/${PROMPT_HOOK_SCRIPT_NAME}`;
+const GEMINI_STOP_COMMAND = `"$GEMINI_PROJECT_DIR"/${CONFIG_DIR_NAME}/hooks/${STOP_HOOK_SCRIPT_NAME}`;
 
-KANVIBE_URL="${kanvibeUrl}"
-${buildShellTaskIdResolver(taskId)}
-${buildShellKanvibeStatusUpdater("progress")}
+const GEMINI_HOOK_SCRIPTS: ShellHookScriptDefinition[] = [
+  {
+    fileName: PROMPT_HOOK_SCRIPT_NAME,
+    eventLabel: "BeforeAgent",
+    description: "사용자가 prompt를 입력하면 현재 task를 PROGRESS로 변경한다.",
+    status: "progress",
+    runtimeNote: JSON_ONLY_STDOUT_NOTE,
+    trailingOutput: EMPTY_JSON_OUTPUT,
+  },
+  {
+    fileName: STOP_HOOK_SCRIPT_NAME,
+    eventLabel: "AfterAgent",
+    description: "AI 응답이 완료되면 현재 task를 REVIEW로 변경한다.",
+    status: "review",
+    runtimeNote: JSON_ONLY_STDOUT_NOTE,
+    trailingOutput: EMPTY_JSON_OUTPUT,
+  },
+];
 
-echo '{}'
-exit 0
-`;
-}
-
-/** AfterAgent hook bash 스크립트를 생성한다 */
-export function generateStopHookScript(kanvibeUrl: string, taskId: string): string {
-  return `#!/bin/bash
-
-# KanVibe Gemini CLI Hook: AfterAgent
-# AI 응답이 완료되면 현재 task를 REVIEW로 변경한다.
-# Gemini CLI hooks는 stdout에 JSON만 출력해야 한다.
-
-KANVIBE_URL="${kanvibeUrl}"
-${buildShellTaskIdResolver(taskId)}
-${buildShellKanvibeStatusUpdater("review")}
-
-echo '{}'
-exit 0
-`;
-}
-
-interface GeminiSettings {
-  hooks?: Record<string, unknown[]>;
-  [key: string]: unknown;
-}
-
-interface GeminiHookConfig {
-  name?: string;
-  type: string;
-  command: string;
-  timeout: number;
-  description?: string;
-}
-
-interface GeminiHookEntry {
-  matcher: string;
-  hooks: GeminiHookConfig[];
-}
-
-const GEMINI_PROMPT_COMMAND = '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-prompt-hook.sh';
-const GEMINI_STOP_COMMAND = '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-stop-hook.sh';
-
-/** 기존 settings.json을 읽거나 빈 객체를 반환한다 */
-async function readSettingsJson(settingsPath: string, sshHost?: string | null): Promise<GeminiSettings> {
-  return parseSettingsJson(await readTextFile(settingsPath, sshHost));
-}
-
-function parseSettingsJson(content: string): GeminiSettings {
-  if (!content) {
-    return {};
-  }
-
-  try {
-    return JSON.parse(content);
-  } catch {
-    return {};
-  }
-}
-
-/** 현재 bucket에 원하는 Gemini hook command가 정확히 등록되어 있는지 확인한다 */
-function hasGeminiHook(hookEntries: unknown[], matcher: string, command: string): boolean {
-  if (!Array.isArray(hookEntries)) return false;
-  return hookEntries.some((entry) => {
-    const typed = entry as GeminiHookEntry;
-    return typed.matcher === matcher && typed.hooks?.some((hook) => hook.type === "command" && hook.command === command);
-  });
-}
-
-function referencesScriptName(entry: unknown, scriptName: string): boolean {
-  return JSON.stringify(entry).includes(scriptName);
-}
-
-function upsertGeminiHookEntries(hookEntries: unknown[] | undefined, scriptName: string, nextEntry: GeminiHookEntry): GeminiHookEntry[] {
-  const preservedEntries = Array.isArray(hookEntries)
-    ? hookEntries.filter((entry) => !referencesScriptName(entry, scriptName)) as GeminiHookEntry[]
-    : [];
-  preservedEntries.push(nextEntry);
-  return preservedEntries;
-}
-
-/**
- * 지정된 repo에 Gemini CLI hooks를 설정한다.
- * 기존 settings.json이 있으면 kanvibe hooks만 추가하고 나머지는 보존한다.
- */
-export async function setupGeminiHooks(
-  repoPath: string,
-  taskId: string,
-  kanvibeUrl: string,
-): Promise<void> {
-  const geminiDir = path.join(repoPath, ".gemini");
-  const hooksDir = path.join(geminiDir, "hooks");
-  const settingsPath = path.join(geminiDir, "settings.json");
-
-  await mkdir(hooksDir, { recursive: true });
-
-  const promptScriptPath = path.join(hooksDir, "kanvibe-prompt-hook.sh");
-  const stopScriptPath = path.join(hooksDir, "kanvibe-stop-hook.sh");
-
-  await writeFile(promptScriptPath, generatePromptHookScript(kanvibeUrl, taskId), "utf-8");
-  await writeFile(stopScriptPath, generateStopHookScript(kanvibeUrl, taskId), "utf-8");
-  await chmod(promptScriptPath, 0o755);
-  await chmod(stopScriptPath, 0o755);
-
-  const settings = await readSettingsJson(settingsPath);
-  if (!settings.hooks) {
-    settings.hooks = {};
-  }
-
-  const hooks = settings.hooks as Record<string, unknown[]>;
-
-  hooks.BeforeAgent = upsertGeminiHookEntries(hooks.BeforeAgent, "kanvibe-prompt-hook.sh", {
-    matcher: "*",
-    hooks: [
-      {
-        type: "command",
-        command: GEMINI_PROMPT_COMMAND,
-        timeout: 10000,
-      },
-    ],
-  });
-
-  hooks.AfterAgent = upsertGeminiHookEntries(hooks.AfterAgent, "kanvibe-stop-hook.sh", {
-    matcher: "*",
-    hooks: [
-      {
-        type: "command",
-        command: GEMINI_STOP_COMMAND,
-        timeout: 10000,
-      },
-    ],
-  });
-
-  await writeFile(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
-
-  try {
-    await addAiToolPatternsToGitExclude(repoPath);
-  } catch (error) {
-    console.error("git exclude 패턴 추가 실패:", error);
-  }
-}
-
-export interface GeminiHooksStatus {
+export interface GeminiHooksStatus extends Partial<ShellHookScriptsStatus> {
   installed: boolean;
   hasPromptHook: boolean;
   hasStopHook: boolean;
   hasSettingsEntry: boolean;
-  hasTaskIdBinding?: boolean;
-  hasExpectedTaskId?: boolean;
-  hasStatusMappings?: boolean;
-  hasStatusJsonPersistence?: boolean;
-  hasTargetFanout?: boolean;
-  hasExpectedHookServerUrl?: boolean;
-  hasReachableHookServer?: boolean;
-  boundTaskId?: string | null;
-  configuredHookServerUrl?: string | null;
-  expectedHookServerUrl?: string | null;
+}
+
+/** BeforeAgent hook bash 스크립트를 생성한다 */
+export function generatePromptHookScript(kanvibeUrl: string, taskId: string): string {
+  return generateShellHookScript(AGENT_LABEL, GEMINI_HOOK_SCRIPTS[0], kanvibeUrl, taskId);
+}
+
+/** AfterAgent hook bash 스크립트를 생성한다 */
+export function generateStopHookScript(kanvibeUrl: string, taskId: string): string {
+  return generateShellHookScript(AGENT_LABEL, GEMINI_HOOK_SCRIPTS[1], kanvibeUrl, taskId);
+}
+
+/** 설치 파일을 만들기 전에 읽어야 하는 기존 설정 파일 경로 */
+export function getGeminiHookInstallInputPaths(repoPath: string, sshHost?: string | null): string[] {
+  return [getGeminiSettingsPath(repoPath, sshHost)];
+}
+
+/**
+ * Gemini CLI hooks 설치 산출물을 만든다.
+ * 기존 settings.json이 있으면 kanvibe hooks 항목만 갱신하고 나머지는 보존한다.
+ */
+export function buildGeminiHookFiles(
+  repoPath: string,
+  taskId: string,
+  kanvibeUrl: string,
+  settingsContent: string,
+  sshHost?: string | null,
+): ShellHookProviderFile[] {
+  const pathModule = resolvePathModule(sshHost);
+  const hooksDir = pathModule.join(repoPath, CONFIG_DIR_NAME, "hooks");
+  const settings = parseJsonHookSettings(settingsContent);
+  const hooks = ensureJsonHookBuckets(settings);
+
+  hooks.BeforeAgent = upsertJsonHookEntries(
+    hooks.BeforeAgent,
+    PROMPT_HOOK_SCRIPT_NAME,
+    buildMatcherCommandHookEntry(ALL_EVENTS_MATCHER, GEMINI_PROMPT_COMMAND, HOOK_TIMEOUT_MS),
+  );
+  hooks.AfterAgent = upsertJsonHookEntries(
+    hooks.AfterAgent,
+    STOP_HOOK_SCRIPT_NAME,
+    buildMatcherCommandHookEntry(ALL_EVENTS_MATCHER, GEMINI_STOP_COMMAND, HOOK_TIMEOUT_MS),
+  );
+
+  return [
+    ...buildShellHookScriptFiles(hooksDir, AGENT_LABEL, GEMINI_HOOK_SCRIPTS, kanvibeUrl, taskId, sshHost),
+    {
+      filePath: getGeminiSettingsPath(repoPath, sshHost),
+      content: serializeJsonHookSettings(settings),
+    },
+  ];
+}
+
+/** 지정된 repo에 Gemini CLI hooks를 설정한다. 로컬과 원격 repo 모두 같은 산출물을 기록한다 */
+export async function setupGeminiHooks(
+  repoPath: string,
+  taskId: string,
+  kanvibeUrl: string,
+  sshHost?: string | null,
+): Promise<void> {
+  const settingsPath = getGeminiSettingsPath(repoPath, sshHost);
+  const existingFiles = await readTextFiles([settingsPath], sshHost);
+
+  await writeHookProviderFiles(
+    buildGeminiHookFiles(repoPath, taskId, kanvibeUrl, existingFiles.get(settingsPath)?.content ?? "", sshHost),
+    sshHost,
+  );
+
+  await registerKanvibeHookTarget(repoPath, taskId, kanvibeUrl, sshHost);
 }
 
 /** 지정된 repo의 Gemini CLI hooks 설치 상태를 확인한다 */
-export async function getGeminiHooksStatus(repoPath: string, taskId?: string, sshHost?: string | null): Promise<GeminiHooksStatus> {
-  const pathModule = sshHost ? path.posix : path;
-  const geminiDir = pathModule.join(repoPath, ".gemini");
-  const hooksDir = pathModule.join(geminiDir, "hooks");
-  const settingsPath = pathModule.join(geminiDir, "settings.json");
-  const promptScriptPath = pathModule.join(hooksDir, "kanvibe-prompt-hook.sh");
-  const stopScriptPath = pathModule.join(hooksDir, "kanvibe-stop-hook.sh");
-
-  const files = await readTextFiles([
-    promptScriptPath,
-    stopScriptPath,
-    settingsPath,
-  ], sshHost);
-  const promptScript = files.get(promptScriptPath) ?? { exists: false, content: "" };
-  const stopScript = files.get(stopScriptPath) ?? { exists: false, content: "" };
-  const settingsFile = files.get(settingsPath) ?? { exists: false, content: "" };
-  const promptContent = promptScript.content;
-  const stopContent = stopScript.content;
-
-  const scriptContents = [promptContent, stopContent];
-  const { boundTaskId, hasTaskIdBinding, hasExpectedTaskId } = getShellTaskIdBindingStatus(scriptContents, taskId);
-  const hookServerValidation = await validateHookServerConfiguration(
-    scriptContents.map(extractShellHookServerUrl),
-    Boolean(taskId),
+export async function getGeminiHooksStatus(
+  repoPath: string,
+  taskId?: string,
+  sshHost?: string | null,
+): Promise<GeminiHooksStatus> {
+  const settingsPath = getGeminiSettingsPath(repoPath, sshHost);
+  const state = await readShellHookProviderState({
+    repoPath,
+    hooksDir: resolvePathModule(sshHost).join(repoPath, CONFIG_DIR_NAME, "hooks"),
+    definitions: GEMINI_HOOK_SCRIPTS,
+    extraFilePaths: [settingsPath],
+    taskId,
     sshHost,
-  );
-  const hasStatusMappings =
-    promptContent.includes('\\\"status\\\": \\\"progress\\\"') &&
-    stopContent.includes('\\\"status\\\": \\\"review\\\"');
-  const hasStatusJsonPersistence = scriptContents.every(hasShellKanvibeStatusJsonPersistence);
-  const hasTargetFanout = scriptContents.every(hasShellKanvibeTargetFanout);
-
-  let hasSettingsEntry = false;
-  try {
-    const settings = parseSettingsJson(settingsFile.content);
-    const hooks = settings.hooks as Record<string, unknown[]> | undefined;
-    if (hooks) {
-      const hasPrompt = hasGeminiHook(hooks.BeforeAgent || [], "*", GEMINI_PROMPT_COMMAND);
-      const hasStop = hasGeminiHook(hooks.AfterAgent || [], "*", GEMINI_STOP_COMMAND);
-      hasSettingsEntry = hasPrompt && hasStop;
-    }
-  } catch {
-    /* settings.json 없음 */
-  }
-
-  const installed = promptScript.exists
-    && stopScript.exists
-    && hasSettingsEntry
-    && hasTaskIdBinding
-    && hasExpectedTaskId
-    && hasStatusMappings
-    && hasStatusJsonPersistence
-    && hasTargetFanout
-    && hookServerValidation.hasExpectedHookServerUrl;
+  });
+  const [promptScript, stopScript] = state.scriptFiles;
+  const hasSettingsEntry = hasGeminiSettingsEntry(state.files.get(settingsPath)?.content ?? "");
 
   return {
-    installed,
+    installed: isShellHookProviderInstalled(state, [hasSettingsEntry]),
     hasPromptHook: promptScript.exists,
     hasStopHook: stopScript.exists,
     hasSettingsEntry,
-    hasTaskIdBinding,
-    hasExpectedTaskId,
-    hasStatusMappings,
-    hasStatusJsonPersistence,
-    hasTargetFanout,
-    hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
-    hasReachableHookServer: hookServerValidation.hasReachableHookServer,
-    boundTaskId,
-    configuredHookServerUrl: hookServerValidation.configuredHookServerUrl,
-    expectedHookServerUrl: hookServerValidation.expectedHookServerUrl,
+    ...state.status,
   };
+}
+
+function hasGeminiSettingsEntry(settingsContent: string): boolean {
+  const hooks = parseJsonHookSettings(settingsContent).hooks;
+  if (!hooks) {
+    return false;
+  }
+
+  return hasMatcherCommandHookEntry(hooks.BeforeAgent || [], ALL_EVENTS_MATCHER, GEMINI_PROMPT_COMMAND)
+    && hasMatcherCommandHookEntry(hooks.AfterAgent || [], ALL_EVENTS_MATCHER, GEMINI_STOP_COMMAND);
+}
+
+function getGeminiSettingsPath(repoPath: string, sshHost?: string | null): string {
+  return resolvePathModule(sshHost).join(repoPath, CONFIG_DIR_NAME, SETTINGS_FILE_NAME);
 }

--- a/src/lib/gitExclude.ts
+++ b/src/lib/gitExclude.ts
@@ -107,3 +107,22 @@ export async function addAiToolPatternsToGitExclude(
 
   await writeTextFile(excludePath, nextContent, sshHost);
 }
+
+/**
+ * hook 설치 과정에서 git exclude를 갱신한다.
+ * exclude 갱신 실패는 hook 동작을 막지 않으므로 로그만 남기고 설치를 계속한다.
+ */
+export async function ensureAiToolPatternsExcluded(
+  repoPath: string,
+  sshHost?: string | null,
+): Promise<void> {
+  try {
+    await addAiToolPatternsToGitExclude(repoPath, sshHost);
+  } catch (error) {
+    console.warn("[hooks] git exclude 패턴 추가 실패", {
+      repoPath,
+      sshHost: sshHost ?? null,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/src/lib/githubProjectIcon.ts
+++ b/src/lib/githubProjectIcon.ts
@@ -1,0 +1,117 @@
+import { execGit } from "@/lib/gitOperations";
+import { quoteShellArgument } from "@/lib/hostFileAccess";
+
+/** GitHub avatar 응답 크기. 보드 카드와 목록에서 쓰는 최대 크기의 2배(retina)로 맞춘다 */
+const ICON_PIXEL_SIZE = 64;
+const ICON_FETCH_TIMEOUT_MS = 5_000;
+/** data URL로 DB에 저장하므로 비정상적으로 큰 응답은 저장하지 않는다 */
+const MAX_ICON_BYTES = 512 * 1024;
+const ALLOWED_ICON_CONTENT_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+/** GitHub 소유자(사용자/조직) 이름 규칙 */
+const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+
+export interface GitHubRepositoryReference {
+  owner: string;
+  repository: string;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * git remote URL에서 GitHub owner/repository를 뽑아낸다.
+ * `https://github.com/o/r.git`, `git@github.com:o/r.git`, `ssh://git@github.com/o/r` 형식을 지원한다.
+ * GitHub이 아니거나 형식이 다르면 null을 반환한다.
+ */
+export function parseGitHubRepositoryReference(remoteUrl: string): GitHubRepositoryReference | null {
+  const normalizedRemoteUrl = remoteUrl.trim();
+  if (!normalizedRemoteUrl) {
+    return null;
+  }
+
+  const match = normalizedRemoteUrl.match(
+    /^(?:https?:\/\/|ssh:\/\/)?(?:[^@/]+@)?github\.com[:/]+([^/]+)\/([^/]+?)(?:\.git)?\/?$/i,
+  );
+  if (!match) {
+    return null;
+  }
+
+  const [, owner, repository] = match;
+  if (!GITHUB_OWNER_PATTERN.test(owner)) {
+    return null;
+  }
+
+  return { owner, repository };
+}
+
+/** 저장소의 origin remote를 읽어 GitHub owner/repository를 확인한다 */
+export async function resolveGitHubRepositoryReference(
+  repoPath: string,
+  sshHost?: string | null,
+): Promise<GitHubRepositoryReference | null> {
+  try {
+    const remoteUrl = await execGit(
+      `git -C ${quoteShellArgument(repoPath)} config --get remote.origin.url`,
+      sshHost,
+    );
+    return parseGitHubRepositoryReference(remoteUrl);
+  } catch {
+    /** remote가 없는 로컬 전용 저장소는 아이콘 없이 동작한다 */
+    return null;
+  }
+}
+
+/**
+ * GitHub 사용자/조직 아바타를 내려받아 data URL로 변환한다.
+ * 네트워크 실패, 비정상 응답, 과도한 크기는 모두 아이콘 없음으로 처리한다.
+ */
+export async function fetchGitHubOwnerIconDataUrl(owner: string): Promise<string | null> {
+  if (!GITHUB_OWNER_PATTERN.test(owner)) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(
+      `https://github.com/${encodeURIComponent(owner)}.png?size=${ICON_PIXEL_SIZE}`,
+      { signal: AbortSignal.timeout(ICON_FETCH_TIMEOUT_MS) },
+    );
+    if (!response.ok) {
+      return null;
+    }
+
+    const contentType = (response.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
+    if (!ALLOWED_ICON_CONTENT_TYPES.includes(contentType)) {
+      return null;
+    }
+
+    const iconBytes = Buffer.from(await response.arrayBuffer());
+    if (iconBytes.byteLength === 0 || iconBytes.byteLength > MAX_ICON_BYTES) {
+      return null;
+    }
+
+    return `data:${contentType};base64,${iconBytes.toString("base64")}`;
+  } catch (error) {
+    console.warn("[project-icon] GitHub 아이콘 다운로드 실패", {
+      owner,
+      error: getErrorMessage(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * 프로젝트 저장소의 GitHub 아이콘을 확보한다.
+ * GitHub 저장소가 아니거나 아이콘을 받지 못하면 null을 반환해 아이콘 없이 등록되게 한다.
+ */
+export async function resolveProjectIconDataUrl(
+  repoPath: string,
+  sshHost?: string | null,
+): Promise<string | null> {
+  const repositoryReference = await resolveGitHubRepositoryReference(repoPath, sshHost);
+  if (!repositoryReference) {
+    return null;
+  }
+
+  return fetchGitHubOwnerIconDataUrl(repositoryReference.owner);
+}

--- a/src/lib/githubProjectIcon.ts
+++ b/src/lib/githubProjectIcon.ts
@@ -9,6 +9,16 @@ const MAX_ICON_BYTES = 512 * 1024;
 const ALLOWED_ICON_CONTENT_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
 /** GitHub 소유자(사용자/조직) 이름 규칙 */
 const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+/**
+ * 같은 owner의 저장소를 연달아 등록할 때 아바타를 반복해서 내려받지 않도록 캐싱한다.
+ * 실패도 캐싱해 오프라인 상태에서 저장소마다 타임아웃을 다시 기다리지 않게 한다.
+ */
+const OWNER_ICON_CACHE_TTL_MS = 10 * 60 * 1000;
+const ownerIconCache = new Map<string, { expiresAt: number; iconDataUrl: Promise<string | null> }>();
+
+export function clearGitHubOwnerIconCache(): void {
+  ownerIconCache.clear();
+}
 
 export interface GitHubRepositoryReference {
   owner: string;
@@ -71,6 +81,17 @@ export async function fetchGitHubOwnerIconDataUrl(owner: string): Promise<string
     return null;
   }
 
+  const cached = ownerIconCache.get(owner);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.iconDataUrl;
+  }
+
+  const iconDataUrl = downloadGitHubOwnerIconDataUrl(owner);
+  ownerIconCache.set(owner, { expiresAt: Date.now() + OWNER_ICON_CACHE_TTL_MS, iconDataUrl });
+  return iconDataUrl;
+}
+
+async function downloadGitHubOwnerIconDataUrl(owner: string): Promise<string | null> {
   try {
     const response = await fetch(
       `https://github.com/${encodeURIComponent(owner)}.png?size=${ICON_PIXEL_SIZE}`,

--- a/src/lib/hookFileWriter.ts
+++ b/src/lib/hookFileWriter.ts
@@ -1,0 +1,57 @@
+import { chmod, mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { execGit } from "@/lib/gitOperations";
+import { quoteShellArgument } from "@/lib/hostFileAccess";
+import type { ShellHookProviderFile } from "@/lib/shellHookProvider";
+
+/**
+ * hook 설치 산출물(스크립트·설정 파일)을 로컬 또는 원격 repo에 기록한다.
+ * 로컬/원격 설치가 같은 파일 목록을 공유하도록 쓰기 경로만 분리한다.
+ */
+export async function writeHookProviderFiles(
+  files: ShellHookProviderFile[],
+  sshHost?: string | null,
+): Promise<void> {
+  if (files.length === 0) {
+    return;
+  }
+
+  if (!sshHost) {
+    await writeLocalHookProviderFiles(files);
+    return;
+  }
+
+  await writeRemoteHookProviderFiles(files, sshHost);
+}
+
+async function writeLocalHookProviderFiles(files: ShellHookProviderFile[]): Promise<void> {
+  for (const { filePath, content, mode } of files) {
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, content, "utf-8");
+
+    if (mode) {
+      await chmod(filePath, mode);
+    }
+  }
+}
+
+async function writeRemoteHookProviderFiles(
+  files: ShellHookProviderFile[],
+  sshHost: string,
+): Promise<void> {
+  const command = files.map(({ filePath, content, mode }) => {
+    const encodedContent = Buffer.from(content, "utf-8").toString("base64");
+    const parts = [
+      `mkdir -p ${quoteShellArgument(path.posix.dirname(filePath))}`,
+      `printf '%s' ${quoteShellArgument(encodedContent)} | (base64 -d 2>/dev/null || base64 -D) > ${quoteShellArgument(filePath)}`,
+    ];
+
+    if (mode) {
+      parts.push(`chmod ${mode.toString(8)} ${quoteShellArgument(filePath)}`);
+    }
+
+    return parts.join(" && ");
+  }).join(" && ");
+
+  await execGit(command, sshHost);
+}

--- a/src/lib/hookTargetRegistration.ts
+++ b/src/lib/hookTargetRegistration.ts
@@ -1,0 +1,60 @@
+import { ensureAiToolPatternsExcluded } from "@/lib/gitExclude";
+import {
+  hasKanvibeHookTarget,
+  parseKanvibeTargets,
+  upsertKanvibeHookTarget,
+} from "@/lib/kanvibeProjectState";
+
+/**
+ * hook을 설치하는 client를 알림 대상으로 등록하고 `.kanvibe` 상태 디렉터리를 git 추적에서 제외한다.
+ * 같은 client가 다시 설치하면 taskId만 교체되고, 다른 client는 targets.json에 추가된다.
+ */
+export async function registerKanvibeHookTarget(
+  repoPath: string,
+  taskId: string,
+  hookServerUrl: string,
+  sshHost?: string | null,
+): Promise<void> {
+  await ensureAiToolPatternsExcluded(repoPath, sshHost);
+  await upsertKanvibeHookTarget(repoPath, { url: hookServerUrl, taskId }, sshHost);
+}
+
+/**
+ * hook 설치 여부는 스크립트에 박힌 TASK_ID가 아니라 `.kanvibe/targets.json`에
+ * 현재 client(hook 서버 URL)와 현재 taskId 쌍이 등록되어 있는지로 판정한다.
+ * 여러 client가 같은 worktree를 공유해도 서로의 설치 상태를 깨뜨리지 않는다.
+ */
+export interface HookTargetRegistrationStatus {
+  hasRegisteredHookTarget: boolean;
+  registeredHookTargetUrl: string | null;
+}
+
+export function verifyHookTargetRegistration(
+  targetsContent: string,
+  taskId: string | undefined,
+  expectedHookServerUrl: string | null,
+): HookTargetRegistrationStatus {
+  if (!taskId) {
+    return { hasRegisteredHookTarget: true, registeredHookTargetUrl: null };
+  }
+
+  const registeredTarget = parseKanvibeTargets(targetsContent).targets
+    .find((target) => target.taskId === taskId);
+  const registeredHookTargetUrl = registeredTarget?.url ?? null;
+
+  /** 원격 hook 서버 주소를 확정하지 못한 경우에는 taskId 등록 여부만으로 판정한다 */
+  if (!expectedHookServerUrl) {
+    return {
+      hasRegisteredHookTarget: registeredTarget !== undefined,
+      registeredHookTargetUrl,
+    };
+  }
+
+  return {
+    hasRegisteredHookTarget: hasKanvibeHookTarget(targetsContent, {
+      url: expectedHookServerUrl,
+      taskId,
+    }),
+    registeredHookTargetUrl,
+  };
+}

--- a/src/lib/hostFileAccess.ts
+++ b/src/lib/hostFileAccess.ts
@@ -153,6 +153,36 @@ export async function writeTextFile(targetPath: string, content: string, sshHost
   );
 }
 
+/**
+ * 대상 파일이 아직 없을 때만 기록한다.
+ * 이미 존재하는 파일은 다른 주체가 확정한 값이므로 검사와 기록 사이에 끼어든 쓰기도 덮지 않아야 한다.
+ * 그래서 로컬은 `wx` 플래그로, 원격은 존재 검사와 기록을 한 셸 명령으로 묶어 원자성을 확보한다.
+ */
+export async function writeTextFileIfAbsent(
+  targetPath: string,
+  content: string,
+  sshHost?: string | null,
+): Promise<void> {
+  if (!sshHost) {
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    try {
+      await writeFile(targetPath, content, { encoding: "utf-8", flag: "wx" });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+    }
+    return;
+  }
+
+  const encodedContent = Buffer.from(content, "utf-8").toString("base64");
+  const quotedTargetPath = quoteShellArgument(targetPath);
+  await execGit(
+    `mkdir -p ${quoteShellArgument(path.posix.dirname(targetPath))} && if [ -e ${quotedTargetPath} ]; then :; else printf '%s' ${quoteShellArgument(encodedContent)} | (base64 -d 2>/dev/null || base64 -D) > ${quotedTargetPath}; fi`,
+    sshHost,
+  );
+}
+
 export async function readDirectoryFilesBySuffix(
   directoryPath: string,
   suffix: string,

--- a/src/lib/jsonHookSettings.ts
+++ b/src/lib/jsonHookSettings.ts
@@ -1,0 +1,99 @@
+/**
+ * Claude Code / Gemini CLI / Codex CLI가 공통으로 사용하는 JSON hook 설정 파일 조작 유틸리티.
+ * 세 CLI 모두 `{ hooks: { <이벤트>: [ { matcher?, hooks: [{ type, command, timeout }] } ] } }`
+ * 구조를 사용하므로 파싱·upsert·검증 규칙을 한 곳에서 관리한다.
+ */
+
+export interface CommandHookConfig {
+  type: string;
+  command: string;
+  timeout: number;
+}
+
+export interface CommandHookEntry {
+  hooks: CommandHookConfig[];
+}
+
+export interface MatcherCommandHookEntry extends CommandHookEntry {
+  matcher: string;
+}
+
+export interface JsonHookSettings {
+  hooks?: Record<string, unknown[]>;
+  [key: string]: unknown;
+}
+
+export function parseJsonHookSettings(content: string): JsonHookSettings {
+  if (!content) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(content) as JsonHookSettings;
+  } catch {
+    return {};
+  }
+}
+
+export function serializeJsonHookSettings(settings: JsonHookSettings): string {
+  return JSON.stringify(settings, null, 2) + "\n";
+}
+
+/** settings 객체의 hooks bucket 맵을 보장하고 반환한다 */
+export function ensureJsonHookBuckets(settings: JsonHookSettings): Record<string, unknown[]> {
+  if (!settings.hooks) {
+    settings.hooks = {};
+  }
+
+  return settings.hooks;
+}
+
+export function buildCommandHookEntry(command: string, timeout: number): CommandHookEntry {
+  return { hooks: [{ type: "command", command, timeout }] };
+}
+
+export function buildMatcherCommandHookEntry(
+  matcher: string,
+  command: string,
+  timeout: number,
+): MatcherCommandHookEntry {
+  return { matcher, ...buildCommandHookEntry(command, timeout) };
+}
+
+/** 같은 스크립트를 가리키는 기존 entry만 교체하고 사용자가 추가한 다른 entry는 보존한다 */
+export function upsertJsonHookEntries<T>(
+  hookEntries: unknown[] | undefined,
+  scriptName: string,
+  nextEntry: T,
+): T[] {
+  const preservedEntries = Array.isArray(hookEntries)
+    ? hookEntries.filter((entry) => !referencesScriptName(entry, scriptName)) as T[]
+    : [];
+  preservedEntries.push(nextEntry);
+  return preservedEntries;
+}
+
+export function hasCommandHookEntry(hookEntries: unknown[], command: string): boolean {
+  if (!Array.isArray(hookEntries)) return false;
+  return hookEntries.some((entry) => {
+    const typed = entry as CommandHookEntry;
+    return typed.hooks?.some((hook) => hook.type === "command" && hook.command === command);
+  });
+}
+
+export function hasMatcherCommandHookEntry(
+  hookEntries: unknown[],
+  matcher: string,
+  command: string,
+): boolean {
+  if (!Array.isArray(hookEntries)) return false;
+  return hookEntries.some((entry) => {
+    const typed = entry as MatcherCommandHookEntry;
+    return typed.matcher === matcher
+      && typed.hooks?.some((hook) => hook.type === "command" && hook.command === command);
+  });
+}
+
+function referencesScriptName(entry: unknown, scriptName: string): boolean {
+  return JSON.stringify(entry).includes(scriptName);
+}

--- a/src/lib/kanvibeHookProviders.ts
+++ b/src/lib/kanvibeHookProviders.ts
@@ -1,0 +1,137 @@
+import {
+  buildClaudeHookFiles,
+  getClaudeHookInstallInputPaths,
+  getClaudeHooksStatus,
+  setupClaudeHooks,
+  type ClaudeHooksStatus,
+} from "@/lib/claudeHooksSetup";
+import {
+  buildCodexHookFiles,
+  getCodexHookInstallInputPaths,
+  getCodexHooksStatus,
+  setupCodexHooks,
+  type CodexHooksStatus,
+} from "@/lib/codexHooksSetup";
+import {
+  buildGeminiHookFiles,
+  getGeminiHookInstallInputPaths,
+  getGeminiHooksStatus,
+  setupGeminiHooks,
+  type GeminiHooksStatus,
+} from "@/lib/geminiHooksSetup";
+import {
+  buildOpenCodeHookFiles,
+  getOpenCodeHookInstallInputPaths,
+  getOpenCodeHooksStatus,
+  setupOpenCodeHooks,
+  type OpenCodeHooksStatus,
+} from "@/lib/openCodeHooksSetup";
+import type { TextFileReadResult } from "@/lib/hostFileAccess";
+import type { ShellHookProviderFile } from "@/lib/shellHookProvider";
+
+export type KanvibeHookProvider = "claude" | "gemini" | "codex" | "openCode";
+
+export type KanvibeHookStatus =
+  | ClaudeHooksStatus
+  | GeminiHooksStatus
+  | CodexHooksStatus
+  | OpenCodeHooksStatus;
+
+/**
+ * AI CLI 하나의 hook 설치 규약.
+ * 로컬/원격, 단일 provider/일괄 설치가 모두 같은 산출물 생성 규칙을 공유하도록 묶는다.
+ */
+export interface KanvibeHookProviderModule {
+  provider: KanvibeHookProvider;
+  label: string;
+  /** 산출물을 만들기 전에 읽어야 하는 기존 설정 파일 경로 */
+  getInstallInputPaths: (repoPath: string, sshHost?: string | null) => string[];
+  buildFiles: (
+    repoPath: string,
+    taskId: string,
+    hookServerUrl: string,
+    existingFiles: Map<string, TextFileReadResult>,
+    sshHost?: string | null,
+  ) => ShellHookProviderFile[];
+  install: (
+    repoPath: string,
+    taskId: string,
+    hookServerUrl: string,
+    sshHost?: string | null,
+  ) => Promise<void>;
+  getStatus: (
+    repoPath: string,
+    taskId?: string,
+    sshHost?: string | null,
+  ) => Promise<KanvibeHookStatus>;
+}
+
+export const KANVIBE_HOOK_PROVIDER_MODULES: Record<KanvibeHookProvider, KanvibeHookProviderModule> = {
+  claude: {
+    provider: "claude",
+    label: "Claude",
+    getInstallInputPaths: getClaudeHookInstallInputPaths,
+    buildFiles: (repoPath, taskId, hookServerUrl, existingFiles, sshHost) => buildClaudeHookFiles(
+      repoPath,
+      taskId,
+      hookServerUrl,
+      readExistingContent(existingFiles, getClaudeHookInstallInputPaths(repoPath, sshHost)[0]),
+      sshHost,
+    ),
+    install: setupClaudeHooks,
+    getStatus: getClaudeHooksStatus,
+  },
+  gemini: {
+    provider: "gemini",
+    label: "Gemini",
+    getInstallInputPaths: getGeminiHookInstallInputPaths,
+    buildFiles: (repoPath, taskId, hookServerUrl, existingFiles, sshHost) => buildGeminiHookFiles(
+      repoPath,
+      taskId,
+      hookServerUrl,
+      readExistingContent(existingFiles, getGeminiHookInstallInputPaths(repoPath, sshHost)[0]),
+      sshHost,
+    ),
+    install: setupGeminiHooks,
+    getStatus: getGeminiHooksStatus,
+  },
+  codex: {
+    provider: "codex",
+    label: "Codex",
+    getInstallInputPaths: getCodexHookInstallInputPaths,
+    buildFiles: (repoPath, taskId, hookServerUrl, existingFiles, sshHost) => {
+      const [configPath, hooksPath] = getCodexHookInstallInputPaths(repoPath, sshHost);
+      return buildCodexHookFiles(
+        repoPath,
+        taskId,
+        hookServerUrl,
+        readExistingContent(existingFiles, configPath),
+        readExistingContent(existingFiles, hooksPath),
+        sshHost,
+      );
+    },
+    install: setupCodexHooks,
+    getStatus: getCodexHooksStatus,
+  },
+  openCode: {
+    provider: "openCode",
+    label: "OpenCode",
+    getInstallInputPaths: getOpenCodeHookInstallInputPaths,
+    buildFiles: (repoPath, taskId, hookServerUrl, _existingFiles, sshHost) => buildOpenCodeHookFiles(
+      repoPath,
+      taskId,
+      hookServerUrl,
+      sshHost,
+    ),
+    install: setupOpenCodeHooks,
+    getStatus: getOpenCodeHooksStatus,
+  },
+};
+
+export function getKanvibeHookProviderModules(): KanvibeHookProviderModule[] {
+  return Object.values(KANVIBE_HOOK_PROVIDER_MODULES);
+}
+
+function readExistingContent(files: Map<string, TextFileReadResult>, filePath: string | undefined): string {
+  return filePath ? files.get(filePath)?.content ?? "" : "";
+}

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -245,8 +245,9 @@ async function waitForHookInstallRetry(delayMs: number): Promise<void> {
 }
 
 /**
- * 모든 provider의 hook 파일을 한 번에 만들어 기록한다.
- * 기존 설정 파일 읽기와 파일 쓰기를 각각 한 번으로 묶어 원격 설치의 왕복 횟수를 줄인다.
+ * 모든 provider의 hook 파일을 만들어 기록한다.
+ * 기존 설정 파일 읽기는 한 번으로 묶고, 쓰기는 provider 단위로 격리해
+ * 한 provider가 실패해도 나머지 provider의 hook은 설치되게 한다.
  */
 async function installKanvibeHookFilesOnce(
   targetPath: string,
@@ -262,9 +263,10 @@ async function installKanvibeHookFilesOnce(
     sshHost,
   );
 
-  const buildResults = providerModules.map((providerModule) => {
+  const results = await Promise.allSettled(providerModules.map(async (providerModule) => {
     try {
-      return providerModule.buildFiles(targetPath, taskId, hookServerUrl, existingFiles, sshHost);
+      const files = providerModule.buildFiles(targetPath, taskId, hookServerUrl, existingFiles, sshHost);
+      await writeHookProviderFiles(files, sshHost);
     } catch (error) {
       console.error(`[hooks] ${providerModule.label} install failed`, {
         provider: providerModule.label,
@@ -275,9 +277,25 @@ async function installKanvibeHookFilesOnce(
       });
       throw error;
     }
-  });
+  }));
 
-  await writeHookProviderFiles(buildResults.flat(), sshHost);
+  assertHookProviderInstallResults(results, providerModules.map(({ label }) => label));
+}
+
+/** provider 하나라도 실패하면 실패한 provider를 모두 모아 알린다 */
+function assertHookProviderInstallResults(
+  results: PromiseSettledResult<void>[],
+  providerLabels: string[],
+): void {
+  const failedProviders = results.flatMap((result, index) => (
+    result.status === "rejected"
+      ? [`${providerLabels[index]}(${result.reason instanceof Error ? result.reason.message : String(result.reason)})`]
+      : []
+  ));
+
+  if (failedProviders.length > 0) {
+    throw new Error(`hooks 설치 실패: ${failedProviders.join(", ")}`);
+  }
 }
 
 async function installKanvibeHookProviderOnce(

--- a/src/lib/kanvibeHooksInstaller.ts
+++ b/src/lib/kanvibeHooksInstaller.ts
@@ -1,35 +1,22 @@
-import path from "node:path";
-import { execGit } from "@/lib/gitOperations";
-import { setupClaudeHooks, getClaudeHooksStatus, generatePromptHookScript as generateClaudePromptHookScript, generateStopHookScript as generateClaudeStopHookScript, generateQuestionHookScript as generateClaudeQuestionHookScript, type ClaudeHooksStatus } from "@/lib/claudeHooksSetup";
-import { setupGeminiHooks, getGeminiHooksStatus, generatePromptHookScript as generateGeminiPromptHookScript, generateStopHookScript as generateGeminiStopHookScript, type GeminiHooksStatus } from "@/lib/geminiHooksSetup";
-import {
-  setupCodexHooks,
-  getCodexHooksStatus,
-  generatePromptHookScript as generateCodexPromptHookScript,
-  generatePermissionHookScript as generateCodexPermissionHookScript,
-  generatePreToolHookScript as generateCodexPreToolHookScript,
-  generateStopHookScript as generateCodexStopHookScript,
-  upsertCodexConfigToml,
-  upsertCodexHooksJson,
-  PROMPT_HOOK_SCRIPT_NAME,
-  PERMISSION_HOOK_SCRIPT_NAME,
-  PRE_TOOL_HOOK_SCRIPT_NAME,
-  STOP_HOOK_SCRIPT_NAME,
-  HOOKS_FILE_NAME,
-  CONFIG_FILE_NAME,
-  type CodexHooksStatus,
-} from "@/lib/codexHooksSetup";
-import { setupOpenCodeHooks, getOpenCodeHooksStatus, generatePluginScript, PLUGIN_DIR_NAME, PLUGIN_FILE_NAME, type OpenCodeHooksStatus } from "@/lib/openCodeHooksSetup";
+import { readTextFiles } from "@/lib/hostFileAccess";
 import { getHookServerUrl } from "@/lib/hookEndpoint";
-import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
-import { quoteShellArgument, readTextFiles } from "@/lib/hostFileAccess";
-import { upsertKanvibeHookTarget } from "@/lib/kanvibeProjectState";
+import { writeHookProviderFiles } from "@/lib/hookFileWriter";
+import { registerKanvibeHookTarget } from "@/lib/hookTargetRegistration";
+import {
+  getKanvibeHookProviderModules,
+  KANVIBE_HOOK_PROVIDER_MODULES,
+  type KanvibeHookProvider,
+  type KanvibeHookProviderModule,
+  type KanvibeHookStatus,
+} from "@/lib/kanvibeHookProviders";
 
 const HOOK_INSTALL_MAX_ATTEMPTS = 3;
 const HOOK_INSTALL_RETRY_DELAY_MS = 500;
 const NON_BLOCKING_HOOK_STATUS_CHECKS = new Set([
   "hasReachableHookServer",
   "hasDuplicateKanvibePlugins",
+  /** script의 KANVIBE_URL은 targets.json이 없을 때만 쓰는 fallback이므로 설치 실패로 보지 않는다 */
+  "hasExpectedHookServerUrl",
 ]);
 const OPEN_CODE_NON_BLOCKING_INSTALL_CHECKS = new Set([
   "hasRegisteredPlugin",
@@ -38,7 +25,7 @@ const activeHookInstallJobs = new Map<string, Promise<void>>();
 const activeHookFileInstallJobs = new Map<string, Promise<void>>();
 const scheduledHookInstallJobs = new Map<string, ScheduledHookInstallJob>();
 
-export type KanvibeHookProvider = "claude" | "gemini" | "codex" | "openCode";
+export type { KanvibeHookProvider };
 
 interface HookInstallScheduleOptions {
   delayMs?: number;
@@ -60,21 +47,18 @@ export async function installKanvibeHooks(
   taskId: string,
   sshHost?: string | null,
 ): Promise<void> {
-  const installKey = buildHookInstallKey(targetPath, taskId, sshHost, "all");
-  const activeJob = activeHookInstallJobs.get(installKey);
-  if (activeJob) {
-    return activeJob;
-  }
-
-  const installJob = runKanvibeHooksInstallWithRetry(targetPath, taskId, sshHost)
-    .finally(() => {
-      if (activeHookInstallJobs.get(installKey) === installJob) {
-        activeHookInstallJobs.delete(installKey);
-      }
-    });
-
-  activeHookInstallJobs.set(installKey, installJob);
-  return installJob;
+  return runDeduplicatedHookInstall(
+    activeHookInstallJobs,
+    buildHookInstallKey(targetPath, taskId, sshHost, "all"),
+    () => runHookInstallWithRetry(
+      "install",
+      { targetPath, taskId, sshHost },
+      async () => {
+        await installKanvibeHookFilesOnce(targetPath, taskId, sshHost);
+        await verifyHookInstallation(targetPath, taskId, sshHost);
+      },
+    ),
+  );
 }
 
 export async function installKanvibeHookFiles(
@@ -82,21 +66,15 @@ export async function installKanvibeHookFiles(
   taskId: string,
   sshHost?: string | null,
 ): Promise<void> {
-  const installKey = buildHookInstallKey(targetPath, taskId, sshHost, "all-files");
-  const activeJob = activeHookFileInstallJobs.get(installKey);
-  if (activeJob) {
-    return activeJob;
-  }
-
-  const installJob = runKanvibeHookFilesInstallWithRetry(targetPath, taskId, sshHost)
-    .finally(() => {
-      if (activeHookFileInstallJobs.get(installKey) === installJob) {
-        activeHookFileInstallJobs.delete(installKey);
-      }
-    });
-
-  activeHookFileInstallJobs.set(installKey, installJob);
-  return installJob;
+  return runDeduplicatedHookInstall(
+    activeHookFileInstallJobs,
+    buildHookInstallKey(targetPath, taskId, sshHost, "all-files"),
+    () => runHookInstallWithRetry(
+      "file install",
+      { targetPath, taskId, sshHost },
+      () => installKanvibeHookFilesOnce(targetPath, taskId, sshHost),
+    ),
+  );
 }
 
 export async function installKanvibeHookProvider(
@@ -105,21 +83,17 @@ export async function installKanvibeHookProvider(
   provider: KanvibeHookProvider,
   sshHost?: string | null,
 ): Promise<void> {
-  const installKey = buildHookInstallKey(targetPath, taskId, sshHost, provider);
-  const activeJob = activeHookInstallJobs.get(installKey);
-  if (activeJob) {
-    return activeJob;
-  }
+  const providerModule = KANVIBE_HOOK_PROVIDER_MODULES[provider];
 
-  const installJob = runKanvibeHookProviderInstallWithRetry(targetPath, taskId, provider, sshHost)
-    .finally(() => {
-      if (activeHookInstallJobs.get(installKey) === installJob) {
-        activeHookInstallJobs.delete(installKey);
-      }
-    });
-
-  activeHookInstallJobs.set(installKey, installJob);
-  return installJob;
+  return runDeduplicatedHookInstall(
+    activeHookInstallJobs,
+    buildHookInstallKey(targetPath, taskId, sshHost, provider),
+    () => runHookInstallWithRetry(
+      "provider install",
+      { targetPath, taskId, sshHost, provider: providerModule.label },
+      () => installKanvibeHookProviderOnce(providerModule, targetPath, taskId, sshHost),
+    ),
+  );
 }
 
 export function scheduleKanvibeHooksInstall(
@@ -173,6 +147,27 @@ export function scheduleKanvibeHooksVerification(
   }, options.delayMs ?? 0);
 }
 
+/** 같은 대상에 대한 설치 요청은 진행 중인 작업을 공유한다 */
+async function runDeduplicatedHookInstall(
+  activeJobs: Map<string, Promise<void>>,
+  installKey: string,
+  startJob: () => Promise<void>,
+): Promise<void> {
+  const activeJob = activeJobs.get(installKey);
+  if (activeJob) {
+    return activeJob;
+  }
+
+  const installJob = startJob().finally(() => {
+    if (activeJobs.get(installKey) === installJob) {
+      activeJobs.delete(installKey);
+    }
+  });
+
+  activeJobs.set(installKey, installJob);
+  return installJob;
+}
+
 function buildHookInstallKey(
   targetPath: string,
   taskId: string,
@@ -204,51 +199,23 @@ function runHookInstallCallback(callback: () => void): void {
   }
 }
 
-async function runKanvibeHooksInstallWithRetry(
-  targetPath: string,
-  taskId: string,
-  sshHost?: string | null,
-): Promise<void> {
-  let lastError: unknown;
-
-  for (let attempt = 1; attempt <= HOOK_INSTALL_MAX_ATTEMPTS; attempt += 1) {
-    try {
-      await installKanvibeHooksOnce(targetPath, taskId, sshHost);
-      return;
-    } catch (error) {
-      lastError = error;
-
-      if (attempt === HOOK_INSTALL_MAX_ATTEMPTS) {
-        throw error;
-      }
-
-      const retryDelayMs = HOOK_INSTALL_RETRY_DELAY_MS * attempt;
-      console.warn("[hooks] install failed; retrying", {
-        targetPath,
-        taskId,
-        sshHost: sshHost ?? null,
-        attempt,
-        maxAttempts: HOOK_INSTALL_MAX_ATTEMPTS,
-        nextAttemptInMs: retryDelayMs,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      await waitForHookInstallRetry(retryDelayMs);
-    }
-  }
-
-  throw lastError instanceof Error ? lastError : new Error("hooks 설정 실패");
+interface HookInstallContext {
+  targetPath: string;
+  taskId: string;
+  sshHost?: string | null;
+  provider?: string;
 }
 
-async function runKanvibeHookFilesInstallWithRetry(
-  targetPath: string,
-  taskId: string,
-  sshHost?: string | null,
+async function runHookInstallWithRetry(
+  operationLabel: string,
+  context: HookInstallContext,
+  install: () => Promise<void>,
 ): Promise<void> {
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= HOOK_INSTALL_MAX_ATTEMPTS; attempt += 1) {
     try {
-      await installKanvibeHookFilesOnce(targetPath, taskId, sshHost);
+      await install();
       return;
     } catch (error) {
       lastError = error;
@@ -258,47 +225,9 @@ async function runKanvibeHookFilesInstallWithRetry(
       }
 
       const retryDelayMs = HOOK_INSTALL_RETRY_DELAY_MS * attempt;
-      console.warn("[hooks] file install failed; retrying", {
-        targetPath,
-        taskId,
-        sshHost: sshHost ?? null,
-        attempt,
-        maxAttempts: HOOK_INSTALL_MAX_ATTEMPTS,
-        nextAttemptInMs: retryDelayMs,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      await waitForHookInstallRetry(retryDelayMs);
-    }
-  }
-
-  throw lastError instanceof Error ? lastError : new Error("hooks 파일 설정 실패");
-}
-
-async function runKanvibeHookProviderInstallWithRetry(
-  targetPath: string,
-  taskId: string,
-  provider: KanvibeHookProvider,
-  sshHost?: string | null,
-): Promise<void> {
-  let lastError: unknown;
-
-  for (let attempt = 1; attempt <= HOOK_INSTALL_MAX_ATTEMPTS; attempt += 1) {
-    try {
-      await installKanvibeHookProviderOnce(targetPath, taskId, provider, sshHost);
-      return;
-    } catch (error) {
-      lastError = error;
-
-      if (attempt === HOOK_INSTALL_MAX_ATTEMPTS) {
-        throw error;
-      }
-
-      const retryDelayMs = HOOK_INSTALL_RETRY_DELAY_MS * attempt;
-      console.warn("[hooks] provider install failed; retrying", {
-        provider,
-        targetPath,
-        taskId,
-        sshHost: sshHost ?? null,
+      console.warn(`[hooks] ${operationLabel} failed; retrying`, {
+        ...context,
+        sshHost: context.sshHost ?? null,
         attempt,
         maxAttempts: HOOK_INSTALL_MAX_ATTEMPTS,
         nextAttemptInMs: retryDelayMs,
@@ -315,436 +244,53 @@ async function waitForHookInstallRetry(delayMs: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
-interface HookProviderInstaller {
-  provider: KanvibeHookProvider;
-  label: string;
-  install: () => Promise<void>;
-  verify: () => Promise<HookVerificationStatus>;
-}
-
-function createHookProviderInstallers(
-  targetPath: string,
-  taskId: string,
-  hookServerUrl: string,
-  sshHost?: string | null,
-): Record<KanvibeHookProvider, HookProviderInstaller> {
-  return {
-    claude: {
-      provider: "claude",
-      label: "Claude",
-      install: () => sshHost
-        ? setupRemoteClaudeHooks(targetPath, taskId, hookServerUrl, sshHost)
-        : setupClaudeHooks(targetPath, taskId, hookServerUrl),
-      verify: () => getClaudeHooksStatus(targetPath, taskId, sshHost),
-    },
-    gemini: {
-      provider: "gemini",
-      label: "Gemini",
-      install: () => sshHost
-        ? setupRemoteGeminiHooks(targetPath, taskId, hookServerUrl, sshHost)
-        : setupGeminiHooks(targetPath, taskId, hookServerUrl),
-      verify: () => getGeminiHooksStatus(targetPath, taskId, sshHost),
-    },
-    codex: {
-      provider: "codex",
-      label: "Codex",
-      install: () => sshHost
-        ? setupRemoteCodexHooks(targetPath, taskId, hookServerUrl, sshHost)
-        : setupCodexHooks(targetPath, taskId, hookServerUrl),
-      verify: () => getCodexHooksStatus(targetPath, taskId, sshHost),
-    },
-    openCode: {
-      provider: "openCode",
-      label: "OpenCode",
-      install: () => sshHost
-        ? setupRemoteOpenCodeHooks(targetPath, taskId, hookServerUrl, sshHost)
-        : setupOpenCodeHooks(targetPath, taskId, hookServerUrl),
-      verify: () => getOpenCodeHooksStatus(targetPath, taskId, sshHost),
-    },
-  };
-}
-
-async function installKanvibeHooksOnce(
-  targetPath: string,
-  taskId: string,
-  sshHost?: string | null,
-): Promise<void> {
-  await installKanvibeHookFilesOnce(targetPath, taskId, sshHost);
-  await verifyHookInstallation(targetPath, taskId, sshHost);
-}
-
+/**
+ * 모든 provider의 hook 파일을 한 번에 만들어 기록한다.
+ * 기존 설정 파일 읽기와 파일 쓰기를 각각 한 번으로 묶어 원격 설치의 왕복 횟수를 줄인다.
+ */
 async function installKanvibeHookFilesOnce(
   targetPath: string,
   taskId: string,
   sshHost?: string | null,
 ): Promise<void> {
   const hookServerUrl = await getHookServerUrl(sshHost);
-  await upsertKanvibeHookTarget(targetPath, { url: hookServerUrl, taskId }, sshHost);
+  await registerKanvibeHookTarget(targetPath, taskId, hookServerUrl, sshHost);
 
-  if (!sshHost) {
-    const installers = Object.values(createHookProviderInstallers(targetPath, taskId, hookServerUrl, sshHost));
-    const results = await Promise.allSettled(installers.map(({ install }) => install()));
-    assertHookInstallResults(results, installers.map(({ label }) => label));
-  } else {
+  const providerModules = getKanvibeHookProviderModules();
+  const existingFiles = await readTextFiles(
+    providerModules.flatMap((providerModule) => providerModule.getInstallInputPaths(targetPath, sshHost)),
+    sshHost,
+  );
+
+  const buildResults = providerModules.map((providerModule) => {
     try {
-      await addAiToolPatternsToGitExclude(targetPath, sshHost);
+      return providerModule.buildFiles(targetPath, taskId, hookServerUrl, existingFiles, sshHost);
     } catch (error) {
-      console.warn("[hooks] remote git exclude update failed", {
+      console.error(`[hooks] ${providerModule.label} install failed`, {
+        provider: providerModule.label,
         targetPath,
-        sshHost,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-
-    await setupRemoteKanvibeHooks(targetPath, taskId, hookServerUrl, sshHost);
-  }
-}
-
-async function installKanvibeHookProviderOnce(
-  targetPath: string,
-  taskId: string,
-  provider: KanvibeHookProvider,
-  sshHost?: string | null,
-): Promise<void> {
-  const hookServerUrl = await getHookServerUrl(sshHost);
-  await upsertKanvibeHookTarget(targetPath, { url: hookServerUrl, taskId }, sshHost);
-  const installer = createHookProviderInstallers(targetPath, taskId, hookServerUrl, sshHost)[provider];
-
-  if (sshHost) {
-    try {
-      await addAiToolPatternsToGitExclude(targetPath, sshHost);
-    } catch (error) {
-      console.warn("[hooks] remote git exclude update failed", {
-        provider: installer.label,
-        targetPath,
-        sshHost,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-
-  await installer.install();
-  await verifyHookProviderInstallation(installer, targetPath, taskId, sshHost);
-}
-
-async function setupRemoteClaudeHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
-  const claudeDir = path.posix.join(repoPath, ".claude");
-  const settingsPath = path.posix.join(claudeDir, "settings.json");
-  const existingFiles = await readRemoteHookInstallInputs(sshHost, [settingsPath]);
-
-  await writeRemoteTextFiles(
-    [
-      ...buildRemoteClaudeHookFiles(repoPath, taskId, hookServerUrl, existingFiles.get(settingsPath)?.content ?? ""),
-    ],
-    sshHost,
-  );
-}
-
-async function setupRemoteGeminiHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
-  const geminiDir = path.posix.join(repoPath, ".gemini");
-  const settingsPath = path.posix.join(geminiDir, "settings.json");
-  const existingFiles = await readRemoteHookInstallInputs(sshHost, [settingsPath]);
-
-  await writeRemoteTextFiles(
-    [
-      ...buildRemoteGeminiHookFiles(repoPath, taskId, hookServerUrl, existingFiles.get(settingsPath)?.content ?? ""),
-    ],
-    sshHost,
-  );
-}
-
-async function setupRemoteCodexHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
-  const codexDir = path.posix.join(repoPath, ".codex");
-  const configPath = path.posix.join(codexDir, CONFIG_FILE_NAME);
-  const hooksPath = path.posix.join(codexDir, HOOKS_FILE_NAME);
-  const existingFiles = await readRemoteHookInstallInputs(sshHost, [configPath, hooksPath]);
-
-  await writeRemoteTextFiles(
-    [
-      ...buildRemoteCodexHookFiles(
-        repoPath,
         taskId,
-        hookServerUrl,
-        existingFiles.get(configPath)?.content ?? "",
-        existingFiles.get(hooksPath)?.content ?? "",
-      ),
-    ],
-    sshHost,
-  );
-}
-
-async function setupRemoteOpenCodeHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
-  await writeRemoteTextFiles(buildRemoteOpenCodeHookFiles(repoPath, taskId, hookServerUrl), sshHost);
-}
-
-async function setupRemoteKanvibeHooks(repoPath: string, taskId: string, hookServerUrl: string, sshHost: string) {
-  const claudeSettingsPath = path.posix.join(repoPath, ".claude", "settings.json");
-  const geminiSettingsPath = path.posix.join(repoPath, ".gemini", "settings.json");
-  const codexConfigPath = path.posix.join(repoPath, ".codex", CONFIG_FILE_NAME);
-  const codexHooksPath = path.posix.join(repoPath, ".codex", HOOKS_FILE_NAME);
-  const existingFiles = await readRemoteHookInstallInputs(
-    sshHost,
-    [claudeSettingsPath, geminiSettingsPath, codexConfigPath, codexHooksPath],
-  );
-  const plans = [
-    {
-      label: "Claude",
-      files: buildRemoteClaudeHookFiles(repoPath, taskId, hookServerUrl, existingFiles.get(claudeSettingsPath)?.content ?? ""),
-    },
-    {
-      label: "Gemini",
-      files: buildRemoteGeminiHookFiles(repoPath, taskId, hookServerUrl, existingFiles.get(geminiSettingsPath)?.content ?? ""),
-    },
-    {
-      label: "Codex",
-      files: buildRemoteCodexHookFiles(
-        repoPath,
-        taskId,
-        hookServerUrl,
-        existingFiles.get(codexConfigPath)?.content ?? "",
-        existingFiles.get(codexHooksPath)?.content ?? "",
-      ),
-    },
-    {
-      label: "OpenCode",
-      files: buildRemoteOpenCodeHookFiles(repoPath, taskId, hookServerUrl),
-    },
-  ];
-
-  const results = await Promise.allSettled(plans.map(async ({ label, files }) => {
-    try {
-      await writeRemoteTextFiles(files, sshHost);
-    } catch (error) {
-      console.error(`[hooks] ${label} install failed`, {
-        targetPath: repoPath,
-        taskId,
-        sshHost,
+        sshHost: sshHost ?? null,
         error: error instanceof Error ? error.message : String(error),
       });
       throw error;
     }
-  }));
-  assertHookInstallResults(results, plans.map(({ label }) => label));
+  });
+
+  await writeHookProviderFiles(buildResults.flat(), sshHost);
 }
 
-async function readRemoteHookInstallInputs(
-  sshHost: string,
-  filePaths: string[] = [],
-): Promise<Awaited<ReturnType<typeof readTextFiles>>> {
-  return readTextFiles(filePaths, sshHost);
-}
-
-function buildRemoteClaudeHookFiles(
-  repoPath: string,
+async function installKanvibeHookProviderOnce(
+  providerModule: KanvibeHookProviderModule,
+  targetPath: string,
   taskId: string,
-  hookServerUrl: string,
-  settingsContent: string,
-): RemoteTextFile[] {
-  const claudeDir = path.posix.join(repoPath, ".claude");
-  const hooksDir = path.posix.join(claudeDir, "hooks");
-  const settingsPath = path.posix.join(claudeDir, "settings.json");
-  const settings = parseRemoteJsonObject(settingsContent);
-  const hooks = ((settings.hooks as Record<string, unknown[]>) || {});
-  settings.hooks = hooks;
+  sshHost?: string | null,
+): Promise<void> {
+  const hookServerUrl = await getHookServerUrl(sshHost);
 
-  upsertHookEntry(hooks, "UserPromptSubmit", "kanvibe-prompt-hook.sh", {
-    hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh', timeout: 10 }],
-  });
-  upsertHookEntry(hooks, "PreToolUse", "kanvibe-question-hook.sh", {
-    matcher: "AskUserQuestion",
-    hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-question-hook.sh', timeout: 10 }],
-  });
-  upsertHookEntry(hooks, "PostToolUse", "kanvibe-prompt-hook.sh", {
-    matcher: "AskUserQuestion",
-    hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-prompt-hook.sh', timeout: 10 }],
-  });
-  upsertHookEntry(hooks, "Stop", "kanvibe-stop-hook.sh", {
-    hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/kanvibe-stop-hook.sh', timeout: 10 }],
-  });
-
-  return [
-    {
-      filePath: path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"),
-      content: generateClaudePromptHookScript(hookServerUrl, taskId),
-      mode: 0o755,
-    },
-    {
-      filePath: path.posix.join(hooksDir, "kanvibe-stop-hook.sh"),
-      content: generateClaudeStopHookScript(hookServerUrl, taskId),
-      mode: 0o755,
-    },
-    {
-      filePath: path.posix.join(hooksDir, "kanvibe-question-hook.sh"),
-      content: generateClaudeQuestionHookScript(hookServerUrl, taskId),
-      mode: 0o755,
-    },
-    {
-      filePath: settingsPath,
-      content: JSON.stringify(settings, null, 2) + "\n",
-    },
-  ];
+  await providerModule.install(targetPath, taskId, hookServerUrl, sshHost);
+  await verifyHookProviderInstallation(providerModule, targetPath, taskId, sshHost);
 }
-
-function buildRemoteGeminiHookFiles(
-  repoPath: string,
-  taskId: string,
-  hookServerUrl: string,
-  settingsContent: string,
-): RemoteTextFile[] {
-  const geminiDir = path.posix.join(repoPath, ".gemini");
-  const hooksDir = path.posix.join(geminiDir, "hooks");
-  const settingsPath = path.posix.join(geminiDir, "settings.json");
-  const settings = parseRemoteJsonObject(settingsContent);
-  const hooks = ((settings.hooks as Record<string, unknown[]>) || {});
-  settings.hooks = hooks;
-
-  upsertHookEntry(hooks, "BeforeAgent", "kanvibe-prompt-hook.sh", {
-    matcher: "*",
-    hooks: [{ type: "command", command: '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-prompt-hook.sh', timeout: 10000 }],
-  });
-  upsertHookEntry(hooks, "AfterAgent", "kanvibe-stop-hook.sh", {
-    matcher: "*",
-    hooks: [{ type: "command", command: '"$GEMINI_PROJECT_DIR"/.gemini/hooks/kanvibe-stop-hook.sh', timeout: 10000 }],
-  });
-
-  return [
-    {
-      filePath: path.posix.join(hooksDir, "kanvibe-prompt-hook.sh"),
-      content: generateGeminiPromptHookScript(hookServerUrl, taskId),
-      mode: 0o755,
-    },
-    {
-      filePath: path.posix.join(hooksDir, "kanvibe-stop-hook.sh"),
-      content: generateGeminiStopHookScript(hookServerUrl, taskId),
-      mode: 0o755,
-    },
-    {
-      filePath: settingsPath,
-      content: JSON.stringify(settings, null, 2) + "\n",
-    },
-  ];
-}
-
-function buildRemoteCodexHookFiles(
-  repoPath: string,
-  taskId: string,
-  hookServerUrl: string,
-  configContent: string,
-  hooksContent: string,
-): RemoteTextFile[] {
-  const codexDir = path.posix.join(repoPath, ".codex");
-  const hooksDir = path.posix.join(codexDir, "hooks");
-  const configPath = path.posix.join(codexDir, CONFIG_FILE_NAME);
-  const hooksPath = path.posix.join(codexDir, HOOKS_FILE_NAME);
-
-  return [
-    {
-      filePath: path.posix.join(hooksDir, PROMPT_HOOK_SCRIPT_NAME),
-      content: generateCodexPromptHookScript(hookServerUrl, taskId),
-      mode: 0o755,
-    },
-    {
-      filePath: path.posix.join(hooksDir, PERMISSION_HOOK_SCRIPT_NAME),
-      content: generateCodexPermissionHookScript(hookServerUrl, taskId),
-      mode: 0o755,
-    },
-    {
-      filePath: path.posix.join(hooksDir, PRE_TOOL_HOOK_SCRIPT_NAME),
-      content: generateCodexPreToolHookScript(hookServerUrl, taskId),
-      mode: 0o755,
-    },
-    {
-      filePath: path.posix.join(hooksDir, STOP_HOOK_SCRIPT_NAME),
-      content: generateCodexStopHookScript(hookServerUrl, taskId),
-      mode: 0o755,
-    },
-    {
-      filePath: configPath,
-      content: upsertCodexConfigToml(configContent),
-    },
-    {
-      filePath: hooksPath,
-      content: upsertCodexHooksJson(hooksContent),
-    },
-  ];
-}
-
-function buildRemoteOpenCodeHookFiles(
-  repoPath: string,
-  taskId: string,
-  hookServerUrl: string,
-): RemoteTextFile[] {
-  const pluginDir = path.posix.join(repoPath, ".opencode", PLUGIN_DIR_NAME);
-  return [
-    {
-      filePath: path.posix.join(pluginDir, PLUGIN_FILE_NAME),
-      content: generatePluginScript(hookServerUrl, taskId),
-    },
-  ];
-}
-
-function parseRemoteJsonObject(content: string): Record<string, unknown> {
-  if (!content) {
-    return {};
-  }
-
-  try {
-    return JSON.parse(content) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
-}
-
-interface RemoteTextFile {
-  filePath: string;
-  content: string;
-  mode?: number;
-}
-
-async function writeRemoteTextFiles(files: RemoteTextFile[], sshHost: string): Promise<void> {
-  const command = files.map(({ filePath, content, mode }) => {
-    const encodedContent = Buffer.from(content, "utf-8").toString("base64");
-    const parts = [
-      `mkdir -p ${quoteShellArgument(path.posix.dirname(filePath))}`,
-      `printf '%s' ${quoteShellArgument(encodedContent)} | (base64 -d 2>/dev/null || base64 -D) > ${quoteShellArgument(filePath)}`,
-    ];
-
-    if (mode) {
-      parts.push(`chmod ${mode.toString(8)} ${quoteShellArgument(filePath)}`);
-    }
-
-    return parts.join(" && ");
-  }).join(" && ");
-
-  await execGit(command, sshHost);
-}
-
-function upsertHookEntry(
-  hooks: Record<string, unknown[]>,
-  bucket: string,
-  scriptName: string,
-  entry: Record<string, unknown>,
-) {
-  const currentEntries = Array.isArray(hooks[bucket]) ? hooks[bucket] : [];
-  hooks[bucket] = currentEntries.filter((value) => !JSON.stringify(value).includes(scriptName));
-  hooks[bucket].push(entry);
-}
-
-function assertHookInstallResults(results: PromiseSettledResult<unknown>[], providers: string[]) {
-  const failureIndex = results.findIndex((result) => result.status === "rejected");
-  if (failureIndex === -1) {
-    return;
-  }
-
-  const failure = results[failureIndex] as PromiseRejectedResult;
-  console.error(`[hooks] ${providers[failureIndex]} install failed`, {
-    provider: providers[failureIndex],
-    error: failure.reason instanceof Error ? failure.reason.message : String(failure.reason),
-  });
-  throw failure.reason instanceof Error ? failure.reason : new Error("hooks 설정 실패");
-}
-
-type HookVerificationStatus = ClaudeHooksStatus | GeminiHooksStatus | CodexHooksStatus | OpenCodeHooksStatus;
 
 interface HookVerificationFailure {
   provider: string;
@@ -760,12 +306,12 @@ async function verifyHookInstallation(targetPath: string, taskId: string, sshHos
 }
 
 async function verifyHookProviderInstallation(
-  installer: HookProviderInstaller,
+  providerModule: KanvibeHookProviderModule,
   targetPath: string,
   taskId: string,
   sshHost?: string | null,
 ) {
-  const failure = await logHookProviderVerificationStatus(installer, targetPath, taskId, sshHost);
+  const failure = await logHookProviderVerificationStatus(providerModule, targetPath, taskId, sshHost);
   if (failure) {
     throw new Error(`hooks 검증 실패: ${formatHookVerificationFailures([failure])}`);
   }
@@ -776,23 +322,18 @@ async function logHookVerificationStatuses(
   taskId: string,
   sshHost?: string | null,
 ): Promise<HookVerificationFailure[]> {
-  const verifiers = [
-    { provider: "Claude", verify: getClaudeHooksStatus },
-    { provider: "Gemini", verify: getGeminiHooksStatus },
-    { provider: "Codex", verify: getCodexHooksStatus },
-    { provider: "OpenCode", verify: getOpenCodeHooksStatus },
-  ] as const;
-
-  const results = await Promise.allSettled(verifiers.map(({ verify }) => verify(targetPath, taskId, sshHost)));
+  const providerModules = getKanvibeHookProviderModules();
+  const results = await Promise.allSettled(
+    providerModules.map((providerModule) => providerModule.getStatus(targetPath, taskId, sshHost)),
+  );
   const failures: HookVerificationFailure[] = [];
 
   for (const [index, result] of results.entries()) {
-    const provider = verifiers[index].provider;
+    const provider = providerModules[index].label;
     if (result.status === "fulfilled") {
-      const failedChecks = logHookVerificationStatus(provider, result.value, targetPath, taskId, sshHost);
-      const fatalFailedChecks = getFatalHookVerificationFailedChecks(provider, result.value, failedChecks);
-      if (shouldFailHookVerification(result.value, failedChecks, fatalFailedChecks)) {
-        failures.push({ provider, failedChecks: fatalFailedChecks });
+      const failure = evaluateHookVerificationStatus(provider, result.value, targetPath, taskId, sshHost);
+      if (failure) {
+        failures.push(failure);
       }
       continue;
     }
@@ -811,33 +352,44 @@ async function logHookVerificationStatuses(
 }
 
 async function logHookProviderVerificationStatus(
-  installer: HookProviderInstaller,
+  providerModule: KanvibeHookProviderModule,
   targetPath: string,
   taskId: string,
   sshHost?: string | null,
 ): Promise<HookVerificationFailure | null> {
   try {
-    const status = await installer.verify();
-    const failedChecks = logHookVerificationStatus(installer.label, status, targetPath, taskId, sshHost);
-    const fatalFailedChecks = getFatalHookVerificationFailedChecks(installer.label, status, failedChecks);
-    return shouldFailHookVerification(status, failedChecks, fatalFailedChecks)
-      ? { provider: installer.label, failedChecks: fatalFailedChecks }
-      : null;
+    const status = await providerModule.getStatus(targetPath, taskId, sshHost);
+    return evaluateHookVerificationStatus(providerModule.label, status, targetPath, taskId, sshHost);
   } catch (error) {
-    console.warn(`[hooks] ${installer.label} verification unavailable`, {
-      provider: installer.label,
+    console.warn(`[hooks] ${providerModule.label} verification unavailable`, {
+      provider: providerModule.label,
       targetPath,
       taskId,
       sshHost: sshHost ?? null,
       error: error instanceof Error ? error.message : String(error),
     });
-    return { provider: installer.label, error };
+    return { provider: providerModule.label, error };
   }
+}
+
+function evaluateHookVerificationStatus(
+  provider: string,
+  status: KanvibeHookStatus,
+  targetPath: string,
+  taskId: string,
+  sshHost?: string | null,
+): HookVerificationFailure | null {
+  const failedChecks = logHookVerificationStatus(provider, status, targetPath, taskId, sshHost);
+  const fatalFailedChecks = getFatalHookVerificationFailedChecks(provider, status, failedChecks);
+
+  return shouldFailHookVerification(status, failedChecks, fatalFailedChecks)
+    ? { provider, failedChecks: fatalFailedChecks }
+    : null;
 }
 
 function logHookVerificationStatus(
   provider: string,
-  status: HookVerificationStatus,
+  status: KanvibeHookStatus,
   targetPath: string,
   taskId: string,
   sshHost?: string | null,
@@ -851,6 +403,7 @@ function logHookVerificationStatus(
     installed: status.installed,
     failedChecks,
     boundTaskId: status.boundTaskId ?? null,
+    registeredHookTargetUrl: status.registeredHookTargetUrl ?? null,
     configuredHookServerUrl: status.configuredHookServerUrl ?? null,
     expectedHookServerUrl: status.expectedHookServerUrl ?? null,
     registeredPluginUrls: "registeredPluginUrls" in status && Array.isArray(status.registeredPluginUrls)
@@ -867,7 +420,7 @@ function logHookVerificationStatus(
   return failedChecks;
 }
 
-function getHookVerificationFailedChecks(status: HookVerificationStatus): string[] {
+function getHookVerificationFailedChecks(status: KanvibeHookStatus): string[] {
   return Object.entries(status)
     .filter(([key, value]) => key.startsWith("has") && value === false)
     .filter(([key]) => !NON_BLOCKING_HOOK_STATUS_CHECKS.has(key))
@@ -876,7 +429,7 @@ function getHookVerificationFailedChecks(status: HookVerificationStatus): string
 
 function getFatalHookVerificationFailedChecks(
   provider: string,
-  status: HookVerificationStatus,
+  status: KanvibeHookStatus,
   failedChecks: string[],
 ): string[] {
   if (status.installed || provider !== "OpenCode") {
@@ -887,7 +440,7 @@ function getFatalHookVerificationFailedChecks(
 }
 
 function shouldFailHookVerification(
-  status: HookVerificationStatus,
+  status: KanvibeHookStatus,
   failedChecks: string[],
   fatalFailedChecks: string[],
 ): boolean {

--- a/src/lib/kanvibeProjectState.ts
+++ b/src/lib/kanvibeProjectState.ts
@@ -6,10 +6,14 @@ export const KANVIBE_DIR_NAME = ".kanvibe";
 export const TASK_STATE_FILE_NAME = "status.json";
 export const TARGETS_FILE_NAME = "targets.json";
 
+/** `#RRGGBB` 형태의 프로젝트 색상만 허용한다. hook shell script가 같은 규칙으로 검증한다 */
+const PROJECT_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
 export interface KanvibeTaskState {
   schemaVersion: 1;
   status: TaskStatus;
   updatedAt?: string;
+  projectColor?: string;
 }
 
 export interface KanvibeHookTarget {
@@ -21,6 +25,12 @@ export interface KanvibeTargetsState {
   schemaVersion: 1;
   targets: KanvibeHookTarget[];
   updatedAt?: string;
+}
+
+/** status.json에 실제로 담기는 필드. status와 projectColor는 서로 독립적으로 존재할 수 있다 */
+interface KanvibeTaskStateFields {
+  status: TaskStatus | null;
+  projectColor: string | null;
 }
 
 export function getKanvibeTaskStatePath(repoPath: string, sshHost?: string | null): string {
@@ -39,18 +49,48 @@ export async function readKanvibeTaskState(
   return parseKanvibeTaskState(content);
 }
 
-export async function writeKanvibeTaskState(
+/**
+ * 다른 KanVibe client가 기록한 프로젝트 색상을 읽는다.
+ * status가 아직 없는 status.json에서도 색상만 단독으로 읽을 수 있다.
+ */
+export async function readKanvibeProjectColor(
   repoPath: string,
-  taskState: Pick<KanvibeTaskState, "status">,
   sshHost?: string | null,
-): Promise<void> {
-  await writeTextFile(
-    getKanvibeTaskStatePath(repoPath, sshHost),
-    buildKanvibeTaskStateContent(taskState),
-    sshHost,
-  );
+): Promise<string | null> {
+  const content = await readTextFile(getKanvibeTaskStatePath(repoPath, sshHost), sshHost);
+  return parseKanvibeTaskStateFields(content).projectColor;
 }
 
+/** task 상태만 갱신하고 다른 client가 기록한 프로젝트 색상은 그대로 보존한다 */
+export async function writeKanvibeTaskStatus(
+  repoPath: string,
+  status: TaskStatus,
+  sshHost?: string | null,
+): Promise<void> {
+  await mergeKanvibeTaskStateFile(repoPath, sshHost, (current) => ({ ...current, status }));
+}
+
+/** 프로젝트 색상만 갱신하고 기존 task 상태는 그대로 보존한다 */
+export async function writeKanvibeProjectColor(
+  repoPath: string,
+  projectColor: string,
+  sshHost?: string | null,
+): Promise<void> {
+  const normalizedColor = parseProjectColor(projectColor);
+  if (!normalizedColor) {
+    return;
+  }
+
+  await mergeKanvibeTaskStateFile(repoPath, sshHost, (current) => ({
+    ...current,
+    projectColor: normalizedColor,
+  }));
+}
+
+/**
+ * hook 알림 대상을 client(url) 단위로 등록한다.
+ * 같은 client가 다른 task로 재설치하면 taskId만 교체되고, 새로운 client는 뒤에 추가된다.
+ */
 export async function upsertKanvibeHookTarget(
   repoPath: string,
   target: KanvibeHookTarget,
@@ -68,13 +108,26 @@ export async function upsertKanvibeHookTarget(
   );
 }
 
+/** targets.json에 해당 client url과 taskId 쌍이 등록되어 있는지 확인한다 */
+export function hasKanvibeHookTarget(content: string, target: KanvibeHookTarget): boolean {
+  const expectedTarget = normalizeKanvibeTarget(target);
+  if (!expectedTarget) {
+    return false;
+  }
+
+  return parseKanvibeTargets(content).targets.some(
+    (value) => value.url === expectedTarget.url && value.taskId === expectedTarget.taskId,
+  );
+}
+
 export function buildKanvibeTaskStateContent(
-  taskState: Pick<KanvibeTaskState, "status">,
+  taskState: Partial<Pick<KanvibeTaskState, "status" | "projectColor">>,
 ): string {
-  const payload: KanvibeTaskState = {
+  const payload: Partial<KanvibeTaskState> = {
     schemaVersion: 1,
-    status: taskState.status,
+    ...(taskState.status ? { status: taskState.status } : {}),
     updatedAt: new Date().toISOString(),
+    ...(taskState.projectColor ? { projectColor: taskState.projectColor } : {}),
   };
 
   return JSON.stringify(payload, null, 2) + "\n";
@@ -91,33 +144,18 @@ export function buildKanvibeTargetsContent(targets: KanvibeHookTarget[]): string
 }
 
 export function parseKanvibeTaskState(content: string): KanvibeTaskState | null {
-  if (typeof content !== "string" || !content.trim()) {
+  const { status, projectColor } = parseKanvibeTaskStateFields(content);
+  if (!status) {
     return null;
   }
 
-  const statusFromMarkdown = parseTaskStatus(content.trim());
-  if (statusFromMarkdown) {
-    return {
-      schemaVersion: 1,
-      status: statusFromMarkdown,
-    };
-  }
-
-  try {
-    const parsed = JSON.parse(content) as { status?: unknown; updatedAt?: unknown };
-    const status = parseTaskStatus(parsed.status);
-    if (!status) {
-      return null;
-    }
-
-    return {
-      schemaVersion: 1,
-      status,
-      ...(typeof parsed.updatedAt === "string" && parsed.updatedAt.length > 0 ? { updatedAt: parsed.updatedAt } : {}),
-    };
-  } catch {
-    return null;
-  }
+  const updatedAt = parseUpdatedAt(content);
+  return {
+    schemaVersion: 1,
+    status,
+    ...(updatedAt ? { updatedAt } : {}),
+    ...(projectColor ? { projectColor } : {}),
+  };
 }
 
 export function parseKanvibeTargets(content: string): KanvibeTargetsState {
@@ -147,6 +185,64 @@ export function parseTaskStatus(value: unknown): TaskStatus | null {
   return statuses.has(normalized) ? normalized as TaskStatus : null;
 }
 
+export function parseProjectColor(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return PROJECT_COLOR_PATTERN.test(normalized) ? normalized : null;
+}
+
+async function mergeKanvibeTaskStateFile(
+  repoPath: string,
+  sshHost: string | null | undefined,
+  merge: (current: KanvibeTaskStateFields) => KanvibeTaskStateFields,
+): Promise<void> {
+  const statePath = getKanvibeTaskStatePath(repoPath, sshHost);
+  const currentFields = parseKanvibeTaskStateFields(await readTextFile(statePath, sshHost));
+  const nextFields = merge(currentFields);
+
+  await writeTextFile(
+    statePath,
+    buildKanvibeTaskStateContent({
+      ...(nextFields.status ? { status: nextFields.status } : {}),
+      ...(nextFields.projectColor ? { projectColor: nextFields.projectColor } : {}),
+    }),
+    sshHost,
+  );
+}
+
+function parseKanvibeTaskStateFields(content: string): KanvibeTaskStateFields {
+  if (typeof content !== "string" || !content.trim()) {
+    return { status: null, projectColor: null };
+  }
+
+  const statusFromMarkdown = parseTaskStatus(content.trim());
+  if (statusFromMarkdown) {
+    return { status: statusFromMarkdown, projectColor: null };
+  }
+
+  try {
+    const parsed = JSON.parse(content) as { status?: unknown; projectColor?: unknown };
+    return {
+      status: parseTaskStatus(parsed.status),
+      projectColor: parseProjectColor(parsed.projectColor),
+    };
+  } catch {
+    return { status: null, projectColor: null };
+  }
+}
+
+function parseUpdatedAt(content: string): string | null {
+  try {
+    const parsed = JSON.parse(content) as { updatedAt?: unknown };
+    return typeof parsed.updatedAt === "string" && parsed.updatedAt.length > 0 ? parsed.updatedAt : null;
+  } catch {
+    return null;
+  }
+}
+
 function upsertKanvibeTarget(targets: unknown[], target: KanvibeHookTarget): KanvibeHookTarget[] {
   const normalizedTarget = normalizeKanvibeTarget(target);
   if (!normalizedTarget) {
@@ -154,7 +250,7 @@ function upsertKanvibeTarget(targets: unknown[], target: KanvibeHookTarget): Kan
   }
 
   const nextTargets = normalizeKanvibeTargets(targets);
-  const targetIndex = nextTargets.findIndex((value) => value.taskId === normalizedTarget.taskId);
+  const targetIndex = nextTargets.findIndex((value) => value.url === normalizedTarget.url);
   if (targetIndex === -1) {
     return [...nextTargets, normalizedTarget];
   }
@@ -164,15 +260,15 @@ function upsertKanvibeTarget(targets: unknown[], target: KanvibeHookTarget): Kan
 
 function normalizeKanvibeTargets(targets: unknown[]): KanvibeHookTarget[] {
   const nextTargets: KanvibeHookTarget[] = [];
-  const seenTaskIds = new Set<string>();
+  const seenUrls = new Set<string>();
 
   for (const target of targets) {
     const normalizedTarget = normalizeKanvibeTarget(target);
-    if (!normalizedTarget || seenTaskIds.has(normalizedTarget.taskId)) {
+    if (!normalizedTarget || seenUrls.has(normalizedTarget.url)) {
       continue;
     }
 
-    seenTaskIds.add(normalizedTarget.taskId);
+    seenUrls.add(normalizedTarget.url);
     nextTargets.push(normalizedTarget);
   }
 

--- a/src/lib/kanvibeProjectState.ts
+++ b/src/lib/kanvibeProjectState.ts
@@ -4,16 +4,26 @@ import { readTextFile, writeTextFile } from "@/lib/hostFileAccess";
 
 export const KANVIBE_DIR_NAME = ".kanvibe";
 export const TASK_STATE_FILE_NAME = "status.json";
+export const PROJECT_STATE_FILE_NAME = "project.json";
 export const TARGETS_FILE_NAME = "targets.json";
 
-/** `#RRGGBB` 형태의 프로젝트 색상만 허용한다. hook shell script가 같은 규칙으로 검증한다 */
+/** `#RRGGBB` 형태의 프로젝트 색상만 허용한다 */
 const PROJECT_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 
 export interface KanvibeTaskState {
   schemaVersion: 1;
   status: TaskStatus;
   updatedAt?: string;
-  projectColor?: string;
+}
+
+/**
+ * 프로젝트 단위 공유 상태. task 상태와 파일을 분리해 hook(status.json 기록)과
+ * KanVibe client(project.json 기록)가 서로의 값을 덮어쓸 수 없게 한다.
+ */
+export interface KanvibeProjectState {
+  schemaVersion: 1;
+  projectColor: string;
+  updatedAt?: string;
 }
 
 export interface KanvibeHookTarget {
@@ -27,14 +37,12 @@ export interface KanvibeTargetsState {
   updatedAt?: string;
 }
 
-/** status.json에 실제로 담기는 필드. status와 projectColor는 서로 독립적으로 존재할 수 있다 */
-interface KanvibeTaskStateFields {
-  status: TaskStatus | null;
-  projectColor: string | null;
-}
-
 export function getKanvibeTaskStatePath(repoPath: string, sshHost?: string | null): string {
   return getPathModule(sshHost).join(repoPath, KANVIBE_DIR_NAME, TASK_STATE_FILE_NAME);
+}
+
+export function getKanvibeProjectStatePath(repoPath: string, sshHost?: string | null): string {
+  return getPathModule(sshHost).join(repoPath, KANVIBE_DIR_NAME, PROJECT_STATE_FILE_NAME);
 }
 
 export function getKanvibeTargetsPath(repoPath: string, sshHost?: string | null): string {
@@ -49,28 +57,27 @@ export async function readKanvibeTaskState(
   return parseKanvibeTaskState(content);
 }
 
-/**
- * 다른 KanVibe client가 기록한 프로젝트 색상을 읽는다.
- * status가 아직 없는 status.json에서도 색상만 단독으로 읽을 수 있다.
- */
+/** 다른 KanVibe client가 project.json에 기록한 프로젝트 색상을 읽는다 */
 export async function readKanvibeProjectColor(
   repoPath: string,
   sshHost?: string | null,
 ): Promise<string | null> {
-  const content = await readTextFile(getKanvibeTaskStatePath(repoPath, sshHost), sshHost);
-  return parseKanvibeTaskStateFields(content).projectColor;
+  const content = await readTextFile(getKanvibeProjectStatePath(repoPath, sshHost), sshHost);
+  return parseKanvibeProjectState(content)?.projectColor ?? null;
 }
 
-/** task 상태만 갱신하고 다른 client가 기록한 프로젝트 색상은 그대로 보존한다 */
 export async function writeKanvibeTaskStatus(
   repoPath: string,
   status: TaskStatus,
   sshHost?: string | null,
 ): Promise<void> {
-  await mergeKanvibeTaskStateFile(repoPath, sshHost, (current) => ({ ...current, status }));
+  await writeTextFile(
+    getKanvibeTaskStatePath(repoPath, sshHost),
+    buildKanvibeTaskStateContent({ status }),
+    sshHost,
+  );
 }
 
-/** 프로젝트 색상만 갱신하고 기존 task 상태는 그대로 보존한다 */
 export async function writeKanvibeProjectColor(
   repoPath: string,
   projectColor: string,
@@ -81,10 +88,11 @@ export async function writeKanvibeProjectColor(
     return;
   }
 
-  await mergeKanvibeTaskStateFile(repoPath, sshHost, (current) => ({
-    ...current,
-    projectColor: normalizedColor,
-  }));
+  await writeTextFile(
+    getKanvibeProjectStatePath(repoPath, sshHost),
+    buildKanvibeProjectStateContent(normalizedColor),
+    sshHost,
+  );
 }
 
 /**
@@ -121,13 +129,22 @@ export function hasKanvibeHookTarget(content: string, target: KanvibeHookTarget)
 }
 
 export function buildKanvibeTaskStateContent(
-  taskState: Partial<Pick<KanvibeTaskState, "status" | "projectColor">>,
+  taskState: Pick<KanvibeTaskState, "status">,
 ): string {
-  const payload: Partial<KanvibeTaskState> = {
+  const payload: KanvibeTaskState = {
     schemaVersion: 1,
-    ...(taskState.status ? { status: taskState.status } : {}),
+    status: taskState.status,
     updatedAt: new Date().toISOString(),
-    ...(taskState.projectColor ? { projectColor: taskState.projectColor } : {}),
+  };
+
+  return JSON.stringify(payload, null, 2) + "\n";
+}
+
+export function buildKanvibeProjectStateContent(projectColor: string): string {
+  const payload: KanvibeProjectState = {
+    schemaVersion: 1,
+    projectColor,
+    updatedAt: new Date().toISOString(),
   };
 
   return JSON.stringify(payload, null, 2) + "\n";
@@ -144,18 +161,52 @@ export function buildKanvibeTargetsContent(targets: KanvibeHookTarget[]): string
 }
 
 export function parseKanvibeTaskState(content: string): KanvibeTaskState | null {
-  const { status, projectColor } = parseKanvibeTaskStateFields(content);
-  if (!status) {
+  if (typeof content !== "string" || !content.trim()) {
     return null;
   }
 
-  const updatedAt = parseUpdatedAt(content);
-  return {
-    schemaVersion: 1,
-    status,
-    ...(updatedAt ? { updatedAt } : {}),
-    ...(projectColor ? { projectColor } : {}),
-  };
+  const statusFromMarkdown = parseTaskStatus(content.trim());
+  if (statusFromMarkdown) {
+    return { schemaVersion: 1, status: statusFromMarkdown };
+  }
+
+  try {
+    const parsed = JSON.parse(content) as { status?: unknown; updatedAt?: unknown };
+    const status = parseTaskStatus(parsed.status);
+    if (!status) {
+      return null;
+    }
+
+    return {
+      schemaVersion: 1,
+      status,
+      ...(isNonEmptyString(parsed.updatedAt) ? { updatedAt: parsed.updatedAt } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function parseKanvibeProjectState(content: string): KanvibeProjectState | null {
+  if (typeof content !== "string" || !content.trim()) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(content) as { projectColor?: unknown; updatedAt?: unknown };
+    const projectColor = parseProjectColor(parsed.projectColor);
+    if (!projectColor) {
+      return null;
+    }
+
+    return {
+      schemaVersion: 1,
+      projectColor,
+      ...(isNonEmptyString(parsed.updatedAt) ? { updatedAt: parsed.updatedAt } : {}),
+    };
+  } catch {
+    return null;
+  }
 }
 
 export function parseKanvibeTargets(content: string): KanvibeTargetsState {
@@ -194,53 +245,8 @@ export function parseProjectColor(value: unknown): string | null {
   return PROJECT_COLOR_PATTERN.test(normalized) ? normalized : null;
 }
 
-async function mergeKanvibeTaskStateFile(
-  repoPath: string,
-  sshHost: string | null | undefined,
-  merge: (current: KanvibeTaskStateFields) => KanvibeTaskStateFields,
-): Promise<void> {
-  const statePath = getKanvibeTaskStatePath(repoPath, sshHost);
-  const currentFields = parseKanvibeTaskStateFields(await readTextFile(statePath, sshHost));
-  const nextFields = merge(currentFields);
-
-  await writeTextFile(
-    statePath,
-    buildKanvibeTaskStateContent({
-      ...(nextFields.status ? { status: nextFields.status } : {}),
-      ...(nextFields.projectColor ? { projectColor: nextFields.projectColor } : {}),
-    }),
-    sshHost,
-  );
-}
-
-function parseKanvibeTaskStateFields(content: string): KanvibeTaskStateFields {
-  if (typeof content !== "string" || !content.trim()) {
-    return { status: null, projectColor: null };
-  }
-
-  const statusFromMarkdown = parseTaskStatus(content.trim());
-  if (statusFromMarkdown) {
-    return { status: statusFromMarkdown, projectColor: null };
-  }
-
-  try {
-    const parsed = JSON.parse(content) as { status?: unknown; projectColor?: unknown };
-    return {
-      status: parseTaskStatus(parsed.status),
-      projectColor: parseProjectColor(parsed.projectColor),
-    };
-  } catch {
-    return { status: null, projectColor: null };
-  }
-}
-
-function parseUpdatedAt(content: string): string | null {
-  try {
-    const parsed = JSON.parse(content) as { updatedAt?: unknown };
-    return typeof parsed.updatedAt === "string" && parsed.updatedAt.length > 0 ? parsed.updatedAt : null;
-  } catch {
-    return null;
-  }
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
 }
 
 function upsertKanvibeTarget(targets: unknown[], target: KanvibeHookTarget): KanvibeHookTarget[] {

--- a/src/lib/kanvibeProjectState.ts
+++ b/src/lib/kanvibeProjectState.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { TaskStatus } from "@/entities/KanbanTask";
-import { readTextFile, writeTextFile } from "@/lib/hostFileAccess";
+import { readTextFile, writeTextFile, writeTextFileIfAbsent } from "@/lib/hostFileAccess";
 
 export const KANVIBE_DIR_NAME = ".kanvibe";
 export const TASK_STATE_FILE_NAME = "status.json";
@@ -89,6 +89,27 @@ export async function writeKanvibeProjectColor(
   }
 
   await writeTextFile(
+    getKanvibeProjectStatePath(repoPath, sshHost),
+    buildKanvibeProjectStateContent(normalizedColor),
+    sshHost,
+  );
+}
+
+/**
+ * 아직 색상 파일이 없는 저장소에만 씨앗 색상을 기록한다.
+ * 이미 파일이 있으면 그 값이 권위이므로 기록하지 않는다.
+ */
+export async function writeKanvibeProjectColorIfAbsent(
+  repoPath: string,
+  projectColor: string,
+  sshHost?: string | null,
+): Promise<void> {
+  const normalizedColor = parseProjectColor(projectColor);
+  if (!normalizedColor) {
+    return;
+  }
+
+  await writeTextFileIfAbsent(
     getKanvibeProjectStatePath(repoPath, sshHost),
     buildKanvibeProjectStateContent(normalizedColor),
     sshHost,

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -1,14 +1,19 @@
-import { writeFile, mkdir } from "fs/promises";
-import path from "path";
 import { pathToFileURL } from "node:url";
 import {
-  addAiToolPatternsToGitExclude,
   KANVIBE_GIT_EXCLUDE_MARKER,
   KANVIBE_STATE_DIR_EXCLUDE_PATTERN,
 } from "@/lib/gitExclude";
 import { readTextFiles } from "@/lib/hostFileAccess";
+import { writeHookProviderFiles } from "@/lib/hookFileWriter";
 import { extractPluginHookServerUrl, validateHookServerConfiguration } from "@/lib/hookServerStatus";
+import {
+  registerKanvibeHookTarget,
+  verifyHookTargetRegistration,
+  type HookTargetRegistrationStatus,
+} from "@/lib/hookTargetRegistration";
+import { getKanvibeTargetsPath } from "@/lib/kanvibeProjectState";
 import { getOpenCodeRegisteredKanvibePluginUrls } from "@/lib/openCodePluginRegistry";
+import { resolvePathModule, type ShellHookProviderFile } from "@/lib/shellHookProvider";
 
 /**
  * OpenCode는 `.opencode/plugins/` 디렉토리에 TypeScript 플러그인을 배치하여 hooks를 등록한다.
@@ -18,6 +23,7 @@ import { getOpenCodeRegisteredKanvibePluginUrls } from "@/lib/openCodePluginRegi
 
 export const PLUGIN_FILE_NAME = "kanvibe-plugin.ts";
 export const PLUGIN_DIR_NAME = "plugins";
+const CONFIG_DIR_NAME = ".opencode";
 
 /** OpenCode plugin TypeScript 파일 내용을 생성한다 */
 export function generatePluginScript(kanvibeUrl: string, taskId: string): string {
@@ -41,6 +47,7 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
   const KANVIBE_TARGETS_FILE = resolve(KANVIBE_STATE_DIR, "targets.json");
   const KANVIBE_STATE_DIR_EXCLUDE_PATTERN = ${JSON.stringify(KANVIBE_STATE_DIR_EXCLUDE_PATTERN)};
   const KANVIBE_GIT_EXCLUDE_MARKER = ${JSON.stringify(KANVIBE_GIT_EXCLUDE_MARKER)};
+  const KANVIBE_PROJECT_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
   const lastStatusBySession = new Map<string, string>();
   const lastUserMessageBySession = new Map<string, string>();
 
@@ -69,13 +76,30 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
     }
   }
 
+  /** 다른 KanVibe client가 기록한 프로젝트 색상은 상태를 덮어쓸 때도 보존한다 */
+  function readKanvibeProjectColor(): string | null {
+    try {
+      const parsed = JSON.parse(readFileSync(KANVIBE_STATUS_FILE, "utf8"));
+      const projectColor = typeof parsed?.projectColor === "string" ? parsed.projectColor.trim() : "";
+      return KANVIBE_PROJECT_COLOR_PATTERN.test(projectColor) ? projectColor : null;
+    } catch {
+      return null;
+    }
+  }
+
   function writeKanvibeTaskState(status: string): void {
     try {
       ensureKanvibeStatusExcluded();
+      const projectColor = readKanvibeProjectColor();
       mkdirSync(KANVIBE_STATE_DIR, { recursive: true });
       writeFileSync(
         KANVIBE_STATUS_FILE,
-        JSON.stringify({ schemaVersion: 1, status, updatedAt: new Date().toISOString() }, null, 2) + "\\n",
+        JSON.stringify({
+          schemaVersion: 1,
+          status,
+          updatedAt: new Date().toISOString(),
+          ...(projectColor ? { projectColor } : {}),
+        }, null, 2) + "\\n",
         "utf8",
       );
     } catch {
@@ -93,19 +117,20 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
     return [{ url: normalizeKanvibeUrl(KANVIBE_URL), taskId: TASK_ID }];
   }
 
+  /** targets.json은 client(url) 단위로 등록되므로 같은 url의 중복 항목만 제거한다 */
   function readKanvibeTargets(): KanvibeTarget[] {
     try {
       const parsed = JSON.parse(readFileSync(KANVIBE_TARGETS_FILE, "utf8"));
       const targets = Array.isArray(parsed?.targets) ? parsed.targets : [];
-      const seenTaskIds = new Set<string>();
+      const seenUrls = new Set<string>();
       const normalizedTargets: KanvibeTarget[] = [];
 
       for (const target of targets) {
         const url = typeof target?.url === "string" ? normalizeKanvibeUrl(target.url) : "";
         const taskId = typeof target?.taskId === "string" ? target.taskId.trim() : "";
-        if (!url || !taskId || seenTaskIds.has(taskId)) continue;
+        if (!url || !taskId || seenUrls.has(url)) continue;
 
-        seenTaskIds.add(taskId);
+        seenUrls.add(url);
         normalizedTargets.push({ url, taskId });
       }
 
@@ -127,10 +152,9 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
     }
   }
 
+  /** 등록된 모든 client에 병렬로 통보한다. 느린 client가 다른 client를 막지 않는다 */
   async function fanoutKanvibeStatus(status: string): Promise<void> {
-    for (const target of readKanvibeTargets()) {
-      await postKanvibeStatus(target, status);
-    }
+    await Promise.all(readKanvibeTargets().map((target) => postKanvibeStatus(target, status)));
   }
 
   function getSessionID(source: any): string | undefined {
@@ -273,38 +297,24 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
 `;
 }
 
-/** 플러그인 파일에 kanvibe 관련 코드가 포함되어 있는지 확인한다 */
-function hasKanvibePlugin(pluginContent: string): boolean {
-  return pluginContent.includes("KanvibePlugin") && pluginContent.includes("/api/hooks/status");
+/** OpenCode plugin은 기존 설정 파일을 병합하지 않으므로 미리 읽어야 할 파일이 없다 */
+export function getOpenCodeHookInstallInputPaths(): string[] {
+  return [];
 }
 
-function hasOpenCodeStatusJsonPersistence(pluginContent: string): boolean {
-  return pluginContent.includes("status.json")
-    && pluginContent.includes("KANVIBE_STATE_DIR_EXCLUDE_PATTERN")
-    && pluginContent.includes("--git-common-dir")
-    && pluginContent.includes("includes(KANVIBE_STATE_DIR_EXCLUDE_PATTERN)")
-    && pluginContent.includes("JSON.stringify({ schemaVersion: 1, status, updatedAt: new Date().toISOString() }");
-}
-
-function hasOpenCodeTargetFanout(pluginContent: string): boolean {
-  return pluginContent.includes("targets.json")
-    && pluginContent.includes("KANVIBE_TARGETS_FILE")
-    && pluginContent.includes("readKanvibeTargets")
-    && pluginContent.includes("fanoutKanvibeStatus")
-    && pluginContent.includes("postKanvibeStatus")
-    && pluginContent.includes("taskId: target.taskId")
-    && pluginContent.includes("/api/hooks/status");
-}
-
-function extractPluginTaskId(pluginContent: string): string | null {
-  const match = pluginContent.match(/const TASK_ID = ("(?:\\.|[^"\\])*");/);
-  if (!match) return null;
-
-  try {
-    return JSON.parse(match[1]) as string;
-  } catch {
-    return null;
-  }
+/** OpenCode plugin 설치 산출물을 만든다 */
+export function buildOpenCodeHookFiles(
+  repoPath: string,
+  taskId: string,
+  kanvibeUrl: string,
+  sshHost?: string | null,
+): ShellHookProviderFile[] {
+  return [
+    {
+      filePath: getOpenCodePluginPath(repoPath, sshHost),
+      content: generatePluginScript(kanvibeUrl, taskId),
+    },
+  ];
 }
 
 /**
@@ -315,33 +325,25 @@ export async function setupOpenCodeHooks(
   repoPath: string,
   taskId: string,
   kanvibeUrl: string,
+  sshHost?: string | null,
 ): Promise<void> {
-  const openCodeDir = path.join(repoPath, ".opencode");
-  const pluginsDir = path.join(openCodeDir, PLUGIN_DIR_NAME);
+  await writeHookProviderFiles(buildOpenCodeHookFiles(repoPath, taskId, kanvibeUrl, sshHost), sshHost);
 
-  await mkdir(pluginsDir, { recursive: true });
-
-  const pluginPath = path.join(pluginsDir, PLUGIN_FILE_NAME);
-  await writeFile(pluginPath, generatePluginScript(kanvibeUrl, taskId), "utf-8");
-
-  try {
-    await addAiToolPatternsToGitExclude(repoPath);
-  } catch (error) {
-    console.error("git exclude 패턴 추가 실패:", error);
-  }
+  await registerKanvibeHookTarget(repoPath, taskId, kanvibeUrl, sshHost);
 }
 
-export interface OpenCodeHooksStatus {
+export interface OpenCodeHooksStatus extends Partial<HookTargetRegistrationStatus> {
   installed: boolean;
   hasPlugin: boolean;
   hasRegisteredPlugin?: boolean;
   hasDuplicateKanvibePlugins?: boolean;
   hasTaskIdBinding?: boolean;
-  hasExpectedTaskId?: boolean;
   hasStatusEndpoint?: boolean;
   hasEventMappings?: boolean;
   hasStatusJsonPersistence?: boolean;
+  hasProjectColorPersistence?: boolean;
   hasTargetFanout?: boolean;
+  hasParallelTargetFanout?: boolean;
   hasMainSessionGuard?: boolean;
   hasDuplicateProgressGuard?: boolean;
   hasExpectedHookServerUrl?: boolean;
@@ -355,87 +357,68 @@ export interface OpenCodeHooksStatus {
 }
 
 /** 지정된 repo의 OpenCode plugin 설치 상태를 확인한다 */
-export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, sshHost?: string | null): Promise<OpenCodeHooksStatus> {
-  const pathModule = sshHost ? path.posix : path;
-  const openCodeDir = pathModule.join(repoPath, ".opencode");
-  const pluginsDir = pathModule.join(openCodeDir, PLUGIN_DIR_NAME);
-  const pluginPath = pathModule.join(pluginsDir, PLUGIN_FILE_NAME);
-
-  const files = await readTextFiles([pluginPath], sshHost);
+export async function getOpenCodeHooksStatus(
+  repoPath: string,
+  taskId?: string,
+  sshHost?: string | null,
+): Promise<OpenCodeHooksStatus> {
+  const pluginPath = getOpenCodePluginPath(repoPath, sshHost);
+  const targetsPath = getKanvibeTargetsPath(repoPath, sshHost);
+  const files = await readTextFiles([pluginPath, targetsPath], sshHost);
   const pluginFile = files.get(pluginPath) ?? { exists: false, content: "" };
+  const pluginContent = pluginFile.content;
 
-  let hasPlugin = false;
-  let boundTaskId: string | null = null;
-  let hasTaskIdBinding = false;
-  let hasStatusEndpoint = false;
-  let hasEventMappings = false;
-  let hasStatusJsonPersistence = false;
-  let hasTargetFanout = false;
-  let hasMainSessionGuard = false;
-  let hasDuplicateProgressGuard = false;
-  let hasRegisteredPlugin = sshHost ? true : false;
-  let hasDuplicateKanvibePlugins = false;
-  let registeredPluginUrls: string[] = [];
-  let configuredHookServerUrl: string | null = null;
-  let hasExpectedTaskId = false;
-  if (pluginFile.exists) {
-    try {
-      const content = pluginFile.content;
-      hasPlugin = hasKanvibePlugin(content);
-      configuredHookServerUrl = extractPluginHookServerUrl(content);
-      boundTaskId = extractPluginTaskId(content);
-      hasTaskIdBinding =
-        boundTaskId !== null
-        && content.includes("taskId: TASK_ID");
-      hasExpectedTaskId = hasTaskIdBinding && (!taskId || boundTaskId === taskId);
-      hasStatusEndpoint = content.includes("/api/hooks/status");
-      hasEventMappings = ["progress", "pending", "review", "done", "message.updated", "question.asked", "question.replied", "session.idle", "session.deleted"].every((fragment) => content.includes(fragment));
-      hasStatusJsonPersistence = hasOpenCodeStatusJsonPersistence(content);
-      hasTargetFanout = hasOpenCodeTargetFanout(content);
-      hasMainSessionGuard = content.includes("isMainSession(message)") && content.includes("isMainSession(event.properties)");
-      hasDuplicateProgressGuard = content.includes("lastUserMessageBySession") && content.includes("buildMessageSignature") && content.includes("dedupeMessage: true");
-    } catch {
-      /* 파일 읽기 실패 */
-    }
-  }
-
-  if (!sshHost) {
-    const expectedPluginUrl = pathToFileURL(pluginPath).href;
-    registeredPluginUrls = await getOpenCodeRegisteredKanvibePluginUrls(repoPath);
-    hasRegisteredPlugin = registeredPluginUrls.some((value) => value === expectedPluginUrl);
-    hasDuplicateKanvibePlugins = registeredPluginUrls.length > 1;
-  }
-
+  const boundTaskId = extractPluginTaskId(pluginContent);
+  const hasTaskIdBinding = boundTaskId !== null && pluginContent.includes("taskId: TASK_ID");
+  const pluginRegistration = await resolveOpenCodePluginRegistration(repoPath, pluginPath, sshHost);
   const hookServerValidation = await validateHookServerConfiguration(
-    [configuredHookServerUrl],
+    [extractPluginHookServerUrl(pluginContent)],
     Boolean(taskId),
     sshHost,
   );
+  const targetRegistration = verifyHookTargetRegistration(
+    files.get(targetsPath)?.content ?? "",
+    taskId,
+    hookServerValidation.expectedHookServerUrl,
+  );
+
+  const hasPlugin = hasKanvibePlugin(pluginContent);
+  const hasStatusEndpoint = pluginContent.includes("/api/hooks/status");
+  const hasEventMappings = OPEN_CODE_EVENT_FRAGMENTS.every((fragment) => pluginContent.includes(fragment));
+  const hasStatusJsonPersistence = hasOpenCodeStatusJsonPersistence(pluginContent);
+  const hasProjectColorPersistence = hasOpenCodeProjectColorPersistence(pluginContent);
+  const hasTargetFanout = hasOpenCodeTargetFanout(pluginContent);
+  const hasParallelTargetFanout = hasOpenCodeParallelTargetFanout(pluginContent);
+  const hasMainSessionGuard = pluginContent.includes("isMainSession(message)")
+    && pluginContent.includes("isMainSession(event.properties)");
+  const hasDuplicateProgressGuard = pluginContent.includes("lastUserMessageBySession")
+    && pluginContent.includes("buildMessageSignature")
+    && pluginContent.includes("dedupeMessage: true");
 
   const installed = pluginFile.exists
     && hasPlugin
     && hasTaskIdBinding
-    && hasExpectedTaskId
+    && targetRegistration.hasRegisteredHookTarget
     && hasStatusEndpoint
     && hasEventMappings
     && hasStatusJsonPersistence
+    && hasProjectColorPersistence
     && hasTargetFanout
+    && hasParallelTargetFanout
     && hasMainSessionGuard
     && hasDuplicateProgressGuard
-    && hasRegisteredPlugin
-    && hookServerValidation.hasExpectedHookServerUrl;
+    && pluginRegistration.hasRegisteredPlugin;
 
   return {
     installed,
     hasPlugin,
-    hasRegisteredPlugin,
-    hasDuplicateKanvibePlugins,
     hasTaskIdBinding,
-    hasExpectedTaskId,
     hasStatusEndpoint,
     hasEventMappings,
     hasStatusJsonPersistence,
+    hasProjectColorPersistence,
     hasTargetFanout,
+    hasParallelTargetFanout,
     hasMainSessionGuard,
     hasDuplicateProgressGuard,
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
@@ -443,8 +426,92 @@ export async function getOpenCodeHooksStatus(repoPath: string, taskId?: string, 
     boundTaskId,
     targetPath: repoPath,
     pluginPath,
-    registeredPluginUrls,
     configuredHookServerUrl: hookServerValidation.configuredHookServerUrl,
     expectedHookServerUrl: hookServerValidation.expectedHookServerUrl,
+    ...pluginRegistration,
+    ...targetRegistration,
   };
+}
+
+const OPEN_CODE_EVENT_FRAGMENTS = [
+  "progress",
+  "pending",
+  "review",
+  "done",
+  "message.updated",
+  "question.asked",
+  "question.replied",
+  "session.idle",
+  "session.deleted",
+];
+
+/** 플러그인 파일에 kanvibe 관련 코드가 포함되어 있는지 확인한다 */
+function hasKanvibePlugin(pluginContent: string): boolean {
+  return pluginContent.includes("KanvibePlugin") && pluginContent.includes("/api/hooks/status");
+}
+
+function hasOpenCodeStatusJsonPersistence(pluginContent: string): boolean {
+  return pluginContent.includes("status.json")
+    && pluginContent.includes("KANVIBE_STATE_DIR_EXCLUDE_PATTERN")
+    && pluginContent.includes("--git-common-dir")
+    && pluginContent.includes("includes(KANVIBE_STATE_DIR_EXCLUDE_PATTERN)")
+    && pluginContent.includes("schemaVersion: 1")
+    && pluginContent.includes("updatedAt: new Date().toISOString()");
+}
+
+function hasOpenCodeProjectColorPersistence(pluginContent: string): boolean {
+  return pluginContent.includes("readKanvibeProjectColor")
+    && pluginContent.includes("KANVIBE_PROJECT_COLOR_PATTERN")
+    && pluginContent.includes("projectColor ? { projectColor } : {}");
+}
+
+function hasOpenCodeTargetFanout(pluginContent: string): boolean {
+  return pluginContent.includes("targets.json")
+    && pluginContent.includes("KANVIBE_TARGETS_FILE")
+    && pluginContent.includes("readKanvibeTargets")
+    && pluginContent.includes("fanoutKanvibeStatus")
+    && pluginContent.includes("postKanvibeStatus")
+    && pluginContent.includes("taskId: target.taskId")
+    && pluginContent.includes("/api/hooks/status");
+}
+
+/** fan-out이 순차 await 루프가 아니라 Promise.all 병렬 호출인지 확인한다 */
+function hasOpenCodeParallelTargetFanout(pluginContent: string): boolean {
+  return pluginContent.includes("await Promise.all(readKanvibeTargets().map(");
+}
+
+function extractPluginTaskId(pluginContent: string): string | null {
+  const match = pluginContent.match(/const TASK_ID = ("(?:\\.|[^"\\])*");/);
+  if (!match) return null;
+
+  try {
+    return JSON.parse(match[1]) as string;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveOpenCodePluginRegistration(
+  repoPath: string,
+  pluginPath: string,
+  sshHost?: string | null,
+): Promise<{ hasRegisteredPlugin: boolean; hasDuplicateKanvibePlugins: boolean; registeredPluginUrls: string[] }> {
+  /** 원격 repo는 OpenCode 설정 레지스트리를 조회할 수 없으므로 등록 여부를 검증하지 않는다 */
+  if (sshHost) {
+    return { hasRegisteredPlugin: true, hasDuplicateKanvibePlugins: false, registeredPluginUrls: [] };
+  }
+
+  const expectedPluginUrl = pathToFileURL(pluginPath).href;
+  const registeredPluginUrls = await getOpenCodeRegisteredKanvibePluginUrls(repoPath);
+
+  return {
+    hasRegisteredPlugin: registeredPluginUrls.some((value) => value === expectedPluginUrl),
+    hasDuplicateKanvibePlugins: registeredPluginUrls.length > 1,
+    registeredPluginUrls,
+  };
+}
+
+function getOpenCodePluginPath(repoPath: string, sshHost?: string | null): string {
+  const pathModule = resolvePathModule(sshHost);
+  return pathModule.join(repoPath, CONFIG_DIR_NAME, PLUGIN_DIR_NAME, PLUGIN_FILE_NAME);
 }

--- a/src/lib/openCodeHooksSetup.ts
+++ b/src/lib/openCodeHooksSetup.ts
@@ -45,9 +45,10 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
   const KANVIBE_STATE_DIR = resolve(KANVIBE_REPO_ROOT, ".kanvibe");
   const KANVIBE_STATUS_FILE = resolve(KANVIBE_STATE_DIR, "status.json");
   const KANVIBE_TARGETS_FILE = resolve(KANVIBE_STATE_DIR, "targets.json");
+  /** 이미 종료된 client가 targets.json에 남아 있어도 통보가 매달리지 않도록 상한을 둔다 */
+  const KANVIBE_NOTIFY_TIMEOUT_MS = 3000;
   const KANVIBE_STATE_DIR_EXCLUDE_PATTERN = ${JSON.stringify(KANVIBE_STATE_DIR_EXCLUDE_PATTERN)};
   const KANVIBE_GIT_EXCLUDE_MARKER = ${JSON.stringify(KANVIBE_GIT_EXCLUDE_MARKER)};
-  const KANVIBE_PROJECT_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
   const lastStatusBySession = new Map<string, string>();
   const lastUserMessageBySession = new Map<string, string>();
 
@@ -76,21 +77,9 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
     }
   }
 
-  /** 다른 KanVibe client가 기록한 프로젝트 색상은 상태를 덮어쓸 때도 보존한다 */
-  function readKanvibeProjectColor(): string | null {
-    try {
-      const parsed = JSON.parse(readFileSync(KANVIBE_STATUS_FILE, "utf8"));
-      const projectColor = typeof parsed?.projectColor === "string" ? parsed.projectColor.trim() : "";
-      return KANVIBE_PROJECT_COLOR_PATTERN.test(projectColor) ? projectColor : null;
-    } catch {
-      return null;
-    }
-  }
-
   function writeKanvibeTaskState(status: string): void {
     try {
       ensureKanvibeStatusExcluded();
-      const projectColor = readKanvibeProjectColor();
       mkdirSync(KANVIBE_STATE_DIR, { recursive: true });
       writeFileSync(
         KANVIBE_STATUS_FILE,
@@ -98,7 +87,6 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
           schemaVersion: 1,
           status,
           updatedAt: new Date().toISOString(),
-          ...(projectColor ? { projectColor } : {}),
         }, null, 2) + "\\n",
         "utf8",
       );
@@ -146,6 +134,7 @@ export const KanvibePlugin: Plugin = async ({ client }) => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ taskId: target.taskId, status }),
+        signal: AbortSignal.timeout(KANVIBE_NOTIFY_TIMEOUT_MS),
       });
     } catch {
       /* 네트워크 에러 무시 */
@@ -341,7 +330,7 @@ export interface OpenCodeHooksStatus extends Partial<HookTargetRegistrationStatu
   hasStatusEndpoint?: boolean;
   hasEventMappings?: boolean;
   hasStatusJsonPersistence?: boolean;
-  hasProjectColorPersistence?: boolean;
+  hasBoundedNotifyTimeout?: boolean;
   hasTargetFanout?: boolean;
   hasParallelTargetFanout?: boolean;
   hasMainSessionGuard?: boolean;
@@ -386,7 +375,7 @@ export async function getOpenCodeHooksStatus(
   const hasStatusEndpoint = pluginContent.includes("/api/hooks/status");
   const hasEventMappings = OPEN_CODE_EVENT_FRAGMENTS.every((fragment) => pluginContent.includes(fragment));
   const hasStatusJsonPersistence = hasOpenCodeStatusJsonPersistence(pluginContent);
-  const hasProjectColorPersistence = hasOpenCodeProjectColorPersistence(pluginContent);
+  const hasBoundedNotifyTimeout = hasOpenCodeBoundedNotifyTimeout(pluginContent);
   const hasTargetFanout = hasOpenCodeTargetFanout(pluginContent);
   const hasParallelTargetFanout = hasOpenCodeParallelTargetFanout(pluginContent);
   const hasMainSessionGuard = pluginContent.includes("isMainSession(message)")
@@ -402,7 +391,7 @@ export async function getOpenCodeHooksStatus(
     && hasStatusEndpoint
     && hasEventMappings
     && hasStatusJsonPersistence
-    && hasProjectColorPersistence
+    && hasBoundedNotifyTimeout
     && hasTargetFanout
     && hasParallelTargetFanout
     && hasMainSessionGuard
@@ -416,7 +405,7 @@ export async function getOpenCodeHooksStatus(
     hasStatusEndpoint,
     hasEventMappings,
     hasStatusJsonPersistence,
-    hasProjectColorPersistence,
+    hasBoundedNotifyTimeout,
     hasTargetFanout,
     hasParallelTargetFanout,
     hasMainSessionGuard,
@@ -459,10 +448,10 @@ function hasOpenCodeStatusJsonPersistence(pluginContent: string): boolean {
     && pluginContent.includes("updatedAt: new Date().toISOString()");
 }
 
-function hasOpenCodeProjectColorPersistence(pluginContent: string): boolean {
-  return pluginContent.includes("readKanvibeProjectColor")
-    && pluginContent.includes("KANVIBE_PROJECT_COLOR_PATTERN")
-    && pluginContent.includes("projectColor ? { projectColor } : {}");
+/** 응답 없는 client가 plugin을 붙잡지 못하도록 통보에 상한이 걸려 있는지 확인한다 */
+function hasOpenCodeBoundedNotifyTimeout(pluginContent: string): boolean {
+  return pluginContent.includes("KANVIBE_NOTIFY_TIMEOUT_MS")
+    && pluginContent.includes("AbortSignal.timeout(KANVIBE_NOTIFY_TIMEOUT_MS)");
 }
 
 function hasOpenCodeTargetFanout(pluginContent: string): boolean {

--- a/src/lib/projectColor.ts
+++ b/src/lib/projectColor.ts
@@ -5,6 +5,9 @@ const PRESET_COLORS = [
   "#FDBA74", "#FDE047", "#5EEAD4", "#A5B4FC",
 ];
 
+const TEXT_ON_LIGHT_BACKGROUND = "#111827";
+const TEXT_ON_DARK_BACKGROUND = "#FFFFFF";
+
 /** 프로젝트명을 기반으로 결정론적 해시 색상을 계산한다 */
 export function computeProjectColor(projectName: string): string {
   let hash = 0;
@@ -12,4 +15,54 @@ export function computeProjectColor(projectName: string): string {
     hash = (hash * 31 + projectName.charCodeAt(i)) | 0;
   }
   return PRESET_COLORS[((hash % 8) + 8) % 8];
+}
+
+/**
+ * 프로젝트 색상 위에 올릴 글자색을 고른다.
+ * 사용자가 어떤 색을 지정하든 이니셜이 읽히도록 배경 휘도에 따라 검정/흰색을 선택한다.
+ * @param backgroundColor - `#RRGGBB` 형태의 배경색. 형식이 다르면 어두운 글자를 반환한다
+ */
+export function getReadableTextColor(backgroundColor: string): string {
+  const rgb = parseHexColor(backgroundColor);
+  if (!rgb) {
+    return TEXT_ON_LIGHT_BACKGROUND;
+  }
+
+  const backgroundLuminance = rgb.reduce(
+    (total, channel, index) => total + toLinearChannel(channel) * SRGB_LUMINANCE_WEIGHTS[index],
+    0,
+  );
+
+  return getContrastRatio(backgroundLuminance, DARK_TEXT_LUMINANCE)
+    >= getContrastRatio(backgroundLuminance, WHITE_TEXT_LUMINANCE)
+    ? TEXT_ON_LIGHT_BACKGROUND
+    : TEXT_ON_DARK_BACKGROUND;
+}
+
+const SRGB_LUMINANCE_WEIGHTS = [0.2126, 0.7152, 0.0722];
+const DARK_TEXT_LUMINANCE = 0.0092;
+const WHITE_TEXT_LUMINANCE = 1;
+
+/** WCAG 대비율 `(밝은 쪽 + 0.05) / (어두운 쪽 + 0.05)` */
+function getContrastRatio(luminanceA: number, luminanceB: number): number {
+  const lighter = Math.max(luminanceA, luminanceB);
+  const darker = Math.min(luminanceA, luminanceB);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function parseHexColor(color: string): [number, number, number] | null {
+  const matched = color.trim().match(/^#([0-9a-fA-F]{6})$/);
+  if (!matched) {
+    return null;
+  }
+
+  const value = Number.parseInt(matched[1], 16);
+  return [(value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff];
+}
+
+function toLinearChannel(channel: number): number {
+  const normalized = channel / 255;
+  return normalized <= 0.03928
+    ? normalized / 12.92
+    : ((normalized + 0.055) / 1.055) ** 2.4;
 }

--- a/src/lib/shellHookProvider.ts
+++ b/src/lib/shellHookProvider.ts
@@ -15,8 +15,8 @@ import {
   buildShellKanvibeStatusUpdater,
   buildShellTaskIdResolver,
   getShellTaskIdBindingStatus,
+  hasShellKanvibeBoundedNotifyTimeout,
   hasShellKanvibeParallelTargetFanout,
-  hasShellKanvibeProjectColorPersistence,
   hasShellKanvibeStatusJsonPersistence,
   hasShellKanvibeTargetFanout,
   type ShellHookStatus,
@@ -47,8 +47,8 @@ export interface ShellHookScriptsStatus extends HookTargetRegistrationStatus {
   hasTaskIdBinding: boolean;
   hasStatusMappings: boolean;
   hasStatusJsonPersistence: boolean;
-  hasProjectColorPersistence: boolean;
   hasTargetFanout: boolean;
+  hasBoundedNotifyTimeout: boolean;
   hasParallelTargetFanout: boolean;
   hasExpectedHookServerUrl: boolean;
   hasReachableHookServer: boolean;
@@ -187,8 +187,8 @@ function buildShellHookScriptsStatus(options: {
       scriptContents[index]?.includes(buildStatusPayloadFragment(definition.status)) ?? false
     )),
     hasStatusJsonPersistence: scriptContents.every(hasShellKanvibeStatusJsonPersistence),
-    hasProjectColorPersistence: scriptContents.every(hasShellKanvibeProjectColorPersistence),
     hasTargetFanout: scriptContents.every(hasShellKanvibeTargetFanout),
+    hasBoundedNotifyTimeout: scriptContents.every(hasShellKanvibeBoundedNotifyTimeout),
     hasParallelTargetFanout: scriptContents.every(hasShellKanvibeParallelTargetFanout),
     hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
     hasReachableHookServer: hookServerValidation.hasReachableHookServer,
@@ -221,8 +221,8 @@ export function isShellHookProviderInstalled(
     && status.hasRegisteredHookTarget
     && status.hasStatusMappings
     && status.hasStatusJsonPersistence
-    && status.hasProjectColorPersistence
     && status.hasTargetFanout
+    && status.hasBoundedNotifyTimeout
     && status.hasParallelTargetFanout;
 }
 

--- a/src/lib/shellHookProvider.ts
+++ b/src/lib/shellHookProvider.ts
@@ -1,0 +1,235 @@
+import { chmod, mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { getKanvibeTargetsPath } from "@/lib/kanvibeProjectState";
+import { readTextFiles, type TextFileReadResult } from "@/lib/hostFileAccess";
+import {
+  extractShellHookServerUrl,
+  validateHookServerConfiguration,
+  type HookServerValidation,
+} from "@/lib/hookServerStatus";
+import {
+  verifyHookTargetRegistration,
+  type HookTargetRegistrationStatus,
+} from "@/lib/hookTargetRegistration";
+import {
+  buildShellKanvibeStatusUpdater,
+  buildShellTaskIdResolver,
+  getShellTaskIdBindingStatus,
+  hasShellKanvibeParallelTargetFanout,
+  hasShellKanvibeProjectColorPersistence,
+  hasShellKanvibeStatusJsonPersistence,
+  hasShellKanvibeTargetFanout,
+  type ShellHookStatus,
+} from "@/lib/shellHookScript";
+
+const HOOK_SCRIPT_FILE_MODE = 0o755;
+
+/** 하나의 CLI 이벤트에 대응하는 KanVibe hook shell script 정의 */
+export interface ShellHookScriptDefinition {
+  fileName: string;
+  eventLabel: string;
+  description: string;
+  status: ShellHookStatus;
+  /** stdout에 JSON만 허용하는 런타임(Gemini CLI)을 위해 종료 직전 출력할 내용 */
+  trailingOutput?: string;
+  /** 스크립트 상단 주석에 덧붙일 런타임 제약 설명 */
+  runtimeNote?: string;
+}
+
+export interface ShellHookProviderFile {
+  filePath: string;
+  content: string;
+  mode?: number;
+}
+
+/** 모든 shell hook provider가 공유하는 설치 상태 지표 */
+export interface ShellHookScriptsStatus extends HookTargetRegistrationStatus {
+  hasTaskIdBinding: boolean;
+  hasStatusMappings: boolean;
+  hasStatusJsonPersistence: boolean;
+  hasProjectColorPersistence: boolean;
+  hasTargetFanout: boolean;
+  hasParallelTargetFanout: boolean;
+  hasExpectedHookServerUrl: boolean;
+  hasReachableHookServer: boolean;
+  boundTaskId: string | null;
+  configuredHookServerUrl: string | null;
+  expectedHookServerUrl: string | null;
+}
+
+export interface ShellHookProviderState {
+  /** 정의 순서대로의 스크립트 존재 여부와 내용 */
+  scriptFiles: TextFileReadResult[];
+  hasAllScripts: boolean;
+  /** `extraFilePaths`로 요청한 파일 내용 */
+  files: Map<string, TextFileReadResult>;
+  status: ShellHookScriptsStatus;
+}
+
+/** hook shell script 한 개의 내용을 만든다 */
+export function generateShellHookScript(
+  agentLabel: string,
+  definition: ShellHookScriptDefinition,
+  kanvibeUrl: string,
+  taskId: string,
+): string {
+  const headerComments = [
+    `# KanVibe ${agentLabel} Hook: ${definition.eventLabel}`,
+    `# ${definition.description}`,
+    ...(definition.runtimeNote ? [`# ${definition.runtimeNote}`] : []),
+  ].join("\n");
+  const trailingLines = [
+    ...(definition.trailingOutput ? [definition.trailingOutput] : []),
+    "exit 0",
+  ].join("\n");
+
+  return `#!/bin/bash
+
+${headerComments}
+
+KANVIBE_URL="${kanvibeUrl}"
+${buildShellTaskIdResolver(taskId)}
+${buildShellKanvibeStatusUpdater(definition.status)}
+
+${trailingLines}
+`;
+}
+
+/** hook script 파일 목록을 만든다. 로컬 설치와 원격 설치가 같은 내용을 공유한다 */
+export function buildShellHookScriptFiles(
+  hooksDir: string,
+  agentLabel: string,
+  definitions: ShellHookScriptDefinition[],
+  kanvibeUrl: string,
+  taskId: string,
+  sshHost?: string | null,
+): ShellHookProviderFile[] {
+  const pathModule = resolvePathModule(sshHost);
+
+  return definitions.map((definition) => ({
+    filePath: pathModule.join(hooksDir, definition.fileName),
+    content: generateShellHookScript(agentLabel, definition, kanvibeUrl, taskId),
+    mode: HOOK_SCRIPT_FILE_MODE,
+  }));
+}
+
+/** 로컬 repo에 hook script를 기록하고 실행 권한을 부여한다 */
+export async function writeLocalShellHookScripts(
+  hooksDir: string,
+  agentLabel: string,
+  definitions: ShellHookScriptDefinition[],
+  kanvibeUrl: string,
+  taskId: string,
+): Promise<void> {
+  await mkdir(hooksDir, { recursive: true });
+
+  const files = buildShellHookScriptFiles(hooksDir, agentLabel, definitions, kanvibeUrl, taskId);
+  for (const file of files) {
+    await writeFile(file.filePath, file.content, "utf-8");
+    await chmod(file.filePath, HOOK_SCRIPT_FILE_MODE);
+  }
+}
+
+/**
+ * hook script와 provider별 설정 파일, `.kanvibe/targets.json`을 한 번에 읽어
+ * 모든 shell hook provider가 공유하는 설치 상태를 계산한다.
+ */
+export async function readShellHookProviderState(options: {
+  repoPath: string;
+  hooksDir: string;
+  definitions: ShellHookScriptDefinition[];
+  extraFilePaths?: string[];
+  taskId?: string;
+  sshHost?: string | null;
+}): Promise<ShellHookProviderState> {
+  const { repoPath, hooksDir, definitions, extraFilePaths = [], taskId, sshHost } = options;
+  const pathModule = resolvePathModule(sshHost);
+  const scriptPaths = definitions.map((definition) => pathModule.join(hooksDir, definition.fileName));
+  const targetsPath = getKanvibeTargetsPath(repoPath, sshHost);
+
+  const files = await readTextFiles([...scriptPaths, ...extraFilePaths, targetsPath], sshHost);
+  const scriptFiles = scriptPaths.map((scriptPath) => files.get(scriptPath) ?? emptyFile());
+  const scriptContents = scriptFiles.map((file) => file.content);
+
+  const hookServerValidation = await validateHookServerConfiguration(
+    scriptContents.map(extractShellHookServerUrl),
+    Boolean(taskId),
+    sshHost,
+  );
+
+  return {
+    scriptFiles,
+    hasAllScripts: scriptFiles.every((file) => file.exists),
+    files,
+    status: buildShellHookScriptsStatus({
+      definitions,
+      scriptContents,
+      targetsContent: (files.get(targetsPath) ?? emptyFile()).content,
+      taskId,
+      hookServerValidation,
+    }),
+  };
+}
+
+function buildShellHookScriptsStatus(options: {
+  definitions: ShellHookScriptDefinition[];
+  scriptContents: string[];
+  targetsContent: string;
+  taskId?: string;
+  hookServerValidation: HookServerValidation;
+}): ShellHookScriptsStatus {
+  const { definitions, scriptContents, targetsContent, taskId, hookServerValidation } = options;
+  const { boundTaskId, hasTaskIdBinding } = getShellTaskIdBindingStatus(scriptContents);
+
+  return {
+    hasTaskIdBinding,
+    hasStatusMappings: definitions.every((definition, index) => (
+      scriptContents[index]?.includes(buildStatusPayloadFragment(definition.status)) ?? false
+    )),
+    hasStatusJsonPersistence: scriptContents.every(hasShellKanvibeStatusJsonPersistence),
+    hasProjectColorPersistence: scriptContents.every(hasShellKanvibeProjectColorPersistence),
+    hasTargetFanout: scriptContents.every(hasShellKanvibeTargetFanout),
+    hasParallelTargetFanout: scriptContents.every(hasShellKanvibeParallelTargetFanout),
+    hasExpectedHookServerUrl: hookServerValidation.hasExpectedHookServerUrl,
+    hasReachableHookServer: hookServerValidation.hasReachableHookServer,
+    boundTaskId,
+    configuredHookServerUrl: hookServerValidation.configuredHookServerUrl,
+    expectedHookServerUrl: hookServerValidation.expectedHookServerUrl,
+    ...verifyHookTargetRegistration(targetsContent, taskId, hookServerValidation.expectedHookServerUrl),
+  };
+}
+
+/** hook script가 자신의 상태를 실제로 payload에 담고 있는지 확인할 문자열 */
+function buildStatusPayloadFragment(status: ShellHookStatus): string {
+  return `\\"status\\": \\"${status}\\"`;
+}
+
+/**
+ * hook script와 설정이 모두 정상인지 판정한다. provider별 추가 조건은 호출부가 결합한다.
+ * 알림 대상은 script에 박힌 URL이 아니라 targets.json 등록 여부로 판정하므로,
+ * 다른 client가 script의 fallback URL/TASK_ID를 덮어써도 설치 상태가 깨지지 않는다.
+ */
+export function isShellHookProviderInstalled(
+  state: ShellHookProviderState,
+  providerChecks: boolean[],
+): boolean {
+  const { status } = state;
+
+  return state.hasAllScripts
+    && providerChecks.every(Boolean)
+    && status.hasTaskIdBinding
+    && status.hasRegisteredHookTarget
+    && status.hasStatusMappings
+    && status.hasStatusJsonPersistence
+    && status.hasProjectColorPersistence
+    && status.hasTargetFanout
+    && status.hasParallelTargetFanout;
+}
+
+export function resolvePathModule(sshHost?: string | null): typeof path.posix | typeof path {
+  return sshHost ? path.posix : path;
+}
+
+function emptyFile(): TextFileReadResult {
+  return { exists: false, content: "" };
+}

--- a/src/lib/shellHookScript.ts
+++ b/src/lib/shellHookScript.ts
@@ -3,6 +3,9 @@ import {
   KANVIBE_STATE_DIR_EXCLUDE_PATTERN,
 } from "@/lib/gitExclude";
 
+/** hook이 KanVibe에 통보할 수 있는 task 상태 */
+export type ShellHookStatus = "progress" | "pending" | "review" | "done";
+
 function escapeShellDoubleQuotedValue(value: string) {
   return value
     .replace(/\\/g, "\\\\")
@@ -26,11 +29,14 @@ export function extractShellTaskId(content: string): string | null {
 
 export interface ShellTaskIdBindingStatus {
   hasTaskIdBinding: boolean;
-  hasExpectedTaskId: boolean;
   boundTaskId: string | null;
 }
 
-export function buildShellKanvibeStatusUpdater(status: "progress" | "pending" | "review" | "done") {
+/**
+ * hook이 상태를 status.json에 기록하고 targets.json의 모든 client에 병렬로 통보하는 shell 조각을 만든다.
+ * 다른 client가 기록한 프로젝트 색상은 재기록 시에도 보존한다.
+ */
+export function buildShellKanvibeStatusUpdater(status: ShellHookStatus) {
   return `KANVIBE_STATUS="${status}"
 KANVIBE_REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "\${BASH_SOURCE[0]}")/../.." && pwd))"
 KANVIBE_STATE_DIR="\${KANVIBE_REPO_ROOT}/.kanvibe"
@@ -40,11 +46,16 @@ ${buildShellKanvibeStatusExcludeUpdater()}
 
 mkdir -p "\${KANVIBE_STATE_DIR}" 2>/dev/null || true
 KANVIBE_UPDATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || true)"
+${buildShellKanvibeProjectColorReader()}
+
+KANVIBE_TASK_STATE_JSON="{\\"schemaVersion\\":1,\\"status\\":\\"\${KANVIBE_STATUS}\\""
 if [ -n "\${KANVIBE_UPDATED_AT}" ]; then
-  printf '{"schemaVersion":1,"status":"%s","updatedAt":"%s"}\\n' "\${KANVIBE_STATUS}" "\${KANVIBE_UPDATED_AT}" > "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null || true
-else
-  printf '{"schemaVersion":1,"status":"%s"}\\n' "\${KANVIBE_STATUS}" > "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null || true
+  KANVIBE_TASK_STATE_JSON="\${KANVIBE_TASK_STATE_JSON},\\"updatedAt\\":\\"\${KANVIBE_UPDATED_AT}\\""
 fi
+if [ -n "\${KANVIBE_PROJECT_COLOR}" ]; then
+  KANVIBE_TASK_STATE_JSON="\${KANVIBE_TASK_STATE_JSON},\\"projectColor\\":\\"\${KANVIBE_PROJECT_COLOR}\\""
+fi
+printf '%s}\\n' "\${KANVIBE_TASK_STATE_JSON}" > "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null || true
 
 KANVIBE_TARGET_ROWS="$(
   if [ -f "\${KANVIBE_TARGETS_FILE}" ]; then
@@ -52,7 +63,7 @@ KANVIBE_TARGET_ROWS="$(
       | awk '
           { s=$0; sub(/^"[^"]*"[[:space:]]*:[[:space:]]*"/,"",s); sub(/"$/,"",s) }
           /^"url"/ { u=s; sub(/\\/+$/,"",u); haveUrl=1; next }
-          /^"taskId"/ { if(haveUrl){ if(u!="" && s!="" && !(s in seen)){ seen[s]=1; print u "\\t" s } haveUrl=0 } }
+          /^"taskId"/ { if(haveUrl){ if(u!="" && s!="" && !(u in seen)){ seen[u]=1; print u "\\t" s } haveUrl=0 } }
         ' 2>/dev/null || true
   else
     printf '%s\t%s\n' "\${KANVIBE_URL%/}" "\${TASK_ID}"
@@ -62,15 +73,35 @@ if [ -z "\${KANVIBE_TARGET_ROWS}" ]; then
   KANVIBE_TARGET_ROWS="$(printf '%s\t%s\n' "\${KANVIBE_URL%/}" "\${TASK_ID}")"
 fi
 
-printf '%s\n' "\${KANVIBE_TARGET_ROWS}" | while IFS="$(printf '\\t')" read -r KANVIBE_TARGET_URL KANVIBE_TARGET_TASK_ID; do
-  if [ -z "\${KANVIBE_TARGET_URL}" ] || [ -z "\${KANVIBE_TARGET_TASK_ID}" ]; then
-    continue
+printf '%s\n' "\${KANVIBE_TARGET_ROWS}" | {
+  while IFS="$(printf '\\t')" read -r KANVIBE_TARGET_URL KANVIBE_TARGET_TASK_ID; do
+    if [ -z "\${KANVIBE_TARGET_URL}" ] || [ -z "\${KANVIBE_TARGET_TASK_ID}" ]; then
+      continue
+    fi
+    curl -s -X POST "\${KANVIBE_TARGET_URL%/}/api/hooks/status" \
+      -H "Content-Type: application/json" \
+      -d "{\\"taskId\\": \\"\${KANVIBE_TARGET_TASK_ID}\\", \\"status\\": \\"${status}\\"}" \
+      > /dev/null 2>&1 &
+  done
+  wait
+}`;
+}
+
+/**
+ * status.json에 이미 기록된 프로젝트 색상을 읽어 재기록 시 보존한다.
+ * 파일 내용이 shell로 흘러들지 않도록 `#RRGGBB` 형태만 통과시킨다.
+ */
+function buildShellKanvibeProjectColorReader() {
+  return `KANVIBE_PROJECT_COLOR="$(
+  if [ -f "\${KANVIBE_TASK_STATE_FILE}" ]; then
+    grep -oE '"projectColor"[[:space:]]*:[[:space:]]*"[^"]*"' "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null \
+      | sed -E -n 's/.*"([^"]*)"$/\\1/p;q' 2>/dev/null || true
   fi
-  curl -s -X POST "\${KANVIBE_TARGET_URL%/}/api/hooks/status" \
-    -H "Content-Type: application/json" \
-    -d "{\\"taskId\\": \\\"\${KANVIBE_TARGET_TASK_ID}\\\", \\\"status\\\": \\\"${status}\\\"}" \
-    > /dev/null 2>&1 || true
-done`;
+)"
+case "\${KANVIBE_PROJECT_COLOR}" in
+  "#"[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]) ;;
+  *) KANVIBE_PROJECT_COLOR="" ;;
+esac`;
 }
 
 function buildShellKanvibeStatusExcludeUpdater() {
@@ -95,8 +126,15 @@ export function hasShellKanvibeStatusJsonPersistence(content: string): boolean {
     && content.includes("--git-common-dir")
     && content.includes("KANVIBE_GIT_EXCLUDE_FILE")
     && content.includes(KANVIBE_STATE_DIR_EXCLUDE_PATTERN)
-    && content.includes('"schemaVersion":1')
-    && content.includes('"status":"%s"');
+    && content.includes("KANVIBE_TASK_STATE_JSON")
+    && content.includes('\\"schemaVersion\\":1')
+    && content.includes('\\"status\\":\\"${KANVIBE_STATUS}\\"');
+}
+
+export function hasShellKanvibeProjectColorPersistence(content: string): boolean {
+  return content.includes("KANVIBE_PROJECT_COLOR")
+    && content.includes('"projectColor"')
+    && content.includes('\\"projectColor\\":\\"${KANVIBE_PROJECT_COLOR}\\"');
 }
 
 export function hasShellKanvibeTargetFanout(content: string): boolean {
@@ -110,10 +148,15 @@ export function hasShellKanvibeTargetFanout(content: string): boolean {
     && content.includes("taskId");
 }
 
-export function getShellTaskIdBindingStatus(
-  contents: string[],
-  expectedTaskId?: string,
-): ShellTaskIdBindingStatus {
+/** curl fan-out이 순차 실행이 아니라 병렬 실행 후 wait로 수렴하는지 확인한다 */
+export function hasShellKanvibeParallelTargetFanout(content: string): boolean {
+  return hasShellKanvibeTargetFanout(content)
+    && content.includes("> /dev/null 2>&1 &")
+    && /\n\s*wait\n/.test(content);
+}
+
+/** 모든 hook script가 같은 fallback task id를 고정하고 payload에서 사용하는지 확인한다 */
+export function getShellTaskIdBindingStatus(contents: string[]): ShellTaskIdBindingStatus {
   const hasTaskIdPayloadBindings = contents.every((content) => (
     content.includes("taskId") && content.includes("${TASK_ID}")
   ));
@@ -122,12 +165,9 @@ export function getShellTaskIdBindingStatus(
   const boundTaskId = firstTaskId && boundTaskIds.every((value) => value === firstTaskId)
     ? firstTaskId
     : null;
-  const hasTaskIdBinding = hasTaskIdPayloadBindings && boundTaskId !== null;
-  const hasExpectedTaskId = hasTaskIdBinding && (!expectedTaskId || boundTaskId === expectedTaskId);
 
   return {
-    hasTaskIdBinding,
-    hasExpectedTaskId,
+    hasTaskIdBinding: hasTaskIdPayloadBindings && boundTaskId !== null,
     boundTaskId,
   };
 }

--- a/src/lib/shellHookScript.ts
+++ b/src/lib/shellHookScript.ts
@@ -6,6 +6,12 @@ import {
 /** hook이 KanVibe에 통보할 수 있는 task 상태 */
 export type ShellHookStatus = "progress" | "pending" | "review" | "done";
 
+/**
+ * targets.json에는 이미 종료된 client의 주소가 남을 수 있다.
+ * 응답하지 않는 client 하나가 hook 전체를 붙잡지 않도록 통보에 상한을 둔다.
+ */
+const HOOK_NOTIFY_TIMEOUT_SECONDS = 3;
+
 function escapeShellDoubleQuotedValue(value: string) {
   return value
     .replace(/\\/g, "\\\\")
@@ -34,7 +40,7 @@ export interface ShellTaskIdBindingStatus {
 
 /**
  * hook이 상태를 status.json에 기록하고 targets.json의 모든 client에 병렬로 통보하는 shell 조각을 만든다.
- * 다른 client가 기록한 프로젝트 색상은 재기록 시에도 보존한다.
+ * 프로젝트 색상은 project.json에 따로 있으므로 이 경로에서는 건드리지 않는다.
  */
 export function buildShellKanvibeStatusUpdater(status: ShellHookStatus) {
   return `KANVIBE_STATUS="${status}"
@@ -46,14 +52,10 @@ ${buildShellKanvibeStatusExcludeUpdater()}
 
 mkdir -p "\${KANVIBE_STATE_DIR}" 2>/dev/null || true
 KANVIBE_UPDATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || true)"
-${buildShellKanvibeProjectColorReader()}
 
 KANVIBE_TASK_STATE_JSON="{\\"schemaVersion\\":1,\\"status\\":\\"\${KANVIBE_STATUS}\\""
 if [ -n "\${KANVIBE_UPDATED_AT}" ]; then
   KANVIBE_TASK_STATE_JSON="\${KANVIBE_TASK_STATE_JSON},\\"updatedAt\\":\\"\${KANVIBE_UPDATED_AT}\\""
-fi
-if [ -n "\${KANVIBE_PROJECT_COLOR}" ]; then
-  KANVIBE_TASK_STATE_JSON="\${KANVIBE_TASK_STATE_JSON},\\"projectColor\\":\\"\${KANVIBE_PROJECT_COLOR}\\""
 fi
 printf '%s}\\n' "\${KANVIBE_TASK_STATE_JSON}" > "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null || true
 
@@ -78,30 +80,13 @@ printf '%s\n' "\${KANVIBE_TARGET_ROWS}" | {
     if [ -z "\${KANVIBE_TARGET_URL}" ] || [ -z "\${KANVIBE_TARGET_TASK_ID}" ]; then
       continue
     fi
-    curl -s -X POST "\${KANVIBE_TARGET_URL%/}/api/hooks/status" \
+    curl -s --max-time ${HOOK_NOTIFY_TIMEOUT_SECONDS} -X POST "\${KANVIBE_TARGET_URL%/}/api/hooks/status" \
       -H "Content-Type: application/json" \
       -d "{\\"taskId\\": \\"\${KANVIBE_TARGET_TASK_ID}\\", \\"status\\": \\"${status}\\"}" \
       > /dev/null 2>&1 &
   done
   wait
 }`;
-}
-
-/**
- * status.json에 이미 기록된 프로젝트 색상을 읽어 재기록 시 보존한다.
- * 파일 내용이 shell로 흘러들지 않도록 `#RRGGBB` 형태만 통과시킨다.
- */
-function buildShellKanvibeProjectColorReader() {
-  return `KANVIBE_PROJECT_COLOR="$(
-  if [ -f "\${KANVIBE_TASK_STATE_FILE}" ]; then
-    grep -oE '"projectColor"[[:space:]]*:[[:space:]]*"[^"]*"' "\${KANVIBE_TASK_STATE_FILE}" 2>/dev/null \
-      | sed -E -n 's/.*"([^"]*)"$/\\1/p;q' 2>/dev/null || true
-  fi
-)"
-case "\${KANVIBE_PROJECT_COLOR}" in
-  "#"[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]) ;;
-  *) KANVIBE_PROJECT_COLOR="" ;;
-esac`;
 }
 
 function buildShellKanvibeStatusExcludeUpdater() {
@@ -131,12 +116,6 @@ export function hasShellKanvibeStatusJsonPersistence(content: string): boolean {
     && content.includes('\\"status\\":\\"${KANVIBE_STATUS}\\"');
 }
 
-export function hasShellKanvibeProjectColorPersistence(content: string): boolean {
-  return content.includes("KANVIBE_PROJECT_COLOR")
-    && content.includes('"projectColor"')
-    && content.includes('\\"projectColor\\":\\"${KANVIBE_PROJECT_COLOR}\\"');
-}
-
 export function hasShellKanvibeTargetFanout(content: string): boolean {
   return content.includes("targets.json")
     && content.includes("KANVIBE_TARGETS_FILE")
@@ -146,6 +125,11 @@ export function hasShellKanvibeTargetFanout(content: string): boolean {
     && content.includes("while IFS=")
     && content.includes("/api/hooks/status")
     && content.includes("taskId");
+}
+
+/** 응답 없는 client가 hook을 붙잡지 못하도록 통보에 상한이 걸려 있는지 확인한다 */
+export function hasShellKanvibeBoundedNotifyTimeout(content: string): boolean {
+  return content.includes(`--max-time ${HOOK_NOTIFY_TIMEOUT_SECONDS}`);
 }
 
 /** curl fan-out이 순차 실행이 아니라 병렬 실행 후 wait로 수렴하는지 확인한다 */

--- a/src/lib/sqliteSchema.ts
+++ b/src/lib/sqliteSchema.ts
@@ -30,6 +30,7 @@ function ensureBaseTables(database: Database.Database): void {
       ssh_host TEXT,
       is_worktree INTEGER NOT NULL DEFAULT 0,
       color TEXT DEFAULT NULL,
+      icon_data_url TEXT DEFAULT NULL,
       created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
     );
 
@@ -79,6 +80,7 @@ function ensureBaseTables(database: Database.Database): void {
 function ensureColumns(database: Database.Database): void {
   ensureColumn(database, "projects", "is_worktree", "is_worktree INTEGER NOT NULL DEFAULT 0");
   ensureColumn(database, "projects", "color", "color TEXT DEFAULT NULL");
+  ensureColumn(database, "projects", "icon_data_url", "icon_data_url TEXT DEFAULT NULL");
 
   ensureColumn(database, "kanban_tasks", "project_id", "project_id TEXT");
   ensureColumn(database, "kanban_tasks", "base_branch", "base_branch TEXT");

--- a/src/lib/typeorm-cli.config.ts
+++ b/src/lib/typeorm-cli.config.ts
@@ -17,6 +17,7 @@ import { AddColorIndexToProjects1771343199455 } from "../migrations/177134319945
 import { AddPriorityToKanbanTasks1771344000000 } from "../migrations/1771344000000-AddPriorityToKanbanTasks";
 import { ReplaceColorIndexWithColor1771388085809 } from "../migrations/1771388085809-ReplaceColorIndexWithColor";
 import { FillEmptyBaseBranch1771400000000 } from "../migrations/1771400000000-FillEmptyBaseBranch";
+import { AddIconDataUrlToProjects1771500000000 } from "../migrations/1771500000000-AddIconDataUrlToProjects";
 
 /** TypeORM CLI 전용 DataSource 설정. 내장 SQLite DB를 조회하거나 ad-hoc 점검할 때 사용한다. */
 export default new DataSource({
@@ -36,6 +37,7 @@ export default new DataSource({
     AddPriorityToKanbanTasks1771344000000,
     ReplaceColorIndexWithColor1771388085809,
     FillEmptyBaseBranch1771400000000,
+    AddIconDataUrlToProjects1771500000000,
   ],
   synchronize: false,
   logging: process.env.TYPEORM_LOGGING === "true",

--- a/src/migrations/1771500000000-AddIconDataUrlToProjects.ts
+++ b/src/migrations/1771500000000-AddIconDataUrlToProjects.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { addColumnIfNotExists } from "./sqliteMigrationUtils";
+
+interface ColumnInfo {
+  name: string;
+}
+
+/** 프로젝트 제목 앞에 표시할 GitHub repo/org 아이콘을 data URL로 보관한다 */
+export class AddIconDataUrlToProjects1771500000000 implements MigrationInterface {
+  name = "AddIconDataUrlToProjects1771500000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await addColumnIfNotExists(queryRunner, "projects", "icon_data_url", `"icon_data_url" TEXT DEFAULT NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const columns: ColumnInfo[] = await queryRunner.query(`PRAGMA table_info("projects")`);
+    if (columns.some((column) => column.name === "icon_data_url")) {
+      await queryRunner.query(`ALTER TABLE "projects" DROP COLUMN "icon_data_url"`);
+    }
+  }
+}


### PR DESCRIPTION
## 어떤 작업인가요?
- 같은 저장소를 여러 KanVibe client에서 열 때 hook 설치 상태와 프로젝트 색상이 서로 덮어써지던 문제를 `.kanvibe` 상태 파일 공유 방식으로 해결하고, 보드 카드의 프로젝트 마커를 점에서 GitHub 아이콘으로 교체합니다.

## 어떻게 해결했나요?
**hook 설치 파이프라인 재구성**
- 네 CLI(claude/gemini/codex/openCode)의 hook 설치 코드에 중복돼 있던 파일 쓰기·JSON 설정 upsert·shell script 생성 로직을 공통 모듈로 모읍니다.
- hook 알림 대상을 taskId가 아닌 client(hook 서버 URL) 단위로 `targets.json`에 등록해, 여러 client가 같은 worktree를 공유해도 서로의 설치 상태를 깨뜨리지 않게 합니다.

**상태와 색상의 파일 분리**
- task 상태(`status.json`)와 프로젝트 색상(`project.json`)을 별도 파일로 나눠, hook과 client가 서로의 최신 값을 되돌릴 수 없게 합니다.
- 색상은 등록·동기화 시 파일에서 먼저 읽어 이어받으므로 보드마다 색이 달라지지 않습니다.

**보드 카드 프로젝트 마커 교체**
- 프로젝트명 앞의 점을 없애고 GitHub 아이콘을 놓습니다. 아이콘이 없는 프로젝트는 프로젝트 색상의 이니셜 배지를 그려 모든 카드가 같은 규격의 마커를 갖습니다.

## 중요한 변경 사항은 무엇인가요?
### hook 설치 파이프라인 재구성

**설치 산출물 생성/기록 경로 공통화**
- **변경 이유**: 네 provider가 각자 shell script 생성, 로컬/원격 파일 쓰기, JSON hook 설정 병합을 따로 구현하고 있어 규칙이 갈라졌습니다.
- **수정 파일**: `src/lib/hookFileWriter.ts`, `src/lib/jsonHookSettings.ts`, `src/lib/shellHookProvider.ts`, `src/lib/shellHookScript.ts`(구 `hookTaskBinding.ts`), `src/lib/kanvibeHookProviders.ts`, `src/lib/kanvibeHooksInstaller.ts`, `src/lib/{claude,gemini,codex,openCode}HooksSetup.ts`

**provider 단위 설치 격리**
- **변경 이유**: 리팩터링 초안이 모든 provider 파일을 한 번의 쓰기 배치로 묶어, 한 provider의 실패가 나머지 provider의 hook 설치까지 막았습니다. `Promise.allSettled` + `assertHookProviderInstallResults`로 provider 경계를 되살렸습니다.
- **수정 파일**: `src/lib/kanvibeHooksInstaller.ts`

**hook 대상 등록 키를 taskId → client URL로 변경**
- **변경 이유**: taskId 기준으로 upsert하면 같은 worktree를 보는 다른 client의 등록이 밀려났습니다. 설치 여부 판정도 스크립트에 박힌 `TASK_ID` 대신 `targets.json` 등록 여부로 옮깁니다.
- **수정 파일**: `src/lib/kanvibeProjectState.ts`, `src/lib/hookTargetRegistration.ts`, `src/lib/kanvibeHooksInstaller.ts`

**통보 타임아웃**
- **변경 이유**: `targets.json`에는 이미 종료된 client 주소가 남을 수 있는데, 응답 없는 주소 하나가 hook 전체를 기본 연결 타임아웃까지 붙잡았습니다. shell은 `curl --max-time 3`, OpenCode plugin은 3초 `AbortSignal`로 상한을 두고, 상한 없는 예전 스크립트는 재설치되도록 설치 판정에 포함했습니다.
- **수정 파일**: `src/lib/shellHookScript.ts`, `src/lib/openCodeHooksSetup.ts`, `src/lib/shellHookProvider.ts`

### 상태와 색상의 파일 분리

**`status.json` / `project.json` 분리**
- **변경 이유**: 한 파일을 read-modify-write 하면 hook의 상태 갱신과 client의 색상 갱신이 서로의 최신 값을 되돌릴 수 있었습니다. 파일을 나누면 겹치는 writer가 없어져 잠금 없이 경합이 사라지고, hook shell script와 OpenCode plugin의 색상 보존 로직도 함께 제거됩니다.
- **수정 파일**: `src/lib/kanvibeProjectState.ts`, `src/lib/shellHookScript.ts`, `src/lib/openCodeHooksSetup.ts`, `src/desktop/main/services/kanvibeTaskStateService.ts`

**색상 결정과 전파**
- **변경 이유**: client마다 프로젝트명 해시로 색을 계산해 같은 프로젝트가 다른 색으로 보였습니다. 등록·worktree 동기화 시 공유 파일의 색상을 먼저 읽고, 없을 때만 해시 색상을 계산합니다. 전파는 exclude 갱신을 저장소당 1회로 줄이고 경로별 기록을 병렬화했습니다.
- **수정 파일**: `src/desktop/main/services/kanvibeProjectColorService.ts`, `src/desktop/main/services/projectService.ts`, `src/desktop/main/services/kanbanService.ts`

### GitHub 아이콘과 보드 마커

**아이콘 확보 경로**
- **변경 이유**: 아이콘을 data URL로 보관해 오프라인에서도 보이게 하고, 허용 content-type과 512KB 상한을 검사합니다. owner 단위 10분 캐시(실패도 캐싱)로 같은 소유자 저장소를 연달아 등록해도 요청은 1회입니다. 스캔 루프에서는 네트워크 호출을 빼고 `syncMissingProjectIcon`이 후속 sync에서 채우므로, 이전 버전에서 등록됐거나 등록 시점에 오프라인이었던 프로젝트도 수렴합니다.
- **수정 파일**: `src/lib/githubProjectIcon.ts`, `src/desktop/main/services/projectService.ts`, `src/entities/Project.ts`, `src/migrations/1771500000000-AddIconDataUrlToProjects.ts`, `src/lib/sqliteSchema.ts`, `src/lib/database.ts`

**보드 카드 마커**
- **변경 이유**: 점과 아이콘이 나란히 놓여 마커가 둘로 보였습니다. 점을 없애고 아이콘을 그 자리로 옮기되, 아이콘이 없는 프로젝트는 이니셜 배지로 채워 모든 카드가 같은 규격을 갖게 합니다. 프리셋 팔레트가 파스텔이라 배지 글자는 WCAG 대비율로 검정/흰색을 골라야 읽힙니다.
- **수정 파일**: `src/components/ProjectIcon.tsx`, `src/components/TaskCard.tsx`, `src/components/Column.tsx`, `src/components/Board.tsx`, `src/components/ProjectSelector.tsx`, `src/components/ProjectRegistryDialog.tsx`, `src/desktop/renderer/routes/BoardRoute.tsx`, `src/lib/projectColor.ts`

## 남은 작업
- docs 스크린샷은 이번 PR에 포함하지 않았습니다. 보드 카드가 보이는 이미지 10종 중 docs-site 5종은 다크 테마 한 장면을 공유하고, README 3종은 손으로 그린 주석이 들어가 있어 일괄 재생성이 필요합니다.

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
