### PR TITLE
fix: tmux·zellij 기본 소켓 통일, OSC 52 클립보드, 원격 hook 설치 HTTP 전환

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,16 @@
 - Route local child process and terminal environment creation through `createLocalShellEnvironment()` so `PORT`, `HOST`, `NODE_ENV`, and KanVibe internal `KANVIBE_*` values are stripped before user-visible shells run.
 - When changing terminal or child process environment handling, add focused tests that assert server/runtime variables do not appear in task terminal environments.
 
+### Approved Exception: tmux `set-clipboard`
+
+The rule above forbids tmux-wide side effects. tmux `set-clipboard` is an approved exception, because OSC 52 clipboard forwarding cannot be delivered without it and tmux offers no narrower scope.
+
+- `set-clipboard` is a tmux **server** option. `-s`, `-g`, and `-t <session>` all land on the same server-wide value, so KanVibe cannot confine it to its own sessions. KanVibe also creates sessions on the default socket, so the effect reaches every session on that server.
+- KanVibe may set `set-clipboard on` only while bootstrapping its own tmux session, and only when the user's tmux configuration does not already choose a value. An explicit user choice always wins and is never overwritten or restored later.
+- Detection must follow tmux's own configuration search order, including the system config and `${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf`. Do not hardcode `$HOME/.config`. `source-file` indirection is out of scope.
+- When detection cannot run, treat the result as unknown and leave the option alone. Never treat a failed check as permission to write.
+- Keep this exception narrow. Any other server-wide, user-wide, shell-wide, tmux-wide, or zellij-wide side effect needs its own entry here, with the same three parts: why no narrower scope exists, what guard respects an explicit user choice, and what the failure default is. Do not add one silently.
+
 ## App-Wide UI Settings
 
 - Store app-wide UI preferences in the app settings layer (`appSettingsService` / `AppSettings`), not in route-specific state or route cache.

--- a/electron/hookServer.js
+++ b/electron/hookServer.js
@@ -1,14 +1,14 @@
 const http = require("node:http");
 const path = require("node:path");
 
