### PR TITLE
fix(shortcut): 작업 정보 dock을 Mod+숫자로 되돌리고 터미널 탭 이동을 Mod+Alt+숫자로 옮긴다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,8 @@ The rule above forbids tmux-wide side effects. tmux `set-clipboard` is an approv
 - Renderer keyboard events and Electron `before-input-event` inputs must be routed through the same shared matcher so macOS and Linux behavior stays consistent.
 - Shortcut capture UIs must store normalized shortcut strings from the shared capture helper, not hand-built modifier strings.
 - When adding or changing a shortcut, cover the shared command definition, display formatting, Electron input matching, renderer global handling, and any user-configurable capture flow with focused tests.
-- Task detail dock shortcuts must use the shared dock shortcut helpers: macOS uses `Cmd+Option+{number}` and Linux uses `Alt+{number}`. Electron `before-input-event` must intercept these before terminal input receives them.
-- Terminal tab shortcuts use `Mod+{number}`, so on macOS plain `Cmd+{number}` belongs to tab navigation and the dock takes `Cmd+Option+{number}`.
+- Task detail dock shortcuts must use the shared dock shortcut helpers and bind to `Mod+{number}`. Electron `before-input-event` must intercept these before terminal input receives them.
+- Terminal tab shortcuts use `Mod+Alt+{number}`, so plain `Mod+{number}` stays with the task detail dock.
 - Do not bind an app shortcut to `Cmd+Shift+{number}` on macOS. The system claims `Cmd+Shift+3/4/5` for screenshots and never delivers them to the app, so such a binding fails silently on some numbers only.
 - Task detail dock numbering excludes the back-to-board button and must be derived from the dock item array order, not hard-coded per item. Keep PR as the conditional slot after the first three dock items: with PR it is slot 4 and later items shift to 5+, without PR the next dock item gets slot 4.
 

--- a/docs-site/content/en/shortcuts.mdx
+++ b/docs-site/content/en/shortcuts.mdx
@@ -23,8 +23,8 @@ KanVibe keeps global, board, and task-detail shortcuts separated so terminal foc
 | `Cmd/Ctrl+Shift+I` | Board | Open the notifications dropdown |
 | `Cmd+[` / `Cmd+]` (macOS), `Ctrl+[` / `Ctrl+]` (Linux) | Global | Navigate back/forward through app history |
 | `Cmd/Ctrl+Shift+N` | Global | Open the current view in a new window |
-| `Cmd+Option+1/2/3` (macOS), `Alt+1/2/3` (Linux) | Task detail | Activate info, status/hooks, and AI chat dock items |
-| `Cmd+Option+4` (macOS), `Alt+4` (Linux) | Task detail | Open the PR in the browser when a PR exists |
+| `Cmd/Ctrl+1/2/3` | Task detail | Activate info, status/hooks, and AI chat dock items |
+| `Cmd/Ctrl+4` | Task detail | Open the PR in the browser when a PR exists |
 | `Cmd/Ctrl+N` | Global | Open the new task modal. Inside quick task search it creates a branch TODO from the highlighted task |
 | `↑ / ↓ / Enter / Shift+Enter / Esc` | Quick task search | Move selection, open, open in new window, close |
 | `↑ / ↓ / Enter / Esc` | Project filter | Move selection, toggle, close |
@@ -40,7 +40,7 @@ Tab actions work while the task detail terminal is visible; closing the window w
 | `Cmd/Ctrl+W` | Close the current tab; closes the window when it was the last tab, or when no terminal is open |
 | `Cmd/Ctrl+Shift+W` | Close the window regardless of open tabs |
 | `Cmd/Ctrl+Shift+[` / `Cmd/Ctrl+Shift+]` | Previous / next tab |
-| `Cmd/Ctrl+1` – `Cmd/Ctrl+5` | Jump straight to tab 1–5 |
+| `Cmd+Option+1` – `Cmd+Option+5` (macOS), `Ctrl+Alt+1` – `Ctrl+Alt+5` (Linux) | Jump straight to tab 1–5 |
 
 <div className="kv-note">
   On Linux these use `Ctrl`, so `Ctrl+T` (transpose), `Ctrl+W` (delete word), and `Ctrl+[` (ESC) no longer reach the shell inside the terminal.

