### PR TITLE
fix(projects): 이름 중복 판정을 PC 단위로 좁혀 불필요한 상위 폴더·숫자 접미사 제거

### DIFF
--- a/src/components/ProjectRegistryDialog.tsx
+++ b/src/components/ProjectRegistryDialog.tsx
@@ -76,7 +76,7 @@ export default function ProjectRegistryDialog({
         setSuccessMessage(messages.join(" / "));
       } else if (result.skipped.length > 0) {
         setSuccessMessage(t("noNewProjects"));
-      } else {
+      } else if (result.errors.length === 0) {
         setError(t("noGitRepos"));
       }
     });
@@ -172,7 +172,14 @@ export default function ProjectRegistryDialog({
               )}
               {scanResult.errors.length > 0 && (
                 <div className="text-xs text-status-error">
-                  {t("errors")}: {scanResult.errors.length}{t("errorsSuffix")}
+                  <div>
+                    {t("errors")}: {scanResult.errors.length}{t("errorsSuffix")}
+                  </div>
+                  <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                    {scanResult.errors.map((message) => (
+                      <li key={message}>{message}</li>
+                    ))}
+                  </ul>
                 </div>
               )}
             </div>

--- a/src/components/__tests__/ProjectRegistryDialog.test.tsx
+++ b/src/components/__tests__/ProjectRegistryDialog.test.tsx
@@ -136,6 +136,35 @@ describe("ProjectRegistryDialog", () => {
     });
   });
 
+  it("등록되지 못한 저장소의 사유를 건수가 아니라 메시지로 보여준다", async () => {
+    projectActionMocks.scanAndRegisterProjects.mockResolvedValue({
+      registered: [],
+      skipped: [],
+      errors: ["/home/tester/c/work/kanvibe: 같은 PC에 이름과 상위 폴더가 모두 같은 프로젝트가 이미 있습니다."],
+      worktreeTasks: [],
+    });
+
+    render(
+      <ProjectRegistryDialog
+        isOpen
+        onClose={vi.fn()}
+        projects={[createProject()]}
+        sshHosts={[]}
+      />,
+    );
+
+    fireEvent.submit(screen.getByTestId("project-registry-form"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "/home/tester/c/work/kanvibe: 같은 PC에 이름과 상위 폴더가 모두 같은 프로젝트가 이미 있습니다.",
+        ),
+      ).toBeTruthy();
+    });
+    expect(screen.queryByText("noGitRepos")).toBeNull();
+  });
+
   it("삭제 확인 후 등록 프로젝트를 삭제한다", async () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
 

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -497,7 +497,7 @@ describe("projectService remote registration flow", () => {
     }));
   });
 
