### PR TITLE
chore(release): publish KanVibe 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Bump the desktop package version from `1.0.6` to `1.0.7` for the published KanVibe 1.0.7 release. This branch carries only the version bump; every user-visible change already landed on `dev`.

## Test Plan

- `pnpm install --frozen-lockfile` → exit 0, `better-sqlite3` rebuilt for the Electron runtime
- `pnpm run deploy` → exit 0, dependency collector reported `pm=npm`, packaging guard reported `packaged node_modules verified: 278 packages`
- `xcrun notarytool submit --wait` → `status: Accepted`
- `xcrun stapler validate dist/KanVibe-1.0.7.dmg` → `The validate action worked!`
- Smoke test on the exact published DMG:
  - `spctl -a -t exec -vv` on the mounted app → `accepted`, `source=Notarized Developer ID`
  - process alive 15s after `open -a` → ALIVE
  - module-error count in `kanvibe-desktop.log` → `0`
  - `invoke-succeeded` count → `104`
- `curl -sL <release asset> | shasum -a 256` → matches the local DMG checksum

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.0.7
- DMG asset: `dist/KanVibe-1.0.7.dmg` (168451204 bytes)
- SHA-256: `129854dfdfff7886d7c6b346a9097a4d18ca7238f73ee976ae24841b1772cfd4`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@8b93f0b` — `version` and `sha256` updated to 1.0.7 and pushed to `main`