--- a/docs-site/content/ko/shortcuts.mdx
+++ b/docs-site/content/ko/shortcuts.mdx
@@ -23,8 +23,8 @@ KanVibe는 터미널 포커스를 깨지 않도록 전역/보드/상세 단축�
 | `Cmd/Ctrl+Shift+I` | 보드 | 알림 드롭다운 열기 |
 | `Cmd+[` / `Cmd+]` (macOS), `Ctrl+[` / `Ctrl+]` (Linux) | 전역 | 앱 히스토리 뒤로/앞으로 이동 |
 | `Cmd/Ctrl+Shift+N` | 전역 | 현재 화면을 새 창으로 열기 |
-| `Cmd+Option+1/2/3` (macOS), `Alt+1/2/3` (Linux) | 태스크 상세 | 정보, 상태/hooks, AI 채팅 dock 항목 활성화 |
-| `Cmd+Option+4` (macOS), `Alt+4` (Linux) | 태스크 상세 | PR이 있으면 브라우저에서 PR 열기 |
+| `Cmd/Ctrl+1/2/3` | 태스크 상세 | 정보, 상태/hooks, AI 채팅 dock 항목 활성화 |
+| `Cmd/Ctrl+4` | 태스크 상세 | PR이 있으면 브라우저에서 PR 열기 |
 | `Cmd/Ctrl+N` | 전역 | 새 작업 모달 열기. 빠른 태스크 검색에서는 하이라이트된 태스크 기준으로 새 branch TODO를 만듭니다 |
 | `↑ / ↓ / Enter / Shift+Enter / Esc` | 빠른 태스크 검색 | 선택 이동, 열기, 새 창 열기, 닫기 |
 | `↑ / ↓ / Enter / Esc` | 프로젝트 필터 | 선택 이동, 토글, 닫기 |
@@ -40,7 +40,7 @@ KanVibe는 터미널 포커스를 깨지 않도록 전역/보드/상세 단축�
 | `Cmd/Ctrl+W` | 현재 탭 닫기. 마지막 탭이면 창까지 닫고, 터미널이 없는 화면에서는 창을 닫습니다 |
 | `Cmd/Ctrl+Shift+W` | 탭과 무관하게 창 닫기 |
 | `Cmd/Ctrl+Shift+[` / `Cmd/Ctrl+Shift+]` | 이전 / 다음 탭 |
-| `Cmd/Ctrl+1` ~ `Cmd/Ctrl+5` | 1~5번 탭으로 바로 이동 |
+| `Cmd+Option+1` ~ `Cmd+Option+5` (macOS), `Ctrl+Alt+1` ~ `Ctrl+Alt+5` (Linux) | 1~5번 탭으로 바로 이동 |
 
 <div className="kv-note">
   Linux에서는 이 단축키들이 `Ctrl` 조합이라 터미널 안의 `Ctrl+T`(문자 교환), `Ctrl+W`(단어 삭제), `Ctrl+[`(ESC)가 셸로 전달되지 않습니다.

--- a/docs-site/content/zh/shortcuts.mdx
+++ b/docs-site/content/zh/shortcuts.mdx
@@ -23,8 +23,8 @@ KanVibe 明确区分全局、看板和任务详情快捷键，让终端焦点保
 | `Cmd/Ctrl+Shift+I` | 看板 | 打开通知下拉框 |
 | `Cmd+[` / `Cmd+]` (macOS), `Ctrl+[` / `Ctrl+]` (Linux) | 全局 | 在应用历史中后退/前进 |
 | `Cmd/Ctrl+Shift+N` | 全局 | 在新窗口中打开当前页面 |
