### PR TITLE
fix(project-filter): IME 조합 중 검색 입력 반영

### DIFF
--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -66,7 +66,6 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
   const [searchQuery, setSearchQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
-  const isComposingRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const optionItemRefs = useRef<Array<HTMLLIElement | null>>([]);
@@ -180,21 +179,7 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
 
   const handleSearchInput = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (isComposingRef.current) return;
       setSearchQuery(e.target.value);
-      setHighlightedIndex(0);
-    },
-    []
-  );
-
-  const handleCompositionStart = useCallback(() => {
-    isComposingRef.current = true;
-  }, []);
-
-  const handleCompositionEnd = useCallback(
-    (e: React.CompositionEvent<HTMLInputElement>) => {
-      isComposingRef.current = false;
-      setSearchQuery(e.currentTarget.value);
       setHighlightedIndex(0);
     },
     []
@@ -323,8 +308,6 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
                 ref={searchInputRef}
                 type="text"
                 value={searchQuery}
-                onCompositionStart={handleCompositionStart}
-                onCompositionEnd={handleCompositionEnd}
                 onChange={handleSearchInput}
                 placeholder={searchPlaceholder}
                 className="w-full px-2 py-1 text-sm bg-bg-page border border-border-default rounded text-text-primary focus:outline-none focus:border-brand-primary"
@@ -493,8 +476,6 @@ const ProjectSelector = forwardRef<ProjectSelectorHandle, ProjectSelectorProps>(
               ref={searchInputRef}
               type="text"
               value={searchQuery}
-              onCompositionStart={handleCompositionStart}
-              onCompositionEnd={handleCompositionEnd}
               onChange={handleSearchInput}
               placeholder={searchPlaceholder}
               className="w-full px-2 py-1 text-sm bg-bg-page border border-border-default rounded text-text-primary focus:outline-none focus:border-brand-primary"

--- a/src/components/__tests__/ProjectSelector.test.tsx
+++ b/src/components/__tests__/ProjectSelector.test.tsx
@@ -144,6 +144,58 @@ describe("ProjectSelector chip truncation", () => {
     expect(screen.queryByText("Local API")).toBeNull();
   });
 
+  it("should filter projects while Korean text is still composing", () => {
+    const selectorProjects = [
+      createProject("korean", "한글 프로젝트"),
+      createProject("english", "English Project"),
+    ];
+
+    render(
+      <ProjectSelector
+        multiple
+        projects={selectorProjects}
+        selectedProjectIds={[]}
+        onSelectionChange={vi.fn()}
+        placeholder="All projects"
+        searchPlaceholder="Search project..."
+      />,
+    );
+
+    fireEvent.click(screen.getByText("All projects"));
+    const searchInput = screen.getByPlaceholderText("Search project...");
+    fireEvent.compositionStart(searchInput);
+    fireEvent.change(searchInput, { target: { value: "한글" } });
+
+    expect(screen.getByText("한글 프로젝트")).toBeTruthy();
+    expect(screen.queryByText("English Project")).toBeNull();
+  });
+
+  it("should keep filtering when English is entered after an unfinished composition", () => {
+    const selectorProjects = [
+      createProject("korean", "한글 프로젝트"),
+      createProject("english", "English Project"),
+    ];
+
+    render(
+      <ProjectSelector
+        multiple
+        projects={selectorProjects}
+        selectedProjectIds={[]}
+        onSelectionChange={vi.fn()}
+        placeholder="All projects"
+        searchPlaceholder="Search project..."
+      />,
+    );
+
+    fireEvent.click(screen.getByText("All projects"));
+    const searchInput = screen.getByPlaceholderText("Search project...");
+    fireEvent.compositionStart(searchInput);
+    fireEvent.change(searchInput, { target: { value: "English" } });
+
+    expect(screen.getByText("English Project")).toBeTruthy();
+    expect(screen.queryByText("한글 프로젝트")).toBeNull();
+  });
+
   it("should keep selected projects at the top and toggle the highlighted project after imperative open", () => {
     const ref = createRef<ProjectSelectorHandle>();
     const onSelectionChange = vi.fn();


### PR DESCRIPTION
## 어떤 작업인가요?
- 프로젝트 필터 검색창이 한국어 IME 조합 중 입력을 반영하지 않고, 조합 상태가 끝나지 않으면 이후 영어 입력도 검색되지 않는 문제를 수정합니다.

## 어떻게 해결했나요?
**검색 상태 동기화**
- composition 여부와 관계없이 모든 change 이벤트의 현재 입력값을 검색 상태에 반영합니다.
- 입력을 버리던 composition 전용 상태와 핸들러를 제거합니다.

**회귀 방지**
- 한국어 조합 중 즉시 목록이 필터링되는 경로를 검증합니다.
- compositionEnd 없이 영어가 입력돼도 목록이 필터링되는 경로를 검증합니다.

## 중요한 변경 사항은 무엇인가요?
### 프로젝트 필터 입력 처리

**IME 입력 이벤트를 검색 상태에 즉시 반영**
- **변경 이유**: composition 중 change 이벤트를 무시하면 한글 검색이 지연되고 종료 이벤트 누락 시 다른 언어 입력까지 계속 무시됩니다.
- **수정 파일**: src/components/ProjectSelector.tsx

**한국어·영어 회귀 테스트 추가**
- **변경 이유**: Electron 환경에서 발생 가능한 composition 이벤트 순서를 컴포넌트 테스트로 고정합니다.
- **수정 파일**: src/components/__tests__/ProjectSelector.test.tsx

Co-Authored-By: OpenAI Codex <codex@openai.com>