### PR TITLE
fix(desktop): 2GiB 초과 진단 로그에서 트림이 영구 실패하는 문제 수정

### DIFF
--- a/electron/diagnostics.js
+++ b/electron/diagnostics.js
@@ -37,13 +37,25 @@ function trimDesktopLogHead(logPath, bytesToRemove) {
     return;
   }
 
-  const content = fs.readFileSync(logPath);
-  if (content.length <= bytesToRemove) {
+  const fileBytes = getFileSize(logPath);
+  if (fileBytes <= bytesToRemove) {
     fs.writeFileSync(logPath, "", "utf8");
     return;
   }
 
-  fs.writeFileSync(logPath, content.subarray(bytesToRemove));
+  // 파일 전체를 한 Buffer에 담으면 2GiB를 넘긴 로그에서는 읽기 자체가 실패해 트림이 영원히 불가능해지므로,
+  // 남길 뒷부분만 읽어 재기록한다. 남길 크기는 항상 trimToBytes 이하라 파일이 아무리 커도 안전하다.
+  const keptBytes = fileBytes - bytesToRemove;
+  const keptContent = Buffer.alloc(keptBytes);
+  const logFileDescriptor = fs.openSync(logPath, "r");
+  let readBytes = 0;
+  try {
+    readBytes = fs.readSync(logFileDescriptor, keptContent, 0, keptBytes, bytesToRemove);
+  } finally {
+    fs.closeSync(logFileDescriptor);
+  }
+
+  fs.writeFileSync(logPath, keptContent.subarray(0, readBytes));
 }
 
 function trimDesktopLogIfNeeded(logPath, incomingBytes, maxFileBytes, trimToBytes) {

--- a/electron/diagnostics.js
+++ b/electron/diagnostics.js
@@ -48,9 +48,25 @@ function trimDesktopLogHead(logPath, bytesToRemove) {
   const keptBytes = fileBytes - bytesToRemove;
   const keptContent = Buffer.alloc(keptBytes);
   const logFileDescriptor = fs.openSync(logPath, "r");
+  // readSync는 요청한 길이를 다 채운다고 보장하지 않는다. 한 번만 읽고 끝내면 짧은 읽기가 발생했을 때
+  // 보존 구간의 뒤쪽, 즉 가장 최신 로그가 잘려나가므로 버퍼가 찰 때까지 이어 읽는다.
   let readBytes = 0;
   try {
-    readBytes = fs.readSync(logFileDescriptor, keptContent, 0, keptBytes, bytesToRemove);
+    while (readBytes < keptBytes) {
+      const chunkBytes = fs.readSync(
+        logFileDescriptor,
+        keptContent,
+        readBytes,
+        keptBytes - readBytes,
+        bytesToRemove + readBytes,
+      );
+      if (chunkBytes === 0) {
+        // 트림 도중 파일이 줄어 EOF에 닿은 경우다.
+        break;
+      }
+
+      readBytes += chunkBytes;
+    }
   } finally {
     fs.closeSync(logFileDescriptor);
   }

--- a/electron/diagnostics.test.mjs
+++ b/electron/diagnostics.test.mjs
@@ -28,6 +28,7 @@ function getFileSize(filePath) {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   while (tempDirs.length > 0) {
     const tempDir = tempDirs.pop();
     fs.rmSync(tempDir, { recursive: true, force: true });
@@ -68,32 +69,38 @@ describe("Electron desktop diagnostics", () => {
       trimToBytes: 150,
       maxEntryBytes: 180,
     });
+    const readFileSync = vi.spyOn(fs, "readFileSync");
 
     diagnostics.log("main:start", { ok: true });
 
+    // 파일 전체를 한 Buffer에 담으면 2GiB를 넘긴 로그에서 트림이 영구 실패하므로 tail만 읽어야 한다.
+    const wholeFileReads = readFileSync.mock.calls.filter(([target]) => target === logPath);
+    expect(wholeFileReads).toHaveLength(0);
     const content = fs.readFileSync(logPath, "utf8");
     expect(content).not.toContain("legacy-start");
+    expect(content).toContain("legacy-tail");
     expect(content).toContain("main:start");
     expect(getFileSize(logPath)).toBeLessThanOrEqual(maxFileBytes);
     expect(fs.existsSync(`${logPath}.1`)).toBe(false);
   });
 
-  it("trims an oversized log by reading only the retained tail", () => {
+  it("keeps reading until the retained tail is complete when a read returns early", () => {
     const logPath = createTempLogPath();
     fs.mkdirSync(path.dirname(logPath), { recursive: true });
-    fs.writeFileSync(logPath, `legacy-start\n${"legacy-middle".repeat(50)}\nlegacy-tail\n`, "utf8");
+    fs.writeFileSync(logPath, `legacy-start\n${"legacy-middle".repeat(20)}\nlegacy-tail\n`, "utf8");
     const diagnostics = createDiagnostics(logPath, {
       maxFileBytes: 220,
       trimToBytes: 150,
       maxEntryBytes: 180,
     });
-    const readFileSync = vi.spyOn(fs, "readFileSync");
+    const originalReadSync = fs.readSync;
+    vi.spyOn(fs, "readSync").mockImplementationOnce(
+      (fileDescriptor, buffer, offset, length, position) =>
+        originalReadSync(fileDescriptor, buffer, offset, 1, position),
+    );
 
     diagnostics.log("main:start", { ok: true });
 
-    const wholeFileReads = readFileSync.mock.calls.filter(([target]) => target === logPath);
-    readFileSync.mockRestore();
-    expect(wholeFileReads).toHaveLength(0);
     const content = fs.readFileSync(logPath, "utf8");
     expect(content).toContain("legacy-tail");
     expect(content).toContain("main:start");

--- a/electron/diagnostics.test.mjs
+++ b/electron/diagnostics.test.mjs
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const require = createRequire(import.meta.url);
 const tempDirs = [];
@@ -76,6 +76,27 @@ describe("Electron desktop diagnostics", () => {
     expect(content).toContain("main:start");
     expect(getFileSize(logPath)).toBeLessThanOrEqual(maxFileBytes);
     expect(fs.existsSync(`${logPath}.1`)).toBe(false);
+  });
+
+  it("trims an oversized log by reading only the retained tail", () => {
+    const logPath = createTempLogPath();
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.writeFileSync(logPath, `legacy-start\n${"legacy-middle".repeat(50)}\nlegacy-tail\n`, "utf8");
+    const diagnostics = createDiagnostics(logPath, {
+      maxFileBytes: 220,
+      trimToBytes: 150,
+      maxEntryBytes: 180,
+    });
+    const readFileSync = vi.spyOn(fs, "readFileSync");
+
+    diagnostics.log("main:start", { ok: true });
+
+    const wholeFileReads = readFileSync.mock.calls.filter(([target]) => target === logPath);
+    readFileSync.mockRestore();
+    expect(wholeFileReads).toHaveLength(0);
+    const content = fs.readFileSync(logPath, "utf8");
+    expect(content).toContain("legacy-tail");
+    expect(content).toContain("main:start");
   });
 
   it("truncates oversized diagnostic entries before appending them", () => {


### PR DESCRIPTION
## 문제

데스크톱 진단 로그가 2GiB를 넘기면 아래 에러가 IPC 호출마다 무한 반복된다.

```
[kanvibe] failed to write desktop diagnostics log: RangeError [ERR_FS_FILE_TOO_LARGE]:
File size (25703546658) is greater than 2 GiB
    at trimDesktopLogHead (electron/diagnostics.js:40:22)
    at trimDesktopLogIfNeeded (electron/diagnostics.js:56:3)
    at Object.log (electron/diagnostics.js:162:7)
```

## 원인

`815619e`(2026-05-02)에서 진단 로그가 상한 없는 append로 도입되어, 이 시기에 로그가 무제한으로 자랐다. `4e1073c`(2026-06-03, 1.0.2)에서 10MB 상한이 추가됐지만 `trimDesktopLogHead`가 `fs.readFileSync(logPath)`로 **파일 전체를 Buffer에 올리는** 구현이었다.

Node의 `readFileSync`는 단일 Buffer 상한이 2GiB라, 그 이전에 커져버린 로그에서는 읽기 시도 자체가 throw한다. 이 예외를 `log()`의 catch가 삼키면서 **트림도 실패하고 append도 건너뛰는** 상태가 되고, 앱을 재시작해도 파일이 그대로라 영원히 회복되지 않는다.

## 변경

`trimDesktopLogHead`가 파일 전체 대신 **보존할 tail 구간만** `openSync`/`readSync`로 읽어 재기록한다. 보존 크기는 호출부 계산상 항상 `trimToBytes`(기본 8MB) 이하이므로, 원본이 25GB든 그 이상이든 2GiB 문제가 구조적으로 사라진다.

`readSync`의 실제 반환 바이트 수로 잘라 쓰기 때문에 짧은 읽기가 발생해도 0바이트 패딩으로 로그가 오염되지 않는다.

이미 비대해진 로그를 쓰는 사용자도 **다음 로그 기록 시점에 자동으로 상한 크기까지 트림**되어 회복된다. 수동 삭제가 필요 없다.

## 테스트

회귀 테스트 1건 추가 — 트림 시 `fs.readFileSync`가 로그 경로로 호출되지 않으며, 최신 tail과 새 엔트리가 모두 보존됨을 검증한다.

| 게이트 | 명령 | 결과 |
| --- | --- | --- |
| 좁은 게이트 | `vitest run electron/diagnostics.test.mjs src/lib/__tests__/desktopDiagnostics.test.ts` | exit 0 (8 passed) |
| 회귀 유효성 | 수정 전 구현으로 되돌려 동일 테스트 실행 | exit 1 — 신규 테스트만 실패 |
| 린트 | `eslint electron/diagnostics.js electron/diagnostics.test.mjs` | exit 0 |
| 타입체크 | `tsc --noEmit` | exit 0 |
| 전체 | `vitest run` | 830 passed / 7 failed |

전체 실행의 실패 7건은 이번 변경과 무관한 환경 문제다. 변경분을 stash하고 재실행해 확인했다.

- `databaseMigrations.test.ts` 4건 — stash 상태에서도 동일 실패. `better_sqlite3.node`가 Electron ABI(`NODE_MODULE_VERSION 128`)로 빌드돼 Node 24(`137`)에서 로드 불가한 기존 문제다.
- `Terminal.test.tsx` 2건 / `launchElectron.test.mjs` 1건 — 격리 실행 시 통과. 전체 실행 시 worker 기동 타임아웃 플레이크다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)