-| `Cmd+Option+1/2/3` (macOS), `Alt+1/2/3` (Linux) | 任务详情 | 激活信息、状态/hooks、AI 聊天 dock 项 |
-| `Cmd+Option+4` (macOS), `Alt+4` (Linux) | 任务详情 | 存在 PR 时在浏览器中打开 PR |
+| `Cmd/Ctrl+1/2/3` | 任务详情 | 激活信息、状态/hooks、AI 聊天 dock 项 |
+| `Cmd/Ctrl+4` | 任务详情 | 存在 PR 时在浏览器中打开 PR |
 | `Cmd/Ctrl+N` | 全局 | 打开新建任务弹窗。在快速任务搜索中则基于高亮任务创建 branch TODO |
 | `↑ / ↓ / Enter / Shift+Enter / Esc` | 快速任务搜索 | 移动选择、打开、新窗口打开、关闭 |
 | `↑ / ↓ / Enter / Esc` | 项目过滤 | 移动选择、切换、关闭 |
@@ -40,7 +40,7 @@ KanVibe 明确区分全局、看板和任务详情快捷键，让终端焦点保
 | `Cmd/Ctrl+W` | 关闭当前标签页；若是最后一个标签页则一并关闭窗口，在没有终端的界面上则直接关闭窗口 |
 | `Cmd/Ctrl+Shift+W` | 无论有多少标签页都直接关闭窗口 |
 | `Cmd/Ctrl+Shift+[` / `Cmd/Ctrl+Shift+]` | 上一个 / 下一个标签页 |
-| `Cmd/Ctrl+1` ~ `Cmd/Ctrl+5` | 直接跳转到第 1~5 个标签页 |
+| `Cmd+Option+1` ~ `Cmd+Option+5` (macOS), `Ctrl+Alt+1` ~ `Ctrl+Alt+5` (Linux) | 直接跳转到第 1~5 个标签页 |
 
 <div className="kv-note">
   在 Linux 上这些快捷键使用 `Ctrl` 组合，因此终端内的 `Ctrl+T`（交换字符）、`Ctrl+W`（删除单词）、`Ctrl+[`（ESC）不会再传递给 shell。

--- a/qa/electron/flows/terminal-tab.cjs
+++ b/qa/electron/flows/terminal-tab.cjs
@@ -11,8 +11,9 @@ const TERMINAL_TAB_SCOPE = "터미널 탭: terminal 세션에서 탭 생성·전
 
 /** Linux Electron에서 Mod는 Control이다 */
 const MOD_KEY = process.platform === "darwin" ? "Meta" : "Control";
-/** macOS의 `Cmd+숫자`는 탭 이동이 가져갔으므로 dock은 Option을 더해 비켜 간다 */
-const DOCK_SHORTCUT_PREFIX = process.platform === "darwin" ? "Meta+Alt+" : "Alt+";
+const DOCK_SHORTCUT_PREFIX = `${MOD_KEY}+`;
+/** `Mod+숫자`는 dock이 가져갔으므로 탭 번호 이동은 Alt를 더해 비켜 간다 */
+const TAB_NUMBER_SHORTCUT_PREFIX = `${MOD_KEY}+Alt+`;
 
 /** 정리 명령이 응답하지 않아도 QA 실행이 끝나야 한다 */
 const SESSION_CLEANUP_TIMEOUT_MS = 10_000;
@@ -400,18 +401,18 @@ async function main() {
       return `${before.length} -> ${tabs.length}`;
     });
 
