### PR TITLE
feat: task 설명을 .kanvibe/task.json으로 여러 기기에 동기화한다

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -2461,3 +2461,83 @@ describe("kanbanService.getSearchableTasks", () => {
     ]);
   });
 });
+
+describe("kanbanService.updateTask", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.readTextFile.mockResolvedValue("");
+    mocks.taskRepo.save.mockImplementation(async (value) => value);
+  });
+
+  it("설명을 바꾸면 공유 task.json에 기록해 다른 기기와 맞춘다", async () => {
+    // Given
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-1",
+      title: "알림 회귀 수정",
+      description: null,
+      worktreePath: "/workspace/repo-worktrees/task-1",
+      sshHost: null,
+      projectId: "project-1",
+      branchName: "fix/notifications",
+    });
+
+    const { updateTask } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    await updateTask("task-1", { description: "결제 실패 로그 원인 추적" });
+
+    // Then
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/workspace/repo-worktrees/task-1/.kanvibe/task.json",
+      expect.stringContaining('"description": "결제 실패 로그 원인 추적"'),
+      null,
+    );
+  });
+
+  it("설명을 지우면 null을 기록해 다른 기기에서도 지워지게 한다", async () => {
+    // Given
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-1",
+      title: "알림 회귀 수정",
+      description: "결제 실패 로그 원인 추적",
+      worktreePath: "/workspace/repo-worktrees/task-1",
+      sshHost: null,
+      projectId: "project-1",
+      branchName: "fix/notifications",
+    });
+
+    const { updateTask } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    await updateTask("task-1", { description: null });
+
+    // Then
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/workspace/repo-worktrees/task-1/.kanvibe/task.json",
+      expect.stringContaining('"description": null'),
+      null,
+    );
+  });
+
+  it("설명이 빠진 부분 수정은 공유 설명 파일을 건드리지 않는다", async () => {
+    // Given
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-1",
+      title: "알림 회귀 수정",
+      description: "결제 실패 로그 원인 추적",
+      worktreePath: "/workspace/repo-worktrees/task-1",
+      sshHost: null,
+      projectId: "project-1",
+      branchName: "fix/notifications",
+    });
+
+    const { updateTask } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    await updateTask("task-1", { title: "알림 회귀 재수정" });
+
+    // Then
+    expect(mocks.writeTextFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -32,6 +32,10 @@ const mocks = vi.hoisted(() => ({
   scheduleKanvibeHooksInstall: vi.fn(),
   broadcastBoardUpdate: vi.fn(),
   readTextFile: vi.fn(),
+  /** 공유 파일이 없는 저장소가 기본값이라 테스트마다 따로 준비하지 않아도 된다 */
+  readTextFiles: vi.fn(async (targetPaths: string[]) => new Map(
+    targetPaths.map((targetPath) => [targetPath, { exists: false, content: "" }]),
+  )),
   writeTextFile: vi.fn(),
   writeTextFileIfAbsent: vi.fn(),
   quoteShellArgument: vi.fn((value: string) => `'${value}'`),
@@ -149,6 +153,7 @@ vi.mock("@/lib/kanvibeHooksInstaller", () => ({
 
 vi.mock("@/lib/hostFileAccess", () => ({
   readTextFile: mocks.readTextFile,
+  readTextFiles: mocks.readTextFiles,
   writeTextFile: mocks.writeTextFile,
   writeTextFileIfAbsent: mocks.writeTextFileIfAbsent,
   quoteShellArgument: mocks.quoteShellArgument,
@@ -1989,6 +1994,21 @@ describe("projectService local hook installation", () => {
     }));
   });
 
+  /** 지정한 저장소 경로의 status.json에만 상태가 기록된 공유 파일 배치 읽기를 준비한다 */
+  function mockSharedTaskStatusFiles(statusByRepoPath: Record<string, string>): void {
+    mocks.readTextFiles.mockImplementation(async (targetPaths: string[]) => new Map(
+      targetPaths.map((targetPath) => {
+        const status = statusByRepoPath[targetPath.replace("/.kanvibe/status.json", "")];
+        return [
+          targetPath,
+          targetPath.endsWith("/.kanvibe/status.json") && status
+            ? { exists: true, content: JSON.stringify({ schemaVersion: 1, status }) }
+            : { exists: false, content: "" },
+        ];
+      }),
+    ));
+  }
+
   it("등록된 프로젝트 background sync는 .kanvibe task 상태가 있으면 그 상태로 새 worktree를 등록한다", async () => {
     mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
     mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
@@ -2003,7 +2023,7 @@ describe("projectService local hook installation", () => {
     ]);
     mocks.formatSessionName.mockReturnValue("api-feature-review");
     mocks.isSessionAlive.mockResolvedValue(false);
-    mocks.readTextFile.mockResolvedValue(JSON.stringify({ schemaVersion: 1, status: "review", updatedAt: "2026-06-03T00:00:00.000Z" }));
+    mockSharedTaskStatusFiles({ "/workspace/api__worktrees/feature-review": "review" });
 
     mocks.getProjectRepository.mockResolvedValue({
       find: vi.fn().mockResolvedValue([
@@ -2041,8 +2061,11 @@ describe("projectService local hook installation", () => {
 
     await syncRegisteredProjectWorktrees();
 
-    expect(mocks.readTextFile).toHaveBeenCalledWith(
-      "/workspace/api__worktrees/feature-review/.kanvibe/status.json",
+    expect(mocks.readTextFiles).toHaveBeenCalledWith(
+      [
+        "/workspace/api__worktrees/feature-review/.kanvibe/status.json",
+        "/workspace/api__worktrees/feature-review/.kanvibe/task.json",
+      ],
       null,
     );
     expect(taskSave).toHaveBeenCalledWith(expect.objectContaining({
@@ -2063,7 +2086,7 @@ describe("projectService local hook installation", () => {
         isBare: false,
       },
     ]);
-    mocks.readTextFile.mockResolvedValue(JSON.stringify({ schemaVersion: 1, status: "pending" }));
+    mockSharedTaskStatusFiles({ "/workspace/api__worktrees/feature-pending": "pending" });
 
     const existingTask = {
       id: "task-worktree",
@@ -2181,9 +2204,7 @@ describe("projectService local hook installation", () => {
         isBare: false,
       },
     ]);
-    mocks.readTextFile.mockImplementation(async (filePath: string) => (
-      filePath.includes("feature-orphan") ? JSON.stringify({ schemaVersion: 1, status: "done" }) : ""
-    ));
+    mockSharedTaskStatusFiles({ "/workspace/api__worktrees/feature-orphan": "done" });
     mocks.formatSessionName.mockReturnValue("api-feature-orphan");
     mocks.isSessionAlive.mockResolvedValue(false);
 
@@ -2702,5 +2723,124 @@ describe("projectService remote hook and AI session support", () => {
       query: "claude",
       sshHost: "remote-host",
     });
+  });
+});
+
+describe("projectService task description sync", () => {
+  const WORKTREE_PATH = "/workspace/api-worktrees/feature-login";
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.readTextFile.mockReset();
+    mocks.execGit.mockResolvedValue("");
+    mocks.getDefaultSessionType.mockResolvedValue("tmux");
+    mocks.getClaudeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getGeminiHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getCodexHooksStatus.mockResolvedValue({ installed: true });
+    mocks.getOpenCodeHooksStatus.mockResolvedValue({ installed: true });
+    mocks.listWorktrees.mockResolvedValue([
+      { path: "/workspace/api", branch: "main", isBare: false },
+      { path: WORKTREE_PATH, branch: "feature/login", isBare: false },
+    ]);
+    mocks.getProjectRepository.mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          id: "project-1",
+          name: "api",
+          repoPath: "/workspace/api",
+          defaultBranch: "main",
+          sshHost: null,
+        },
+      ]),
+    });
+  });
+
+  function mockWorktreeTaskRepository(save: ReturnType<typeof vi.fn>): void {
+    mocks.getTaskRepository.mockResolvedValue({
+      findOneBy: vi.fn(async (criteria: { branchName?: string; projectId?: string | null }) => {
+        if (criteria.projectId !== "project-1") {
+          return null;
+        }
+
+        if (criteria.branchName === "main") {
+          return {
+            id: "task-main",
+            branchName: "main",
+            projectId: "project-1",
+            baseBranch: "main",
+            worktreePath: "/workspace/api",
+            sshHost: null,
+            description: null,
+          };
+        }
+
+        if (criteria.branchName === "feature/login") {
+          return {
+            id: "task-login",
+            branchName: "feature/login",
+            projectId: "project-1",
+            baseBranch: "main",
+            worktreePath: WORKTREE_PATH,
+            sshHost: null,
+            description: "옛 설명",
+          };
+        }
+
+        return null;
+      }),
+      create: vi.fn((value) => value),
+      save,
+    });
+  }
+
+  /** 지정한 경로에만 내용이 있고 나머지 공유 파일은 없는 저장소를 흉내낸다 */
+  function mockSharedTaskFiles(contentByPath: Record<string, string>): void {
+    mocks.readTextFiles.mockImplementation(async (targetPaths: string[]) => new Map(
+      targetPaths.map((targetPath) => [
+        targetPath,
+        { exists: targetPath in contentByPath, content: contentByPath[targetPath] ?? "" },
+      ]),
+    ));
+  }
+
+  it("다른 기기가 task.json에 남긴 설명을 DB로 가져온다", async () => {
+    // Given
+    const save = vi.fn(async (value) => value);
+    mockWorktreeTaskRepository(save);
+    mockSharedTaskFiles({
+      [`${WORKTREE_PATH}/.kanvibe/task.json`]: JSON.stringify({
+        schemaVersion: 1,
+        description: "결제 실패 로그 원인 추적",
+      }),
+    });
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const result = await syncRegisteredProjectWorktrees();
+
+    // Then
+    expect(result.changed).toBe(true);
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({
+      id: "task-login",
+      description: "결제 실패 로그 원인 추적",
+    }));
+  });
+
+  it("task.json이 없으면 DB에 있던 설명을 지우지 않는다", async () => {
+    // Given
+    const save = vi.fn(async (value) => value);
+    mockWorktreeTaskRepository(save);
+    mockSharedTaskFiles({});
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+
+    // When
+    const result = await syncRegisteredProjectWorktrees();
+
+    // Then
+    expect(result.changed).toBe(false);
+    expect(save).not.toHaveBeenCalled();
   });
 });

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -20,7 +20,10 @@ import {
 } from "@/lib/kanvibeHooksInstaller";
 import { execGit, pullCurrentBranch, remoteBranchExists } from "@/lib/gitOperations";
 import { detachSession } from "@/lib/terminal";
-import { persistTaskStateForTask as persistTaskState } from "@/desktop/main/services/kanvibeTaskStateService";
+import {
+  persistTaskDescriptionForTask as persistTaskDescription,
+  persistTaskStateForTask as persistTaskState,
+} from "@/desktop/main/services/kanvibeTaskStateService";
 import { persistProjectColorToKanvibeState } from "@/desktop/main/services/kanvibeProjectColorService";
 
 export type TasksByStatus = Record<TaskStatus, KanbanTask[]>;
@@ -580,6 +583,10 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
 
   await persistTaskState(saved);
 
+  if (saved.description) {
+    await persistTaskDescription(saved);
+  }
+
   broadcastBoardUpdate();
 
   return serialize(saved);
@@ -615,6 +622,11 @@ export async function updateTask(
   if (updates.priority !== undefined) task.priority = updates.priority;
 
   const saved = await repo.save(task);
+
+  if (updates.description !== undefined) {
+    await persistTaskDescription(saved);
+  }
+
   broadcastBoardUpdate();
   return serialize(saved);
 }

--- a/src/desktop/main/services/kanvibeTaskStateService.ts
+++ b/src/desktop/main/services/kanvibeTaskStateService.ts
@@ -1,11 +1,22 @@
 import type { KanbanTask, TaskStatus } from "@/entities/KanbanTask";
 import { getProjectRepository } from "@/lib/database";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
-import { readKanvibeTaskState, writeKanvibeTaskStatus } from "@/lib/kanvibeProjectState";
+import type { KanvibeTaskSyncState } from "@/lib/kanvibeProjectState";
+import {
+  readKanvibeTaskState,
+  readKanvibeTaskSyncState,
+  writeKanvibeTaskDescription,
+  writeKanvibeTaskStatus,
+} from "@/lib/kanvibeProjectState";
 
 type TaskStateTask = Pick<KanbanTask, "id" | "status">;
 
 type TaskWithOptionalLocation = Pick<KanbanTask, "id" | "status" | "worktreePath" | "sshHost"> & {
+  projectId?: string | null;
+  branchName?: string | null;
+};
+
+type TaskDescriptionTask = Pick<KanbanTask, "id" | "description" | "worktreePath" | "sshHost"> & {
   projectId?: string | null;
   branchName?: string | null;
 };
@@ -29,6 +40,18 @@ export async function readPersistedTaskStatusAtPath(
   }
 
   return (await readKanvibeTaskState(repoPath, sshHost))?.status ?? null;
+}
+
+/** 다른 기기가 남긴 상태와 설명을 함께 읽는다. 기록이 없으면 null이라 DB 값을 그대로 둔다 */
+export async function readPersistedTaskSyncStateAtPath(
+  repoPath: string | null | undefined,
+  sshHost?: string | null,
+): Promise<KanvibeTaskSyncState> {
+  if (!repoPath) {
+    return { status: null, description: null };
+  }
+
+  return readKanvibeTaskSyncState(repoPath, sshHost);
 }
 
 export async function persistTaskStateAtPath(
@@ -73,6 +96,30 @@ async function ensureKanvibeStateDirectoryExcluded(
 export async function persistTaskStateForTask(task: TaskWithOptionalLocation): Promise<void> {
   const resolvedLocation = await resolveTaskStateLocation(task);
   await persistTaskStateAtPath(resolvedLocation?.repoPath, task, resolvedLocation?.sshHost ?? null);
+}
+
+/** 사용자가 남긴 설명을 공유 파일에 기록해 같은 저장소를 보는 다른 기기와 맞춘다 */
+export async function persistTaskDescriptionForTask(task: TaskDescriptionTask): Promise<void> {
+  const resolvedLocation = await resolveTaskStateLocation(task);
+  if (!resolvedLocation) {
+    return;
+  }
+
+  try {
+    await ensureKanvibeStateDirectoryExcluded(resolvedLocation.repoPath, resolvedLocation.sshHost);
+    await writeKanvibeTaskDescription(
+      resolvedLocation.repoPath,
+      task.description,
+      resolvedLocation.sshHost,
+    );
+  } catch (error) {
+    console.error(".kanvibe task 설명 저장 실패:", {
+      repoPath: resolvedLocation.repoPath,
+      taskId: task.id,
+      sshHost: resolvedLocation.sshHost,
+      error: getErrorMessage(error),
+    });
+  }
 }
 
 async function resolveTaskStateLocation(

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -22,6 +22,7 @@ import { installKanvibeHooks, installKanvibeHookProvider, scheduleKanvibeHooksIn
 import {
   persistTaskStateAtPath as persistTaskState,
   readPersistedTaskStatusAtPath as readPersistedTaskStatus,
+  readPersistedTaskSyncStateAtPath as readPersistedTaskSyncState,
 } from "@/desktop/main/services/kanvibeTaskStateService";
 import {
   persistProjectColorToKanvibeState,
@@ -315,7 +316,10 @@ async function ensureProjectRootTask(
   }
 
   const expectedDefaultBranchWorktreePath = await resolveProjectDefaultBranchWorktreePath(project);
-  const persistedStatus = await readPersistedTaskStatus(expectedDefaultBranchWorktreePath || project.repoPath, project.sshHost);
+  const {
+    status: persistedStatus,
+    description: persistedDescription,
+  } = await readPersistedTaskSyncState(expectedDefaultBranchWorktreePath || project.repoPath, project.sshHost);
 
   let shouldSaveTask = false;
   if (task.baseBranch !== project.defaultBranch) {
@@ -335,6 +339,11 @@ async function ensureProjectRootTask(
 
   if (persistedStatus !== null && task.status !== persistedStatus) {
     task.status = persistedStatus;
+    shouldSaveTask = true;
+  }
+
+  if (persistedDescription !== null && task.description !== persistedDescription.description) {
+    task.description = persistedDescription.description;
     shouldSaveTask = true;
   }
 
@@ -707,11 +716,15 @@ async function syncProjectWorktrees(
 
       /** 해당 프로젝트에 이미 동일 브랜치 태스크가 있으면 건너뛴다 */
       const existingTask = await taskRepo.findOneBy({ branchName: wt.branch, projectId: project.id });
-      const persistedStatus = await readPersistedTaskStatus(wt.path, project.sshHost);
+      const {
+        status: persistedStatus,
+        description: persistedDescription,
+      } = await readPersistedTaskSyncState(wt.path, project.sshHost);
       if (existingTask) {
         const shouldRepairTask = !matchesTaskLocation(existingTask, wt.path, project.sshHost)
           || existingTask.baseBranch !== project.defaultBranch
-          || (persistedStatus !== null && existingTask.status !== persistedStatus);
+          || (persistedStatus !== null && existingTask.status !== persistedStatus)
+          || (persistedDescription !== null && existingTask.description !== persistedDescription.description);
         let taskToPersist = existingTask;
         if (shouldRepairTask) {
           existingTask.worktreePath = wt.path;
@@ -719,6 +732,9 @@ async function syncProjectWorktrees(
           existingTask.baseBranch = project.defaultBranch;
           if (persistedStatus !== null) {
             existingTask.status = persistedStatus;
+          }
+          if (persistedDescription !== null) {
+            existingTask.description = persistedDescription.description;
           }
           const savedTask = await taskRepo.save(existingTask);
           taskToPersist = savedTask;
@@ -738,6 +754,9 @@ async function syncProjectWorktrees(
         orphanTask.sshHost = project.sshHost;
         orphanTask.baseBranch = orphanTask.baseBranch || project.defaultBranch;
         orphanTask.status = persistedStatus ?? TaskStatus.TODO;
+        if (persistedDescription !== null) {
+          orphanTask.description = persistedDescription.description;
+        }
         const savedTask = await taskRepo.save(orphanTask);
         result.changed = true;
         await persistTaskState(wt.path, savedTask, project.sshHost);
@@ -768,6 +787,7 @@ async function syncProjectWorktrees(
         projectId: project.id,
         baseBranch: project.defaultBranch,
         status: persistedStatus ?? TaskStatus.TODO,
+        description: persistedDescription?.description ?? null,
         ...(hasSession && {
           sessionType: SessionType.TMUX,
           sessionName,

--- a/src/lib/__tests__/kanvibeProjectState.test.ts
+++ b/src/lib/__tests__/kanvibeProjectState.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { TaskStatus } from "@/entities/KanbanTask";
 
-const { mockReadTextFile, mockWriteTextFile, mockWriteTextFileIfAbsent } = vi.hoisted(() => ({
+const { mockReadTextFile, mockReadTextFiles, mockWriteTextFile, mockWriteTextFileIfAbsent } = vi.hoisted(() => ({
   mockReadTextFile: vi.fn(),
+  mockReadTextFiles: vi.fn(),
   mockWriteTextFile: vi.fn(),
   mockWriteTextFileIfAbsent: vi.fn(),
 }));
 
 vi.mock("@/lib/hostFileAccess", () => ({
   readTextFile: (...args: unknown[]) => mockReadTextFile(...args),
+  readTextFiles: (...args: unknown[]) => mockReadTextFiles(...args),
   writeTextFile: (...args: unknown[]) => mockWriteTextFile(...args),
   writeTextFileIfAbsent: (...args: unknown[]) => mockWriteTextFileIfAbsent(...args),
 }));
@@ -16,20 +18,25 @@ vi.mock("@/lib/hostFileAccess", () => ({
 import {
   buildKanvibeProjectStateContent,
   buildKanvibeTargetsContent,
+  buildKanvibeTaskDescriptionContent,
   buildKanvibeTaskStateContent,
   getKanvibeProjectStatePath,
   getKanvibeTargetsPath,
+  getKanvibeTaskDescriptionPath,
   getKanvibeTaskStatePath,
   hasKanvibeHookTarget,
   parseKanvibeTargets,
+  parseKanvibeTaskDescription,
   parseKanvibeTaskState,
   parseProjectColor,
   parseTaskStatus,
   readKanvibeProjectColor,
   readKanvibeTaskState,
+  readKanvibeTaskSyncState,
   upsertKanvibeHookTarget,
   writeKanvibeProjectColor,
   writeKanvibeProjectColorIfAbsent,
+  writeKanvibeTaskDescription,
   writeKanvibeTaskStatus,
 } from "@/lib/kanvibeProjectState";
 
@@ -272,5 +279,69 @@ describe("kanvibeProjectState", () => {
     expect(hasKanvibeHookTarget(content, { url: "http://127.0.0.1:19736", taskId: "task-2" })).toBe(false);
     expect(hasKanvibeHookTarget(content, { url: "http://10.0.0.5:19736", taskId: "task-1" })).toBe(false);
     expect(hasKanvibeHookTarget("", { url: "http://127.0.0.1:19736", taskId: "task-1" })).toBe(false);
+  });
+
+  it("task 설명을 status.json이 아닌 task.json에 기록한다", async () => {
+    await writeKanvibeTaskDescription("/local/repo", "결제 실패 로그 원인 추적");
+
+    expect(mockWriteTextFile).toHaveBeenCalledWith(
+      "/local/repo/.kanvibe/task.json",
+      expect.any(String),
+      undefined,
+    );
+    expect(JSON.parse(getLastWrittenContent())).toEqual({
+      schemaVersion: 1,
+      description: "결제 실패 로그 원인 추적",
+      updatedAt: expect.any(String),
+    });
+    expect(getKanvibeTaskDescriptionPath("/local/repo")).toBe("/local/repo/.kanvibe/task.json");
+    expect(getKanvibeTaskDescriptionPath("/remote/repo", "build-host")).toBe("/remote/repo/.kanvibe/task.json");
+  });
+
+  it("설명을 지우면 null을 기록해 다른 기기에서도 지워지게 한다", () => {
+    const content = buildKanvibeTaskDescriptionContent(null);
+
+    expect(JSON.parse(content)).toEqual({
+      schemaVersion: 1,
+      description: null,
+      updatedAt: expect.any(String),
+    });
+    expect(parseKanvibeTaskDescription(content)?.description).toBeNull();
+  });
+
+  it("설명 파일이 없거나 형식이 깨지면 정보 없음으로 본다", () => {
+    expect(parseKanvibeTaskDescription("")).toBeNull();
+    expect(parseKanvibeTaskDescription("not json")).toBeNull();
+    expect(parseKanvibeTaskDescription(JSON.stringify({ schemaVersion: 1 }))).toBeNull();
+    expect(parseKanvibeTaskDescription(JSON.stringify({ description: 123 }))).toBeNull();
+  });
+
+  it("상태와 설명을 원격 왕복 한 번으로 함께 읽어온다", async () => {
+    mockReadTextFiles.mockResolvedValue(new Map([
+      ["/local/repo/.kanvibe/status.json", { exists: true, content: JSON.stringify({ status: "review" }) }],
+      ["/local/repo/.kanvibe/task.json", { exists: true, content: JSON.stringify({ description: "결제 실패 로그 원인 추적" }) }],
+    ]));
+
+    const syncState = await readKanvibeTaskSyncState("/local/repo");
+
+    expect(syncState.status).toBe(TaskStatus.REVIEW);
+    expect(syncState.description?.description).toBe("결제 실패 로그 원인 추적");
+    expect(mockReadTextFiles).toHaveBeenCalledTimes(1);
+    expect(mockReadTextFiles).toHaveBeenCalledWith(
+      ["/local/repo/.kanvibe/status.json", "/local/repo/.kanvibe/task.json"],
+      undefined,
+    );
+  });
+
+  it("상태나 설명 파일이 없으면 각각 기록 없음으로 돌려준다", async () => {
+    mockReadTextFiles.mockResolvedValue(new Map([
+      ["/local/repo/.kanvibe/status.json", { exists: true, content: JSON.stringify({ status: "review" }) }],
+      ["/local/repo/.kanvibe/task.json", { exists: false, content: "" }],
+    ]));
+
+    expect(await readKanvibeTaskSyncState("/local/repo")).toEqual({
+      status: TaskStatus.REVIEW,
+      description: null,
+    });
   });
 });

--- a/src/lib/kanvibeProjectState.ts
+++ b/src/lib/kanvibeProjectState.ts
@@ -1,11 +1,12 @@
 import path from "path";
 import { TaskStatus } from "@/entities/KanbanTask";
-import { readTextFile, writeTextFile, writeTextFileIfAbsent } from "@/lib/hostFileAccess";
+import { readTextFile, readTextFiles, writeTextFile, writeTextFileIfAbsent } from "@/lib/hostFileAccess";
 
 export const KANVIBE_DIR_NAME = ".kanvibe";
 export const TASK_STATE_FILE_NAME = "status.json";
 export const PROJECT_STATE_FILE_NAME = "project.json";
 export const TARGETS_FILE_NAME = "targets.json";
+export const TASK_DESCRIPTION_FILE_NAME = "task.json";
 
 /** `#RRGGBB` 형태의 프로젝트 색상만 허용한다 */
 const PROJECT_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
@@ -24,6 +25,23 @@ export interface KanvibeProjectState {
   schemaVersion: 1;
   projectColor: string;
   updatedAt?: string;
+}
+
+/**
+ * task 설명 공유 상태. hook이 통째로 재작성하는 status.json과 파일을 분리해
+ * agent가 상태를 기록해도 사용자가 남긴 설명이 지워지지 않게 한다.
+ * description이 null이면 다른 기기에서도 설명을 지우라는 뜻이다.
+ */
+export interface KanvibeTaskDescription {
+  schemaVersion: 1;
+  description: string | null;
+  updatedAt?: string;
+}
+
+/** 다른 기기의 상태를 한 번에 반영하기 위해 함께 읽는 값들. 각 항목의 null은 "기록 없음"이다 */
+export interface KanvibeTaskSyncState {
+  status: TaskStatus | null;
+  description: KanvibeTaskDescription | null;
 }
 
 export interface KanvibeHookTarget {
@@ -49,6 +67,10 @@ export function getKanvibeTargetsPath(repoPath: string, sshHost?: string | null)
   return getPathModule(sshHost).join(repoPath, KANVIBE_DIR_NAME, TARGETS_FILE_NAME);
 }
 
+export function getKanvibeTaskDescriptionPath(repoPath: string, sshHost?: string | null): string {
+  return getPathModule(sshHost).join(repoPath, KANVIBE_DIR_NAME, TASK_DESCRIPTION_FILE_NAME);
+}
+
 export async function readKanvibeTaskState(
   repoPath: string,
   sshHost?: string | null,
@@ -66,6 +88,24 @@ export async function readKanvibeProjectColor(
   return parseKanvibeProjectState(content)?.projectColor ?? null;
 }
 
+/**
+ * 다른 기기가 남긴 task 상태와 설명을 함께 읽는다.
+ * 두 값은 늘 같은 시점에 필요하므로 원격 저장소에서도 한 번의 왕복으로 가져온다.
+ */
+export async function readKanvibeTaskSyncState(
+  repoPath: string,
+  sshHost?: string | null,
+): Promise<KanvibeTaskSyncState> {
+  const taskStatePath = getKanvibeTaskStatePath(repoPath, sshHost);
+  const taskDescriptionPath = getKanvibeTaskDescriptionPath(repoPath, sshHost);
+  const files = await readTextFiles([taskStatePath, taskDescriptionPath], sshHost);
+
+  return {
+    status: parseKanvibeTaskState(files.get(taskStatePath)?.content ?? "")?.status ?? null,
+    description: parseKanvibeTaskDescription(files.get(taskDescriptionPath)?.content ?? ""),
+  };
+}
+
 export async function writeKanvibeTaskStatus(
   repoPath: string,
   status: TaskStatus,
@@ -74,6 +114,18 @@ export async function writeKanvibeTaskStatus(
   await writeTextFile(
     getKanvibeTaskStatePath(repoPath, sshHost),
     buildKanvibeTaskStateContent({ status }),
+    sshHost,
+  );
+}
+
+export async function writeKanvibeTaskDescription(
+  repoPath: string,
+  description: string | null,
+  sshHost?: string | null,
+): Promise<void> {
+  await writeTextFile(
+    getKanvibeTaskDescriptionPath(repoPath, sshHost),
+    buildKanvibeTaskDescriptionContent(description),
     sshHost,
   );
 }
@@ -161,6 +213,16 @@ export function buildKanvibeTaskStateContent(
   return JSON.stringify(payload, null, 2) + "\n";
 }
 
+export function buildKanvibeTaskDescriptionContent(description: string | null): string {
+  const payload: KanvibeTaskDescription = {
+    schemaVersion: 1,
+    description,
+    updatedAt: new Date().toISOString(),
+  };
+
+  return JSON.stringify(payload, null, 2) + "\n";
+}
+
 export function buildKanvibeProjectStateContent(projectColor: string): string {
   const payload: KanvibeProjectState = {
     schemaVersion: 1,
@@ -201,6 +263,31 @@ export function parseKanvibeTaskState(content: string): KanvibeTaskState | null 
     return {
       schemaVersion: 1,
       status,
+      ...(isNonEmptyString(parsed.updatedAt) ? { updatedAt: parsed.updatedAt } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * description이 문자열이거나 명시적 null일 때만 유효한 기록으로 본다.
+ * 파일이 없거나 형식이 깨진 경우는 "정보 없음"이므로 null을 돌려 DB 값을 유지하게 한다.
+ */
+export function parseKanvibeTaskDescription(content: string): KanvibeTaskDescription | null {
+  if (typeof content !== "string" || !content.trim()) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(content) as { description?: unknown; updatedAt?: unknown };
+    if (typeof parsed.description !== "string" && parsed.description !== null) {
+      return null;
+    }
+
+    return {
+      schemaVersion: 1,
+      description: parsed.description,
       ...(isNonEmptyString(parsed.updatedAt) ? { updatedAt: parsed.updatedAt } : {}),
     };
   } catch {


### PR DESCRIPTION
## Summary
- task 설명을 `.kanvibe/task.json`에 기록해 같은 저장소를 보는 다른 기기와 동기화한다
- agent hook이 통째로 재작성하는 `status.json`과 파일을 분리해, hook 실행 시 설명이 지워지지 않게 한다 (hook 코드 변경 없음)
- description이 `null`이면 다른 기기에서도 설명을 지운다; 파일이 없거나 깨지면 "정보 없음"으로 보고 DB 값을 유지한다
- 원격(ssh) 저장소에서는 `readTextFiles`로 상태·설명을 한 번의 왕복에 함께 읽어 기존 대비 원격 호출 횟수가 늘지 않는다

## Test plan
- [x] `pnpm check` (tsc --noEmit) exit 0
- [x] `pnpm lint` exit 0
- [x] `pnpm test` — 101 files / 938 tests 통과