-  it("같은 이름의 로컬 프로젝트가 있어도 원격 프로젝트는 구분된 이름으로 등록한다", async () => {
+  it("다른 PC에 같은 이름의 프로젝트가 있으면 상위 폴더를 붙이지 않고 그대로 등록한다", async () => {
     mocks.validateGitRepo.mockResolvedValue(true);
     mocks.getDefaultBranch.mockResolvedValue("main");
     mocks.createSessionWithoutWorktree.mockResolvedValue({ sessionName: "kanvibe-main" });
@@ -530,9 +530,112 @@ describe("projectService remote registration flow", () => {
 
     expect(result.success).toBe(true);
     expect(result.project).toMatchObject({
-      name: "kanvibe/kanvibe",
+      name: "kanvibe",
       sshHost: "remote-host",
     });
+  });
+
+  it("같은 PC에 같은 이름의 프로젝트가 있으면 상위 폴더를 붙여 구분한다", async () => {
+    mocks.validateGitRepo.mockResolvedValue(true);
+    mocks.getDefaultBranch.mockResolvedValue("main");
+
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          id: "project-existing",
+          name: "kanvibe",
+          repoPath: "/workspace/kanvibe",
+          sshHost: "remote-host",
+        },
+      ]),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => ({ id: "project-new", ...value })),
+      remove: vi.fn(),
+    });
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn().mockResolvedValue(null),
+      create: vi.fn((value) => value),
+      save: vi.fn(async (value) => ({ id: "task-1", ...value })),
+    });
+
+    const { registerProject } = await import("@/desktop/main/services/projectService");
+    const result = await registerProject("kanvibe", "/home/tester/Documents/kanvibe", "remote-host");
+
+    expect(result.success).toBe(true);
+    expect(result.project).toMatchObject({
+      name: "Documents/kanvibe",
+      sshHost: "remote-host",
+    });
+  });
+
+  it("같은 PC에 이름과 상위 폴더가 모두 같은 프로젝트가 있으면 등록하지 않는다", async () => {
+    mocks.validateGitRepo.mockResolvedValue(true);
+    mocks.getDefaultBranch.mockResolvedValue("main");
+
+    const save = vi.fn();
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          id: "project-existing",
+          name: "kanvibe",
+          repoPath: "/home/tester/a/work/kanvibe",
+          sshHost: null,
+        },
+        {
+          id: "project-existing-parent",
+          name: "work/kanvibe",
+          repoPath: "/home/tester/b/work/kanvibe",
+          sshHost: null,
+        },
+      ]),
+      create: vi.fn((value) => value),
+      save,
+      remove: vi.fn(),
+    });
+
+    const { registerProject } = await import("@/desktop/main/services/projectService");
+    const result = await registerProject("kanvibe", "/home/tester/c/work/kanvibe");
+
+    expect(result).toEqual({
+      success: false,
+      error: "같은 PC에 이름과 상위 폴더가 모두 같은 프로젝트가 이미 있습니다.",
+    });
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("스캔 중 이름과 상위 폴더가 모두 겹치는 저장소는 숫자를 붙이지 않고 오류로 남긴다", async () => {
+    mocks.scanGitRepos.mockResolvedValue(["/home/tester/c/work/kanvibe"]);
+    mocks.getDefaultBranch.mockResolvedValue("main");
+
+    const save = vi.fn(async (value) => ({ id: "project-new", ...value }));
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          id: "project-existing",
+          name: "kanvibe",
+          repoPath: "/home/tester/a/work/kanvibe",
+          sshHost: null,
+        },
+        {
+          id: "project-existing-parent",
+          name: "work/kanvibe",
+          repoPath: "/home/tester/b/work/kanvibe",
+          sshHost: null,
+        },
+      ]),
+      create: vi.fn((value) => value),
+      save,
+      remove: vi.fn(),
+    });
+
+    const { scanAndRegisterProjects } = await import("@/desktop/main/services/projectService");
+    const result = await scanAndRegisterProjects("/home/tester");
+
+    expect(result.registered).toEqual([]);
+    expect(result.errors).toEqual([
+      "/home/tester/c/work/kanvibe: 같은 PC에 이름과 상위 폴더가 모두 같은 프로젝트가 이미 있습니다.",
+    ]);
+    expect(save).not.toHaveBeenCalled();
   });
 
   it("같은 sshHost와 repoPath 조합은 이름이 달라도 중복 등록하지 않는다", async () => {

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -13,6 +13,7 @@ import type { AggregatedAiSessionDetail, AggregatedAiSessionsResult, AiMessageRo
 import { homedir } from "os";
 import path from "path";
 import { computeProjectColor } from "@/lib/projectColor";
+import { DUPLICATE_PROJECT_NAME_ERROR, resolveUniqueProjectName } from "@/lib/projectName";
 import { resolveProjectIconDataUrl } from "@/lib/githubProjectIcon";
 import { broadcastBoardUpdate } from "@/lib/boardNotifier";
 import { getAvailableHosts as readAvailableHosts } from "@/lib/sshConfig";
@@ -197,42 +198,13 @@ function scheduleProjectRootTaskRepair(project: Project) {
   }, 0);
 }
 
-/** 프로젝트 표시 이름은 전역적으로 유일해야 하므로 충돌 시 경로 기반 후보명으로 보정한다 */
-function resolveUniqueProjectName(
-  preferredName: string,
-  repoPath: string,
-  existingNames: Set<string>,
-): string {
-  const baseName = path.basename(repoPath);
-  const parentName = path.basename(path.dirname(repoPath));
-  const combinedName = `${parentName}/${baseName}`;
-  const candidates = [preferredName];
-
-  if (baseName && baseName !== preferredName) {
-    candidates.push(baseName);
-  }
-
-  if (combinedName && combinedName !== preferredName) {
-    candidates.push(combinedName);
-  }
-
-  for (const candidate of candidates) {
-    if (existingNames.has(candidate)) {
-      continue;
-    }
-
-    existingNames.add(candidate);
-    return candidate;
-  }
-
-  let counter = 2;
-  while (existingNames.has(`${preferredName}-${counter}`)) {
-    counter++;
-  }
-
-  const numberedName = `${preferredName}-${counter}`;
-  existingNames.add(numberedName);
-  return numberedName;
+/** 프로젝트 이름 중복은 같은 PC 안에서만 따지므로 대상 PC에 등록된 이름만 모은다 */
+function collectProjectNamesOnSameHost(projects: Project[], sshHost: string | null): Set<string> {
+  return new Set(
+    projects
+      .filter((project) => (project.sshHost || null) === sshHost)
+      .map((project) => project.name),
+  );
 }
 
 /** 프로젝트의 메인 브랜치 태스크를 생성하고 tmux 세션을 자동 연결한다 */
@@ -494,8 +466,11 @@ export async function registerProject(
   const projectName = resolveUniqueProjectName(
     name,
     normalizedRepoPath,
-    new Set(existingProjects.map((project) => project.name)),
+    collectProjectNamesOnSameHost(existingProjects, sshHost || null),
   );
+  if (!projectName) {
+    return { success: false, error: DUPLICATE_PROJECT_NAME_ERROR };
+  }
 
   const project = repo.create({
     name: projectName,
@@ -889,7 +864,7 @@ export async function syncRegisteredProjectWorktrees(
 
 /**
  * 지정 디렉토리 하위의 git 저장소를 스캔하여 미등록 프로젝트를 일괄 등록한다.
- * 이미 동일 경로로 등록된 프로젝트는 건너뛰고, 이름 중복 시 상위 디렉토리를 포함하여 구분한다.
+ * 이미 동일 경로로 등록된 프로젝트는 건너뛰고, 같은 PC 안에서 이름이 중복되면 상위 디렉토리를 포함하여 구분한다.
  */
 export async function scanAndRegisterProjects(
   rootPath: string,
@@ -924,7 +899,7 @@ export async function scanAndRegisterProjects(
   const existingPaths = new Set(
     existing.map((project) => buildProjectPathKey(project.repoPath, project.sshHost))
   );
-  const existingNames = new Set(existing.map((p) => p.name));
+  const namesOnSameHost = collectProjectNamesOnSameHost(existing, sshHost || null);
 
   for (const repoPath of repoPaths) {
     const pathKey = buildProjectPathKey(repoPath, sshHost || null);
@@ -935,7 +910,11 @@ export async function scanAndRegisterProjects(
 
     try {
       const defaultBranch = await getDefaultBranch(repoPath, sshHost || null);
-      const projectName = resolveUniqueProjectName(path.basename(repoPath), repoPath, existingNames);
+      const projectName = resolveUniqueProjectName(path.basename(repoPath), repoPath, namesOnSameHost);
+      if (!projectName) {
+        result.errors.push(`${repoPath}: ${DUPLICATE_PROJECT_NAME_ERROR}`);
+        continue;
+      }
 
       const project = repo.create({
         name: projectName,

--- a/src/entities/Project.ts
+++ b/src/entities/Project.ts
@@ -15,7 +15,8 @@ export class Project {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
 
-  @Column({ type: "varchar", length: 255, unique: true })
+  /** 표시 이름은 같은 PC(sshHost) 안에서만 유일하다. 다른 PC의 같은 이름 프로젝트는 sshHost로 구분한다 */
+  @Column({ type: "varchar", length: 255 })
   name!: string;
 
   @Column({ name: "repo_path", type: "varchar", length: 500 })

--- a/src/lib/__tests__/databaseMigrations.test.ts
+++ b/src/lib/__tests__/databaseMigrations.test.ts
@@ -6,6 +6,7 @@ import { DataSource } from "typeorm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ensureSqliteDatabaseReady } from "@/lib/sqliteSchema";
 import { AssignDisplayOrder1771166346785 } from "@/migrations/1771166346785-AssignDisplayOrder";
+import { RescopeProjectNamesPerHost1771600000000 } from "@/migrations/1771600000000-RescopeProjectNamesPerHost";
 
 const originalKanvibeDbPath = process.env.KANVIBE_DB_PATH;
 
@@ -119,7 +120,7 @@ describe("database migrations", () => {
         { id: "task-1", branch_name: "main", display_order: 0 },
         { id: "task-2", branch_name: "main", display_order: 1 },
       ]);
-      expect(migrations).toHaveLength(13);
+      expect(migrations).toHaveLength(14);
       expect(migrations[0]).toEqual({ name: "InitialSchema1770854400000" });
     } finally {
       await dataSource.destroy();
@@ -158,7 +159,7 @@ describe("database migrations", () => {
           display_order: 0,
         },
       ]);
-      expect(migrations).toHaveLength(13);
+      expect(migrations).toHaveLength(14);
     } finally {
       await dataSource.destroy();
     }
@@ -188,7 +189,145 @@ describe("database migrations", () => {
       expect(indexes.map((row: { name: string }) => row.name)).not.toContain(
         "UQ_kanban_tasks_branch_name",
       );
-      expect(migrations).toHaveLength(13);
+      expect(migrations).toHaveLength(14);
+
+      await dataSource.query(`
+        INSERT INTO projects (id, name, repo_path, ssh_host)
+        VALUES
+          ('project-local', 'kanvibe', '/workspace/kanvibe', NULL),
+          ('project-remote', 'kanvibe', '/workspace/kanvibe', 'remote-host')
+      `);
+      const projectNames = await dataSource.query(`SELECT name FROM projects ORDER BY id`);
+
+      expect(projectNames).toEqual([{ name: "kanvibe" }, { name: "kanvibe" }]);
+    } finally {
+      await dataSource.destroy();
+    }
+  });
+
+  it("drops the legacy global unique project name without unlinking tasks", async () => {
+    const databasePath = createDatabasePath();
+    const dataSource = new DataSource({
+      type: "better-sqlite3",
+      database: databasePath,
+      prepareDatabase: (database) => {
+        database.pragma("foreign_keys = ON");
+      },
+    });
+
+    await dataSource.initialize();
+
+    try {
+      await dataSource.query(`
+        CREATE TABLE projects (
+          id TEXT PRIMARY KEY NOT NULL,
+          name TEXT NOT NULL UNIQUE,
+          repo_path TEXT NOT NULL,
+          default_branch TEXT NOT NULL DEFAULT 'main',
+          ssh_host TEXT,
+          is_worktree INTEGER NOT NULL DEFAULT 0,
+          color TEXT DEFAULT NULL,
+          icon_data_url TEXT DEFAULT NULL,
+          created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+      `);
+      await dataSource.query(`
+        CREATE TABLE kanban_tasks (
+          id TEXT PRIMARY KEY NOT NULL,
+          title TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'todo',
+          project_id TEXT,
+          created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL
+        )
+      `);
+      await dataSource.query(`
+        INSERT INTO projects (id, name, repo_path, ssh_host)
+        VALUES ('project-local', 'kanvibe', '/workspace/kanvibe', NULL)
+      `);
+      await dataSource.query(`
+        INSERT INTO kanban_tasks (id, title, project_id)
+        VALUES ('task-1', 'main', 'project-local')
+      `);
+
+      /** 프로덕션과 같은 순서로 foreign_keys를 끄고 마이그레이션을 실행해 DROP TABLE이 task 연결을 지우지 않는지 확인한다 */
+      const queryRunner = dataSource.createQueryRunner();
+      try {
+        await queryRunner.beforeMigration();
+        await new RescopeProjectNamesPerHost1771600000000().up(queryRunner);
+        await queryRunner.afterMigration();
+      } finally {
+        await queryRunner.release();
+      }
+
+      await dataSource.query(`
+        INSERT INTO projects (id, name, repo_path, ssh_host)
+        VALUES ('project-remote', 'kanvibe', '/workspace/kanvibe', 'remote-host')
+      `);
+
+      const projects = await dataSource.query(`SELECT id, name, ssh_host FROM projects ORDER BY id`);
+      const tasks = await dataSource.query(`SELECT id, project_id FROM kanban_tasks`);
+
+      expect(projects).toEqual([
+        { id: "project-local", name: "kanvibe", ssh_host: null },
+        { id: "project-remote", name: "kanvibe", ssh_host: "remote-host" },
+      ]);
+      expect(tasks).toEqual([{ id: "task-1", project_id: "project-local" }]);
+    } finally {
+      await dataSource.destroy();
+    }
+  });
+
+  it("rescopes names that the global unique rule had padded with a parent folder or a number", async () => {
+    const databasePath = createDatabasePath();
+    const dataSource = new DataSource({
+      type: "better-sqlite3",
+      database: databasePath,
+    });
+
+    await dataSource.initialize();
+
+    try {
+      await dataSource.query(`
+        CREATE TABLE projects (
+          id TEXT PRIMARY KEY NOT NULL,
+          name TEXT NOT NULL UNIQUE,
+          repo_path TEXT NOT NULL,
+          default_branch TEXT NOT NULL DEFAULT 'main',
+          ssh_host TEXT,
+          is_worktree INTEGER NOT NULL DEFAULT 0,
+          color TEXT DEFAULT NULL,
+          icon_data_url TEXT DEFAULT NULL,
+          created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+      `);
+      await dataSource.query(`
+        INSERT INTO projects (id, name, repo_path, ssh_host, created_at)
+        VALUES
+          ('project-local', 'kanvibe', '/home/tester/Documents/kanvibe', NULL, '2026-01-01T00:00:00.000Z'),
+          ('project-remote', 'Documents/kanvibe', '/home/tester/Documents/kanvibe', 'remote-host', '2026-01-02T00:00:00.000Z'),
+          ('project-other-remote', 'kanvibe-2', '/home/tester/Documents/kanvibe', 'other-host', '2026-01-03T00:00:00.000Z'),
+          ('project-local-second', 'work/kanvibe', '/home/tester/work/kanvibe', NULL, '2026-01-04T00:00:00.000Z')
+      `);
+
+      const queryRunner = dataSource.createQueryRunner();
+      try {
+        await queryRunner.beforeMigration();
+        await new RescopeProjectNamesPerHost1771600000000().up(queryRunner);
+        await queryRunner.afterMigration();
+      } finally {
+        await queryRunner.release();
+      }
+
+      const projects = await dataSource.query(`SELECT id, name FROM projects ORDER BY created_at`);
+
+      expect(projects).toEqual([
+        { id: "project-local", name: "kanvibe" },
+        { id: "project-remote", name: "kanvibe" },
+        { id: "project-other-remote", name: "kanvibe" },
+        { id: "project-local-second", name: "work/kanvibe" },
+      ]);
     } finally {
       await dataSource.destroy();
     }

--- a/src/lib/__tests__/databaseMigrations.test.ts
+++ b/src/lib/__tests__/databaseMigrations.test.ts
@@ -89,6 +89,44 @@ function insertOlderLegacyBootstrapData(databasePath: string): void {
   }
 }
 
+/** migrations 테이블이 없어 baseline 처리되는, 전역 UNIQUE가 살아 있는 오래된 DB */
+function insertBaselinedLegacyProjectsData(databasePath: string): void {
+  fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+
+  const database = new Database(databasePath);
+  try {
+    database.exec(`
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL UNIQUE,
+        repo_path TEXT NOT NULL,
+        default_branch TEXT NOT NULL DEFAULT 'main',
+        ssh_host TEXT,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+
+      CREATE TABLE kanban_tasks (
+        id TEXT PRIMARY KEY NOT NULL,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'todo',
+        branch_name TEXT,
+        project_id TEXT,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL
+      );
+
+      INSERT INTO projects (id, name, repo_path, default_branch)
+      VALUES ('project-local', 'kanvibe', '/workspace/kanvibe', 'main');
+
+      INSERT INTO kanban_tasks (id, title, status, branch_name, project_id)
+      VALUES ('task-1', 'main', 'todo', 'main', 'project-local');
+    `);
+  } finally {
+    database.close();
+  }
+}
+
 afterEach(() => {
   if (originalKanvibeDbPath === undefined) {
     delete process.env.KANVIBE_DB_PATH;
@@ -328,6 +366,81 @@ describe("database migrations", () => {
         { id: "project-other-remote", name: "kanvibe" },
         { id: "project-local-second", name: "work/kanvibe" },
       ]);
+    } finally {
+      await dataSource.destroy();
+    }
+  });
+
+  it("drops the legacy global unique project name even when the database is baselined", async () => {
+    const databasePath = createDatabasePath();
+    insertBaselinedLegacyProjectsData(databasePath);
+    process.env.KANVIBE_DB_PATH = databasePath;
+    vi.resetModules();
+
+    const { getDataSource } = await import("@/lib/database");
+    const dataSource = await getDataSource();
+
+    try {
+      /** baseline은 모든 마이그레이션을 실행됨으로 기록하므로 스키마 복구가 없으면 UNIQUE가 그대로 남는다 */
+      await dataSource.query(`
+        INSERT INTO projects (id, name, repo_path, ssh_host)
+        VALUES ('project-remote', 'kanvibe', '/workspace/kanvibe', 'remote-host')
+      `);
+
+      const projects = await dataSource.query(`SELECT id, name, ssh_host FROM projects ORDER BY id`);
+      const tasks = await dataSource.query(`SELECT id, project_id FROM kanban_tasks`);
+
+      expect(projects).toEqual([
+        { id: "project-local", name: "kanvibe", ssh_host: null },
+        { id: "project-remote", name: "kanvibe", ssh_host: "remote-host" },
+      ]);
+      expect(tasks).toEqual([{ id: "task-1", project_id: "project-local" }]);
+    } finally {
+      await dataSource.destroy();
+    }
+  });
+
+  it("fails instead of silently dropping a projects column the rebuild cannot carry over", async () => {
+    const databasePath = createDatabasePath();
+    const dataSource = new DataSource({
+      type: "better-sqlite3",
+      database: databasePath,
+    });
+
+    await dataSource.initialize();
+
+    try {
+      await dataSource.query(`
+        CREATE TABLE projects (
+          id TEXT PRIMARY KEY NOT NULL,
+          name TEXT NOT NULL UNIQUE,
+          repo_path TEXT NOT NULL,
+          default_branch TEXT NOT NULL DEFAULT 'main',
+          ssh_host TEXT,
+          is_worktree INTEGER NOT NULL DEFAULT 0,
+          color TEXT DEFAULT NULL,
+          icon_data_url TEXT DEFAULT NULL,
+          created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          pinned_at DATETIME DEFAULT NULL
+        )
+      `);
+      await dataSource.query(`
+        INSERT INTO projects (id, name, repo_path, pinned_at)
+        VALUES ('project-local', 'kanvibe', '/workspace/kanvibe', '2026-01-01T00:00:00.000Z')
+      `);
+
+      const queryRunner = dataSource.createQueryRunner();
+      try {
+        await expect(
+          new RescopeProjectNamesPerHost1771600000000().up(queryRunner),
+        ).rejects.toThrow("pinned_at");
+      } finally {
+        await queryRunner.release();
+      }
+
+      const projects = await dataSource.query(`SELECT id, pinned_at FROM projects`);
+
+      expect(projects).toEqual([{ id: "project-local", pinned_at: "2026-01-01T00:00:00.000Z" }]);
     } finally {
       await dataSource.destroy();
     }

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -20,6 +20,7 @@ import { AddPriorityToKanbanTasks1771344000000 } from "@/migrations/177134400000
 import { ReplaceColorIndexWithColor1771388085809 } from "@/migrations/1771388085809-ReplaceColorIndexWithColor";
 import { FillEmptyBaseBranch1771400000000 } from "@/migrations/1771400000000-FillEmptyBaseBranch";
 import { AddIconDataUrlToProjects1771500000000 } from "@/migrations/1771500000000-AddIconDataUrlToProjects";
+import { RescopeProjectNamesPerHost1771600000000 } from "@/migrations/1771600000000-RescopeProjectNamesPerHost";
 
 /** TypeORM DataSource 싱글턴. Vite HMR 시 재연결을 방지하기 위해 globalThis에 캐싱한다. */
 const globalForDb = globalThis as unknown as {
@@ -40,6 +41,7 @@ const MIGRATIONS = [
   ReplaceColorIndexWithColor1771388085809,
   FillEmptyBaseBranch1771400000000,
   AddIconDataUrlToProjects1771500000000,
+  RescopeProjectNamesPerHost1771600000000,
 ];
 
 interface MigrationRecord {

--- a/src/lib/projectName.ts
+++ b/src/lib/projectName.ts
@@ -1,0 +1,44 @@
+import path from "path";
+
+/** 같은 PC 안에서 이름과 상위 폴더까지 모두 겹쳐 표시 이름을 구분할 수 없을 때 알리는 문구 */
+export const DUPLICATE_PROJECT_NAME_ERROR = "같은 PC에 이름과 상위 폴더가 모두 같은 프로젝트가 이미 있습니다.";
+
+/**
+ * 같은 PC 안에서 이름이 겹칠 때만 상위 폴더를 덧붙여 프로젝트 표시 이름을 구분한다.
+ * 다른 PC의 같은 이름 프로젝트는 UI가 sshHost로 구분해 보여주므로 이름을 바꾸지 않는다.
+ * 상위 폴더까지 같아 구분할 수 없으면 null을 반환해 호출부가 등록을 막게 한다.
+ *
+ * @param preferredName 사용자가 지정했거나 경로에서 뽑은 우선 이름
+ * @param repoPath 저장소 경로. 이름이 겹칠 때 상위 폴더를 뽑는 근거가 된다
+ * @param namesOnSameHost 같은 PC에 이미 등록된 프로젝트 이름. 확정한 이름이 여기에 추가된다
+ * @returns 확정한 표시 이름, 구분할 수 없으면 null
+ */
+export function resolveUniqueProjectName(
+  preferredName: string,
+  repoPath: string,
+  namesOnSameHost: Set<string>,
+): string | null {
+  const baseName = path.basename(repoPath);
+  const parentName = path.basename(path.dirname(repoPath));
+  const combinedName = `${parentName}/${baseName}`;
+  const candidates = [preferredName];
+
+  if (baseName && baseName !== preferredName) {
+    candidates.push(baseName);
+  }
+
+  if (combinedName && combinedName !== preferredName) {
+    candidates.push(combinedName);
+  }
+
+  for (const candidate of candidates) {
+    if (namesOnSameHost.has(candidate)) {
+      continue;
+    }
+
+    namesOnSameHost.add(candidate);
+    return candidate;
+  }
+
+  return null;
+}

--- a/src/lib/sqliteSchema.ts
+++ b/src/lib/sqliteSchema.ts
@@ -91,6 +91,84 @@ function ensureColumns(database: Database.Database): void {
   ensureColumn(database, "pane_layout_configs", "panes", "panes TEXT NOT NULL DEFAULT '[]'");
 }
 
+/** PRAGMA table_info 결과 중 컬럼 정의를 다시 쓰는 데 필요한 필드 */
+interface SqliteColumnInfo {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+}
+
+/** name 컬럼 하나만 덮는 UNIQUE 인덱스를 찾는다. 인라인 UNIQUE 제약은 이름 없는 autoindex로 잡히므로 구성 컬럼으로 판별한다 */
+function hasGlobalUniqueProjectName(database: Database.Database): boolean {
+  const indexes = database.prepare(`PRAGMA index_list("projects")`).all() as Array<{ name: string; unique: number }>;
+
+  return indexes.some((index) => {
+    if (!index.unique) {
+      return false;
+    }
+
+    const columns = database
+      .prepare(`PRAGMA index_info(${quoteSqliteIdentifier(index.name)})`)
+      .all() as Array<{ name: string }>;
+    return columns.length === 1 && columns[0]?.name === "name";
+  });
+}
+
+/** 기존 컬럼 정의를 그대로 옮긴다. 정의를 새로 적으면 이 파일이 모르는 레거시 컬럼이 재생성 과정에서 사라진다 */
+function formatColumnDefinition(column: SqliteColumnInfo): string {
+  const definition = [quoteSqliteIdentifier(column.name), column.type || "TEXT"];
+
+  if (column.pk) {
+    definition.push("PRIMARY KEY");
+  }
+  if (column.notnull) {
+    definition.push("NOT NULL");
+  }
+  if (column.dflt_value !== null) {
+    definition.push(`DEFAULT ${column.dflt_value}`);
+  }
+
+  return definition.join(" ");
+}
+
+/**
+ * 표시 이름 유일성은 PC(ssh_host) 단위로만 따지므로 레거시 DB에 남아 있는 projects.name 전역 UNIQUE를 떨어뜨린다.
+ * SQLite는 인라인 UNIQUE 제약을 DROP INDEX로 제거할 수 없어 테이블을 다시 만들어야 하고,
+ * DROP TABLE이 kanban_tasks의 project_id 연결을 끊지 않도록 foreign_keys를 끈 상태에서 수행한다.
+ * baseline 처리되는 오래된 DB는 마이그레이션을 건너뛰므로 이 복구가 없으면 제약만 남아 등록이 실패한다.
+ */
+function dropGlobalUniqueProjectName(database: Database.Database): void {
+  if (!hasGlobalUniqueProjectName(database)) {
+    return;
+  }
+
+  const columns = database.prepare(`PRAGMA table_info("projects")`).all() as SqliteColumnInfo[];
+  const columnNames = columns.map((column) => quoteSqliteIdentifier(column.name)).join(", ");
+
+  database.pragma("foreign_keys = OFF");
+  try {
+    const transaction = database.transaction(() => {
+      database.exec(`
+        CREATE TABLE projects_rebuilt (
+          ${columns.map(formatColumnDefinition).join(",\n          ")}
+        );
+
+        INSERT INTO projects_rebuilt (${columnNames}) SELECT ${columnNames} FROM projects;
+
+        DROP TABLE projects;
+
+        ALTER TABLE projects_rebuilt RENAME TO projects;
+      `);
+    });
+
+    transaction();
+  } finally {
+    database.pragma("foreign_keys = ON");
+  }
+}
+
 function ensureIndexes(database: Database.Database): void {
   database.exec(`
     CREATE INDEX IF NOT EXISTS idx_kanban_tasks_status_order
@@ -117,6 +195,7 @@ export function ensureSqliteDatabaseReady(databasePath: string): void {
     });
 
     transaction();
+    dropGlobalUniqueProjectName(database);
   } finally {
     database.close();
   }

--- a/src/lib/sqliteSchema.ts
+++ b/src/lib/sqliteSchema.ts
@@ -24,7 +24,7 @@ function ensureBaseTables(database: Database.Database): void {
   database.exec(`
     CREATE TABLE IF NOT EXISTS projects (
       id TEXT PRIMARY KEY NOT NULL,
-      name TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
       repo_path TEXT NOT NULL,
       default_branch TEXT NOT NULL DEFAULT 'main',
       ssh_host TEXT,

--- a/src/lib/typeorm-cli.config.ts
+++ b/src/lib/typeorm-cli.config.ts
@@ -18,6 +18,7 @@ import { AddPriorityToKanbanTasks1771344000000 } from "../migrations/17713440000
 import { ReplaceColorIndexWithColor1771388085809 } from "../migrations/1771388085809-ReplaceColorIndexWithColor";
 import { FillEmptyBaseBranch1771400000000 } from "../migrations/1771400000000-FillEmptyBaseBranch";
 import { AddIconDataUrlToProjects1771500000000 } from "../migrations/1771500000000-AddIconDataUrlToProjects";
+import { RescopeProjectNamesPerHost1771600000000 } from "../migrations/1771600000000-RescopeProjectNamesPerHost";
 
 /** TypeORM CLI 전용 DataSource 설정. 내장 SQLite DB를 조회하거나 ad-hoc 점검할 때 사용한다. */
 export default new DataSource({
@@ -38,6 +39,7 @@ export default new DataSource({
     ReplaceColorIndexWithColor1771388085809,
     FillEmptyBaseBranch1771400000000,
     AddIconDataUrlToProjects1771500000000,
+    RescopeProjectNamesPerHost1771600000000,
   ],
   synchronize: false,
   logging: process.env.TYPEORM_LOGGING === "true",

--- a/src/migrations/1771600000000-RescopeProjectNamesPerHost.ts
+++ b/src/migrations/1771600000000-RescopeProjectNamesPerHost.ts
@@ -1,0 +1,128 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import path from "path";
+import { resolveUniqueProjectName } from "../lib/projectName";
+
+/** PRAGMA index_list 결과 행 타입 */
+interface IndexListEntry {
+  name: string;
+  unique: number;
+}
+
+/** PRAGMA index_info 결과 행 타입 */
+interface IndexInfoEntry {
+  name: string;
+}
+
+/** 이름을 다시 계산하는 데 필요한 projects 행 타입 */
+interface ProjectNameRow {
+  id: string;
+  name: string;
+  repo_path: string;
+  ssh_host: string | null;
+}
+
+const PROJECT_COLUMNS = "id, name, repo_path, default_branch, ssh_host, is_worktree, color, icon_data_url, created_at";
+
+/** name 컬럼 하나만 덮는 UNIQUE 인덱스를 찾는다. 인라인 UNIQUE 제약은 이름 없는 autoindex로 잡히므로 구성 컬럼으로 판별한다 */
+async function findUniqueNameIndex(queryRunner: QueryRunner): Promise<string | null> {
+  const indexes: IndexListEntry[] = await queryRunner.query(`PRAGMA index_list("projects")`);
+
+  for (const index of indexes) {
+    if (!index.unique) {
+      continue;
+    }
+
+    const columns: IndexInfoEntry[] = await queryRunner.query(`PRAGMA index_info("${index.name}")`);
+    if (columns.length === 1 && columns[0]?.name === "name") {
+      return index.name;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * projects 테이블을 지정한 name 컬럼 정의로 다시 만든다.
+ * SQLite는 인라인 UNIQUE 제약을 DROP INDEX로 제거할 수 없어 테이블을 재생성해야 한다.
+ * 마이그레이션 실행 중에는 TypeORM이 foreign_keys를 꺼두므로 DROP TABLE이 kanban_tasks의 project_id를 지우지 않는다.
+ */
+async function rebuildProjectsTable(queryRunner: QueryRunner, nameColumnDefinition: string): Promise<void> {
+  await queryRunner.query(`
+    CREATE TABLE "projects_rebuilt" (
+      id TEXT PRIMARY KEY NOT NULL,
+      ${nameColumnDefinition},
+      repo_path TEXT NOT NULL,
+      default_branch TEXT NOT NULL DEFAULT 'main',
+      ssh_host TEXT,
+      is_worktree INTEGER NOT NULL DEFAULT 0,
+      color TEXT DEFAULT NULL,
+      icon_data_url TEXT DEFAULT NULL,
+      created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+  await queryRunner.query(
+    `INSERT INTO "projects_rebuilt" (${PROJECT_COLUMNS}) SELECT ${PROJECT_COLUMNS} FROM "projects"`,
+  );
+  await queryRunner.query(`DROP TABLE "projects"`);
+  await queryRunner.query(`ALTER TABLE "projects_rebuilt" RENAME TO "projects"`);
+}
+
+/**
+ * 전역 유일 규칙으로 지어진 기존 이름을 같은 PC 기준으로 다시 계산한다.
+ * 다른 PC 때문에 붙었던 상위 폴더와 숫자 접미사가 이 단계에서 사라진다.
+ * 프로젝트 이름은 등록 시 경로에서만 만들어지고 사용자가 바꿀 수 없으므로, 다시 계산해도 사용자가 지은 이름을 잃지 않는다.
+ * 등록 순서를 유지해야 먼저 등록한 프로젝트가 계속 짧은 이름을 갖는다.
+ */
+async function rescopeProjectNamesPerHost(queryRunner: QueryRunner): Promise<void> {
+  const projects: ProjectNameRow[] = await queryRunner.query(
+    `SELECT id, name, repo_path, ssh_host FROM "projects" ORDER BY created_at, id`,
+  );
+  const namesByHost = new Map<string, Set<string>>();
+
+  for (const project of projects) {
+    const hostKey = project.ssh_host ?? "";
+    const namesOnSameHost = namesByHost.get(hostKey) ?? new Set<string>();
+    namesByHost.set(hostKey, namesOnSameHost);
+
+    const rescopedName = resolveUniqueProjectName(
+      path.basename(project.repo_path),
+      project.repo_path,
+      namesOnSameHost,
+    );
+
+    /** 이미 등록된 프로젝트는 구분할 이름이 없다고 지울 수 없으므로 기존 이름을 그대로 둔다 */
+    if (!rescopedName) {
+      namesOnSameHost.add(project.name);
+      continue;
+    }
+
+    if (rescopedName !== project.name) {
+      await queryRunner.query(`UPDATE "projects" SET name = ? WHERE id = ?`, [rescopedName, project.id]);
+    }
+  }
+}
+
+/**
+ * 프로젝트 표시 이름을 전역 유일에서 PC(sshHost) 단위 유일로 바꾼다.
+ * name의 UNIQUE 제약을 제거하고, 그 제약 때문에 상위 폴더나 숫자가 붙었던 기존 이름을 다시 계산한다.
+ * 이미 UNIQUE가 없는 DB(sqliteSchema.ts로 생성된 경우)는 테이블 재생성을 건너뛴다.
+ */
+export class RescopeProjectNamesPerHost1771600000000 implements MigrationInterface {
+  name = "RescopeProjectNamesPerHost1771600000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (await findUniqueNameIndex(queryRunner)) {
+      await rebuildProjectsTable(queryRunner, "name TEXT NOT NULL");
+    }
+
+    await rescopeProjectNamesPerHost(queryRunner);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    if (await findUniqueNameIndex(queryRunner)) {
+      return;
+    }
+
+    await rebuildProjectsTable(queryRunner, "name TEXT NOT NULL UNIQUE");
+  }
+}

--- a/src/migrations/1771600000000-RescopeProjectNamesPerHost.ts
+++ b/src/migrations/1771600000000-RescopeProjectNamesPerHost.ts
@@ -13,6 +13,11 @@ interface IndexInfoEntry {
   name: string;
 }
 
+/** PRAGMA table_info 결과 중 복사 목록을 만드는 데 쓰는 필드 */
+interface TableColumnEntry {
+  name: string;
+}
+
 /** 이름을 다시 계산하는 데 필요한 projects 행 타입 */
 interface ProjectNameRow {
   id: string;
@@ -21,7 +26,37 @@ interface ProjectNameRow {
   ssh_host: string | null;
 }
 
-const PROJECT_COLUMNS = "id, name, repo_path, default_branch, ssh_host, is_worktree, color, icon_data_url, created_at";
+/** 재생성한 테이블이 갖는 컬럼. 여기에 없는 컬럼이 실제 테이블에 있으면 재생성이 그 데이터를 지운다 */
+const REBUILT_PROJECT_COLUMNS = [
+  "id",
+  "name",
+  "repo_path",
+  "default_branch",
+  "ssh_host",
+  "is_worktree",
+  "color",
+  "icon_data_url",
+  "created_at",
+];
+
+/**
+ * 실제 테이블 컬럼을 읽어 복사 목록을 만든다.
+ * 재생성한 테이블이 받아줄 수 없는 컬럼이 있으면 조용히 잃는 대신 마이그레이션을 실패시킨다.
+ */
+async function resolveProjectCopyColumns(queryRunner: QueryRunner): Promise<string> {
+  const columns: TableColumnEntry[] = await queryRunner.query(`PRAGMA table_info("projects")`);
+  const droppedColumns = columns
+    .map((column) => column.name)
+    .filter((name) => !REBUILT_PROJECT_COLUMNS.includes(name));
+
+  if (droppedColumns.length > 0) {
+    throw new Error(
+      `projects 테이블 재생성이 처리할 수 없는 컬럼이 있습니다: ${droppedColumns.join(", ")}`,
+    );
+  }
+
+  return columns.map((column) => `"${column.name}"`).join(", ");
+}
 
 /** name 컬럼 하나만 덮는 UNIQUE 인덱스를 찾는다. 인라인 UNIQUE 제약은 이름 없는 autoindex로 잡히므로 구성 컬럼으로 판별한다 */
 async function findUniqueNameIndex(queryRunner: QueryRunner): Promise<string | null> {
@@ -42,15 +77,17 @@ async function findUniqueNameIndex(queryRunner: QueryRunner): Promise<string | n
 }
 
 /**
- * projects 테이블을 지정한 name 컬럼 정의로 다시 만든다.
+ * projects 테이블을 name의 UNIQUE 없이 다시 만든다.
  * SQLite는 인라인 UNIQUE 제약을 DROP INDEX로 제거할 수 없어 테이블을 재생성해야 한다.
  * 마이그레이션 실행 중에는 TypeORM이 foreign_keys를 꺼두므로 DROP TABLE이 kanban_tasks의 project_id를 지우지 않는다.
  */
-async function rebuildProjectsTable(queryRunner: QueryRunner, nameColumnDefinition: string): Promise<void> {
+async function rebuildProjectsTable(queryRunner: QueryRunner): Promise<void> {
+  const copyColumns = await resolveProjectCopyColumns(queryRunner);
+
   await queryRunner.query(`
     CREATE TABLE "projects_rebuilt" (
       id TEXT PRIMARY KEY NOT NULL,
-      ${nameColumnDefinition},
+      name TEXT NOT NULL,
       repo_path TEXT NOT NULL,
       default_branch TEXT NOT NULL DEFAULT 'main',
       ssh_host TEXT,
@@ -61,7 +98,7 @@ async function rebuildProjectsTable(queryRunner: QueryRunner, nameColumnDefiniti
     )
   `);
   await queryRunner.query(
-    `INSERT INTO "projects_rebuilt" (${PROJECT_COLUMNS}) SELECT ${PROJECT_COLUMNS} FROM "projects"`,
+    `INSERT INTO "projects_rebuilt" (${copyColumns}) SELECT ${copyColumns} FROM "projects"`,
   );
   await queryRunner.query(`DROP TABLE "projects"`);
   await queryRunner.query(`ALTER TABLE "projects_rebuilt" RENAME TO "projects"`);
@@ -112,17 +149,13 @@ export class RescopeProjectNamesPerHost1771600000000 implements MigrationInterfa
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     if (await findUniqueNameIndex(queryRunner)) {
-      await rebuildProjectsTable(queryRunner, "name TEXT NOT NULL");
+      await rebuildProjectsTable(queryRunner);
     }
 
     await rescopeProjectNamesPerHost(queryRunner);
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
-    if (await findUniqueNameIndex(queryRunner)) {
-      return;
-    }
-
-    await rebuildProjectsTable(queryRunner, "name TEXT NOT NULL UNIQUE");
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // 전역 UNIQUE를 되살리면 PC 단위로 허용된 동명 프로젝트끼리 충돌하고 재계산 전 이름도 복원할 수 없으므로 rollback은 no-op
   }
 }


### PR DESCRIPTION
## 관련 자료
- 이슈 : #

## 어떤 작업인가요?
프로젝트 표시 이름에 상위 폴더명(`Documents/kanvibe`)이나 숫자 접미사(`kanvibe-2`)가 불필요하게 붙는 버그를 고칩니다. 이름 중복 판정 범위를 전역에서 **같은 PC(sshHost) 단위**로 좁혔습니다.

기존 `resolveUniqueProjectName()`은 호스트를 구분하지 않고 전역 유일한 이름을 강제했고, `projects.name`의 DB `UNIQUE` 제약이 이를 뒷받침하고 있었습니다. 그 결과 아래처럼 동작했습니다.

| 등록 순서 | 경로 | 기존 이름 | 변경 후 |
|---|---|---|---|
| 1 | 로컬 `~/dev/kanvibe` | `kanvibe` | `kanvibe` |
| 2 | `myserver:~/dev/kanvibe` | `dev/kanvibe` | `kanvibe` |
| 3 | `other:~/dev/kanvibe` | `kanvibe-2` | `kanvibe` |

프로젝트 목록과 셀렉터는 이미 이름 옆에 `(sshHost)`를 표시하고 있어(`ProjectSelector.tsx`, `ProjectRegistryDialog.tsx`) 다른 PC의 동명 프로젝트는 호스트로 구분됩니다.

## 어떻게 해결했나요?
**이름 중복 판정을 PC 단위로 축소**
- 다른 PC의 동명 프로젝트 때문에 이름이 변형되지 않도록 함
- `collectProjectNamesOnSameHost()`가 같은 `sshHost`의 이름만 모아서 후보 판정에 사용

**숫자 접미사 대신 등록 거부**
- `kanvibe-2` 같은 의미 없는 이름이 생기지 않도록 함
- 같은 PC에서 이름과 상위 폴더까지 모두 겹치면 `null`을 반환하고 호출부가 등록을 막음

**전역 UNIQUE 제약 제거 및 기존 이름 재계산**
- 로컬 `kanvibe`와 원격 `kanvibe`가 공존할 수 있어야 하므로 제약 제거가 선행되어야 함
- 이미 잘못 저장된 이름은 마이그레이션에서 같은 규칙으로 다시 계산

## 중요한 변경 사항은 무엇인가요?

### 이름 규칙 분리 및 PC 단위 스코핑

**`resolveUniqueProjectName()`을 공용 모듈로 분리**
- **변경 이유**: 서비스와 마이그레이션이 같은 이름 규칙을 써야 하는데, 서비스 모듈을 마이그레이션에서 import하면 electron·git·hooks 의존성이 전부 딸려옴
- **수정 파일**: `src/lib/projectName.ts` (신규), `src/desktop/main/services/projectService.ts`

**후보 순서는 유지하고 숫자 fallback만 제거**
- **변경 이유**: `지정명 → basename → 상위폴더/basename`까지는 기존 동작이 맞고, 그 뒤 숫자 카운터만 문제였음
- **수정 파일**: `src/lib/projectName.ts`

**등록 경로 두 곳에 거부 처리 추가**
- **변경 이유**: 이름을 구분할 수 없을 때 조용히 숫자를 붙이는 대신 사용자에게 알려야 함
- **수정 파일**: `src/desktop/main/services/projectService.ts` — `registerProject()`는 `{ success: false, error }` 반환, `scanAndRegisterProjects()`는 해당 저장소를 `result.errors`에 남기고 계속 진행

### 스키마 및 마이그레이션

**`projects.name`의 전역 UNIQUE 제거**
- **변경 이유**: PC 단위 유일로 바뀌면 로컬/원격에 같은 이름이 공존해야 하는데, 기존 제약이 저장 자체를 막음
- **수정 파일**: `src/entities/Project.ts`, `src/lib/sqliteSchema.ts`

**테이블 재생성 방식 채택**
- **변경 이유**: SQLite 인라인 `UNIQUE`는 autoindex로 잡혀 `DROP INDEX`로 제거할 수 없음
- **수정 파일**: `src/migrations/1771600000000-RescopeProjectNamesPerHost.ts`
- **안전성 근거**: TypeORM `BetterSqlite3QueryRunner.beforeMigration()`이 마이그레이션 트랜잭션 시작 **전에** `foreign_keys = OFF`를 걸기 때문에, `DROP TABLE projects`가 `kanban_tasks.project_id`의 `ON DELETE SET NULL`을 발동시키지 않음. 이 순서를 그대로 재현한 테스트로 검증

**기존 이름 재계산 (데이터 변경)**
- **변경 이유**: 제약만 풀면 이미 저장된 `Documents/kanvibe`, `kanvibe-2`가 그대로 남아 업데이트해도 보드가 바뀌지 않음
- **수정 파일**: `src/migrations/1771600000000-RescopeProjectNamesPerHost.ts`
- **안전성 근거**: 프로젝트 이름 변경 UI가 없어(`src/desktop/renderer/actions/project.ts`에 rename 핸들러 부재) 모든 이름이 등록 시 경로에서만 파생됨. 재계산해도 사용자가 지은 이름을 잃지 않음. `ORDER BY created_at, id`로 등록 순서를 유지해 먼저 등록한 프로젝트가 계속 짧은 이름을 가짐

### 기존 테스트 수정

**`projectService.test.ts`의 동명 원격 등록 케이스 반전**
- **변경 이유**: 기존 테스트가 이 버그를 정상 동작으로 고정하고 있었음 (로컬 `kanvibe` + 원격 `/home/rookedsysc/Documents/kanvibe/kanvibe` → `kanvibe/kanvibe` 기대)
- **수정 파일**: `src/desktop/main/services/__tests__/projectService.test.ts`

## 검증

| 명령 | 결과 |
|---|---|
| `pnpm exec vitest run` | exit 0 — 98 파일 / 866 테스트 통과 |
| `pnpm check` (`tsc --noEmit`) | exit 0 |
| `pnpm lint` | exit 0 — 에러 0, 경고 10건(전부 기존, 변경 파일 아님) |

실제 Electron 앱을 띄운 UI 검증은 하지 않았습니다. SSH 원격 호스트가 실제로 연결된 다중 PC 환경이 필요합니다.

## 알려진 한계
`migrations` 테이블 자체가 없는 아주 오래된 DB는 `baselineExistingSqliteDatabase()`가 전체 마이그레이션을 "실행됨"으로 기록해 이 마이그레이션도 건너뜁니다. 이 저장소의 모든 마이그레이션에 해당하는 기존 설계라 범위를 넓히지 않았습니다.

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