-    await optionalStep(checks, `요구사항① ${MOD_KEY}+1 로 1번 탭으로 바로 이동한다`, async () => {
+    await optionalStep(checks, `요구사항① ${TAB_NUMBER_SHORTCUT_PREFIX}1 로 1번 탭으로 바로 이동한다`, async () => {
       const before = await readTabs(page);
       if (before.findIndex((tab) => tab.isActive) === 0) {
-        await page.keyboard.press(`${MOD_KEY}+2`);
+        await page.keyboard.press(`${TAB_NUMBER_SHORTCUT_PREFIX}2`);
         await waitForTabs(page, (list) => list.findIndex((tab) => tab.isActive) === 1, "2번 탭으로 이동하지 않았다");
       }
 
-      await page.keyboard.press(`${MOD_KEY}+1`);
+      await page.keyboard.press(`${TAB_NUMBER_SHORTCUT_PREFIX}1`);
       const tabs = await waitForTabs(
         page,
         (list) => list.findIndex((tab) => tab.isActive) === 0,
-        `${MOD_KEY}+1로 1번 탭이 활성이 되지 않았다`,
+        `${TAB_NUMBER_SHORTCUT_PREFIX}1로 1번 탭이 활성이 되지 않았다`,
       );
       await takeScreenshot(page, run, "terminal-session-shortcut-go-to-tab", screenshots);
       return `activeIndex -> ${tabs.findIndex((tab) => tab.isActive)}`;

--- a/src/desktop/renderer/components/__tests__/TerminalTabBar.test.tsx
+++ b/src/desktop/renderer/components/__tests__/TerminalTabBar.test.tsx
@@ -123,8 +123,8 @@ describe("TerminalTabBar", () => {
     renderTabBar();
 
     const [firstTab, secondTab] = screen.getAllByRole("tab");
-    expect(firstTab.textContent).toContain("Ctrl+1");
-    expect(secondTab.textContent).toContain("Ctrl+2");
+    expect(firstTab.textContent).toContain("Ctrl+Alt+1");
+    expect(secondTab.textContent).toContain("Ctrl+Alt+2");
   });
 
   it("6번째 탭부터는 대응하는 단축키가 없어 힌트를 붙이지 않는다", () => {
@@ -137,8 +137,8 @@ describe("TerminalTabBar", () => {
     renderTabBar({ tabs: manyTabs });
 
     const tabs = screen.getAllByRole("tab");
-    expect(tabs[4].textContent).toContain("Ctrl+5");
-    expect(tabs[5].textContent).not.toContain("Ctrl+");
+    expect(tabs[4].textContent).toContain("Ctrl+Alt+5");
+    expect(tabs[5].textContent).not.toContain("Ctrl+Alt+");
   });
 
   it("활성 탭 양옆에는 구분선을 겹쳐 그리지 않는다", () => {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -759,7 +759,7 @@ describe("TaskDetailRoute", () => {
 
     const wasNotPrevented = fireEvent.keyDown(terminalInput, {
       key: "1",
-      altKey: true,
+      ctrlKey: true,
     });
     terminalInput.removeEventListener("keydown", terminalKeyDown);
     window.removeEventListener("keydown", windowBubbleKeyDown);
@@ -797,11 +797,11 @@ describe("TaskDetailRoute", () => {
     );
 
     const prLink = await screen.findByRole("link", { name: "PR" });
-    expect(prLink.getAttribute("title")).toContain("Alt+4");
+    expect(prLink.getAttribute("title")).toContain("Ctrl+4");
 
     const wasNotPrevented = fireEvent.keyDown(window, {
       key: "4",
-      altKey: true,
+      ctrlKey: true,
     });
 
     expect(wasNotPrevented).toBe(false);
@@ -995,7 +995,7 @@ describe("TaskDetailRoute", () => {
 
     const wasNotPrevented = fireEvent.keyDown(window, {
       key: "2",
-      altKey: true,
+      ctrlKey: true,
     });
     act(() => {
       dockShortcutListener?.(2);

--- a/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
+++ b/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
@@ -119,6 +119,7 @@ describe("keyboardShortcut", () => {
       const macEvent = new KeyboardEvent("keydown", {
         key: String(shortcutIndex),
         metaKey: true,
+        altKey: true,
       });
 
       expect(matchTerminalTabShortcutEvent(macEvent, "mac")).toBe(shortcutIndex);
@@ -130,7 +131,9 @@ describe("keyboardShortcut", () => {
   it("탭 번호 단축키는 macOS 스크린샷 조합인 Cmd+Shift+숫자를 쓰지 않는다", () => {
     for (const shortcutIndex of TERMINAL_TAB_SHORTCUT_INDEXES) {
       expect(formatShortcutForDisplay(createTerminalTabShortcut(shortcutIndex), "mac"))
-        .toBe(`Cmd+${shortcutIndex}`);
+        .toBe(`Cmd+Option+${shortcutIndex}`);
+      expect(formatShortcutForDisplay(createTerminalTabShortcut(shortcutIndex), "linux"))
+        .toBe(`Ctrl+Alt+${shortcutIndex}`);
       expect(matchShortcutEvent(new KeyboardEvent("keydown", {
         key: String(shortcutIndex),
         metaKey: true,
@@ -140,14 +143,14 @@ describe("keyboardShortcut", () => {
   });
 
   it("dock 번호 입력은 탭 번호 단축키로 매칭하지 않는다", () => {
-    const dockEvent = new KeyboardEvent("keydown", { key: "1", altKey: true });
+    const dockEvent = new KeyboardEvent("keydown", { key: "1", ctrlKey: true });
 
     expect(matchTaskDetailDockShortcutEvent(dockEvent, "linux")).toBe(1);
     expect(matchTerminalTabShortcutEvent(dockEvent, "linux")).toBeNull();
   });
 
-  it("macOS dock 입력은 Option이 더해져 탭 번호 단축키와 갈린다", () => {
-    const dockEvent = new KeyboardEvent("keydown", { key: "1", metaKey: true, altKey: true });
+  it("macOS dock 입력은 Option이 없어 탭 번호 단축키와 갈린다", () => {
+    const dockEvent = new KeyboardEvent("keydown", { key: "1", metaKey: true });
 
     expect(matchTaskDetailDockShortcutEvent(dockEvent, "mac")).toBe(1);
     expect(matchTerminalTabShortcutEvent(dockEvent, "mac")).toBeNull();
@@ -158,6 +161,7 @@ describe("keyboardShortcut", () => {
       type: "keyDown",
       key: "3",
       control: true,
+      alt: true,
     }, "linux")).toBe(3);
   });
 
@@ -278,32 +282,32 @@ describe("keyboardShortcut", () => {
     }, SHORTCUTS.pageForward, "linux")).toBe(true);
   });
 
-  it("상세 dock shortcut은 macOS Cmd+Option+숫자와 Linux Alt+숫자로 표시하고 매칭한다", () => {
+  it("상세 dock shortcut은 macOS Cmd+숫자와 Linux Ctrl+숫자로 표시하고 매칭한다", () => {
     expect(TASK_DETAIL_DOCK_SHORTCUT_INDEXES).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "mac")).toBe("Cmd+Option+1");
-    expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "linux")).toBe("Alt+1");
+    expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "mac")).toBe("Cmd+1");
+    expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "linux")).toBe("Ctrl+1");
 
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "1",
       metaKey: true,
-      altKey: true,
     }), createTaskDetailDockShortcut(1), "mac")).toBe(true);
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "1",
-      altKey: true,
+      ctrlKey: true,
     }), createTaskDetailDockShortcut(1), "linux")).toBe(true);
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "1",
       metaKey: true,
+      altKey: true,
     }), createTaskDetailDockShortcut(1), "mac")).toBe(false);
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "1",
-      altKey: true,
+      ctrlKey: true,
       shiftKey: true,
     }), createTaskDetailDockShortcut(1), "linux")).toBe(false);
     expect(matchShortcutEvent(new KeyboardEvent("keydown", {
       key: "1",
-      ctrlKey: true,
+      altKey: true,
     }), createTaskDetailDockShortcut(1), "linux")).toBe(false);
   });
 
@@ -311,15 +315,14 @@ describe("keyboardShortcut", () => {
     expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
       key: "4",
       metaKey: true,
-      altKey: true,
     }), "mac")).toBe(4);
     expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
       key: "4",
