### PR TITLE
chore(release): publish KanVibe 1.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Publish KanVibe 1.0.8. This PR carries only the version bump; the DMG release and Homebrew cask update are already live.

- `package.json` / `package-lock.json`: `1.0.7` → `1.0.8`

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.0.8
- DMG asset: `dist/KanVibe-1.0.8.dmg` (168,470,116 bytes)
- SHA-256: `29601477889cba19cfc208c24c7209981f4fcb5344e21aeaa0b2f0f9bf70020b`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@27d85c2` — `brew fetch --cask rookedsysc/kanvibe/kanvibe` → `✔︎ Cask kanvibe (1.0.8)`

## Test Plan

- [x] `pnpm install --frozen-lockfile` — native rebuild completed under pnpm 10.34.5
- [x] `pnpm run deploy` — collector `pm=npm`, packaging guard `278 packages verified`, notarization `Accepted`, staple validated
- [x] Smoke test on the published bundle: `spctl -a -t exec` → `accepted / source=Notarized Developer ID`; process alive after launch; module-error count `0`; `invoke-succeeded` count `74`
- [x] `curl -sL <release asset> | shasum -a 256` matches the local DMG hash byte-for-byte
- [x] `gh api repos/rookedsysc/kanvibe/releases/latest` → `1.0.8`
