### PR TITLE
build(toolchain): devEngines로 pnpm 버전을 고정해 무시되던 native build script 복구

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,13 @@
     "test:watch": "vitest",
     "postinstall": "node scripts/postinstall.cjs"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10.34.5",
+      "onFail": "error"
+    }
+  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "@parcel/watcher",


### PR DESCRIPTION
## 문제

`pnpm install`이 `ERR_PNPM_IGNORED_BUILDS`로 실패하고, 로그에 경고가 함께 찍힌다.

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
       The following keys were ignored: "pnpm.onlyBuiltDependencies"
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher, @swc/core,
  better-sqlite3, electron-winstaller, electron, esbuild, node-pty, sharp
```

레포에 패키지 매니저 핀이 없어 corepack이 최신 pnpm 11.17.0을 끌어왔고, pnpm 11부터는 `package.json`의 `pnpm.onlyBuiltDependencies`를 읽지 않는다. CI는 `pnpm/action-setup`으로 10을 고정하고 있어 **CI는 통과하고 로컬만 깨지는** 형태였다.

## 왜 `packageManager`를 되돌리지 않는가

`packageManager` 필드는 `4d3be6b`에서 의도적으로 제거된 것이다. `app-builder-lib`의 `detectPackageManager`가 그 필드를 **최우선**으로 읽는다:

```js
const packageManager = (await fs.readJson(packageJsonPath)).packageManager
if (packageManager) { ... detectionMethod: "packageManager field" }   // ← 즉시 확정

if (detected.length === 1) return detected[0]   // 락파일이 정확히 1개일 때만
return null                                      // 이 레포는 2개라 여기서 null

pm = detectPackageManagerByEnv() || PM.NPM       // dist-deploy.cjs가 env를 지움 → npm
```

필드가 있으면 pnpm으로 판정되고, 그 수집 경로가 hoisted 레이아웃의 전이 의존성을 놓쳐 1.0.4가 `Cannot find module 'ms'`로 기동 불가 상태로 배포됐다.

## 해결

`devEngines.packageManager`를 쓴다. corepack은 이 필드를 `packageManager`와 동일하게, 오히려 **우선하여** 해석한다. 반면 `app-builder-lib@26.8.1`은 `devEngines`를 어디에서도 참조하지 않는다 (`grep -rn "devEngines" node_modules/app-builder-lib/out/` → 0건).

즉 로컬 pnpm 버전만 고정되고 패키징 판정 경로는 손대지 않는다.

## 검증

| 확인 항목 | 결과 |
|---|---|
| `pnpm --version` | 11.17.0 → **10.34.5** (corepack 자동 결정) |
| `pnpm install` | 통과, `ERR_PNPM_IGNORED_BUILDS` 해소 |
| native 산출물 | electron / better-sqlite3 / @swc/core 빌드됨 (node-pty·sharp는 프리빌트 사용) |
| `node_modules` | 36개 → 620개, `.bin` 15개 → 67개 |
| `pnpm test` | **98개 파일 861개 테스트 전부 통과** |
| 최상위 `packageManager` | `undefined` — electron-builder 판정 경로 불변 |
| `app-builder-lib`의 `devEngines` 참조 | 0건 (설치된 실물 기준) |

pnpm 자체는 `devEngines`를 `devEngines.runtime` → `devDependencies` 변환에만 쓰고 `devEngines.packageManager`를 검증하지 않으므로, CI의 `action-setup`이 설치하는 10.x가 10.34.5가 아니어도 영향이 없다.

## 남은 범위

실제 DMG 패키징은 이 PR에서 돌리지 않았다. 소스 레벨로 판정 경로가 불변임을 확인했고, 다음 릴리스 때 `dist-deploy.cjs`의 asar 검사 게이트가 최종 확인한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)