-      altKey: true,
+      ctrlKey: true,
     }), "linux")).toBe(4);
     expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
       key: "4",
-      ctrlKey: true,
+      altKey: true,
     }), "linux")).toBeNull();
   });
 
@@ -368,13 +371,13 @@ describe("keyboardShortcut", () => {
 });
 
 describe("터미널 탭 단축키 명령 해석", () => {
-  const macInput = (key: string, modifiers: { meta?: boolean; shift?: boolean } = {}) => ({
+  const macInput = (key: string, modifiers: { meta?: boolean; alt?: boolean; shift?: boolean } = {}) => ({
     type: "keyDown",
     isAutoRepeat: false,
     key,
     meta: modifiers.meta ?? false,
     control: false,
-    alt: false,
+    alt: modifiers.alt ?? false,
     shift: modifiers.shift ?? false,
   });
 
@@ -388,7 +391,7 @@ describe("터미널 탭 단축키 명령 해석", () => {
   });
 
   it("숫자 단축키는 이동할 탭 위치를 담는다", () => {
-    expect(resolveTerminalTabShortcutCommand(macInput("3", { meta: true }), "mac", true))
+    expect(resolveTerminalTabShortcutCommand(macInput("3", { meta: true, alt: true }), "mac", true))
       .toEqual({ type: "go-to-tab", position: 3 });
   });
 
@@ -432,7 +435,7 @@ describe("렌더러 keydown도 같은 탭 명령으로 해석한다", () => {
 
   it("렌더러 경로에서도 탭 번호와 창 닫기를 해석한다", () => {
     expect(resolveTerminalTabShortcutEvent(
-      new KeyboardEvent("keydown", { key: "2", ctrlKey: true }),
+      new KeyboardEvent("keydown", { key: "2", ctrlKey: true, altKey: true }),
       "linux",
       true,
     )).toEqual({ type: "go-to-tab", position: 2 });

--- a/src/desktop/shared/keyboardShortcut.ts
+++ b/src/desktop/shared/keyboardShortcut.ts
@@ -279,15 +279,9 @@ export function matchElectronShortcutInput(
   }, shortcut, platform);
 }
 
-/**
- * dock 항목 n번을 여는 단축키.
- * macOS의 `Cmd+숫자`는 터미널 탭 이동이 가져갔으므로 Option을 더해 비켜 간다.
- */
+/** dock 항목 n번을 여는 단축키 */
 export function createTaskDetailDockShortcut(index: TaskDetailDockShortcutIndex): ShortcutDefinition {
-  return {
-    mac: `Meta+Alt+${index}`,
-    linux: `Alt+${index}`,
-  };
+  return `Mod+${index}`;
 }
 
 export function matchTaskDetailDockShortcutEvent(
@@ -317,11 +311,11 @@ export function matchTaskDetailDockShortcutInput(
 }
 
 /**
- * 터미널 탭 n번으로 바로 이동하는 단축키. 브라우저·터미널 앱이 쓰는 `Mod+숫자` 관례를 따른다.
- * macOS의 `Cmd+Shift+3~5`는 OS 스크린샷이 먼저 가져가 앱에 도달하지 않으므로 Shift를 쓸 수 없다.
+ * 터미널 탭 n번으로 바로 이동하는 단축키. `Mod+숫자`는 dock 항목이 쓰므로 Alt를 더해 비켜 간다.
+ * macOS의 `Cmd+Shift+3~5`는 OS 스크린샷이 먼저 가져가 앱에 도달하지 않으므로 Shift로는 비켜 갈 수 없다.
  */
 export function createTerminalTabShortcut(index: TerminalTabShortcutIndex): ShortcutDefinition {
-  return `Mod+${index}`;
+  return `Mod+Alt+${index}`;
 }
 
 export function matchTerminalTabShortcutEvent(


### PR DESCRIPTION
## 요약

`Cmd+1`로 작업 정보 패널이 열리지 않는 문제를 고친다. PR #331이 터미널 탭 이동에 `Mod+숫자`를 주고 dock을 `Cmd+Option+숫자`로 밀었는데, 합의된 배치는 그 반대다. 두 자리를 맞바꾼다.

| 명령 | AS-IS (#331) | TO-BE |
| --- | --- | --- |
| 태스크 상세 dock n번 | `Cmd+Option+{n}` / `Alt+{n}` | `Mod+{n}` — `Cmd+{n}` / `Ctrl+{n}` |
| 터미널 탭 n번 이동 | `Mod+{n}` | `Mod+Alt+{n}` — `Cmd+Option+{n}` / `Ctrl+Alt+{n}` |

## 설계

바뀌는 것은 `src/desktop/shared/keyboardShortcut.ts`의 팩토리 두 개뿐이다. 매칭·표시·Electron `before-input-event` 가로채기는 모두 이 두 함수를 거치므로 정의만 바꾸면 렌더러와 main이 함께 따라온다. `electron/main.js`는 dock을 탭 명령보다 먼저 검사하지만 두 조합의 modifier 상태가 서로 배타적이라 순서는 영향이 없다.

Linux도 macOS와 같은 모양으로 맞췄다. 그 결과 두 정의가 모두 `Mod`로 표현돼 플랫폼별 레코드(`{ mac, linux }`)가 필요 없어졌고, CLAUDE.md의 "cross-platform 단축키는 `Mod`로 표현한다" 규약과도 맞아떨어진다.

`Cmd+Shift+{숫자}`를 쓰지 말라는 규약은 근거(macOS가 `Cmd+Shift+3/4/5`를 스크린샷으로 선점)가 그대로여서 유지했다.

## 검증

| 게이트 | 결과 |
| --- | --- |
| `pnpm test` | 1054 passed / 108 files |
| `pnpm exec tsc --noEmit` | 0 errors |
| `pnpm lint` | 0 errors |
| `pnpm qa:terminal-tab` (Electron 영상 QA) | 아래 참조 |

Electron QA에서 이번 변경의 핵심 두 가지가 실기로 확인됐다. 5회 실행 전부 통과했다.

- `Ctrl+1` → 작업 정보 패널이 열리고 닫힌다
- `Ctrl+Alt+1` → 1번 탭으로 이동한다 (`activeIndex -> 0`)

## 알려진 이슈 — 드래그 탭 재정렬 QA 스텝의 불안정성

QA 실행 5회에서 드래그 재정렬 스텝의 결과가 갈렸다.

| 트리 | 1회 | 2회 | 3회 |
| --- | --- | --- | --- |
| 이 브랜치 | FAIL (terminal 드래그) | FAIL (terminal + zellij 드래그) | PASS |
| `origin/dev` 기준선 | PASS | PASS | — |

동일한 브랜치 트리에서 3회차가 드래그 포함 전체 통과했고, 이 PR의 diff에는 드래그 관련 코드가 한 줄도 없다(변경은 단축키 정의·테스트·문서·QA 키 상수뿐). 따라서 결정적으로 깨진 것이 아니라 Playwright `dragTo`(HTML5 DnD 시뮬레이션) 스텝이 불안정한 것으로 본다. 다만 기준선보다 실패 빈도가 높게 나온 것은 사실이므로 숨기지 않고 남긴다. 이 스텝의 안정화는 이번 범위 밖으로 둔다.

## 실기 검증하지 못한 것

- **macOS 실기 검증은 못 했다.** 개발·QA 환경이 Linux다. macOS 조합(`Cmd+{n}`, `Cmd+Option+{n}`)은 공유 matcher 단위 테스트로만 덮여 있다. 다만 `Cmd+Option+{n}`은 #331이 dock에 쓰던 자리라 앱에 도달하는 것 자체는 이미 확인된 조합이다.
- **Linux의 `Ctrl+Alt+{숫자}`는 데스크톱 환경이 선점할 수 있다.** KDE·XFCE·i3 등에서 워크스페이스 전환에 흔히 쓰인다. Xvfb QA에는 WM이 없어 이 충돌이 드러나지 않으므로, 실기 환경에서 확인이 필요하다.

## 문서

`docs-site` 세 로케일(ko/en/zh)의 단축키 표 두 줄을 맞바꿨다. `CLAUDE.md`의 dock·탭 단축키 규약도 새 배치로 갱신했다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>