-function getHookServiceModulePath() {
+function getRuntimeModulePath(...moduleSegments) {
   const appRoot = path.join(__dirname, "..");
 
   if (process.env.KANVIBE_RENDERER_URL) {
-    return path.join(appRoot, "src", "desktop", "main", "services", "hookService.ts");
+    return path.join(appRoot, "src", ...moduleSegments) + ".ts";
   }
 
-  return path.join(appRoot, "build", "main", "src", "desktop", "main", "services", "hookService.js");
+  return path.join(appRoot, "build", "main", "src", ...moduleSegments) + ".js";
 }
 
 function readJsonBody(request) {
@@ -33,12 +33,32 @@ function writeJson(response, statusCode, payload) {
   response.end(JSON.stringify(payload));
 }
 
+function writeShellScript(response, script) {
+  response.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
+  response.end(script);
+}
+
 function createHookServer({ host, port }) {
-  const hookService = require(getHookServiceModulePath());
+  const hookService = require(getRuntimeModulePath("desktop", "main", "services", "hookService"));
+  const hookInstallBundle = require(getRuntimeModulePath("lib", "hookInstallBundle"));
 
   const server = http.createServer(async (request, response) => {
     if (request.method === "GET" && request.url === "/api/hooks/health") {
       writeJson(response, 200, { success: true });
+      return;
+    }
+
+    /** 원격 호스트가 hook 설치 산출물을 직접 내려받는 경로. 토큰이 맞아야만 스크립트를 내준다 */
+    if (request.method === "GET" && request.url.startsWith(hookInstallBundle.HOOK_INSTALL_SCRIPT_PATH)) {
+      const requestUrl = new URL(request.url, `http://${host}:${port}`);
+      const installScript = hookInstallBundle.readHookInstallScript(requestUrl.searchParams.get("token"));
+
+      if (!installScript) {
+        writeJson(response, 404, { success: false, error: "Not found" });
+        return;
+      }
+
+      writeShellScript(response, installScript);
       return;
     }
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useCallback } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { createTerminalOptions, installMacShiftSelectionPatch } from "@/lib/terminalMouseSelection";
+import { installOsc52ClipboardHandler } from "@/lib/terminalClipboard";
 
 interface TerminalProps {
   taskId: string;
@@ -51,6 +52,7 @@ export default function Terminal({ taskId }: TerminalProps) {
     term.loadAddon(new WebLinksAddon());
     term.open(terminalRef.current);
     const disposeMacShiftSelectionPatch = installMacShiftSelectionPatch(term);
+    const osc52ClipboardHandler = installOsc52ClipboardHandler(term);
 
     /** 웹폰트 로드 완료 후 fontFamily를 재설정하여 xterm.js 글리프 캐시를 강제 갱신 */
     term.options.fontFamily = "monospace";
@@ -125,6 +127,7 @@ export default function Terminal({ taskId }: TerminalProps) {
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       disposeMacShiftSelectionPatch();
+      osc52ClipboardHandler.dispose();
       resizeObserver.disconnect();
       ws.close();
       term.dispose();

--- a/src/desktop/renderer/components/Terminal.tsx
+++ b/src/desktop/renderer/components/Terminal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { createTerminalOptions, installMacShiftSelectionPatch } from "@/lib/terminalMouseSelection";
+import { installOsc52ClipboardHandler } from "@/lib/terminalClipboard";
 import { REQUEST_ACTIVE_TERMINAL_FOCUS_EVENT, hasTerminalFocusBlocker } from "@/desktop/renderer/utils/terminalFocus";
 
 interface TerminalProps {
@@ -84,6 +85,7 @@ export default function Terminal({ taskId }: TerminalProps) {
     terminal.loadAddon(new WebLinksAddon());
     terminal.open(containerRef.current);
     const disposeMacShiftSelectionPatch = installMacShiftSelectionPatch(terminal);
+    const osc52ClipboardHandler = installOsc52ClipboardHandler(terminal);
     terminal.options.fontFamily = FALLBACK_FONT_FAMILY;
 
     const unsubscribeData = window.kanvibeDesktop!.onTerminalData((event: { taskId: string; data: string }) => {
@@ -131,6 +133,7 @@ export default function Terminal({ taskId }: TerminalProps) {
       return () => {
         isTerminalDisposed = true;
         disposeMacShiftSelectionPatch();
+        osc52ClipboardHandler.dispose();
         unsubscribeData();
         unsubscribeClose();
         terminal.dispose();
@@ -187,6 +190,7 @@ export default function Terminal({ taskId }: TerminalProps) {
       window.removeEventListener("focus", handleWindowFocus);
       window.removeEventListener(REQUEST_ACTIVE_TERMINAL_FOCUS_EVENT, handleRequestTerminalFocus);
       disposeMacShiftSelectionPatch();
+      osc52ClipboardHandler.dispose();
       resizeObserver.disconnect();
       unsubscribeData();
       unsubscribeClose();

--- a/src/desktop/renderer/components/__tests__/Terminal.test.tsx
+++ b/src/desktop/renderer/components/__tests__/Terminal.test.tsx
@@ -49,6 +49,7 @@ class MockXTerm {
   focus = mockTerminalFocus;
   onData = vi.fn();
   onResize = vi.fn();
+  parser = { registerOscHandler: vi.fn().mockReturnValue({ dispose: vi.fn() }) };
 }
 
 vi.mock("@xterm/xterm", () => ({

--- a/src/lib/__tests__/hookFileWriter.test.ts
+++ b/src/lib/__tests__/hookFileWriter.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { HOOK_INSTALL_SUCCESS_MARKER } from "@/lib/hookInstallBundle";
+
+const mockExecGit = vi.fn();
+
+vi.mock("@/lib/gitOperations", () => ({
+  execGit: (...args: unknown[]) => mockExecGit(...args),
+}));
+
+const mockGetHookServerUrl = vi.fn();
+
+vi.mock("@/lib/hookEndpoint", () => ({
+  getHookServerUrl: (...args: unknown[]) => mockGetHookServerUrl(...args),
+}));
+
+const hookFiles = [
+  {
+    filePath: "/home/user/project/.claude/hooks/kanvibe-stop-hook.sh",
+    content: "#!/bin/bash\necho '작업 완료'\n",
+    mode: 0o755,
+  },
+  {
+    filePath: "/home/user/project/.claude/settings.json",
+    content: '{\n  "hooks": {}\n}\n',
+  },
+];
+
+describe("writeHookProviderFiles — 원격 설치", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetHookServerUrl.mockResolvedValue("http://192.168.0.10:9736");
+  });
+
+  it("should install through a single short bootstrap command instead of injecting the payload", async () => {
+    // Given
+    mockExecGit.mockResolvedValue(`${HOOK_INSTALL_SUCCESS_MARKER}\n`);
+    const { writeHookProviderFiles } = await import("@/lib/hookFileWriter");
+
+    // When
+    await writeHookProviderFiles(hookFiles, "remote-host");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledTimes(1);
+    const [command, sshHost] = mockExecGit.mock.calls[0];
+    expect(sshHost).toBe("remote-host");
+    expect(Buffer.byteLength(String(command))).toBeLessThan(400);
+    expect(String(command)).toContain("/api/install/hooks.sh?token=");
+    expect(String(command)).not.toContain("base64 -d");
+  });
+
+  it("should fall back to SSH injection when the remote cannot reach the hook server", async () => {
+    // Given
+    mockExecGit
+      .mockRejectedValueOnce(new Error("curl: (7) Failed to connect"))
+      .mockResolvedValueOnce("");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { writeHookProviderFiles } = await import("@/lib/hookFileWriter");
+
+    // When
+    await writeHookProviderFiles(hookFiles, "remote-host");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledTimes(2);
+    const fallbackCommand = String(mockExecGit.mock.calls[1][0]);
+    expect(fallbackCommand).toContain("base64 -d");
+    expect(fallbackCommand).toContain("/home/user/project/.claude/hooks/kanvibe-stop-hook.sh");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("should fall back when the bootstrap script does not report completion", async () => {
+    // Given
+    mockExecGit
+      .mockResolvedValueOnce("sh: curl: not found\n")
+      .mockResolvedValueOnce("");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { writeHookProviderFiles } = await import("@/lib/hookFileWriter");
+
+    // When
+    await writeHookProviderFiles(hookFiles, "remote-host");
+
+    // Then
+    expect(mockExecGit).toHaveBeenCalledTimes(2);
+    expect(String(mockExecGit.mock.calls[1][0])).toContain("base64 -d");
+    warn.mockRestore();
+  });
+
+  it("should not touch the remote at all when there are no files", async () => {
+    // Given
+    const { writeHookProviderFiles } = await import("@/lib/hookFileWriter");
+
+    // When
+    await writeHookProviderFiles([], "remote-host");
+
+    // Then
+    expect(mockExecGit).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/hookFileWriter.test.ts
+++ b/src/lib/__tests__/hookFileWriter.test.ts
@@ -44,9 +44,55 @@ describe("writeHookProviderFiles — 원격 설치", () => {
     expect(mockExecGit).toHaveBeenCalledTimes(1);
     const [command, sshHost] = mockExecGit.mock.calls[0];
     expect(sshHost).toBe("remote-host");
-    expect(Buffer.byteLength(String(command))).toBeLessThan(400);
+    expect(Buffer.byteLength(String(command))).toBeLessThan(700);
     expect(String(command)).toContain("/api/install/hooks.sh?token=");
     expect(String(command)).not.toContain("base64 -d");
+  });
+
+  it("should bound the install command so an unreachable hook server falls back quickly", async () => {
+    // Given
+    mockExecGit.mockResolvedValue(`${HOOK_INSTALL_SUCCESS_MARKER}\n`);
+    const { writeHookProviderFiles } = await import("@/lib/hookFileWriter");
+
+    // When
+    await writeHookProviderFiles(hookFiles, "remote-host");
+
+    // Then
+    expect(mockExecGit.mock.calls[0][2]).toEqual({ timeoutMs: 30_000 });
+  });
+
+  it("should revoke the install token once the install finishes", async () => {
+    // Given
+    mockExecGit.mockResolvedValue(`${HOOK_INSTALL_SUCCESS_MARKER}\n`);
+    const { writeHookProviderFiles } = await import("@/lib/hookFileWriter");
+    const { readHookInstallScript } = await import("@/lib/hookInstallBundle");
+
+    // When
+    await writeHookProviderFiles(hookFiles, "remote-host");
+
+    // Then
+    const issuedToken = String(mockExecGit.mock.calls[0][0]).match(/token=([0-9a-f]+)/)?.[1];
+    expect(issuedToken).toBeDefined();
+    expect(readHookInstallScript(issuedToken)).toBeNull();
+  });
+
+  it("should revoke the install token even when the HTTP install fails", async () => {
+    // Given
+    mockExecGit
+      .mockRejectedValueOnce(new Error("curl: (7) Failed to connect"))
+      .mockResolvedValueOnce("");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { writeHookProviderFiles } = await import("@/lib/hookFileWriter");
+    const { readHookInstallScript } = await import("@/lib/hookInstallBundle");
+
+    // When
+    await writeHookProviderFiles(hookFiles, "remote-host");
+
+    // Then
+    const issuedToken = String(mockExecGit.mock.calls[0][0]).match(/token=([0-9a-f]+)/)?.[1];
+    expect(issuedToken).toBeDefined();
+    expect(readHookInstallScript(issuedToken)).toBeNull();
+    warn.mockRestore();
   });
 
   it("should fall back to SSH injection when the remote cannot reach the hook server", async () => {

--- a/src/lib/__tests__/hookInstallBundle.test.ts
+++ b/src/lib/__tests__/hookInstallBundle.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { execFileSync } from "node:child_process";
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   buildHookInstallBootstrapCommand,
@@ -8,6 +9,7 @@ import {
   HOOK_INSTALL_SUCCESS_MARKER,
   issueHookInstallScript,
   readHookInstallScript,
+  revokeHookInstallScript,
 } from "@/lib/hookInstallBundle";
 
 const hookFiles = [
@@ -68,13 +70,15 @@ describe("buildHookInstallScript", () => {
   });
 });
 
+const sampleTicket = { token: "token-value", scriptSha256: "a".repeat(64) };
+
 describe("issueHookInstallScript / readHookInstallScript", () => {
   it("should return the registered script for its token", () => {
     // Given
-    const token = issueHookInstallScript(hookFiles);
+    const ticket = issueHookInstallScript(hookFiles);
 
     // When
-    const script = readHookInstallScript(token);
+    const script = readHookInstallScript(ticket.token);
 
     // Then
     expect(script).toBe(buildHookInstallScript(hookFiles));
@@ -82,13 +86,24 @@ describe("issueHookInstallScript / readHookInstallScript", () => {
 
   it("should stay readable so a retried install can reuse the same token", () => {
     // Given
-    const token = issueHookInstallScript(hookFiles);
+    const ticket = issueHookInstallScript(hookFiles);
 
     // When
-    readHookInstallScript(token);
+    readHookInstallScript(ticket.token);
 
     // Then
-    expect(readHookInstallScript(token)).not.toBeNull();
+    expect(readHookInstallScript(ticket.token)).not.toBeNull();
+  });
+
+  it("should stop serving the script once the install revokes its token", () => {
+    // Given
+    const ticket = issueHookInstallScript(hookFiles);
+
+    // When
+    revokeHookInstallScript(ticket.token);
+
+    // Then
+    expect(readHookInstallScript(ticket.token)).toBeNull();
   });
 
   it("should reject an unknown token", () => {
@@ -113,27 +128,62 @@ describe("issueHookInstallScript / readHookInstallScript", () => {
 
   it("should issue an unguessable token per install", () => {
     // When
-    const firstToken = issueHookInstallScript(hookFiles);
-    const secondToken = issueHookInstallScript(hookFiles);
+    const firstTicket = issueHookInstallScript(hookFiles);
+    const secondTicket = issueHookInstallScript(hookFiles);
 
     // Then
-    expect(firstToken).not.toBe(secondToken);
-    expect(firstToken).toMatch(/^[0-9a-f]{48}$/);
+    expect(firstTicket.token).not.toBe(secondTicket.token);
+    expect(firstTicket.token).toMatch(/^[0-9a-f]{48}$/);
+  });
+
+  it("should issue a checksum that changes with the install payload", () => {
+    // When
+    const ticket = issueHookInstallScript(hookFiles);
+    const otherTicket = issueHookInstallScript([hookFiles[1]]);
+
+    // Then
+    expect(ticket.scriptSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(ticket.scriptSha256).not.toBe(otherTicket.scriptSha256);
+  });
+
+  it("should issue the checksum the remote computes for the script it restores", () => {
+    // Given
+    const ticket = issueHookInstallScript(hookFiles);
+    const script = readHookInstallScript(ticket.token) ?? "";
+
+    /** `$(...)`가 끝 개행을 떼고 원격이 `printf '%s\n'`으로 되살리는 과정을 그대로 재현한다 */
+    // When
+    const remoteChecksum = execFileSync(
+      "sh",
+      [
+        "-c",
+        `__downloaded=$(printf '%s' "$1");`
+        + ` printf '%s\\n' "$__downloaded" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -d' ' -f1`,
+        "sh",
+        script,
+      ],
+      { encoding: "utf-8" },
+    ).trim();
+
+    // Then
+    expect(remoteChecksum).toBe(ticket.scriptSha256);
   });
 });
 
 describe("buildHookInstallBootstrapCommand", () => {
   it("should keep the SSH command short instead of carrying the payload", () => {
     // Given
-    const token = issueHookInstallScript(hookFiles);
+    const ticket = issueHookInstallScript(hookFiles);
 
     // When
-    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", token);
+    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", ticket);
 
     // Then
-    expect(Buffer.byteLength(command)).toBeLessThan(400);
+    expect(Buffer.byteLength(command)).toBeLessThan(700);
     expect(command).not.toContain("base64 -d");
-    expect(command).toContain(`http://192.168.0.10:9736${HOOK_INSTALL_SCRIPT_PATH}?token=${token}`);
+    expect(command).toContain(
+      `http://192.168.0.10:9736${HOOK_INSTALL_SCRIPT_PATH}?token=${ticket.token}`,
+    );
   });
 
   it("should keep the SSH command the same size no matter how large the install payload is", () => {
@@ -149,35 +199,59 @@ describe("buildHookInstallBootstrapCommand", () => {
       "http://192.168.0.10:9736",
       issueHookInstallScript(hookFiles),
     );
-    const bulkyToken = issueHookInstallScript(bulkyFiles);
-    const bulkyCommand = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", bulkyToken);
+    const bulkyTicket = issueHookInstallScript(bulkyFiles);
+    const bulkyCommand = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", bulkyTicket);
 
     // Then
-    expect(Buffer.byteLength(readHookInstallScript(bulkyToken) ?? "")).toBeGreaterThan(100_000);
+    expect(Buffer.byteLength(readHookInstallScript(bulkyTicket.token) ?? "")).toBeGreaterThan(100_000);
     expect(bulkyCommand.length).toBe(smallCommand.length);
   });
 
   it("should fall back to wget when curl is missing", () => {
     // When
-    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", "token-value");
+    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", sampleTicket);
 
     // Then
-    expect(command).toContain("curl -fsSL");
-    expect(command).toContain("wget -qO-");
+    expect(command).toContain("curl --connect-timeout 3 --max-time 10 -fsSL");
+    expect(command).toContain("wget --timeout=3 --tries=1 -qO-");
+  });
+
+  it("should bound the download so an unreachable hook server falls back quickly", () => {
+    // When
+    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", sampleTicket);
+
+    // Then
+    expect(command).toContain("--connect-timeout 3");
+    expect(command).toContain("--max-time 10");
+    expect(command).toContain("--tries=1");
   });
 
   it("should download fully before executing so a truncated script never runs", () => {
     // When
-    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", "token-value");
+    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", sampleTicket);
 
     // Then
     expect(command).toMatch(/^__kanvibe_install_script=\$\(/);
     expect(command).toContain('printf \'%s\\n\' "$__kanvibe_install_script" | sh');
   });
 
+  it("should execute the downloaded script only after its checksum matches", () => {
+    // When
+    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", sampleTicket);
+
+    // Then
+    const checksumGuardIndex = command.indexOf(
+      `[ "$__kanvibe_install_checksum" = '${sampleTicket.scriptSha256}' ]`,
+    );
+    const executionIndex = command.indexOf('printf \'%s\\n\' "$__kanvibe_install_script" | sh');
+    expect(checksumGuardIndex).toBeGreaterThan(-1);
+    expect(executionIndex).toBeGreaterThan(checksumGuardIndex);
+    expect(command).toContain("sha256sum 2>/dev/null || shasum -a 256");
+  });
+
   it("should not double the slash when the hook server url has a trailing slash", () => {
     // When
-    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736/", "token-value");
+    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736/", sampleTicket);
 
     // Then
     expect(command).toContain("http://192.168.0.10:9736/api/install/hooks.sh?token=token-value");

--- a/src/lib/__tests__/hookInstallBundle.test.ts
+++ b/src/lib/__tests__/hookInstallBundle.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  buildHookInstallBootstrapCommand,
+  buildHookInstallScript,
+  clearHookInstallScripts,
+  HOOK_INSTALL_SCRIPT_PATH,
+  HOOK_INSTALL_SUCCESS_MARKER,
+  issueHookInstallScript,
+  readHookInstallScript,
+} from "@/lib/hookInstallBundle";
+
+const hookFiles = [
+  {
+    filePath: "/home/user/project/.claude/hooks/kanvibe-stop-hook.sh",
+    content: "#!/bin/bash\necho '작업 완료'\n",
+    mode: 0o755,
+  },
+  {
+    filePath: "/home/user/project/.claude/settings.json",
+    content: '{\n  "hooks": {}\n}\n',
+  },
+];
+
+beforeEach(() => {
+  clearHookInstallScripts();
+});
+
+describe("buildHookInstallScript", () => {
+  it("should write every provider file and mark completion", () => {
+    // When
+    const script = buildHookInstallScript(hookFiles);
+
+    // Then
+    expect(script).toContain("set -e");
+    expect(script).toContain("mkdir -p '/home/user/project/.claude/hooks'");
+    expect(script).toContain("> '/home/user/project/.claude/hooks/kanvibe-stop-hook.sh'");
+    expect(script).toContain("chmod 755 '/home/user/project/.claude/hooks/kanvibe-stop-hook.sh'");
+    expect(script).toContain("> '/home/user/project/.claude/settings.json'");
+    expect(script.trimEnd().endsWith(`printf '%s\\n' '${HOOK_INSTALL_SUCCESS_MARKER}'`)).toBe(true);
+  });
+
+  it("should carry file content as base64 so quotes and newlines survive", () => {
+    // When
+    const script = buildHookInstallScript(hookFiles);
+
+    // Then
+    const encodedStopHook = Buffer.from(hookFiles[0].content, "utf-8").toString("base64");
+    expect(script).toContain(`printf '%s' '${encodedStopHook}'`);
+    expect(script).not.toContain("echo '작업 완료'");
+  });
+
+  it("should not set a mode for files that do not need one", () => {
+    // When
+    const script = buildHookInstallScript([hookFiles[1]]);
+
+    // Then
+    expect(script).not.toContain("chmod");
+  });
+
+  it("should produce the same script for the same files", () => {
+    // When
+    const first = buildHookInstallScript(hookFiles);
+    const second = buildHookInstallScript(hookFiles);
+
+    // Then
+    expect(first).toBe(second);
+  });
+});
+
+describe("issueHookInstallScript / readHookInstallScript", () => {
+  it("should return the registered script for its token", () => {
+    // Given
+    const token = issueHookInstallScript(hookFiles);
+
+    // When
+    const script = readHookInstallScript(token);
+
+    // Then
+    expect(script).toBe(buildHookInstallScript(hookFiles));
+  });
+
+  it("should stay readable so a retried install can reuse the same token", () => {
+    // Given
+    const token = issueHookInstallScript(hookFiles);
+
+    // When
+    readHookInstallScript(token);
+
+    // Then
+    expect(readHookInstallScript(token)).not.toBeNull();
+  });
+
+  it("should reject an unknown token", () => {
+    // Given
+    issueHookInstallScript(hookFiles);
+
+    // When
+    const script = readHookInstallScript("0".repeat(48));
+
+    // Then
+    expect(script).toBeNull();
+  });
+
+  it("should reject a missing token", () => {
+    // Given
+    issueHookInstallScript(hookFiles);
+
+    // When & Then
+    expect(readHookInstallScript(null)).toBeNull();
+    expect(readHookInstallScript("")).toBeNull();
+  });
+
+  it("should issue an unguessable token per install", () => {
+    // When
+    const firstToken = issueHookInstallScript(hookFiles);
+    const secondToken = issueHookInstallScript(hookFiles);
+
+    // Then
+    expect(firstToken).not.toBe(secondToken);
+    expect(firstToken).toMatch(/^[0-9a-f]{48}$/);
+  });
+});
+
+describe("buildHookInstallBootstrapCommand", () => {
+  it("should keep the SSH command short instead of carrying the payload", () => {
+    // Given
+    const token = issueHookInstallScript(hookFiles);
+
+    // When
+    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", token);
+
+    // Then
+    expect(Buffer.byteLength(command)).toBeLessThan(400);
+    expect(command).not.toContain("base64 -d");
+    expect(command).toContain(`http://192.168.0.10:9736${HOOK_INSTALL_SCRIPT_PATH}?token=${token}`);
+  });
+
+  it("should keep the SSH command the same size no matter how large the install payload is", () => {
+    // Given
+    const bulkyFiles = Array.from({ length: 40 }, (_, index) => ({
+      filePath: `/home/user/project/.claude/hooks/hook-${index}.sh`,
+      content: "#!/bin/bash\n".concat("echo hook payload\n".repeat(200)),
+      mode: 0o755,
+    }));
+
+    // When
+    const smallCommand = buildHookInstallBootstrapCommand(
+      "http://192.168.0.10:9736",
+      issueHookInstallScript(hookFiles),
+    );
+    const bulkyToken = issueHookInstallScript(bulkyFiles);
+    const bulkyCommand = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", bulkyToken);
+
+    // Then
+    expect(Buffer.byteLength(readHookInstallScript(bulkyToken) ?? "")).toBeGreaterThan(100_000);
+    expect(bulkyCommand.length).toBe(smallCommand.length);
+  });
+
+  it("should fall back to wget when curl is missing", () => {
+    // When
+    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", "token-value");
+
+    // Then
+    expect(command).toContain("curl -fsSL");
+    expect(command).toContain("wget -qO-");
+  });
+
+  it("should download fully before executing so a truncated script never runs", () => {
+    // When
+    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736", "token-value");
+
+    // Then
+    expect(command).toMatch(/^__kanvibe_install_script=\$\(/);
+    expect(command).toContain('printf \'%s\\n\' "$__kanvibe_install_script" | sh');
+  });
+
+  it("should not double the slash when the hook server url has a trailing slash", () => {
+    // When
+    const command = buildHookInstallBootstrapCommand("http://192.168.0.10:9736/", "token-value");
+
+    // Then
+    expect(command).toContain("http://192.168.0.10:9736/api/install/hooks.sh?token=token-value");
+    expect(command).not.toContain("9736//api");
+  });
+});

--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -643,7 +643,13 @@ describe("attachRemoteSession — zellij 원격 세션", () => {
     const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
     const remoteShellCommand = sshArgs.at(-1) ?? "";
     const attachCommand = extractRemoteShellPayload(remoteShellCommand);
-    expect(attachCommand).toContain("zellij attach 'remote-session'");
+    /** 존재 확인에만 stderr를 감춰야 대화형 세션이 내는 zellij 오류가 사용자에게 보인다 */
+    expect(attachCommand).toContain("zellij list-sessions 2>/dev/null");
+    expect(attachCommand).toContain("exec zellij attach 'remote-session';");
+    expect(attachCommand).not.toContain("zellij attach 'remote-session' 2>/dev/null");
+    /** cd 실패를 조용히 넘기면 레이아웃은 맞는데 작업 디렉터리만 엉뚱한 세션이 생긴다 */
+    expect(attachCommand).toContain("cd '/remote/worktree' || printf");
+    expect(attachCommand).toContain("cannot enter /remote/worktree");
     expect(attachCommand).toContain("exec zellij --session 'remote-session' --new-session-with-layout '/remote/worktree/.zellij-layout.kdl'");
     expect(attachCommand).toContain("exec zellij --session 'remote-session'");
     expectValidPosixShellSyntax(remoteShellCommand);
@@ -677,7 +683,8 @@ describe("attachRemoteSession — zellij 원격 세션", () => {
     // Then
     const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
     const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
-    expect(attachCommand).toContain("zellij attach 'remote-session' 2>/dev/null || exec zellij --session 'remote-session'");
+    expect(attachCommand).toContain("| grep -qFx -- 'remote-session'; then exec zellij attach 'remote-session'; fi;");
+    expect(attachCommand).toContain("exec zellij --session 'remote-session'");
     expectValidPosixShellSyntax(attachCommand);
   });
 });
@@ -989,15 +996,15 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     expect(attachCommand.match(/has-session/g)).toHaveLength(1);
     expect(attachCommand).toContain("tmux session setup failed; leaving the SSH shell open");
     expect(attachCommand).toContain('exec "${SHELL:-/bin/sh}" -l');
-    expect(Buffer.byteLength(attachCommand)).toBeLessThan(1_500);
+    /** 클립보드 판정을 원격 셸로 내리면서 부트스트랩이 켬/끔 두 벌로 늘었다. 왕복은 사라졌지만 길이는 감시한다 */
+    expect(Buffer.byteLength(attachCommand)).toBeLessThan(3_000);
     expectValidPosixShellSyntax(remoteShellCommand);
     expectValidPosixShellSyntax(attachCommand);
     expect(mockPtyWrite).not.toHaveBeenCalled();
   });
 
-  it("should enable OSC 52 forwarding on the remote host the same way it does locally", async () => {
+  it("should decide the remote OSC 52 forwarding inside the remote shell without an extra SSH round trip", async () => {
     // Given
-    mockExecGit.mockResolvedValue("");
     const { attachRemoteSession } = await import("@/lib/terminal");
 
     // When
@@ -1023,15 +1030,18 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     const nodePty = await import("node-pty");
     const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
     const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
-    expect(String(mockExecGit.mock.calls[0][0])).toContain("set-clipboard");
-    expect(mockExecGit.mock.calls[0][1]).toBe("remote-host");
+    /** 재attach가 대부분인데 판정 왕복을 매번 붙이면 터미널이 열리기 전에 순수 지연만 늘어난다 */
+    expect(mockExecGit).not.toHaveBeenCalled();
+    /** 세션이 이미 있으면 판정 자체에 도달하지 않는다 */
+    expect(attachCommand).toContain(
+      "if tmux has-session -t 'remote-session' 2>/dev/null; then exec tmux attach-session -t 'remote-session'; elif ",
+    );
     expect(attachCommand).toContain("set-option -s set-clipboard on");
     expectValidPosixShellSyntax(attachCommand);
   });
 
-  it("should leave the remote set-clipboard alone when the remote tmux config already chose a value", async () => {
+  it("should skip the remote set-clipboard branch when the remote tmux config already chose a value", async () => {
     // Given
-    mockExecGit.mockResolvedValue("kanvibe-user-set-clipboard");
     const { attachRemoteSession } = await import("@/lib/terminal");
 
     // When
@@ -1057,8 +1067,11 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     const nodePty = await import("node-pty");
     const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
     const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
-    expect(attachCommand).not.toContain("set-clipboard");
-    expect(attachCommand).toContain("set-option -t 'remote-session' destroy-unattached off");
+    const [userChoseBranch, kanvibeEnablesBranch] = attachCommand.split("; else ");
+    /** 사용자가 값을 정해 뒀을 때 실행되는 분기에는 set-clipboard 변경이 없어야 한다 */
+    expect(userChoseBranch).toContain("set-option -t 'remote-session' destroy-unattached off");
+    expect(userChoseBranch).not.toContain("set-option -s set-clipboard on");
+    expect(kanvibeEnablesBranch).toContain("set-option -s set-clipboard on");
   });
 
   it("should build POSIX-valid remote tmux attach commands for multiline quoted pane commands", async () => {

--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -158,9 +158,96 @@ describe("attachLocalSession — tmux 세션 자동 생성", () => {
     // Then
     const bootstrapCmd = findExecSyncCall("new-session");
     expect(bootstrapCmd).toContain("tmux new-session -d -s 'feat-login' -c '/workspace'");
-    expect(bootstrapCmd).toContain("tmux split-window -h -t 'feat-login:0' -c '/workspace'");
-    expect(bootstrapCmd).toContain("tmux send-keys -t 'feat-login:0.0' -- 'pnpm dev' Enter");
-    expect(bootstrapCmd).toContain("tmux send-keys -t 'feat-login:0.1' -- 'pnpm test' Enter");
+    expect(bootstrapCmd).toContain("split-window -h -t 'feat-login:0' -c '/workspace'");
+    expect(bootstrapCmd).toContain("send-keys -t 'feat-login:0.0' -- 'pnpm dev' Enter");
+    expect(bootstrapCmd).toContain("send-keys -t 'feat-login:0.1' -- 'pnpm test' Enter");
+    /** 사용자 설정이 세션을 지우기 전에 옵션이 적용되도록 한 번의 tmux 호출로 묶여야 한다 */
+    expect(String(bootstrapCmd).split("tmux ").length - 1).toBe(1);
+  });
+
+  it("should keep a local session alive when the user tmux config destroys unattached sessions", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) {
+        throw new Error("session not found");
+      }
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-hardening",
+      SessionType.TMUX,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    const bootstrapCmd = findExecSyncCall("new-session");
+    expect(bootstrapCmd).toContain("set-option -t 'feat-login' destroy-unattached off");
+  });
+
+  it("should scope the terminal size option to the KanVibe session instead of the user tmux server", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) {
+        throw new Error("session not found");
+      }
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-window-size",
+      SessionType.TMUX,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    const executedCommands = mockExecSync.mock.calls.map((call) => String(call[0]));
+    expect(executedCommands.some((command) => command.includes("set-option -g window-size"))).toBe(false);
+    expect(findExecSyncCall("new-session")).toContain("set-option -t 'feat-login' window-size latest");
+  });
+
+  it("should retry local bootstrap without the user tmux config when the first attempt fails", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    let newSessionAttempts = 0;
+    mockExecSync.mockImplementation((cmd: string) => {
+      const command = String(cmd);
+      if (command.includes("has-session")) {
+        throw new Error("session not found");
+      }
+      if (command.includes("new-session")) {
+        newSessionAttempts += 1;
+        if (newSessionAttempts === 1) {
+          throw new Error("no sessions");
+        }
+      }
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-retry",
+      SessionType.TMUX,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    const bootstrapCommands = mockExecSync.mock.calls
+      .map((call) => String(call[0]))
+      .filter((command) => command.includes("new-session"));
+    expect(bootstrapCommands).toHaveLength(2);
+    expect(bootstrapCommands[0]).not.toContain("-f /dev/null");
+    expect(bootstrapCommands[1]).toContain("tmux -f /dev/null new-session");
   });
 
   it("should build POSIX-valid local tmux bootstrap commands for multiline quoted pane commands", async () => {
@@ -410,6 +497,103 @@ describe("attachLocalSession — zellij 세션 생성 및 레이아웃 적용", 
       expect.any(Object),
     );
   });
+
+  it("should treat an exited local zellij session as missing so it can be recreated", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
+    mockZellijSessions("EXITED: feat-login\n");
+    mockExistsSync.mockReturnValue(false);
+
+    // When
+    await attachLocalSession(
+      "task-z6",
+      SessionType.ZELLIJ,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    expect(nodePty.spawn).toHaveBeenCalledWith(
+      "zellij",
+      ["--session", "feat-login"],
+      expect.objectContaining({ cwd: "/workspace" }),
+    );
+  });
+});
+
+describe("attachRemoteSession — zellij 원격 세션", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("should create the remote zellij session with its layout when attach finds no session", async () => {
+    // Given
+    const { attachRemoteSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
+
+    // When
+    await attachRemoteSession(
+      "task-remote-zellij",
+      "remote-host",
+      SessionType.ZELLIJ,
+      "remote-session",
+      createMockWs(),
+      {
+        host: "remote-host",
+        hostname: "example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/tmp/test-key",
+      },
+      120,
+      30,
+      "/remote/worktree",
+    );
+
+    // Then
+    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+    const remoteShellCommand = sshArgs.at(-1) ?? "";
+    const attachCommand = extractRemoteShellPayload(remoteShellCommand);
+    expect(attachCommand).toContain("zellij attach 'remote-session'");
+    expect(attachCommand).toContain("exec zellij --session 'remote-session' --new-session-with-layout '/remote/worktree/.zellij-layout.kdl'");
+    expect(attachCommand).toContain("exec zellij --session 'remote-session'");
+    expectValidPosixShellSyntax(remoteShellCommand);
+    expectValidPosixShellSyntax(attachCommand);
+  });
+
+  it("should still create the remote zellij session when no worktree path is known", async () => {
+    // Given
+    const { attachRemoteSession } = await import("@/lib/terminal");
+    const nodePty = await import("node-pty");
+
+    // When
+    await attachRemoteSession(
+      "task-remote-zellij-no-worktree",
+      "remote-host",
+      SessionType.ZELLIJ,
+      "remote-session",
+      createMockWs(),
+      {
+        host: "remote-host",
+        hostname: "example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/tmp/test-key",
+      },
+      120,
+      30,
+      null,
+    );
+
+    // Then
+    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+    const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
+    expect(attachCommand).toContain("zellij attach 'remote-session' 2>/dev/null || exec zellij --session 'remote-session'");
+    expectValidPosixShellSyntax(attachCommand);
+  });
 });
 
 describe("focusSession — 렌더러 포커스 처리", () => {
@@ -501,8 +685,8 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
       expect(sshArgs).not.toContain("-Y");
       expect(sshArgs).not.toContain("ControlMaster=auto");
       const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
-      expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null has-session -t 'remote-session'");
-      expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null new-session -d -s 'remote-session' -c '/remote/worktree'");
+      expect(attachCommand).toContain("tmux has-session -t 'remote-session'");
+      expect(attachCommand).toContain("tmux new-session -d -s 'remote-session' -c '/remote/worktree'");
       expect(mockPtyWrite).not.toHaveBeenCalled();
     } finally {
       if (originalDisplay === undefined) {
@@ -586,7 +770,7 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
       const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
       expect(sshArgs.at(-2)).toBe("remote-host");
       expect(sshArgs.at(-1)).toEqual(expect.stringMatching(/^sh -lc /));
-      expect(extractRemoteShellPayload(sshArgs.at(-1) ?? "")).toContain("tmux -L 'kanvibe' -f /dev/null has-session -t 'remote-session'");
+      expect(extractRemoteShellPayload(sshArgs.at(-1) ?? "")).toContain("tmux has-session -t 'remote-session'");
       expect(mockPtyWrite).not.toHaveBeenCalled();
     } finally {
       if (originalDisplay === undefined) {
@@ -665,17 +849,17 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     const nodePty = await import("node-pty");
     const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
     const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
-    expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null split-window -h -t 'remote-session:0' -c '/remote/worktree'");
-    expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null send-keys -t 'remote-session:0.0' -- 'pnpm dev' Enter");
-    expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null send-keys -t 'remote-session:0.1' -- 'pnpm test' Enter");
+    expect(attachCommand).toContain("split-window -h -t 'remote-session:0' -c '/remote/worktree'");
+    expect(attachCommand).toContain("send-keys -t 'remote-session:0.0' -- 'pnpm dev' Enter");
+    expect(attachCommand).toContain("send-keys -t 'remote-session:0.1' -- 'pnpm test' Enter");
     expect(mockPtyWrite).not.toHaveBeenCalled();
   });
 
-  it("should use a KanVibe isolated tmux socket without duplicating the bootstrap flow", async () => {
+  it("should bootstrap and attach the default tmux socket in one hardened command sequence", async () => {
     const { attachRemoteSession } = await import("@/lib/terminal");
 
     await attachRemoteSession(
-      "task-r-tmux-isolated",
+      "task-r-tmux-default-socket",
       "remote-host",
       SessionType.TMUX,
       "remote-session",
@@ -703,21 +887,23 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     const remoteShellCommand = sshArgs.at(-1) ?? "";
     const attachCommand = extractRemoteShellPayload(remoteShellCommand);
 
+    /** 사용자가 원격에서 직접 tmux attach를 쳐도 같은 세션에 붙도록 기본 소켓만 쓴다 */
+    expect(attachCommand).not.toContain("-L 'kanvibe'");
+    expect(attachCommand).toContain("if tmux has-session -t 'remote-session' 2>/dev/null;");
+    expect(attachCommand).toContain("exec tmux attach-session -t 'remote-session';");
+    /** 생성부터 attach까지가 하나의 tmux 명령 시퀀스여야 사용자 설정이 세션을 지우기 전에 옵션이 적용된다 */
     expect(attachCommand).toContain(
-      "tmux -L 'kanvibe' -f /dev/null has-session -t 'remote-session'",
+      "tmux new-session -d -s 'remote-session' -c '/remote/worktree' \\; set-option -t 'remote-session' destroy-unattached off",
     );
-    expect(attachCommand).toContain(
-      "tmux -L 'kanvibe' -f /dev/null new-session -d -s 'remote-session' -c '/remote/worktree' && tmux -L 'kanvibe' -f /dev/null split-window",
-    );
-    expect(attachCommand).toContain(
-      "tmux -L 'kanvibe' -f /dev/null attach-session -t 'remote-session'",
-    );
+    expect(attachCommand).toContain("\\; attach-session -t 'remote-session'");
+    /** 사용자 설정 때문에 실패하면 소켓은 그대로 둔 채 설정 없이 한 번 더 시도한다 */
+    expect(attachCommand).toContain("tmux -f /dev/null new-session -d -s 'remote-session'");
     expect(attachCommand).not.toContain("tmux default server failed");
     expect(attachCommand).not.toContain("kanvibe-fallback");
     expect(attachCommand.match(/has-session/g)).toHaveLength(1);
     expect(attachCommand).toContain("tmux session setup failed; leaving the SSH shell open");
     expect(attachCommand).toContain('exec "${SHELL:-/bin/sh}" -l');
-    expect(Buffer.byteLength(attachCommand)).toBeLessThan(1_000);
+    expect(Buffer.byteLength(attachCommand)).toBeLessThan(1_500);
     expectValidPosixShellSyntax(remoteShellCommand);
     expectValidPosixShellSyntax(attachCommand);
     expect(mockPtyWrite).not.toHaveBeenCalled();
@@ -797,7 +983,7 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     expect(sshArgs.at(-2)).toBe("remote-host");
     expect(remoteShellCommand).toEqual(expect.stringMatching(/^sh -lc /));
     expect(attachCommand).toContain("nvm use 24");
-    expect(attachCommand).toContain("tmux -L 'kanvibe' -f /dev/null");
+    expect(attachCommand).not.toContain("-L 'kanvibe'");
     expect(attachCommand).not.toContain("kanvibe-fallback");
     expect(attachCommand).not.toContain("tmux default server failed");
     expect(attachCommand).toContain(sessionName);

--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -214,6 +214,31 @@ describe("attachLocalSession — tmux 세션 자동 생성", () => {
     expect(findExecSyncCall("new-session")).toContain("set-option -t 'feat-login' window-size latest");
   });
 
+  it("should not change any tmux server option because the default socket is the user's own server", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) {
+        throw new Error("session not found");
+      }
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-server-options",
+      SessionType.TMUX,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    const executedCommands = mockExecSync.mock.calls.map((call) => String(call[0]));
+    expect(executedCommands.some((command) => command.includes("set-option -s"))).toBe(false);
+    expect(executedCommands.some((command) => command.includes("set-clipboard"))).toBe(false);
+  });
+
   it("should retry local bootstrap without the user tmux config when the first attempt fails", async () => {
     // Given
     const { attachLocalSession } = await import("@/lib/terminal");

--- a/src/lib/__tests__/terminal.test.ts
+++ b/src/lib/__tests__/terminal.test.ts
@@ -18,6 +18,15 @@ vi.mock("child_process", async (importOriginal) => {
   };
 });
 
+/** 원격 경로는 tmux 클립보드 설정 확인을 execGit으로 내보낸다. 기본값은 "사용자 설정 없음" */
+const mockExecGit = vi.fn(async (...args: unknown[]): Promise<string> => {
+  void args;
+  return "";
+});
+vi.mock("@/lib/gitOperations", () => ({
+  execGit: (...args: unknown[]) => mockExecGit(...args),
+}));
+
 const mockExistsSync = vi.fn();
 vi.mock("fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs")>();
@@ -214,7 +223,7 @@ describe("attachLocalSession — tmux 세션 자동 생성", () => {
     expect(findExecSyncCall("new-session")).toContain("set-option -t 'feat-login' window-size latest");
   });
 
-  it("should not change any tmux server option because the default socket is the user's own server", async () => {
+  it("should enable OSC 52 forwarding when the user tmux config says nothing about set-clipboard", async () => {
     // Given
     const { attachLocalSession } = await import("@/lib/terminal");
     mockExecSync.mockImplementation((cmd: string) => {
@@ -226,7 +235,7 @@ describe("attachLocalSession — tmux 세션 자동 생성", () => {
 
     // When
     await attachLocalSession(
-      "task-server-options",
+      "task-clipboard-default",
       SessionType.TMUX,
       "feat-login",
       createMockWs(),
@@ -234,9 +243,61 @@ describe("attachLocalSession — tmux 세션 자동 생성", () => {
     );
 
     // Then
-    const executedCommands = mockExecSync.mock.calls.map((call) => String(call[0]));
-    expect(executedCommands.some((command) => command.includes("set-option -s"))).toBe(false);
-    expect(executedCommands.some((command) => command.includes("set-clipboard"))).toBe(false);
+    expect(findExecSyncCall("new-session")).toContain("set-option -s set-clipboard on");
+  });
+
+  it("should leave set-clipboard alone when the user tmux config already chose a value", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) {
+        throw new Error("session not found");
+      }
+      if (typeof cmd === "string" && cmd.includes("set-clipboard")) {
+        return "kanvibe-user-set-clipboard";
+      }
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-clipboard-user-choice",
+      SessionType.TMUX,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    const bootstrapCommand = findExecSyncCall("new-session");
+    expect(bootstrapCommand).not.toContain("set-clipboard");
+    expect(bootstrapCommand).toContain("set-option -t 'feat-login' destroy-unattached off");
+  });
+
+  it("should not touch set-clipboard when the preference check itself fails", async () => {
+    // Given
+    const { attachLocalSession } = await import("@/lib/terminal");
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("has-session")) {
+        throw new Error("session not found");
+      }
+      if (typeof cmd === "string" && cmd.includes("set-clipboard")) {
+        throw new Error("grep unavailable");
+      }
+      return "";
+    });
+
+    // When
+    await attachLocalSession(
+      "task-clipboard-check-failure",
+      SessionType.TMUX,
+      "feat-login",
+      createMockWs(),
+      "/workspace",
+    );
+
+    // Then
+    expect(findExecSyncCall("new-session")).not.toContain("set-clipboard");
   });
 
   it("should retry local bootstrap without the user tmux config when the first attempt fails", async () => {
@@ -932,6 +993,72 @@ describe("attachRemoteSession — ssh 바이너리 기반 연결", () => {
     expectValidPosixShellSyntax(remoteShellCommand);
     expectValidPosixShellSyntax(attachCommand);
     expect(mockPtyWrite).not.toHaveBeenCalled();
+  });
+
+  it("should enable OSC 52 forwarding on the remote host the same way it does locally", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("");
+    const { attachRemoteSession } = await import("@/lib/terminal");
+
+    // When
+    await attachRemoteSession(
+      "task-r-clipboard",
+      "remote-host",
+      SessionType.TMUX,
+      "remote-session",
+      createMockWs(),
+      {
+        host: "remote-host",
+        hostname: "example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/tmp/test-key",
+      },
+      120,
+      30,
+      "/remote/worktree",
+    );
+
+    // Then
+    const nodePty = await import("node-pty");
+    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+    const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
+    expect(String(mockExecGit.mock.calls[0][0])).toContain("set-clipboard");
+    expect(mockExecGit.mock.calls[0][1]).toBe("remote-host");
+    expect(attachCommand).toContain("set-option -s set-clipboard on");
+    expectValidPosixShellSyntax(attachCommand);
+  });
+
+  it("should leave the remote set-clipboard alone when the remote tmux config already chose a value", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("kanvibe-user-set-clipboard");
+    const { attachRemoteSession } = await import("@/lib/terminal");
+
+    // When
+    await attachRemoteSession(
+      "task-r-clipboard-user",
+      "remote-host",
+      SessionType.TMUX,
+      "remote-session",
+      createMockWs(),
+      {
+        host: "remote-host",
+        hostname: "example.com",
+        port: 2202,
+        username: "tester",
+        privateKeyPath: "/tmp/test-key",
+      },
+      120,
+      30,
+      "/remote/worktree",
+    );
+
+    // Then
+    const nodePty = await import("node-pty");
+    const sshArgs = vi.mocked(nodePty.spawn).mock.calls[0][1] as string[];
+    const attachCommand = extractRemoteShellPayload(sshArgs.at(-1) ?? "");
+    expect(attachCommand).not.toContain("set-clipboard");
+    expect(attachCommand).toContain("set-option -t 'remote-session' destroy-unattached off");
   });
 
   it("should build POSIX-valid remote tmux attach commands for multiline quoted pane commands", async () => {

--- a/src/lib/__tests__/terminalClipboard.test.ts
+++ b/src/lib/__tests__/terminalClipboard.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { installOsc52ClipboardHandler, readOsc52ClipboardText } from "@/lib/terminalClipboard";
+
+function encodeBase64Utf8(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  return btoa(String.fromCharCode(...bytes));
+}
+
+describe("readOsc52ClipboardText", () => {
+  it("should decode a base64 clipboard payload", () => {
+    // Given
+    const data = `c;${encodeBase64Utf8("kanvibe")}`;
+
+    // When
+    const result = readOsc52ClipboardText(data);
+
+    // Then
+    expect(result).toBe("kanvibe");
+  });
+
+  it("should decode multibyte text without corruption", () => {
+    // Given
+    const data = `c;${encodeBase64Utf8("한글 복사 ✅")}`;
+
+    // When
+    const result = readOsc52ClipboardText(data);
+
+    // Then
+    expect(result).toBe("한글 복사 ✅");
+  });
+
+  it("should ignore a clipboard read request so terminal content is not sent back", () => {
+    // Given
+    const data = "c;?";
+
+    // When
+    const result = readOsc52ClipboardText(data);
+
+    // Then
+    expect(result).toBeNull();
+  });
+
+  it("should ignore a payload without a selection separator", () => {
+    // Given
+    const data = "c";
+
+    // When
+    const result = readOsc52ClipboardText(data);
+
+    // Then
+    expect(result).toBeNull();
+  });
+
+  it("should ignore an empty payload", () => {
+    // Given
+    const data = "c;";
+
+    // When
+    const result = readOsc52ClipboardText(data);
+
+    // Then
+    expect(result).toBeNull();
+  });
+
+  it("should ignore an undecodable payload", () => {
+    // Given
+    const data = "c;!!!not-base64!!!";
+
+    // When
+    const result = readOsc52ClipboardText(data);
+
+    // Then
+    expect(result).toBeNull();
+  });
+
+  it("should ignore a payload above the size limit", () => {
+    // Given
+    const data = `c;${"A".repeat(1_000_001)}`;
+
+    // When
+    const result = readOsc52ClipboardText(data);
+
+    // Then
+    expect(result).toBeNull();
+  });
+});
+
+describe("installOsc52ClipboardHandler", () => {
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    writeText.mockReset();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(globalThis, "navigator", {
+      value: { clipboard: { writeText } },
+      configurable: true,
+    });
+  });
+
+  function createTerminalStub() {
+    let registeredHandler: ((data: string) => boolean) | null = null;
+    const dispose = vi.fn();
+
+    return {
+      dispose,
+      invoke: (data: string) => registeredHandler?.(data) ?? false,
+      terminal: {
+        parser: {
+          registerOscHandler: (identifier: number, handler: (data: string) => boolean) => {
+            expect(identifier).toBe(52);
+            registeredHandler = handler;
+            return { dispose };
+          },
+        },
+      },
+    };
+  }
+
+  it("should copy the decoded payload to the system clipboard", () => {
+    // Given
+    const stub = createTerminalStub();
+    installOsc52ClipboardHandler(stub.terminal as never);
+
+    // When
+    const handled = stub.invoke(`c;${encodeBase64Utf8("복사 대상")}`);
+
+    // Then
+    expect(handled).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("복사 대상");
+  });
+
+  it("should consume a read request without touching the clipboard", () => {
+    // Given
+    const stub = createTerminalStub();
+    installOsc52ClipboardHandler(stub.terminal as never);
+
+    // When
+    const handled = stub.invoke("c;?");
+
+    // Then
+    expect(handled).toBe(true);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("should keep the terminal usable when the clipboard write is rejected", async () => {
+    // Given
+    const stub = createTerminalStub();
+    writeText.mockRejectedValue(new Error("clipboard blocked"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    installOsc52ClipboardHandler(stub.terminal as never);
+
+    // When
+    const handled = stub.invoke(`c;${encodeBase64Utf8("kanvibe")}`);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Then
+    expect(handled).toBe(true);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("should return a disposable that unregisters the handler", () => {
+    // Given
+    const stub = createTerminalStub();
+
+    // When
+    installOsc52ClipboardHandler(stub.terminal as never).dispose();
+
+    // Then
+    expect(stub.dispose).toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -21,9 +21,11 @@ vi.mock("@/desktop/main/services/paneLayoutService", () => ({
 }));
 
 const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+const mockMkdir = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("fs/promises", () => ({
   writeFile: (...args: unknown[]) => mockWriteFile(...args),
+  mkdir: (...args: unknown[]) => mockMkdir(...args),
 }));
 
 /** execGit 호출 중 특정 패턴을 포함하는 명령어만 필터링한다 */
@@ -147,9 +149,21 @@ describe("isSessionAlive", () => {
     // Then
     expect(result).toBe(true);
     expect(mockExecGit).toHaveBeenCalledWith(
-      'tmux has-session -t "feat-branch" 2>/dev/null',
+      "tmux has-session -t 'feat-branch' 2>/dev/null && exit 0; tmux -L 'kanvibe' has-session -t 'feat-branch' 2>/dev/null && exit 0; exit 1",
       undefined,
     );
+  });
+
+  it("should also look for the session on the socket used before KanVibe 1.0.6", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("");
+    const { isSessionAlive } = await import("@/lib/worktree");
+
+    // When
+    await isSessionAlive(SessionType.TMUX, "feat-branch");
+
+    // Then
+    expect(mockExecGit.mock.calls[0][0]).toContain("tmux -L 'kanvibe' has-session -t 'feat-branch'");
   });
 
   it("should return false when tmux session does not exist", async () => {
@@ -198,9 +212,33 @@ describe("isSessionAlive", () => {
 
     // Then
     expect(mockExecGit).toHaveBeenCalledWith(
-      'tmux has-session -t "feat-branch" 2>/dev/null',
+      expect.stringContaining("tmux has-session -t 'feat-branch'"),
       "remote-host",
     );
+  });
+
+  it("should treat an exited zellij session as not alive", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("EXITED: feat-branch\nother-session\n");
+    const { isSessionAlive } = await import("@/lib/worktree");
+
+    // When
+    const result = await isSessionAlive(SessionType.ZELLIJ, "feat-branch");
+
+    // Then
+    expect(result).toBe(false);
+  });
+
+  it("should not treat a session name prefix as a match", async () => {
+    // Given
+    mockExecGit.mockResolvedValue("feat-branch-extra [Created 1h ago]\n");
+    const { isSessionAlive } = await import("@/lib/worktree");
+
+    // When
+    const result = await isSessionAlive(SessionType.ZELLIJ, "feat-branch");
+
+    // Then
+    expect(result).toBe(false);
   });
 });
 
@@ -424,7 +462,7 @@ describe("removeSessionOnly", () => {
 
     // Then
     expect(mockExecGit).toHaveBeenCalledWith(
-      "tmux kill-session -t 'feat-branch' 2>/dev/null || true",
+      "tmux kill-session -t 'feat-branch' 2>/dev/null || true; tmux -L 'kanvibe' kill-session -t 'feat-branch' 2>/dev/null || true",
       undefined,
     );
   });
@@ -488,9 +526,9 @@ describe("removeSessionOnly", () => {
     // Then
     const command = mockExecGit.mock.calls[0][0] as string;
     expect(command).toContain("command -v tmux >/dev/null 2>&1");
-    expect(command).toContain("tmux -L kanvibe -f /dev/null kill-session -t 'feat-branch'");
+    expect(command).toContain("tmux -L 'kanvibe' kill-session -t 'feat-branch'");
     expect(command).toContain("tmux kill-session -t 'feat-branch'");
-    expect(command).toContain("if tmux -L kanvibe -f /dev/null has-session -t 'feat-branch' 2>/dev/null; then exit 1; fi");
+    expect(command).toContain("if tmux -L 'kanvibe' has-session -t 'feat-branch' 2>/dev/null; then exit 1; fi");
     expect(command).toContain("if tmux has-session -t 'feat-branch' 2>/dev/null; then exit 1; fi");
     expect(command).not.toContain("tmux list-sessions");
     expect(command).not.toContain("grep -Fx");
@@ -891,7 +929,7 @@ describe("createWorktreeWithSession — Zellij KDL layout file persistence", () 
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
-  it("should not write layout file for remote Zellij sessions", async () => {
+  it("should write the layout file to the remote worktree so remote sessions open like local ones", async () => {
     // Given
     mockGetEffectivePaneLayout.mockResolvedValue({
       layoutType: PaneLayoutType.VERTICAL_2,
@@ -914,8 +952,14 @@ describe("createWorktreeWithSession — Zellij KDL layout file persistence", () 
     );
 
     // Then
+    /** 원격 쓰기는 로컬 fs가 아니라 execGit을 통해 나가야 한다 */
     expect(mockWriteFile).not.toHaveBeenCalled();
-    expect(mockGetEffectivePaneLayout).not.toHaveBeenCalled();
+    const remoteLayoutWrites = filterCalls(".zellij-layout.kdl");
+    expect(remoteLayoutWrites).toHaveLength(1);
+    expect(mockExecGit).toHaveBeenCalledWith(
+      expect.stringContaining(".zellij-layout.kdl"),
+      "remote-host",
+    );
   });
 
   it("should fallback gracefully when getEffectivePaneLayout fails", async () => {

--- a/src/lib/__tests__/worktree.test.ts
+++ b/src/lib/__tests__/worktree.test.ts
@@ -133,6 +133,59 @@ describe("sanitizeZellijSessionName", () => {
   });
 });
 
+describe("buildTmuxUserClipboardDirectiveTestCommand", () => {
+  it("should search every tmux config path in tmux's own lookup order", async () => {
+    // Given
+    const { buildTmuxUserClipboardDirectiveTestCommand } = await import("@/lib/worktree");
+
+    // When
+    const command = buildTmuxUserClipboardDirectiveTestCommand();
+
+    // Then
+    /** XDG_CONFIG_HOME이 기본값이 아니면 하드코딩된 ~/.config는 tmux가 읽지도 않는 파일이다 */
+    expect(command).toContain('"${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"');
+    expect(command).not.toContain('"$HOME/.config/tmux/tmux.conf"');
+    expect(command).toContain('"$HOME/.tmux.conf"');
+    /** tmux는 사용자 설정보다 먼저 $prefix/etc/tmux.conf를 읽는다 */
+    expect(command).toContain('"/etc/tmux.conf"');
+    expect(command).toContain('"/opt/homebrew/etc/tmux.conf"');
+    expect(command).toContain("grep -qsE");
+  });
+
+  it("should reuse the same path list for the marker-printing preference command", async () => {
+    // Given
+    const {
+      buildTmuxUserClipboardDirectiveTestCommand,
+      buildTmuxUserClipboardPreferenceCommand,
+      TMUX_USER_CLIPBOARD_PREFERENCE_MARKER,
+    } = await import("@/lib/worktree");
+
+    // When
+    const preferenceCommand = buildTmuxUserClipboardPreferenceCommand();
+
+    // Then
+    expect(preferenceCommand).toContain(buildTmuxUserClipboardDirectiveTestCommand());
+    expect(preferenceCommand).toContain(TMUX_USER_CLIPBOARD_PREFERENCE_MARKER);
+  });
+});
+
+describe("buildZellijAliveSessionCheckCommand", () => {
+  it("should exclude exited sessions the same way the list output parser does", async () => {
+    // Given
+    const { buildZellijAliveSessionCheckCommand } = await import("@/lib/worktree");
+
+    // When
+    const command = buildZellijAliveSessionCheckCommand("feat-login");
+
+    // Then
+    expect(command).toContain('awk \'$1 != "EXITED:" { print $1 }\'');
+    expect(command).toContain("grep -qFx -- 'feat-login'");
+    /** 판정 명령에만 stderr를 감춘다. attach를 조건문에 두면 대화형 세션 오류까지 사라진다 */
+    expect(command).toContain("zellij list-sessions 2>/dev/null");
+    expect(command).not.toContain("attach");
+  });
+});
+
 describe("isSessionAlive", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/lib/hookFileWriter.ts
+++ b/src/lib/hookFileWriter.ts
@@ -1,6 +1,12 @@
 import { chmod, mkdir, writeFile } from "fs/promises";
 import path from "path";
 import { execGit } from "@/lib/gitOperations";
+import { getHookServerUrl } from "@/lib/hookEndpoint";
+import {
+  buildHookInstallBootstrapCommand,
+  HOOK_INSTALL_SUCCESS_MARKER,
+  issueHookInstallScript,
+} from "@/lib/hookInstallBundle";
 import { quoteShellArgument } from "@/lib/hostFileAccess";
 import type { ShellHookProviderFile } from "@/lib/shellHookProvider";
 
@@ -35,7 +41,45 @@ async function writeLocalHookProviderFiles(files: ShellHookProviderFile[]): Prom
   }
 }
 
+/**
+ * 원격 설치는 Hook 서버에서 설치 스크립트를 내려받아 실행하는 경로를 먼저 쓴다.
+ * 파일 본문을 SSH 명령줄에 싣지 않아 명령이 짧아지고, 인용 처리에 걸릴 여지가 사라진다.
+ * 원격에서 Hook 서버로 오는 경로가 막혀 있으면 기존 SSH 주입 방식으로 물러난다.
+ */
 async function writeRemoteHookProviderFiles(
+  files: ShellHookProviderFile[],
+  sshHost: string,
+): Promise<void> {
+  try {
+    await installRemoteHookProviderFilesOverHttp(files, sshHost);
+    return;
+  } catch (error) {
+    console.warn("[hooks] HTTP 설치 경로 실패, SSH 주입으로 대체합니다", {
+      sshHost,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  await injectRemoteHookProviderFilesOverSsh(files, sshHost);
+}
+
+async function installRemoteHookProviderFilesOverHttp(
+  files: ShellHookProviderFile[],
+  sshHost: string,
+): Promise<void> {
+  const hookServerUrl = await getHookServerUrl(sshHost);
+  const installToken = issueHookInstallScript(files);
+  const output = await execGit(
+    buildHookInstallBootstrapCommand(hookServerUrl, installToken),
+    sshHost,
+  );
+
+  if (!output.includes(HOOK_INSTALL_SUCCESS_MARKER)) {
+    throw new Error("원격 hook 설치 스크립트가 완료 표시를 남기지 않았습니다.");
+  }
+}
+
+async function injectRemoteHookProviderFilesOverSsh(
   files: ShellHookProviderFile[],
   sshHost: string,
 ): Promise<void> {

--- a/src/lib/hookFileWriter.ts
+++ b/src/lib/hookFileWriter.ts
@@ -6,6 +6,7 @@ import {
   buildHookInstallBootstrapCommand,
   HOOK_INSTALL_SUCCESS_MARKER,
   issueHookInstallScript,
+  revokeHookInstallScript,
 } from "@/lib/hookInstallBundle";
 import { quoteShellArgument } from "@/lib/hostFileAccess";
 import type { ShellHookProviderFile } from "@/lib/shellHookProvider";
@@ -63,19 +64,31 @@ async function writeRemoteHookProviderFiles(
   await injectRemoteHookProviderFilesOverSsh(files, sshHost);
 }
 
+/**
+ * 원격이 Hook 서버로 되돌아오지 못하는 구성에서 SSH 주입 폴백이 늦어지지 않도록 두는 상한.
+ * 내려받기 자체에도 상한이 있으므로 이 값은 그보다 뒤에서 받쳐 주는 역할만 한다.
+ */
+const REMOTE_HOOK_INSTALL_TIMEOUT_MS = 30_000;
+
 async function installRemoteHookProviderFilesOverHttp(
   files: ShellHookProviderFile[],
   sshHost: string,
 ): Promise<void> {
   const hookServerUrl = await getHookServerUrl(sshHost);
-  const installToken = issueHookInstallScript(files);
-  const output = await execGit(
-    buildHookInstallBootstrapCommand(hookServerUrl, installToken),
-    sshHost,
-  );
+  const installTicket = issueHookInstallScript(files);
 
-  if (!output.includes(HOOK_INSTALL_SUCCESS_MARKER)) {
-    throw new Error("원격 hook 설치 스크립트가 완료 표시를 남기지 않았습니다.");
+  try {
+    const output = await execGit(
+      buildHookInstallBootstrapCommand(hookServerUrl, installTicket),
+      sshHost,
+      { timeoutMs: REMOTE_HOOK_INSTALL_TIMEOUT_MS },
+    );
+
+    if (!output.includes(HOOK_INSTALL_SUCCESS_MARKER)) {
+      throw new Error("원격 hook 설치 스크립트가 완료 표시를 남기지 않았습니다.");
+    }
+  } finally {
+    revokeHookInstallScript(installTicket.token);
   }
 }
 

--- a/src/lib/hookInstallBundle.ts
+++ b/src/lib/hookInstallBundle.ts
@@ -1,0 +1,108 @@
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+import { quoteShellArgument } from "@/lib/hostFileAccess";
+import type { ShellHookProviderFile } from "@/lib/shellHookProvider";
+
+/** 설치 스크립트를 내려주는 Hook 서버 경로 */
+export const HOOK_INSTALL_SCRIPT_PATH = "/api/install/hooks.sh";
+
+/** 설치 스크립트가 모든 파일을 기록한 뒤 마지막 줄에 남기는 표시. 원격 설치 성공 판정에 쓴다 */
+export const HOOK_INSTALL_SUCCESS_MARKER = "__KANVIBE_HOOK_INSTALL_OK__";
+
+/**
+ * 발급한 설치 토큰의 유효 시간.
+ * 설치 실패 시 재시도가 같은 토큰을 다시 쓸 수 있을 만큼 길고, LAN에 오래 남지 않을 만큼 짧게 잡는다.
+ */
+const HOOK_INSTALL_TOKEN_TTL_MS = 5 * 60_000;
+
+interface PendingHookInstall {
+  script: string;
+  expiresAt: number;
+}
+
+const pendingHookInstalls = new Map<string, PendingHookInstall>();
+
+/**
+ * 원격이 내려받아 실행할 설치 스크립트를 등록하고 조회 토큰을 돌려준다.
+ * Hook 서버는 LAN에 열려 있으므로 토큰 없이는 설치 산출물을 내주지 않는다.
+ */
+export function issueHookInstallScript(files: ShellHookProviderFile[]): string {
+  purgeExpiredHookInstalls();
+
+  const token = randomBytes(24).toString("hex");
+  pendingHookInstalls.set(token, {
+    script: buildHookInstallScript(files),
+    expiresAt: Date.now() + HOOK_INSTALL_TOKEN_TTL_MS,
+  });
+
+  return token;
+}
+
+/** 토큰에 해당하는 설치 스크립트를 반환한다. 없거나 만료됐으면 null */
+export function readHookInstallScript(token: string | null | undefined): string | null {
+  if (!token) {
+    return null;
+  }
+
+  purgeExpiredHookInstalls();
+  return pendingHookInstalls.get(token)?.script ?? null;
+}
+
+/** 테스트와 앱 종료 경로에서 대기 중인 설치 토큰을 모두 지운다 */
+export function clearHookInstallScripts(): void {
+  pendingHookInstalls.clear();
+}
+
+function purgeExpiredHookInstalls(): void {
+  const now = Date.now();
+
+  for (const [token, pendingInstall] of pendingHookInstalls) {
+    if (pendingInstall.expiresAt <= now) {
+      pendingHookInstalls.delete(token);
+    }
+  }
+}
+
+/**
+ * hook 산출물을 원격에서 그대로 실행할 수 있는 POSIX sh 스크립트로 만든다.
+ * 파일 본문은 base64로 실어 개행이나 따옴표가 셸 해석에 걸리지 않게 한다.
+ */
+export function buildHookInstallScript(files: ShellHookProviderFile[]): string {
+  const fileCommands = files.map(({ filePath, content, mode }) => {
+    const encodedContent = Buffer.from(content, "utf-8").toString("base64");
+    const quotedFilePath = quoteShellArgument(filePath);
+    const commands = [
+      `mkdir -p ${quoteShellArgument(path.posix.dirname(filePath))}`,
+      `printf '%s' ${quoteShellArgument(encodedContent)} | (base64 -d 2>/dev/null || base64 -D) > ${quotedFilePath}`,
+    ];
+
+    if (mode) {
+      commands.push(`chmod ${mode.toString(8)} ${quotedFilePath}`);
+    }
+
+    return commands.join(" && ");
+  });
+
+  return [
+    "set -e",
+    ...fileCommands,
+    `printf '%s\\n' ${quoteShellArgument(HOOK_INSTALL_SUCCESS_MARKER)}`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * 원격이 설치 스크립트를 내려받아 실행하는 한 줄짜리 명령을 만든다.
+ * 스크립트 본문은 HTTP로 오가므로 SSH에는 짧은 명령만 실린다.
+ */
+export function buildHookInstallBootstrapCommand(hookServerUrl: string, token: string): string {
+  const scriptUrl = quoteShellArgument(
+    `${hookServerUrl.replace(/\/+$/, "")}${HOOK_INSTALL_SCRIPT_PATH}?token=${token}`,
+  );
+
+  /** 내려받기가 중간에 끊긴 스크립트를 실행하지 않도록, 전부 받은 뒤에 sh로 넘긴다 */
+  return [
+    `__kanvibe_install_script=$(curl -fsSL ${scriptUrl} 2>/dev/null || wget -qO- ${scriptUrl} 2>/dev/null)`,
+    `printf '%s\\n' "$__kanvibe_install_script" | sh`,
+  ].join(" && ");
+}

--- a/src/lib/hookInstallBundle.ts
+++ b/src/lib/hookInstallBundle.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import path from "node:path";
 import { quoteShellArgument } from "@/lib/hostFileAccess";
 import type { ShellHookProviderFile } from "@/lib/shellHookProvider";
@@ -20,22 +20,35 @@ interface PendingHookInstall {
   expiresAt: number;
 }
 
+/**
+ * 원격이 설치 스크립트를 내려받아 검증하는 데 필요한 값.
+ * 토큰은 조회 자격이고, 체크섬은 내려받은 본문이 발급 시점 그대로인지 판정하는 근거다.
+ */
+export interface HookInstallTicket {
+  token: string;
+  scriptSha256: string;
+}
+
 const pendingHookInstalls = new Map<string, PendingHookInstall>();
 
 /**
- * 원격이 내려받아 실행할 설치 스크립트를 등록하고 조회 토큰을 돌려준다.
+ * 원격이 내려받아 실행할 설치 스크립트를 등록하고 조회·검증에 필요한 값을 돌려준다.
  * Hook 서버는 LAN에 열려 있으므로 토큰 없이는 설치 산출물을 내주지 않는다.
  */
-export function issueHookInstallScript(files: ShellHookProviderFile[]): string {
+export function issueHookInstallScript(files: ShellHookProviderFile[]): HookInstallTicket {
   purgeExpiredHookInstalls();
 
+  const script = buildHookInstallScript(files);
   const token = randomBytes(24).toString("hex");
   pendingHookInstalls.set(token, {
-    script: buildHookInstallScript(files),
+    script,
     expiresAt: Date.now() + HOOK_INSTALL_TOKEN_TTL_MS,
   });
 
-  return token;
+  return {
+    token,
+    scriptSha256: createHash("sha256").update(buildDownloadedScriptForm(script), "utf-8").digest("hex"),
+  };
 }
 
 /** 토큰에 해당하는 설치 스크립트를 반환한다. 없거나 만료됐으면 null */
@@ -46,6 +59,14 @@ export function readHookInstallScript(token: string | null | undefined): string 
 
   purgeExpiredHookInstalls();
   return pendingHookInstalls.get(token)?.script ?? null;
+}
+
+/**
+ * 설치가 끝난 토큰을 즉시 폐기한다.
+ * 토큰은 SSH 명령줄에 실려 원격 `ps`에 노출되므로, 유효 구간을 설치 명령 수명만큼으로 좁힌다.
+ */
+export function revokeHookInstallScript(token: string): void {
+  pendingHookInstalls.delete(token);
 }
 
 /** 테스트와 앱 종료 경로에서 대기 중인 설치 토큰을 모두 지운다 */
@@ -92,17 +113,45 @@ export function buildHookInstallScript(files: ShellHookProviderFile[]): string {
 }
 
 /**
+ * 원격이 명령 치환으로 받아 되살리는 스크립트 형태.
+ * `$(...)`가 끝의 개행을 모두 떼고 원격이 `printf '%s\n'`으로 한 줄만 되붙이므로,
+ * 체크섬 대상도 그 형태와 정확히 같아야 한다.
+ */
+function buildDownloadedScriptForm(script: string): string {
+  return `${script.replace(/\n+$/, "")}\n`;
+}
+
+/**
+ * 내려받기가 매달린 채로 SSH 명령 타임아웃까지 가지 않도록 두는 상한.
+ * 원격이 Hook 서버로 되돌아오지 못하는 구성에서는 연결 거부가 아니라 무응답이라, 상한이 없으면 폴백이 그만큼 늦어진다.
+ */
+const HOOK_INSTALL_DOWNLOAD_CONNECT_TIMEOUT_SECONDS = 3;
+const HOOK_INSTALL_DOWNLOAD_MAX_TIMEOUT_SECONDS = 10;
+
+/**
  * 원격이 설치 스크립트를 내려받아 실행하는 한 줄짜리 명령을 만든다.
  * 스크립트 본문은 HTTP로 오가므로 SSH에는 짧은 명령만 실린다.
+ * 평문 HTTP 구간은 본문을 바꿔치기당할 수 있으므로, 암호화된 SSH 채널로 전달한 체크섬과 대조한 뒤에만 실행한다.
  */
-export function buildHookInstallBootstrapCommand(hookServerUrl: string, token: string): string {
+export function buildHookInstallBootstrapCommand(
+  hookServerUrl: string,
+  ticket: HookInstallTicket,
+): string {
   const scriptUrl = quoteShellArgument(
-    `${hookServerUrl.replace(/\/+$/, "")}${HOOK_INSTALL_SCRIPT_PATH}?token=${token}`,
+    `${hookServerUrl.replace(/\/+$/, "")}${HOOK_INSTALL_SCRIPT_PATH}?token=${ticket.token}`,
   );
+  const downloadCommands = [
+    `curl --connect-timeout ${HOOK_INSTALL_DOWNLOAD_CONNECT_TIMEOUT_SECONDS}`
+      + ` --max-time ${HOOK_INSTALL_DOWNLOAD_MAX_TIMEOUT_SECONDS} -fsSL ${scriptUrl} 2>/dev/null`,
+    `wget --timeout=${HOOK_INSTALL_DOWNLOAD_CONNECT_TIMEOUT_SECONDS} --tries=1 -qO- ${scriptUrl} 2>/dev/null`,
+  ].join(" || ");
+  const restoredScript = `printf '%s\\n' "$__kanvibe_install_script"`;
 
   /** 내려받기가 중간에 끊긴 스크립트를 실행하지 않도록, 전부 받은 뒤에 sh로 넘긴다 */
   return [
-    `__kanvibe_install_script=$(curl -fsSL ${scriptUrl} 2>/dev/null || wget -qO- ${scriptUrl} 2>/dev/null)`,
-    `printf '%s\\n' "$__kanvibe_install_script" | sh`,
+    `__kanvibe_install_script=$(${downloadCommands})`,
+    `__kanvibe_install_checksum=$(${restoredScript} | { sha256sum 2>/dev/null || shasum -a 256; } | cut -d' ' -f1)`,
+    `[ "$__kanvibe_install_checksum" = ${quoteShellArgument(ticket.scriptSha256)} ]`,
+    `${restoredScript} | sh`,
   ].join(" && ");
 }

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -7,11 +7,14 @@ import type { WebSocket } from "ws";
 import { buildSSHArgs, getKanvibeSSHConnectionHealthOptions, hasLocalX11Display } from "@/lib/sshConfig";
 import {
   buildTmuxSessionBootstrapCommand,
+  buildTmuxUserClipboardPreferenceCommand,
+  hasUserTmuxClipboardPreference,
   parseAliveZellijSessionNames,
   quoteForPosixShell,
   type TmuxPaneLayoutConfig,
   ZELLIJ_LAYOUT_FILENAME,
 } from "@/lib/worktree";
+import { execGit } from "@/lib/gitOperations";
 import { createLocalShellEnvironment } from "@/lib/shellEnvironment";
 
 /**
@@ -74,6 +77,39 @@ function isZellijSessionAlive(sessionName: string): boolean {
  */
 const TMUX_BOOTSTRAP_TIMEOUT_MS = 30_000;
 
+/** 설정 파일 grep 한 번이라 부트스트랩보다 훨씬 짧게 잡는다 */
+const TMUX_CLIPBOARD_PREFERENCE_TIMEOUT_MS = 5_000;
+
+/**
+ * OSC 52 전달을 KanVibe가 켜도 되는지 판단한다.
+ * `set-clipboard`는 서버 옵션이라 사용자의 다른 tmux 세션까지 함께 바뀌므로,
+ * 사용자가 자기 설정에서 값을 정해 뒀으면 그 선택을 그대로 둔다.
+ */
+function shouldEnableLocalTmuxClipboard(terminalEnvironment: NodeJS.ProcessEnv): boolean {
+  try {
+    const output = execSync(buildTmuxUserClipboardPreferenceCommand(), {
+      env: terminalEnvironment,
+      encoding: "utf-8",
+      timeout: TMUX_CLIPBOARD_PREFERENCE_TIMEOUT_MS,
+    });
+    return !hasUserTmuxClipboardPreference(output);
+  } catch {
+    /** 확인에 실패하면 사용자 설정을 덮지 않는 쪽으로 기운다 */
+    return false;
+  }
+}
+
+async function shouldEnableRemoteTmuxClipboard(sshHost: string): Promise<boolean> {
+  try {
+    const output = await execGit(buildTmuxUserClipboardPreferenceCommand(), sshHost, {
+      timeoutMs: TMUX_CLIPBOARD_PREFERENCE_TIMEOUT_MS,
+    });
+    return !hasUserTmuxClipboardPreference(output);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * 로컬 tmux 세션을 만든다.
  * 사용자 설정이 세션 기동을 막으면 설정 파일 없이 한 번 더 시도해, 소켓을 바꾸지 않고도 세션을 살린다.
@@ -88,9 +124,13 @@ function bootstrapLocalTmuxSession(
   const paneLayout = tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
     ? tmuxPaneLayout
     : null;
+  const enableClipboard = shouldEnableLocalTmuxClipboard(terminalEnvironment);
   const runBootstrap = (withoutUserConfigFile: boolean) => {
     execSync(
-      buildTmuxSessionBootstrapCommand(sessionName, workingDir, paneLayout, { withoutUserConfigFile }),
+      buildTmuxSessionBootstrapCommand(sessionName, workingDir, paneLayout, {
+        withoutUserConfigFile,
+        enableClipboard,
+      }),
       { env: terminalEnvironment, timeout: TMUX_BOOTSTRAP_TIMEOUT_MS },
     );
   };
@@ -316,7 +356,12 @@ export async function attachRemoteSession(
 
   const pty = await import("node-pty");
   const attachCommand = sessionType === SessionType.TMUX
-    ? buildRemoteTmuxAttachCommand(sessionName, worktreePath, tmuxPaneLayout)
+    ? buildRemoteTmuxAttachCommand(
+        sessionName,
+        worktreePath,
+        tmuxPaneLayout,
+        await shouldEnableRemoteTmuxClipboard(sshHost),
+      )
     : buildRemoteZellijAttachCommand(sessionName, worktreePath);
   const args = [
     ...buildSSHArgs(sshConfig, {
@@ -399,6 +444,7 @@ function buildRemoteTmuxAttachCommand(
   sessionName: string,
   worktreePath?: string | null,
   tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
+  enableClipboard = false,
 ): string {
   const quotedSessionName = quoteForPosixShell(sessionName);
   const buildBootstrapCommand = (withoutUserConfigFile: boolean) => buildTmuxSessionBootstrapCommand(
@@ -407,7 +453,7 @@ function buildRemoteTmuxAttachCommand(
     tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
       ? tmuxPaneLayout
       : null,
-    { attachAfterBootstrap: true, withoutUserConfigFile },
+    { attachAfterBootstrap: true, withoutUserConfigFile, enableClipboard },
   );
   const bootstrapWithRetry = [
     buildBootstrapCommand(false),

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -6,7 +6,8 @@ import { execSync } from "child_process";
 import type { WebSocket } from "ws";
 import { buildSSHArgs, getKanvibeSSHConnectionHealthOptions, hasLocalX11Display } from "@/lib/sshConfig";
 import {
-  buildTmuxSessionBootstrapCommands,
+  buildTmuxSessionBootstrapCommand,
+  parseAliveZellijSessionNames,
   quoteForPosixShell,
   type TmuxPaneLayoutConfig,
   ZELLIJ_LAYOUT_FILENAME,
@@ -61,9 +62,47 @@ function isZellijSessionAlive(sessionName: string): boolean {
       env: createLocalShellEnvironment(),
       timeout: 3000,
     });
-    return output.split("\n").some((s) => s.trim().startsWith(sessionName));
+    return parseAliveZellijSessionNames(output).includes(sessionName);
   } catch {
     return false;
+  }
+}
+
+/**
+ * tmux 서버 기동은 사용자 설정에 달려 있어 오래 걸릴 수 있다.
+ * 플러그인 관리자를 run-shell로 부르는 설정은 기동에만 수 초가 걸리므로 부트스트랩 상한을 넉넉히 둔다.
+ */
+const TMUX_BOOTSTRAP_TIMEOUT_MS = 30_000;
+
+/**
+ * 로컬 tmux 세션을 만든다.
+ * 사용자 설정이 세션 기동을 막으면 설정 없이 한 번 더 시도해, 소켓을 바꾸지 않고도 세션을 살린다.
+ */
+function bootstrapLocalTmuxSession(
+  sessionName: string,
+  workingDir: string,
+  tmuxPaneLayout: TmuxPaneLayoutConfig | null | undefined,
+  terminalEnvironment: NodeJS.ProcessEnv,
+): void {
+  const paneLayout = tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
+    ? tmuxPaneLayout
+    : null;
+  const runBootstrap = (ignoreUserConfig: boolean) => {
+    execSync(
+      buildTmuxSessionBootstrapCommand(sessionName, workingDir, paneLayout, { ignoreUserConfig }),
+      { env: terminalEnvironment, timeout: TMUX_BOOTSTRAP_TIMEOUT_MS },
+    );
+  };
+
+  try {
+    runBootstrap(false);
+  } catch (error) {
+    console.warn("[터미널] 사용자 tmux 설정으로 세션 생성에 실패해 설정 없이 재시도합니다:", error);
+    execSync(`tmux kill-session -t ${quoteForPosixShell(sessionName)} 2>/dev/null || true`, {
+      env: terminalEnvironment,
+      timeout: TMUX_BOOTSTRAP_TIMEOUT_MS,
+    });
+    runBootstrap(true);
   }
 }
 
@@ -123,18 +162,12 @@ export async function attachLocalSession(
   if (sessionType === SessionType.TMUX) {
     if (!isTmuxSessionAlive(sessionName)) {
       try {
-        const dir = cwd || process.env.HOME || "/";
-        const bootstrapCommands = buildTmuxSessionBootstrapCommands(
+        bootstrapLocalTmuxSession(
           sessionName,
-          dir,
-          tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
-            ? tmuxPaneLayout
-            : null,
+          cwd || process.env.HOME || "/",
+          tmuxPaneLayout,
+          terminalEnvironment,
         );
-        execSync(bootstrapCommands.join("; "), {
-          env: terminalEnvironment,
-          timeout: 5000,
-        });
       } catch (error) {
         console.error(`[터미널] tmux 세션 자동 생성 실패:`, error);
         ws.close(1008, "tmux 세션 생성에 실패했습니다.");
@@ -144,18 +177,6 @@ export async function attachLocalSession(
   } else {
     zellijNeedsCreation = !isZellijSessionAlive(sessionName);
     console.log(`[터미널] zellij sessionName="${sessionName}", needsCreation=${zellijNeedsCreation}, cwd=${cwd}`);
-  }
-
-  /** 웹 터미널 크기가 다른 클라이언트에 제한되지 않도록 최근 활성 클라이언트 기준으로 설정 */
-  if (sessionType === SessionType.TMUX) {
-    try {
-      execSync("tmux set-option -g window-size latest", {
-        env: terminalEnvironment,
-        stdio: "ignore",
-      });
-    } catch {
-      // tmux 구버전에서는 window-size 옵션이 없을 수 있음
-    }
   }
 
   const pty = await import("node-pty");
@@ -295,7 +316,7 @@ export async function attachRemoteSession(
   const pty = await import("node-pty");
   const attachCommand = sessionType === SessionType.TMUX
     ? buildRemoteTmuxAttachCommand(sessionName, worktreePath, tmuxPaneLayout)
-    : `exec zellij attach ${quoteForPosixShell(sessionName)}`;
+    : buildRemoteZellijAttachCommand(sessionName, worktreePath);
   const args = [
     ...buildSSHArgs(sshConfig, {
       forceTty: true,
@@ -367,66 +388,63 @@ function buildRemoteShellCommand(command: string): string {
   return `sh -lc ${quoteForPosixShell(command)}`;
 }
 
-const REMOTE_TMUX_SOCKET_NAME = "kanvibe";
-
+/**
+ * 원격 tmux 세션에 붙는 명령을 만든다.
+ * 세션이 이미 있으면 그대로 attach하고, 없으면 생성부터 attach까지를 tmux 호출 한 번으로 처리한다.
+ * 사용자 설정 때문에 실패하면 소켓은 그대로 둔 채 설정 없이 한 번 더 시도한다.
+ */
 function buildRemoteTmuxAttachCommand(
   sessionName: string,
   worktreePath?: string | null,
   tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
 ): string {
-  const tmuxFlow = buildRemoteTmuxSessionFlow(
-    buildRemoteTmuxCommand(),
+  const quotedSessionName = quoteForPosixShell(sessionName);
+  const buildBootstrapCommand = (ignoreUserConfig: boolean) => buildTmuxSessionBootstrapCommand(
     sessionName,
-    worktreePath,
-    tmuxPaneLayout,
+    worktreePath ?? "",
+    tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
+      ? tmuxPaneLayout
+      : null,
+    { attachAfterBootstrap: true, ignoreUserConfig },
   );
+  const bootstrapWithRetry = [
+    buildBootstrapCommand(false),
+    `{ tmux kill-session -t ${quotedSessionName} 2>/dev/null; ${buildBootstrapCommand(true)}; }`,
+  ].join(" || ");
 
-  return `${tmuxFlow} || { ${buildRemoteInteractiveShellFallbackCommand()}; }`;
+  return [
+    `if tmux has-session -t ${quotedSessionName} 2>/dev/null; then`,
+    `exec tmux attach-session -t ${quotedSessionName};`,
+    `else ${bootstrapWithRetry} || { ${buildRemoteInteractiveShellFallbackCommand()}; };`,
+    "fi",
+  ].join(" ");
 }
 
-function buildRemoteTmuxCommand(): string {
-  return `tmux -L ${quoteForPosixShell(REMOTE_TMUX_SOCKET_NAME)} -f /dev/null`;
-}
-
-function buildRemoteTmuxSessionFlow(
-  tmuxCommand: string,
+/**
+ * 원격 zellij 세션에 붙는 명령을 만든다.
+ * 로컬과 달리 attach만 하면 세션이 없을 때 SSH가 그대로 끊기므로, 로컬처럼 생성과 레이아웃 적용까지 처리한다.
+ */
+function buildRemoteZellijAttachCommand(
   sessionName: string,
   worktreePath?: string | null,
-  tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
 ): string {
   const quotedSessionName = quoteForPosixShell(sessionName);
-  const attachCommand = `${tmuxCommand} attach-session -t ${quotedSessionName}`;
-  const bootstrapCommands = buildRemoteTmuxBootstrapCommands(
-    tmuxCommand,
-    sessionName,
-    worktreePath,
-    tmuxPaneLayout,
-  );
+  const createArguments = ["--session", quotedSessionName];
 
-  return `if ${tmuxCommand} has-session -t ${quotedSessionName} 2>/dev/null; then ${attachCommand}; else ${[
-    ...bootstrapCommands,
-    attachCommand,
-  ].join(" && ")}; fi`;
-}
+  if (worktreePath) {
+    const layoutFile = quoteForPosixShell(path.posix.join(worktreePath, ZELLIJ_LAYOUT_FILENAME));
+    return [
+      `if zellij attach ${quotedSessionName} 2>/dev/null; then exit 0; fi;`,
+      `cd ${quoteForPosixShell(worktreePath)} 2>/dev/null || true;`,
+      `if [ -f ${layoutFile} ]; then`,
+      `exec zellij ${createArguments.join(" ")} --new-session-with-layout ${layoutFile};`,
+      "else",
+      `exec zellij ${createArguments.join(" ")};`,
+      "fi",
+    ].join(" ");
+  }
 
-function buildRemoteTmuxBootstrapCommands(
-  tmuxCommand: string,
-  sessionName: string,
-  worktreePath?: string | null,
-  tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
-): string[] {
-  const quotedSessionName = quoteForPosixShell(sessionName);
-  const defaultBootstrapCommands = worktreePath
-    ? buildTmuxSessionBootstrapCommands(
-        sessionName,
-        worktreePath,
-        tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
-          ? tmuxPaneLayout
-          : null,
-      )
-    : [`tmux new-session -d -s ${quotedSessionName}`];
-
-  return defaultBootstrapCommands.map((command) => command.replace(/^tmux(?=\s)/, tmuxCommand));
+  return `zellij attach ${quotedSessionName} 2>/dev/null || exec zellij ${createArguments.join(" ")}`;
 }
 
 function buildRemoteInteractiveShellFallbackCommand(): string {

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -7,14 +7,15 @@ import type { WebSocket } from "ws";
 import { buildSSHArgs, getKanvibeSSHConnectionHealthOptions, hasLocalX11Display } from "@/lib/sshConfig";
 import {
   buildTmuxSessionBootstrapCommand,
+  buildTmuxUserClipboardDirectiveTestCommand,
   buildTmuxUserClipboardPreferenceCommand,
+  buildZellijAliveSessionCheckCommand,
   hasUserTmuxClipboardPreference,
   parseAliveZellijSessionNames,
   quoteForPosixShell,
   type TmuxPaneLayoutConfig,
   ZELLIJ_LAYOUT_FILENAME,
 } from "@/lib/worktree";
-import { execGit } from "@/lib/gitOperations";
 import { createLocalShellEnvironment } from "@/lib/shellEnvironment";
 
 /**
@@ -84,6 +85,7 @@ const TMUX_CLIPBOARD_PREFERENCE_TIMEOUT_MS = 5_000;
  * OSC 52 전달을 KanVibe가 켜도 되는지 판단한다.
  * `set-clipboard`는 서버 옵션이라 사용자의 다른 tmux 세션까지 함께 바뀌므로,
  * 사용자가 자기 설정에서 값을 정해 뒀으면 그 선택을 그대로 둔다.
+ * 원격은 왕복을 없애려고 같은 판정을 원격 셸 안에서 직접 수행한다(`buildRemoteTmuxAttachCommand` 참고).
  */
 function shouldEnableLocalTmuxClipboard(terminalEnvironment: NodeJS.ProcessEnv): boolean {
   try {
@@ -95,17 +97,6 @@ function shouldEnableLocalTmuxClipboard(terminalEnvironment: NodeJS.ProcessEnv):
     return !hasUserTmuxClipboardPreference(output);
   } catch {
     /** 확인에 실패하면 사용자 설정을 덮지 않는 쪽으로 기운다 */
-    return false;
-  }
-}
-
-async function shouldEnableRemoteTmuxClipboard(sshHost: string): Promise<boolean> {
-  try {
-    const output = await execGit(buildTmuxUserClipboardPreferenceCommand(), sshHost, {
-      timeoutMs: TMUX_CLIPBOARD_PREFERENCE_TIMEOUT_MS,
-    });
-    return !hasUserTmuxClipboardPreference(output);
-  } catch {
     return false;
   }
 }
@@ -356,12 +347,7 @@ export async function attachRemoteSession(
 
   const pty = await import("node-pty");
   const attachCommand = sessionType === SessionType.TMUX
-    ? buildRemoteTmuxAttachCommand(
-        sessionName,
-        worktreePath,
-        tmuxPaneLayout,
-        await shouldEnableRemoteTmuxClipboard(sshHost),
-      )
+    ? buildRemoteTmuxAttachCommand(sessionName, worktreePath, tmuxPaneLayout)
     : buildRemoteZellijAttachCommand(sessionName, worktreePath);
   const args = [
     ...buildSSHArgs(sshConfig, {
@@ -439,31 +425,39 @@ function buildRemoteShellCommand(command: string): string {
  * 세션이 이미 있으면 그대로 attach하고, 없으면 생성부터 attach까지를 tmux 호출 한 번으로 처리한다.
  * 사용자 설정 때문에 실패하면 소켓은 그대로 둔 채 설정 파일 없이 한 번 더 시도한다.
  * 재시도는 원격에 tmux 서버가 아직 없을 때만 설정을 실제로 건너뛴다(`TmuxSessionBootstrapOptions` 참고).
+ *
+ * OSC 52 판정은 원격 설정 파일을 읽는 셸 한 줄이라, 앱에서 미리 SSH로 물어보면
+ * 세션이 살아 있어 결과를 쓰지도 않는 재attach에까지 왕복 지연이 붙는다.
+ * 그래서 판정을 세션 생성 분기 안으로 내려 사용 지점과 같은 원격 셸에서 수행한다.
  */
 function buildRemoteTmuxAttachCommand(
   sessionName: string,
   worktreePath?: string | null,
   tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
-  enableClipboard = false,
 ): string {
   const quotedSessionName = quoteForPosixShell(sessionName);
-  const buildBootstrapCommand = (withoutUserConfigFile: boolean) => buildTmuxSessionBootstrapCommand(
-    sessionName,
-    worktreePath ?? "",
-    tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
-      ? tmuxPaneLayout
-      : null,
-    { attachAfterBootstrap: true, withoutUserConfigFile, enableClipboard },
-  );
-  const bootstrapWithRetry = [
-    buildBootstrapCommand(false),
-    `{ tmux kill-session -t ${quotedSessionName} 2>/dev/null; ${buildBootstrapCommand(true)}; }`,
-  ].join(" || ");
+  const buildBootstrapWithFallback = (enableClipboard: boolean) => {
+    const buildBootstrapCommand = (withoutUserConfigFile: boolean) => buildTmuxSessionBootstrapCommand(
+      sessionName,
+      worktreePath ?? "",
+      tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
+        ? tmuxPaneLayout
+        : null,
+      { attachAfterBootstrap: true, withoutUserConfigFile, enableClipboard },
+    );
+    const bootstrapWithRetry = [
+      buildBootstrapCommand(false),
+      `{ tmux kill-session -t ${quotedSessionName} 2>/dev/null; ${buildBootstrapCommand(true)}; }`,
+    ].join(" || ");
+
+    return `${bootstrapWithRetry} || { ${buildRemoteInteractiveShellFallbackCommand()}; };`;
+  };
 
   return [
     `if tmux has-session -t ${quotedSessionName} 2>/dev/null; then`,
     `exec tmux attach-session -t ${quotedSessionName};`,
-    `else ${bootstrapWithRetry} || { ${buildRemoteInteractiveShellFallbackCommand()}; };`,
+    `elif ${buildTmuxUserClipboardDirectiveTestCommand()}; then ${buildBootstrapWithFallback(false)}`,
+    `else ${buildBootstrapWithFallback(true)}`,
     "fi",
   ].join(" ");
 }
@@ -471,6 +465,10 @@ function buildRemoteTmuxAttachCommand(
 /**
  * 원격 zellij 세션에 붙는 명령을 만든다.
  * 로컬과 달리 attach만 하면 세션이 없을 때 SSH가 그대로 끊기므로, 로컬처럼 생성과 레이아웃 적용까지 처리한다.
+ *
+ * 존재 확인과 attach를 나눈 이유가 두 가지다.
+ * attach를 조건문에 두면 stderr 리다이렉트가 대화형 세션이 사는 내내 유지되어 zellij 오류가 전부 사라지고,
+ * attach의 종료 코드를 "세션 없음" 신호로 재사용하게 되어 사용자가 비정상 코드로 빠져나오면 새 세션이 생긴다.
  */
 function buildRemoteZellijAttachCommand(
   sessionName: string,
@@ -478,12 +476,26 @@ function buildRemoteZellijAttachCommand(
 ): string {
   const quotedSessionName = quoteForPosixShell(sessionName);
   const createArguments = ["--session", quotedSessionName];
+  const attachWhenAlive = [
+    `if ${buildZellijAliveSessionCheckCommand(sessionName)}; then`,
+    `exec zellij attach ${quotedSessionName};`,
+    "fi;",
+  ].join(" ");
 
   if (worktreePath) {
+    const quotedWorktreePath = quoteForPosixShell(worktreePath);
     const layoutFile = quoteForPosixShell(path.posix.join(worktreePath, ZELLIJ_LAYOUT_FILENAME));
+    /** 레이아웃 파일 경로가 절대경로라 cd 실패는 조용히 통과한다. 작업 디렉터리가 어긋난 이유가 보이도록 남긴다 */
+    const changeDirectory = [
+      `cd ${quotedWorktreePath} ||`,
+      `printf '%s\\n' ${quoteForPosixShell(
+        `KanVibe: cannot enter ${worktreePath}; starting the zellij session in the default directory.`,
+      )} >&2;`,
+    ].join(" ");
+
     return [
-      `if zellij attach ${quotedSessionName} 2>/dev/null; then exit 0; fi;`,
-      `cd ${quoteForPosixShell(worktreePath)} 2>/dev/null || true;`,
+      attachWhenAlive,
+      changeDirectory,
       `if [ -f ${layoutFile} ]; then`,
       `exec zellij ${createArguments.join(" ")} --new-session-with-layout ${layoutFile};`,
       "else",
@@ -492,7 +504,7 @@ function buildRemoteZellijAttachCommand(
     ].join(" ");
   }
 
-  return `zellij attach ${quotedSessionName} 2>/dev/null || exec zellij ${createArguments.join(" ")}`;
+  return `${attachWhenAlive} exec zellij ${createArguments.join(" ")}`;
 }
 
 function buildRemoteInteractiveShellFallbackCommand(): string {

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -76,7 +76,8 @@ const TMUX_BOOTSTRAP_TIMEOUT_MS = 30_000;
 
 /**
  * 로컬 tmux 세션을 만든다.
- * 사용자 설정이 세션 기동을 막으면 설정 없이 한 번 더 시도해, 소켓을 바꾸지 않고도 세션을 살린다.
+ * 사용자 설정이 세션 기동을 막으면 설정 파일 없이 한 번 더 시도해, 소켓을 바꾸지 않고도 세션을 살린다.
+ * 재시도는 tmux 서버가 아직 없을 때만 설정을 실제로 건너뛴다(`TmuxSessionBootstrapOptions` 참고).
  */
 function bootstrapLocalTmuxSession(
   sessionName: string,
@@ -87,9 +88,9 @@ function bootstrapLocalTmuxSession(
   const paneLayout = tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
     ? tmuxPaneLayout
     : null;
-  const runBootstrap = (ignoreUserConfig: boolean) => {
+  const runBootstrap = (withoutUserConfigFile: boolean) => {
     execSync(
-      buildTmuxSessionBootstrapCommand(sessionName, workingDir, paneLayout, { ignoreUserConfig }),
+      buildTmuxSessionBootstrapCommand(sessionName, workingDir, paneLayout, { withoutUserConfigFile }),
       { env: terminalEnvironment, timeout: TMUX_BOOTSTRAP_TIMEOUT_MS },
     );
   };
@@ -391,7 +392,8 @@ function buildRemoteShellCommand(command: string): string {
 /**
  * 원격 tmux 세션에 붙는 명령을 만든다.
  * 세션이 이미 있으면 그대로 attach하고, 없으면 생성부터 attach까지를 tmux 호출 한 번으로 처리한다.
- * 사용자 설정 때문에 실패하면 소켓은 그대로 둔 채 설정 없이 한 번 더 시도한다.
+ * 사용자 설정 때문에 실패하면 소켓은 그대로 둔 채 설정 파일 없이 한 번 더 시도한다.
+ * 재시도는 원격에 tmux 서버가 아직 없을 때만 설정을 실제로 건너뛴다(`TmuxSessionBootstrapOptions` 참고).
  */
 function buildRemoteTmuxAttachCommand(
   sessionName: string,
@@ -399,13 +401,13 @@ function buildRemoteTmuxAttachCommand(
   tmuxPaneLayout?: TmuxPaneLayoutConfig | null,
 ): string {
   const quotedSessionName = quoteForPosixShell(sessionName);
-  const buildBootstrapCommand = (ignoreUserConfig: boolean) => buildTmuxSessionBootstrapCommand(
+  const buildBootstrapCommand = (withoutUserConfigFile: boolean) => buildTmuxSessionBootstrapCommand(
     sessionName,
     worktreePath ?? "",
     tmuxPaneLayout && tmuxPaneLayout.layoutType !== PaneLayoutType.SINGLE
       ? tmuxPaneLayout
       : null,
-    { attachAfterBootstrap: true, ignoreUserConfig },
+    { attachAfterBootstrap: true, withoutUserConfigFile },
   );
   const bootstrapWithRetry = [
     buildBootstrapCommand(false),

--- a/src/lib/terminalClipboard.ts
+++ b/src/lib/terminalClipboard.ts
@@ -1,0 +1,71 @@
+import type { IDisposable, Terminal } from "@xterm/xterm";
+
+/** 터미널이 시스템 클립보드에 값을 넣을 때 쓰는 OSC 시퀀스 번호 */
+const OSC_CLIPBOARD_IDENTIFIER = 52;
+
+/**
+ * 클립보드에 넣을 base64 페이로드 상한.
+ * tmux나 zellij 너머의 임의 프로세스가 보내는 값이므로 렌더러가 무한정 받아들이지 않는다.
+ */
+const MAX_CLIPBOARD_PAYLOAD_LENGTH = 1_000_000;
+
+/** OSC 52의 읽기 요청 표기. 터미널 내용이 원격으로 새는 것을 막기 위해 응답하지 않는다 */
+const CLIPBOARD_READ_REQUEST = "?";
+
+/**
+ * xterm.js가 OSC 52를 처리하도록 핸들러를 등록한다.
+ * xterm.js는 OSC 52를 기본 처리하지 않아, 등록하지 않으면 tmux와 zellij가 보낸 복사 요청이 그대로 버려진다.
+ */
+export function installOsc52ClipboardHandler(terminal: Terminal): IDisposable {
+  return terminal.parser.registerOscHandler(OSC_CLIPBOARD_IDENTIFIER, (data) => {
+    const clipboardText = readOsc52ClipboardText(data);
+    if (clipboardText !== null) {
+      void writeSystemClipboard(clipboardText);
+    }
+
+    /** 읽기 요청이나 잘못된 페이로드도 소비해, 처리되지 않은 시퀀스가 화면에 출력되지 않게 한다 */
+    return true;
+  });
+}
+
+/**
+ * OSC 52 페이로드에서 클립보드에 넣을 문자열을 뽑는다.
+ * @param data `<선택 영역>;<base64 본문>` 형식의 OSC 52 본문
+ * @returns 클립보드에 기록할 문자열. 읽기 요청이거나 해석할 수 없으면 null
+ */
+export function readOsc52ClipboardText(data: string): string | null {
+  const separatorIndex = data.indexOf(";");
+  if (separatorIndex === -1) {
+    return null;
+  }
+
+  const encodedText = data.slice(separatorIndex + 1);
+  if (!encodedText || encodedText === CLIPBOARD_READ_REQUEST) {
+    return null;
+  }
+
+  if (encodedText.length > MAX_CLIPBOARD_PAYLOAD_LENGTH) {
+    return null;
+  }
+
+  return decodeBase64Utf8(encodedText);
+}
+
+/** base64 본문을 UTF-8 문자열로 되돌린다. 한글처럼 멀티바이트 문자가 깨지지 않도록 바이트 단위로 디코딩한다 */
+function decodeBase64Utf8(encodedText: string): string | null {
+  try {
+    const binaryText = atob(encodedText);
+    const bytes = Uint8Array.from(binaryText, (character) => character.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+async function writeSystemClipboard(clipboardText: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(clipboardText);
+  } catch (error) {
+    console.warn("터미널 클립보드 복사 실패:", error);
+  }
+}

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -1,8 +1,8 @@
 import path from "path";
-import { writeFile } from "fs/promises";
 import { SessionType } from "@/entities/KanbanTask";
 import { PaneLayoutType, type PaneCommand } from "@/entities/PaneLayoutConfig";
 import { execGit, listWorktrees, type WorktreeInfo } from "@/lib/gitOperations";
+import { writeTextFile } from "@/lib/hostFileAccess";
 import { getEffectivePaneLayout } from "@/desktop/main/services/paneLayoutService";
 
 interface WorktreeSession {
@@ -52,8 +52,21 @@ export function quoteForPosixShell(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
-function buildTmuxCreateSessionCommand(sessionName: string, workingDir: string): string {
-  return `tmux new-session -d -s ${quoteForPosixShell(sessionName)} -c ${quoteForPosixShell(workingDir)}`;
+/**
+ * KanVibe 1.0.6까지 원격 세션이 쓰던 격리 소켓.
+ * 새 세션은 기본 소켓에만 만들고, 조회와 정리에서만 이 소켓에 남은 세션을 흡수한다.
+ */
+const LEGACY_TMUX_SOCKET_NAME = "kanvibe";
+
+/** 세션을 찾아야 하는 tmux 소켓 목록. 기본 소켓이 먼저다 */
+function buildTmuxLookupCommands(): string[] {
+  return ["tmux", `tmux -L ${quoteForPosixShell(LEGACY_TMUX_SOCKET_NAME)}`];
+}
+
+/** 작업 디렉터리를 모르는 원격 세션은 -c 없이 만들어 tmux 기본 디렉터리를 쓰게 한다 */
+function buildTmuxCreateSessionArgument(sessionName: string, workingDir: string): string {
+  const createArgument = `new-session -d -s ${quoteForPosixShell(sessionName)}`;
+  return workingDir ? `${createArgument} -c ${quoteForPosixShell(workingDir)}` : createArgument;
 }
 
 function buildTmuxWindowTarget(sessionName: string): string {
@@ -64,7 +77,7 @@ function buildTmuxPaneTarget(sessionName: string, position: number): string {
   return quoteForPosixShell(`${sessionName}:0.${position}`);
 }
 
-export function buildTmuxPaneLayoutCommands(
+export function buildTmuxPaneLayoutArguments(
   sessionName: string,
   layoutType: PaneLayoutType,
   panes: PaneCommand[],
@@ -72,57 +85,96 @@ export function buildTmuxPaneLayoutCommands(
 ): string[] {
   const target = buildTmuxWindowTarget(sessionName);
 
-  const splitCommands: Record<PaneLayoutType, string[]> = {
+  const splitArguments: Record<PaneLayoutType, string[]> = {
     [PaneLayoutType.SINGLE]: [],
     [PaneLayoutType.HORIZONTAL_2]: [
-      `tmux split-window -v -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
+      `split-window -v -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
     ],
     [PaneLayoutType.VERTICAL_2]: [
-      `tmux split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
+      `split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
     ],
     [PaneLayoutType.LEFT_RIGHT_TB]: [
-      `tmux split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
-      `tmux split-window -v -t ${buildTmuxPaneTarget(sessionName, 1)} -c ${quoteForPosixShell(worktreePath)}`,
+      `split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
+      `split-window -v -t ${buildTmuxPaneTarget(sessionName, 1)} -c ${quoteForPosixShell(worktreePath)}`,
     ],
     [PaneLayoutType.LEFT_TB_RIGHT]: [
-      `tmux split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
-      `tmux split-window -v -t ${buildTmuxPaneTarget(sessionName, 0)} -c ${quoteForPosixShell(worktreePath)}`,
+      `split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
+      `split-window -v -t ${buildTmuxPaneTarget(sessionName, 0)} -c ${quoteForPosixShell(worktreePath)}`,
     ],
     [PaneLayoutType.QUAD]: [
-      `tmux split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
-      `tmux split-window -v -t ${buildTmuxPaneTarget(sessionName, 0)} -c ${quoteForPosixShell(worktreePath)}`,
-      `tmux split-window -v -t ${buildTmuxPaneTarget(sessionName, 2)} -c ${quoteForPosixShell(worktreePath)}`,
+      `split-window -h -t ${target} -c ${quoteForPosixShell(worktreePath)}`,
+      `split-window -v -t ${buildTmuxPaneTarget(sessionName, 0)} -c ${quoteForPosixShell(worktreePath)}`,
+      `split-window -v -t ${buildTmuxPaneTarget(sessionName, 2)} -c ${quoteForPosixShell(worktreePath)}`,
     ],
   };
 
-  const sendKeysCommands = panes
+  const sendKeysArguments = panes
     .filter((pane) => pane.command.trim())
     .map((pane) => (
-      `tmux send-keys -t ${buildTmuxPaneTarget(sessionName, pane.position)} -- ${quoteForPosixShell(pane.command)} Enter`
+      `send-keys -t ${buildTmuxPaneTarget(sessionName, pane.position)} -- ${quoteForPosixShell(pane.command)} Enter`
     ));
 
   return [
-    ...splitCommands[layoutType],
-    ...sendKeysCommands,
+    ...splitArguments[layoutType],
+    ...sendKeysArguments,
   ];
 }
 
-export function buildTmuxSessionBootstrapCommands(
+export interface TmuxSessionBootstrapOptions {
+  /** 같은 tmux 호출에서 attach까지 이어간다. 원격 SSH가 단일 명령으로 세션을 열 때 사용한다 */
+  attachAfterBootstrap?: boolean;
+  /** 사용자 tmux 설정이 세션 기동을 막을 때 설정 없이 다시 시도하는 경로 */
+  ignoreUserConfig?: boolean;
+}
+
+/**
+ * KanVibe가 만드는 tmux 세션에만 적용할 안정화·클립보드 옵션.
+ * destroy-unattached를 끄지 않으면 사용자 설정에 따라 detached 부트스트랩 세션이 생성 직후 사라진다.
+ */
+function buildTmuxSessionHardeningArguments(sessionName: string): string[] {
+  const target = quoteForPosixShell(sessionName);
+
+  return [
+    `set-option -t ${target} destroy-unattached off`,
+    /** 웹 터미널 크기가 다른 클라이언트에 묶이지 않도록 최근 활성 클라이언트를 기준으로 삼는다 */
+    `set-option -t ${target} window-size latest`,
+    /**
+     * OSC 52 클립보드 전달 여부는 tmux 서버 옵션이라 세션 단위로 좁힐 수 없다.
+     * 기본값 external은 애플리케이션이 보낸 OSC 52를 바깥 터미널로 넘기지 않아 복사가 동작하지 않는다.
+     */
+    "set-option -s set-clipboard on",
+  ];
+}
+
+/**
+ * 세션 생성과 안정화, 레이아웃, 선택적 attach를 tmux 호출 한 번으로 실행하는 명령을 만든다.
+ * 한 명령 시퀀스로 묶어야 사용자 설정이 세션을 없애기 전에 안정화 옵션이 적용된다.
+ */
+export function buildTmuxSessionBootstrapCommand(
   sessionName: string,
   workingDir: string,
   paneLayout?: TmuxPaneLayoutConfig | null,
-): string[] {
-  return [
-    buildTmuxCreateSessionCommand(sessionName, workingDir),
-    ...(paneLayout && paneLayout.layoutType !== PaneLayoutType.SINGLE
-      ? buildTmuxPaneLayoutCommands(
+  options: TmuxSessionBootstrapOptions = {},
+): string {
+  const tmuxArguments = [
+    buildTmuxCreateSessionArgument(sessionName, workingDir),
+    ...buildTmuxSessionHardeningArguments(sessionName),
+    /** pane 분할은 각 pane의 작업 디렉터리를 지정해야 하므로 작업 디렉터리를 아는 경우에만 적용한다 */
+    ...(workingDir && paneLayout && paneLayout.layoutType !== PaneLayoutType.SINGLE
+      ? buildTmuxPaneLayoutArguments(
           sessionName,
           paneLayout.layoutType,
           paneLayout.panes,
           workingDir,
         )
       : []),
+    ...(options.attachAfterBootstrap
+      ? [`attach-session -t ${quoteForPosixShell(sessionName)}`]
+      : []),
   ];
+
+  const tmuxCommand = options.ignoreUserConfig ? "tmux -f /dev/null" : "tmux";
+  return `${tmuxCommand} ${tmuxArguments.join(" \\; ")}`;
 }
 
 /** KDL 문자열 내 특수문자를 이스케이프한다 */
@@ -227,14 +279,17 @@ export const ZELLIJ_LAYOUT_FILENAME = ".zellij-layout.kdl";
 
 /**
  * KDL 레이아웃 파일을 worktree 디렉토리에 저장한다.
- * 터미널 연결 시 node-pty가 이 파일을 --layout 플래그로 사용한다.
+ * 터미널 연결 시 zellij가 이 파일을 --new-session-with-layout 플래그로 사용한다.
  */
 async function writeLayoutToWorktree(
   worktreePath: string,
   kdlContent: string,
+  sshHost?: string | null,
 ): Promise<void> {
-  const layoutPath = path.join(worktreePath, ZELLIJ_LAYOUT_FILENAME);
-  await writeFile(layoutPath, kdlContent, "utf-8");
+  const layoutPath = sshHost
+    ? path.posix.join(worktreePath, ZELLIJ_LAYOUT_FILENAME)
+    : path.join(worktreePath, ZELLIJ_LAYOUT_FILENAME);
+  await writeTextFile(layoutPath, kdlContent, sshHost);
 }
 
 /**
@@ -269,21 +324,19 @@ export async function createWorktreeWithSession(
        */
       const zellijSessionName = sanitizeZellijSessionName(sessionName);
 
-      /** 로컬 세션인 경우 KDL 레이아웃 파일을 worktree 디렉토리에 저장한다 */
-      if (!sshHost) {
-        try {
-          const layoutConfig = await getEffectivePaneLayout(projectId ?? undefined);
-          if (layoutConfig && layoutConfig.layoutType !== PaneLayoutType.SINGLE) {
-            const kdl = generateZellijLayoutKdl(
-              layoutConfig.layoutType as PaneLayoutType,
-              layoutConfig.panes,
-              worktreePath,
-            );
-            await writeLayoutToWorktree(worktreePath, kdl);
-          }
-        } catch (error) {
-          console.error("Zellij 레이아웃 파일 생성 실패 (레이아웃 없이 세션 생성 예정):", error);
+      /** 원격도 로컬과 같은 레이아웃으로 열리도록 KDL 레이아웃 파일을 worktree 디렉토리에 저장한다 */
+      try {
+        const layoutConfig = await getEffectivePaneLayout(projectId ?? undefined);
+        if (layoutConfig && layoutConfig.layoutType !== PaneLayoutType.SINGLE) {
+          const kdl = generateZellijLayoutKdl(
+            layoutConfig.layoutType as PaneLayoutType,
+            layoutConfig.panes,
+            worktreePath,
+          );
+          await writeLayoutToWorktree(worktreePath, kdl, sshHost);
         }
+      } catch (error) {
+        console.error("Zellij 레이아웃 파일 생성 실패 (레이아웃 없이 세션 생성 예정):", error);
       }
 
       return { worktreePath, sessionName: zellijSessionName };
@@ -545,7 +598,7 @@ export async function removeSessionOnly(
   try {
     if (sessionType === SessionType.TMUX) {
       await execGit(
-        buildTmuxSessionCleanupCommand(sessionName, options.throwOnError === true, sshHost),
+        buildTmuxSessionCleanupCommand(sessionName, options.throwOnError === true),
         sshHost,
       );
     } else {
@@ -565,12 +618,9 @@ export async function removeSessionOnly(
 function buildTmuxSessionCleanupCommand(
   sessionName: string,
   verifyCleanup: boolean,
-  sshHost?: string | null,
 ): string {
   const target = quoteForPosixShell(sessionName);
-  const tmuxCommands = sshHost
-    ? ["tmux -L kanvibe -f /dev/null", "tmux"]
-    : ["tmux"];
+  const tmuxCommands = buildTmuxLookupCommands();
   const killCommands = tmuxCommands.map((tmuxCommand) => (
     `${tmuxCommand} kill-session -t ${target} 2>/dev/null || true`
   ));
@@ -613,11 +663,11 @@ export async function listActiveSessions(
 ): Promise<string[]> {
   try {
     if (sessionType === SessionType.TMUX) {
-      const output = await execGit(
-        `tmux list-sessions -F '#{session_name}'`,
-        sshHost,
-      );
-      return output.split("\n").filter(Boolean);
+      const listCommands = buildTmuxLookupCommands().map((tmuxCommand) => (
+        `${tmuxCommand} list-sessions -F '#{session_name}' 2>/dev/null || true`
+      ));
+      const output = await execGit(listCommands.join("; "), sshHost);
+      return [...new Set(output.split("\n").map((name) => name.trim()).filter(Boolean))];
     } else {
       const output = await execGit("zellij list-sessions", sshHost);
       return output.split("\n").filter(Boolean);
@@ -625,6 +675,16 @@ export async function listActiveSessions(
   } catch {
     return [];
   }
+}
+
+/** zellij list-sessions는 종료된 세션을 `EXITED: <name>`으로 함께 출력하므로 이름만 뽑아 살아있는 세션과 구분한다 */
+export function parseAliveZellijSessionNames(listSessionsOutput: string): string[] {
+  return listSessionsOutput
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("EXITED:"))
+    .map((line) => line.split(/\s+/)[0])
+    .filter(Boolean);
 }
 
 /** 세션이 활성 상태인지 확인한다 */
@@ -635,11 +695,15 @@ export async function isSessionAlive(
 ): Promise<boolean> {
   try {
     if (sessionType === SessionType.TMUX) {
-      await execGit(`tmux has-session -t "${sessionName}" 2>/dev/null`, sshHost);
+      const target = quoteForPosixShell(sessionName);
+      const hasSessionChecks = buildTmuxLookupCommands().map((tmuxCommand) => (
+        `${tmuxCommand} has-session -t ${target} 2>/dev/null && exit 0`
+      ));
+      await execGit([...hasSessionChecks, "exit 1"].join("; "), sshHost);
       return true;
     } else {
       const output = await execGit("zellij list-sessions", sshHost);
-      return output.split("\n").some((s) => s.trim().startsWith(sessionName));
+      return parseAliveZellijSessionNames(output).includes(sessionName);
     }
   } catch {
     return false;

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -139,10 +139,31 @@ export interface TmuxSessionBootstrapOptions {
 /** 사용자가 tmux 설정에서 `set-clipboard`를 직접 정해 뒀을 때 출력되는 표시 */
 export const TMUX_USER_CLIPBOARD_PREFERENCE_MARKER = "kanvibe-user-set-clipboard";
 
-/** 사용자 tmux 설정이 `set-clipboard`를 다루는지 확인하는 명령. 주석 처리된 줄은 세지 않는다 */
+/**
+ * tmux가 실제로 읽는 설정 파일 목록을 tmux의 검색 순서대로 만든다.
+ * tmux는 `$prefix/etc/tmux.conf`를 먼저 읽고, 그다음 `~/.tmux.conf`나 `$XDG_CONFIG_HOME/tmux/tmux.conf`를 읽는다.
+ * 컴파일 시점 prefix는 알 수 없으므로 실제로 쓰이는 설치 경로를 열거하고,
+ * `XDG_CONFIG_HOME`은 하드코딩하지 않고 tmux와 같은 기본값 규칙으로 전개한다.
+ * `source-file`로 끌어온 파일까지는 따라가지 않는다. 놓친 경우의 비용은 아래 판정 기본값이 흡수한다.
+ */
+function buildTmuxConfigFileCandidates(): string[] {
+  return [
+    '"/etc/tmux.conf"',
+    '"/usr/local/etc/tmux.conf"',
+    '"/opt/homebrew/etc/tmux.conf"',
+    '"$HOME/.tmux.conf"',
+    '"${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"',
+  ];
+}
+
+/** 사용자 tmux 설정이 `set-clipboard`를 다루면 성공(0)을 반환하는 조건 명령. 주석 처리된 줄은 세지 않는다 */
+export function buildTmuxUserClipboardDirectiveTestCommand(): string {
+  return `grep -qsE '^[[:space:]]*set(-option)?[[:space:]].*set-clipboard' ${buildTmuxConfigFileCandidates().join(" ")}`;
+}
+
+/** 위 조건을 별도 프로세스에서 실행할 때 쓰는 명령. 종료 코드 대신 표시 문자열로 결과를 알린다 */
 export function buildTmuxUserClipboardPreferenceCommand(): string {
-  const userConfigFiles = ['"$HOME/.tmux.conf"', '"$HOME/.config/tmux/tmux.conf"'];
-  const hasDirective = `grep -qsE '^[[:space:]]*set(-option)?[[:space:]].*set-clipboard' ${userConfigFiles.join(" ")}`;
+  const hasDirective = buildTmuxUserClipboardDirectiveTestCommand();
 
   return `if ${hasDirective}; then printf '%s' ${quoteForPosixShell(TMUX_USER_CLIPBOARD_PREFERENCE_MARKER)}; fi`;
 }
@@ -166,6 +187,7 @@ function buildTmuxSessionHardeningArguments(sessionName: string, enableClipboard
     /**
      * 기본값 external은 애플리케이션이 보낸 OSC 52를 클라이언트로 넘기지 않아 복사가 동작하지 않는다.
      * 세션 스코프로 좁힐 수 없는 서버 옵션이므로, 사용자가 값을 정해 두지 않은 경우에만 켠다.
+     * 서버 전역 부수효과를 감수하는 근거와 조건은 CLAUDE.md의 tmux `set-clipboard` 예외 항목에 있다.
      */
     ...(enableClipboard ? ["set-option -s set-clipboard on"] : []),
   ];
@@ -679,6 +701,16 @@ function buildZellijSessionCleanupCommand(sessionName: string, verifyCleanup: bo
     ...commands,
     `if zellij list-sessions 2>/dev/null | awk '{ if ($1 == "EXITED:") print $2; else print $1 }' | grep -Fx -- ${target} >/dev/null; then exit 1; fi`,
   ].join("; ");
+}
+
+/**
+ * 살아있는 zellij 세션에 대상 이름이 있으면 성공(0)을 반환하는 조건 명령.
+ * `parseAliveZellijSessionNames`와 같은 규칙으로 종료된 세션을 제외한다.
+ */
+export function buildZellijAliveSessionCheckCommand(sessionName: string): string {
+  const target = quoteForPosixShell(sessionName);
+
+  return `zellij list-sessions 2>/dev/null | awk '$1 != "EXITED:" { print $1 }' | grep -qFx -- ${target}`;
 }
 
 /** zellij list-sessions는 종료된 세션을 `EXITED: <name>`으로 함께 출력하므로 이름만 뽑아 살아있는 세션과 구분한다 */

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -123,8 +123,12 @@ export function buildTmuxPaneLayoutArguments(
 export interface TmuxSessionBootstrapOptions {
   /** 같은 tmux 호출에서 attach까지 이어간다. 원격 SSH가 단일 명령으로 세션을 열 때 사용한다 */
   attachAfterBootstrap?: boolean;
-  /** 사용자 tmux 설정이 세션 기동을 막을 때 설정 없이 다시 시도하는 경로 */
-  ignoreUserConfig?: boolean;
+  /**
+   * 사용자 tmux 설정이 세션 기동을 막을 때 `-f /dev/null`로 다시 시도하는 경로.
+   * tmux는 설정 파일을 서버 기동 시 한 번만 읽으므로, 이 플래그는 서버가 아직 없을 때만 실제로 설정을 건너뛴다.
+   * 사용자가 다른 세션을 쓰고 있어 서버가 살아 있으면 첫 시도와 같은 조건으로 실행된다.
+   */
+  withoutUserConfigFile?: boolean;
 }
 
 /**
@@ -173,7 +177,7 @@ export function buildTmuxSessionBootstrapCommand(
       : []),
   ];
 
-  const tmuxCommand = options.ignoreUserConfig ? "tmux -f /dev/null" : "tmux";
+  const tmuxCommand = options.withoutUserConfigFile ? "tmux -f /dev/null" : "tmux";
   return `${tmuxCommand} ${tmuxArguments.join(" \\; ")}`;
 }
 
@@ -654,27 +658,6 @@ function buildZellijSessionCleanupCommand(sessionName: string, verifyCleanup: bo
     ...commands,
     `if zellij list-sessions 2>/dev/null | awk '{ if ($1 == "EXITED:") print $2; else print $1 }' | grep -Fx -- ${target} >/dev/null; then exit 1; fi`,
   ].join("; ");
-}
-
-/** 활성 tmux/zellij 세션 이름 목록을 반환한다 */
-export async function listActiveSessions(
-  sessionType: SessionType,
-  sshHost?: string | null,
-): Promise<string[]> {
-  try {
-    if (sessionType === SessionType.TMUX) {
-      const listCommands = buildTmuxLookupCommands().map((tmuxCommand) => (
-        `${tmuxCommand} list-sessions -F '#{session_name}' 2>/dev/null || true`
-      ));
-      const output = await execGit(listCommands.join("; "), sshHost);
-      return [...new Set(output.split("\n").map((name) => name.trim()).filter(Boolean))];
-    } else {
-      const output = await execGit("zellij list-sessions", sshHost);
-      return output.split("\n").filter(Boolean);
-    }
-  } catch {
-    return [];
-  }
 }
 
 /** zellij list-sessions는 종료된 세션을 `EXITED: <name>`으로 함께 출력하므로 이름만 뽑아 살아있는 세션과 구분한다 */

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -132,8 +132,13 @@ export interface TmuxSessionBootstrapOptions {
 }
 
 /**
- * KanVibe가 만드는 tmux 세션에만 적용할 안정화·클립보드 옵션.
+ * KanVibe가 만드는 tmux 세션에만 적용할 안정화 옵션.
  * destroy-unattached를 끄지 않으면 사용자 설정에 따라 detached 부트스트랩 세션이 생성 직후 사라진다.
+ *
+ * 세션 스코프(`-t`)로 좁힐 수 있는 것만 둔다. 기본 소켓은 사용자 자신의 tmux 서버이므로,
+ * 서버 스코프(`-s`) 옵션을 건드리면 KanVibe와 무관한 세션까지 함께 바뀐다.
+ * tmux 안에서 애플리케이션의 OSC 52 복사가 동작하려면 서버 옵션 `set-clipboard`가 `on`이어야 하는데,
+ * 그 선택은 사용자 `~/.tmux.conf`의 몫으로 남긴다.
  */
 function buildTmuxSessionHardeningArguments(sessionName: string): string[] {
   const target = quoteForPosixShell(sessionName);
@@ -142,11 +147,6 @@ function buildTmuxSessionHardeningArguments(sessionName: string): string[] {
     `set-option -t ${target} destroy-unattached off`,
     /** 웹 터미널 크기가 다른 클라이언트에 묶이지 않도록 최근 활성 클라이언트를 기준으로 삼는다 */
     `set-option -t ${target} window-size latest`,
-    /**
-     * OSC 52 클립보드 전달 여부는 tmux 서버 옵션이라 세션 단위로 좁힐 수 없다.
-     * 기본값 external은 애플리케이션이 보낸 OSC 52를 바깥 터미널로 넘기지 않아 복사가 동작하지 않는다.
-     */
-    "set-option -s set-clipboard on",
   ];
 }
 

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -129,24 +129,45 @@ export interface TmuxSessionBootstrapOptions {
    * 사용자가 다른 세션을 쓰고 있어 서버가 살아 있으면 첫 시도와 같은 조건으로 실행된다.
    */
   withoutUserConfigFile?: boolean;
+  /**
+   * OSC 52 전달을 켠다. 서버 스코프 옵션이라 사용자의 다른 세션까지 함께 바뀌므로,
+   * 사용자가 자기 tmux 설정에서 `set-clipboard`를 정해 두지 않았을 때만 켜야 한다.
+   */
+  enableClipboard?: boolean;
+}
+
+/** 사용자가 tmux 설정에서 `set-clipboard`를 직접 정해 뒀을 때 출력되는 표시 */
+export const TMUX_USER_CLIPBOARD_PREFERENCE_MARKER = "kanvibe-user-set-clipboard";
+
+/** 사용자 tmux 설정이 `set-clipboard`를 다루는지 확인하는 명령. 주석 처리된 줄은 세지 않는다 */
+export function buildTmuxUserClipboardPreferenceCommand(): string {
+  const userConfigFiles = ['"$HOME/.tmux.conf"', '"$HOME/.config/tmux/tmux.conf"'];
+  const hasDirective = `grep -qsE '^[[:space:]]*set(-option)?[[:space:]].*set-clipboard' ${userConfigFiles.join(" ")}`;
+
+  return `if ${hasDirective}; then printf '%s' ${quoteForPosixShell(TMUX_USER_CLIPBOARD_PREFERENCE_MARKER)}; fi`;
+}
+
+/** 위 명령의 출력으로 사용자가 `set-clipboard`를 직접 정해 뒀는지 판정한다 */
+export function hasUserTmuxClipboardPreference(preferenceCommandOutput: string): boolean {
+  return preferenceCommandOutput.includes(TMUX_USER_CLIPBOARD_PREFERENCE_MARKER);
 }
 
 /**
- * KanVibe가 만드는 tmux 세션에만 적용할 안정화 옵션.
+ * KanVibe가 만드는 tmux 세션에 적용할 안정화·클립보드 옵션.
  * destroy-unattached를 끄지 않으면 사용자 설정에 따라 detached 부트스트랩 세션이 생성 직후 사라진다.
- *
- * 세션 스코프(`-t`)로 좁힐 수 있는 것만 둔다. 기본 소켓은 사용자 자신의 tmux 서버이므로,
- * 서버 스코프(`-s`) 옵션을 건드리면 KanVibe와 무관한 세션까지 함께 바뀐다.
- * tmux 안에서 애플리케이션의 OSC 52 복사가 동작하려면 서버 옵션 `set-clipboard`가 `on`이어야 하는데,
- * 그 선택은 사용자 `~/.tmux.conf`의 몫으로 남긴다.
  */
-function buildTmuxSessionHardeningArguments(sessionName: string): string[] {
+function buildTmuxSessionHardeningArguments(sessionName: string, enableClipboard: boolean): string[] {
   const target = quoteForPosixShell(sessionName);
 
   return [
     `set-option -t ${target} destroy-unattached off`,
     /** 웹 터미널 크기가 다른 클라이언트에 묶이지 않도록 최근 활성 클라이언트를 기준으로 삼는다 */
     `set-option -t ${target} window-size latest`,
+    /**
+     * 기본값 external은 애플리케이션이 보낸 OSC 52를 클라이언트로 넘기지 않아 복사가 동작하지 않는다.
+     * 세션 스코프로 좁힐 수 없는 서버 옵션이므로, 사용자가 값을 정해 두지 않은 경우에만 켠다.
+     */
+    ...(enableClipboard ? ["set-option -s set-clipboard on"] : []),
   ];
 }
 
@@ -162,7 +183,7 @@ export function buildTmuxSessionBootstrapCommand(
 ): string {
   const tmuxArguments = [
     buildTmuxCreateSessionArgument(sessionName, workingDir),
-    ...buildTmuxSessionHardeningArguments(sessionName),
+    ...buildTmuxSessionHardeningArguments(sessionName, options.enableClipboard === true),
     /** pane 분할은 각 pane의 작업 디렉터리를 지정해야 하므로 작업 디렉터리를 아는 경우에만 적용한다 */
     ...(workingDir && paneLayout && paneLayout.layoutType !== PaneLayoutType.SINGLE
       ? buildTmuxPaneLayoutArguments(


### PR DESCRIPTION
## Summary

터미널·hook 설치 경로의 안정성 문제 세 가지를 함께 해결합니다.

1. **tmux/zellij 세션 소켓 통일** — 원격만 격리 소켓(`tmux -L kanvibe -f /dev/null`)을 쓰던 것을 기본 소켓으로 통일하고, 격리 소켓 없이도 세션이 살아남도록 부트스트랩을 안정화
2. **OSC 52 클립보드 복사** — xterm.js가 tmux/zellij의 복사 요청을 버리던 것을 수정
3. **원격 hook 설치** — SSH 명령줄에 산출물 전체를 싣던 방식을 앱 내부 HTTP 부트스트랩으로 전환

## Root cause

### 격리 소켓이 고친 것은 소켓 문제가 아니었다

PR #295는 원격 기본 소켓이 poisoned 상태(`server exited unexpectedly`)라는 판단으로 `-L kanvibe`와 `-f /dev/null`을 **동시에** 바꿨습니다. tmux 3.6b로 각 요인을 분리 재현한 결과:

| 테스트 | 시나리오 | 결과 |
|---|---|---|
| T-D | stale 소켓(서버 죽고 소켓 파일만 잔존) | tmux가 **자동 복구** |
| T-E | 설정에 문법 오류·미지원 옵션 | 서버 **생존** |
| 재현 | `~/.tmux.conf`에 `destroy-unattached on` | `new-session -d` 직후 세션 소멸 → `exit-empty`(기본 on)로 서버 종료 → attach 실패 → `no sessions`, SSH 종료 |

즉 "기본 소켓이라서" 깨진 게 아니라 **detached 부트스트랩이 사용자 설정을 못 견뎌서** 깨진 것이었고, 실제로 방어하고 있던 쪽은 `-f /dev/null`이었습니다.

### 해결: 한 번의 tmux 명령 시퀀스

```
tmux new-session -d -s <N> -c <DIR> \
  \; set-option -t <N> destroy-unattached off \
  \; ... \; attach-session -t <N>
```

같은 command queue라 destroy 검사 전에 세션 옵션이 적용됩니다. 실측(T-A/V1): `destroy-unattached on` 설정 아래에서 세션 생존, split pane 2개 정상, 사용자 `send-prefix` 키바인딩과 `status-style` 모두 유지.

### 곁들여 발견한 버그

- `worktree.ts`의 `listActiveSessions`/`isSessionAlive`가 원격에서도 기본 소켓을 조회해 **KanVibe가 자기 원격 세션을 못 찾고 있었습니다** (기본 소켓 통일로 해소)
- `set-option -g window-size latest`가 **사용자 전역 tmux 옵션을 덮어쓰고** 있었습니다 → 세션 스코프로 변경
- 로컬 부트스트랩 타임아웃 5초는 TPM(`run-shell`) 설정에서 잘릴 수 있었습니다(실측: 8초 설정 → 8초 소요) → 30초
- zellij 원격 경로에 **세션 생성·레이아웃 적용이 아예 없어** attach 실패 시 SSH가 끊겼습니다
- `zellij list-sessions`의 `EXITED:` 항목을 살아있는 세션으로 오판했습니다

### OSC 52

xterm.js 6.0.0 코어에 OSC 52 핸들러가 없고 두 Terminal 컴포넌트 모두 클립보드 애드온을 로드하지 않아 복사 요청이 렌더러에서 버려지고 있었습니다. `@xterm/addon-clipboard` 0.2.0은 peer가 `@xterm/xterm ^5.4.0`이라 v6와 충돌해 `parser.registerOscHandler`로 직접 처리했습니다(의존성 추가 없음).

tmux 쪽 실측:

| `set-clipboard` | 앱의 OSC 52가 바깥 터미널에 도달 |
|---|---|
| `external` (기본값) | **0회** — 차단됨 |
| `on` | 1회 — 전달됨 |

`terminal-features` 추가는 넣지 않았습니다. tmux 기본값이 이미 `xterm*:clipboard`를 포함하고(`FEATURES=[...,clipboard,...]` 실측), `-sa` 추가는 멱등이 아니라 2회 실행 시 항목이 1→3개로 누적됩니다.

### 원격 hook 설치

provider마다 hook 파일 전체를 base64로 인코딩해 하나의 거대한 셸 명령으로 SSH에 실었습니다. Hook 서버는 원격 hook의 상태 통보 경로로 이미 도달 가능하므로, 같은 서버에서 설치 스크립트를 내려주고 원격이 받아 실행하게 바꿨습니다.

검증된 속성: **페이로드 크기와 무관하게 SSH 명령 길이가 불변**(작은 번들 vs 100KB 번들 → 명령 길이 동일, 331바이트).

HTTP 도달 실패나 완료 표시 누락 시 기존 SSH 주입 방식으로 폴백합니다.

## Verification

| 게이트 | 명령 | 결과 |
|---|---|---|
| Narrow | `pnpm exec vitest run` (변경 대상 6개 파일) | **112 passed**, exit 0 |
| Typecheck | `pnpm exec tsc --noEmit` | exit 0 |
| Lint | `pnpm exec eslint src/lib electron` | exit 0 |
| Build | `pnpm run build:main` | exit 0 |
| Full | `pnpm exec vitest run` | 891 passed / 8 failed |

**전체 스위트의 8건은 회귀가 아닙니다.** stash로 베이스라인을 측정해 대조했습니다.

- 베이스라인(변경 제거): **7 failed** — `fixtureRepository`, `launchElectron`, `databaseMigrations`×2, `gitExclude`, `shellHookScript`, `readAiSessions`
- 나머지 1건(`readAiSessions > wildcard characters`)은 단독 실행 시 12/12 통과하고 해당 디렉터리 diff가 0줄이라, 병렬 부하에서 나는 환경 플레이크입니다. `kanbanService` 타임아웃도 같은 성격으로 단독 49/49 통과를 확인했습니다.

빌드 산출물로 모듈 인스턴스 공유도 확인했습니다 — `@/lib/hookInstallBundle`이 `build/main/src/lib/hookInstallBundle.js`로 해석되어 hookServer가 require하는 경로와 동일하므로 설치 토큰 Map이 공유됩니다.

## 검증하지 못한 것

이 머신은 `ssh localhost`가 publickey로 거부되어 **실제 원격 호스트 attach와 OSC 52 복사는 확인하지 못했습니다.** 단위·통합 테스트로 명령 형태까지만 고정했으므로 실기기 확인이 필요합니다.

## 범위 밖으로 남긴 것

`electron/main.js:270`의 `process.env.KANVIBE_HOST = ...`는 CLAUDE.md가 금지한 프로세스 전역 env 변경이지만 이번 변경과 무관해 손대지 않았습니다.

## Breaking change 여부

없습니다. 기존 `kanvibe` 소켓에 남아 있는 세션은 조회와 정리에서 계속 인식되므로 고아가 되지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)