### PR TITLE
chore(release): publish KanVibe 1.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

- Bump the KanVibe desktop package version from `1.0.8` to `1.0.9`.
- Publish the signed, notarized, stapled DMG and update the Homebrew cask to the same artifact checksum.

## Test Plan

- `pnpm install --frozen-lockfile`
- `pnpm run deploy`
- Packaging collector: `pm=npm`
- Packaged dependency guard: `278 packages`
- Gatekeeper: accepted, Notarized Developer ID
- Smoke test: app alive, module errors `0`, `invoke-succeeded` `14`
- `xcrun stapler validate dist/KanVibe-1.0.9.dmg`
- `brew fetch --cask rookedsysc/kanvibe/kanvibe`

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.0.9
- DMG: `dist/KanVibe-1.0.9.dmg`
- SHA-256: `9b1861411d0ff9a4e9c729e61f6f063b10fbfd7b4112d59f5c80e020b2e9b060`
- Homebrew cask commit: `eeb5c3a7e61b8fe4cd4c6e094d47e3be0050a28b`
- Homebrew status: `Cask kanvibe (1.0.9)` fetched successfully
