### PR TITLE
chore(release): publish KanVibe 1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Publish KanVibe 1.0.6. Bumps `package.json` and `package-lock.json` from `1.0.5` to `1.0.6`; no other files change.

The release was cut from `origin/dev` at `ad67349`, which includes the `devEngines` pnpm pin (#321). That pin is what restored the native build scripts for `better-sqlite3`, `electron`, and `node-pty` during this build.

## Test Plan

- `pnpm install --frozen-lockfile` — native rebuild ran (`better-sqlite3`).
- `pnpm run deploy` — signed, notarized (`status: Accepted`), stapled, and validated.
- Dependency collector reported `pm=npm`, not `pm=pnpm`.
- Packaging guard: `packaged node_modules verified: 278 packages`.
- Smoke test on the published DMG (mounted, copied out, launched with `open -a`):
  - `spctl -a -t exec` → `accepted`, `source=Notarized Developer ID`
  - process still alive after startup
  - module-error count: `0`
  - `invoke-succeeded` count: `174` (database and IPC layer came up)
- Checksum of the bytes GitHub serves matches the local artifact exactly.

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.0.6
- DMG asset: `dist/KanVibe-1.0.6.dmg` (168,447,280 bytes)
- SHA-256: `ef0f1d9a2c6ee978a26a8871b7ba3913541ce8b75e47dc18dc391475fbff977f`
- Release target SHA: `2aac83b90fd66709b6f1fa051fda75c1670fc5c2`

## Homebrew Cask

- Repository: `rookedsysc/homebrew-kanvibe`
- Commit: `2b686819a1b9188afedb1bfa1b0a424a3b5e09c4` ("Update KanVibe cask to 1.0.6")
- Only `version` and `sha256` changed; the URL shape is unchanged.
- Verified through the tap: `brew fetch --cask rookedsysc/kanvibe/kanvibe` → `✔︎ Cask kanvibe (1.0.6)`
