### PR TITLE
feat: task 및 project priority 공유 저장 추가

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -2509,6 +2509,56 @@ describe("kanbanService.updateTask", () => {
     );
   });
 
+  it("일반 task priority를 task.json에 기록한다", async () => {
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-1",
+      title: "알림 회귀 수정",
+      description: "설명",
+      priority: null,
+      worktreePath: "/workspace/repo-worktrees/task-1",
+      sshHost: null,
+      projectId: "project-1",
+      branchName: "fix/notifications",
+    });
+
+    const { updateTask } = await import("@/desktop/main/services/kanbanService");
+    await updateTask("task-1", { priority: "high" as never });
+
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/workspace/repo-worktrees/task-1/.kanvibe/task.json",
+      expect.stringContaining('"priority": "high"'),
+      null,
+    );
+  });
+
+  it("project root task priority를 project.json에 기록한다", async () => {
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-main",
+      title: "main",
+      description: null,
+      priority: null,
+      worktreePath: "/workspace/repo",
+      sshHost: null,
+      projectId: "project-1",
+      branchName: "main",
+    });
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-1",
+      repoPath: "/workspace/repo",
+      defaultBranch: "main",
+      sshHost: null,
+    });
+
+    const { updateTask } = await import("@/desktop/main/services/kanbanService");
+    await updateTask("task-main", { priority: "medium" as never });
+
+    expect(mocks.writeTextFile).toHaveBeenCalledWith(
+      "/workspace/repo/.kanvibe/project.json",
+      expect.stringContaining('"priority": "medium"'),
+      null,
+    );
+  });
+
   it("설명이 빠진 부분 수정은 공유 설명 파일을 건드리지 않는다", async () => {
     // Given
     mocks.taskRepo.findOneBy.mockResolvedValue({

--- a/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
+++ b/src/desktop/main/services/__tests__/kanvibeProjectColorService.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   readKanvibeProjectColor: vi.fn(),
   writeKanvibeProjectColor: vi.fn(),
   writeKanvibeProjectColorIfAbsent: vi.fn(),
+  writeKanvibeProjectPriority: vi.fn(),
 }));
 
 vi.mock("@/lib/database", () => ({
@@ -25,11 +26,13 @@ vi.mock("@/lib/kanvibeProjectState", async (importOriginal) => ({
   readKanvibeProjectColor: mocks.readKanvibeProjectColor,
   writeKanvibeProjectColor: mocks.writeKanvibeProjectColor,
   writeKanvibeProjectColorIfAbsent: mocks.writeKanvibeProjectColorIfAbsent,
+  writeKanvibeProjectPriority: mocks.writeKanvibeProjectPriority,
 }));
 
 import type { Project } from "@/entities/Project";
 import {
   persistProjectColorToKanvibeState,
+  persistProjectPriorityToKanvibeState,
   readSharedProjectColor,
   syncProjectColorWithKanvibeState,
 } from "@/desktop/main/services/kanvibeProjectColorService";
@@ -59,6 +62,7 @@ describe("kanvibeProjectColorService", () => {
     mocks.addAiToolPatternsToGitExclude.mockResolvedValue(undefined);
     mocks.writeKanvibeProjectColor.mockResolvedValue(undefined);
     mocks.writeKanvibeProjectColorIfAbsent.mockResolvedValue(undefined);
+    mocks.writeKanvibeProjectPriority.mockResolvedValue(undefined);
     vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
@@ -74,6 +78,20 @@ describe("kanvibeProjectColorService", () => {
     expect(mocks.writeKanvibeProjectColor.mock.calls).toEqual([
       ["/workspace/kanvibe", "#65D08A", "remote-host"],
       ["/workspace/kanvibe__worktrees/feature", "#65D08A", "remote-host"],
+    ]);
+  });
+
+  it("project root task priority를 루트와 소속 worktree에 모두 기록한다", async () => {
+    mocks.taskRepo.findBy.mockResolvedValue([
+      { worktreePath: "/workspace/kanvibe__worktrees/feature" },
+      { worktreePath: null },
+    ]);
+
+    await persistProjectPriorityToKanvibeState(createProject({ sshHost: "remote-host" }), "high" as never);
+
+    expect(mocks.writeKanvibeProjectPriority.mock.calls).toEqual([
+      ["/workspace/kanvibe", "high", "remote-host"],
+      ["/workspace/kanvibe__worktrees/feature", "high", "remote-host"],
     ]);
   });
 

--- a/src/desktop/main/services/__tests__/projectService.test.ts
+++ b/src/desktop/main/services/__tests__/projectService.test.ts
@@ -2075,6 +2075,7 @@ describe("projectService local hook installation", () => {
       [
         "/workspace/api__worktrees/feature-review/.kanvibe/status.json",
         "/workspace/api__worktrees/feature-review/.kanvibe/task.json",
+        "/workspace/api/.kanvibe/project.json",
       ],
       null,
     );
@@ -2852,5 +2853,42 @@ describe("projectService task description sync", () => {
     // Then
     expect(result.changed).toBe(false);
     expect(save).not.toHaveBeenCalled();
+  });
+
+  it("task priority가 있으면 project priority보다 우선해 DB로 가져온다", async () => {
+    const save = vi.fn(async (value) => value);
+    mockWorktreeTaskRepository(save);
+    mockSharedTaskFiles({
+      [`${WORKTREE_PATH}/.kanvibe/task.json`]: JSON.stringify({ priority: "low" }),
+      "/workspace/api/.kanvibe/project.json": JSON.stringify({ priority: "high" }),
+    });
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+    await syncRegisteredProjectWorktrees();
+
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({
+      id: "task-login",
+      priority: "low",
+    }));
+  });
+
+  it("task priority가 없으면 project priority를 DB로 가져온다", async () => {
+    const save = vi.fn(async (value) => value);
+    mockWorktreeTaskRepository(save);
+    mockSharedTaskFiles({
+      "/workspace/api/.kanvibe/project.json": JSON.stringify({ priority: "high" }),
+    });
+
+    const { syncRegisteredProjectWorktrees } = await import("@/desktop/main/services/projectService");
+    await syncRegisteredProjectWorktrees();
+
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({
+      id: "task-main",
+      priority: "high",
+    }));
+    expect(save).not.toHaveBeenCalledWith(expect.objectContaining({
+      id: "task-login",
+      priority: "high",
+    }));
   });
 });

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -21,7 +21,7 @@ import {
 import { execGit, pullCurrentBranch, remoteBranchExists } from "@/lib/gitOperations";
 import { detachSession } from "@/lib/terminal";
 import {
-  persistTaskDescriptionForTask as persistTaskDescription,
+  persistTaskMetadataForTask as persistTaskMetadata,
   persistTaskStateForTask as persistTaskState,
 } from "@/desktop/main/services/kanvibeTaskStateService";
 import { persistProjectColorToKanvibeState } from "@/desktop/main/services/kanvibeProjectColorService";
@@ -575,8 +575,8 @@ export async function createTask(input: CreateTaskInput): Promise<KanbanTask> {
 
   await persistTaskState(saved);
 
-  if (saved.description) {
-    await persistTaskDescription(saved);
+  if (saved.description || saved.priority) {
+    await persistTaskMetadata(saved);
   }
 
   broadcastBoardUpdate();
@@ -615,8 +615,8 @@ export async function updateTask(
 
   const saved = await repo.save(task);
 
-  if (updates.description !== undefined) {
-    await persistTaskDescription(saved);
+  if (updates.description !== undefined || updates.priority !== undefined) {
+    await persistTaskMetadata(saved);
   }
 
   broadcastBoardUpdate();

--- a/src/desktop/main/services/kanvibeProjectColorService.ts
+++ b/src/desktop/main/services/kanvibeProjectColorService.ts
@@ -1,4 +1,5 @@
 import type { Project } from "@/entities/Project";
+import type { TaskPriority } from "@/entities/TaskPriority";
 import { getProjectRepository, getTaskRepository } from "@/lib/database";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
 import {
@@ -6,6 +7,7 @@ import {
   readKanvibeProjectColor,
   writeKanvibeProjectColor,
   writeKanvibeProjectColorIfAbsent,
+  writeKanvibeProjectPriority,
 } from "@/lib/kanvibeProjectState";
 
 /**
@@ -17,7 +19,8 @@ import {
  * 되돌아간 루트 값이 다음 sync에서 다시 DB로 내려가 색이 왕복하게 된다.
  */
 
-type ColorSyncProject = Pick<Project, "id" | "repoPath" | "sshHost" | "color">;
+type ProjectStateSyncProject = Pick<Project, "id" | "repoPath" | "sshHost">;
+type ColorSyncProject = ProjectStateSyncProject & Pick<Project, "color">;
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -38,11 +41,31 @@ export async function persistProjectColorToKanvibeState(project: ColorSyncProjec
 
   await writeProjectColorQuietly(project.repoPath, projectColor, project.sshHost);
 
-  const worktreePaths = (await resolveProjectColorRepoPaths(project))
+  const worktreePaths = (await resolveProjectStateRepoPaths(project))
     .filter((repoPath) => repoPath !== project.repoPath);
   await Promise.all(
     worktreePaths.map((repoPath) => writeProjectColorQuietly(repoPath, projectColor, project.sshHost)),
   );
+}
+
+/** root task priority를 프로젝트 공유 값으로 저장하고 소속 worktree에도 전파한다 */
+export async function persistProjectPriorityToKanvibeState(
+  project: ProjectStateSyncProject,
+  priority: TaskPriority | null,
+): Promise<void> {
+  await excludeKanvibeStateDirectory(project);
+  const repoPaths = await resolveProjectStateRepoPaths(project);
+  await Promise.all(repoPaths.map(async (repoPath) => {
+    try {
+      await writeKanvibeProjectPriority(repoPath, priority, project.sshHost);
+    } catch (error) {
+      console.warn("[project-priority] .kanvibe priority 기록 실패", {
+        repoPath,
+        sshHost: project.sshHost ?? null,
+        error: getErrorMessage(error),
+      });
+    }
+  }));
 }
 
 /** 한 경로의 색상 기록 실패가 나머지 경로 기록을 막지 않도록 경고만 남긴다 */
@@ -62,7 +85,7 @@ async function writeProjectColorQuietly(
   }
 }
 
-async function excludeKanvibeStateDirectory(project: ColorSyncProject): Promise<void> {
+async function excludeKanvibeStateDirectory(project: ProjectStateSyncProject): Promise<void> {
   try {
     await addAiToolPatternsToGitExclude(project.repoPath, project.sshHost);
   } catch (error) {
@@ -171,7 +194,7 @@ async function propagateSharedProjectColorToWorktrees(
   project: ColorSyncProject,
   sharedColor: string,
 ): Promise<void> {
-  const worktreePaths = (await resolveProjectColorRepoPaths(project))
+  const worktreePaths = (await resolveProjectStateRepoPaths(project))
     .filter((repoPath) => repoPath !== project.repoPath);
 
   const outdatedPaths = (await Promise.all(
@@ -191,8 +214,8 @@ async function propagateSharedProjectColorToWorktrees(
   );
 }
 
-/** 색상을 기록할 저장소 경로 목록. 프로젝트 루트와 소속 task worktree를 포함한다 */
-async function resolveProjectColorRepoPaths(project: ColorSyncProject): Promise<string[]> {
+/** 프로젝트 공유 상태를 기록할 경로 목록. 프로젝트 루트와 소속 task worktree를 포함한다 */
+async function resolveProjectStateRepoPaths(project: ProjectStateSyncProject): Promise<string[]> {
   const repoPaths = new Set<string>([project.repoPath]);
 
   try {

--- a/src/desktop/main/services/kanvibeTaskStateService.ts
+++ b/src/desktop/main/services/kanvibeTaskStateService.ts
@@ -1,11 +1,12 @@
 import type { KanbanTask, TaskStatus } from "@/entities/KanbanTask";
 import { getProjectRepository } from "@/lib/database";
 import { addAiToolPatternsToGitExclude } from "@/lib/gitExclude";
+import { persistProjectPriorityToKanvibeState } from "@/desktop/main/services/kanvibeProjectColorService";
 import type { KanvibeTaskSyncState } from "@/lib/kanvibeProjectState";
 import {
   readKanvibeTaskState,
   readKanvibeTaskSyncState,
-  writeKanvibeTaskDescription,
+  writeKanvibeTaskMetadata,
   writeKanvibeTaskStatus,
 } from "@/lib/kanvibeProjectState";
 
@@ -16,15 +17,16 @@ type TaskWithOptionalLocation = Pick<KanbanTask, "id" | "status" | "worktreePath
   branchName?: string | null;
 };
 
-type TaskDescriptionTask = Pick<KanbanTask, "id" | "description" | "worktreePath" | "sshHost"> & {
+type TaskMetadataTask = Pick<KanbanTask, "id" | "description" | "priority" | "worktreePath" | "sshHost"> & {
   projectId?: string | null;
   branchName?: string | null;
 };
 
 type ProjectTaskStateLocation = {
+  id: string;
   repoPath: string;
   defaultBranch: string;
-  sshHost?: string | null;
+  sshHost: string | null;
 };
 
 function getErrorMessage(error: unknown): string {
@@ -46,12 +48,13 @@ export async function readPersistedTaskStatusAtPath(
 export async function readPersistedTaskSyncStateAtPath(
   repoPath: string | null | undefined,
   sshHost?: string | null,
+  projectRepoPath?: string,
 ): Promise<KanvibeTaskSyncState> {
   if (!repoPath) {
     return { status: null, description: null };
   }
 
-  return readKanvibeTaskSyncState(repoPath, sshHost);
+  return readKanvibeTaskSyncState(repoPath, sshHost, projectRepoPath);
 }
 
 export async function persistTaskStateAtPath(
@@ -98,8 +101,8 @@ export async function persistTaskStateForTask(task: TaskWithOptionalLocation): P
   await persistTaskStateAtPath(resolvedLocation?.repoPath, task, resolvedLocation?.sshHost ?? null);
 }
 
-/** 사용자가 남긴 설명을 공유 파일에 기록해 같은 저장소를 보는 다른 기기와 맞춘다 */
-export async function persistTaskDescriptionForTask(task: TaskDescriptionTask): Promise<void> {
+/** task 설명과 priority를 책임에 맞는 공유 파일에 기록한다 */
+export async function persistTaskMetadataForTask(task: TaskMetadataTask): Promise<void> {
   const resolvedLocation = await resolveTaskStateLocation(task);
   if (!resolvedLocation) {
     return;
@@ -107,13 +110,23 @@ export async function persistTaskDescriptionForTask(task: TaskDescriptionTask): 
 
   try {
     await ensureKanvibeStateDirectoryExcluded(resolvedLocation.repoPath, resolvedLocation.sshHost);
-    await writeKanvibeTaskDescription(
+    const project = await resolveProjectRootTaskStateLocation(task);
+    const isProjectRootTask = project !== null && task.branchName === project.defaultBranch;
+
+    await writeKanvibeTaskMetadata(
       resolvedLocation.repoPath,
-      task.description,
+      {
+        description: task.description,
+        ...(!isProjectRootTask ? { priority: task.priority } : {}),
+      },
       resolvedLocation.sshHost,
     );
+
+    if (isProjectRootTask) {
+      await persistProjectPriorityToKanvibeState(project, task.priority);
+    }
   } catch (error) {
-    console.error(".kanvibe task 설명 저장 실패:", {
+    console.error(".kanvibe task 메타데이터 저장 실패:", {
       repoPath: resolvedLocation.repoPath,
       taskId: task.id,
       sshHost: resolvedLocation.sshHost,

--- a/src/desktop/main/services/projectService.ts
+++ b/src/desktop/main/services/projectService.ts
@@ -319,7 +319,12 @@ async function ensureProjectRootTask(
   const {
     status: persistedStatus,
     description: persistedDescription,
-  } = await readPersistedTaskSyncState(expectedDefaultBranchWorktreePath || project.repoPath, project.sshHost);
+    projectPriority: persistedProjectPriority,
+  } = await readPersistedTaskSyncState(
+    expectedDefaultBranchWorktreePath || project.repoPath,
+    project.sshHost,
+    project.repoPath,
+  );
 
   let shouldSaveTask = false;
   if (task.baseBranch !== project.defaultBranch) {
@@ -343,7 +348,12 @@ async function ensureProjectRootTask(
   }
 
   if (persistedDescription !== null && task.description !== persistedDescription.description) {
-    task.description = persistedDescription.description;
+    task.description = persistedDescription.description ?? null;
+    shouldSaveTask = true;
+  }
+
+  if (persistedProjectPriority !== undefined && task.priority !== persistedProjectPriority) {
+    task.priority = persistedProjectPriority;
     shouldSaveTask = true;
   }
 
@@ -719,12 +729,14 @@ async function syncProjectWorktrees(
       const {
         status: persistedStatus,
         description: persistedDescription,
-      } = await readPersistedTaskSyncState(wt.path, project.sshHost);
+        priority: persistedPriority,
+      } = await readPersistedTaskSyncState(wt.path, project.sshHost, project.repoPath);
       if (existingTask) {
         const shouldRepairTask = !matchesTaskLocation(existingTask, wt.path, project.sshHost)
           || existingTask.baseBranch !== project.defaultBranch
           || (persistedStatus !== null && existingTask.status !== persistedStatus)
-          || (persistedDescription !== null && existingTask.description !== persistedDescription.description);
+          || (persistedDescription !== null && existingTask.description !== persistedDescription.description)
+          || (persistedPriority !== undefined && existingTask.priority !== persistedPriority);
         let taskToPersist = existingTask;
         if (shouldRepairTask) {
           existingTask.worktreePath = wt.path;
@@ -734,7 +746,10 @@ async function syncProjectWorktrees(
             existingTask.status = persistedStatus;
           }
           if (persistedDescription !== null) {
-            existingTask.description = persistedDescription.description;
+            existingTask.description = persistedDescription.description ?? null;
+          }
+          if (persistedPriority !== undefined) {
+            existingTask.priority = persistedPriority;
           }
           const savedTask = await taskRepo.save(existingTask);
           taskToPersist = savedTask;
@@ -755,7 +770,10 @@ async function syncProjectWorktrees(
         orphanTask.baseBranch = orphanTask.baseBranch || project.defaultBranch;
         orphanTask.status = persistedStatus ?? TaskStatus.TODO;
         if (persistedDescription !== null) {
-          orphanTask.description = persistedDescription.description;
+          orphanTask.description = persistedDescription.description ?? null;
+        }
+        if (persistedPriority !== undefined) {
+          orphanTask.priority = persistedPriority;
         }
         const savedTask = await taskRepo.save(orphanTask);
         result.changed = true;
@@ -788,6 +806,7 @@ async function syncProjectWorktrees(
         baseBranch: project.defaultBranch,
         status: persistedStatus ?? TaskStatus.TODO,
         description: persistedDescription?.description ?? null,
+        priority: persistedPriority ?? null,
         ...(hasSession && {
           sessionType: SessionType.TMUX,
           sessionName,

--- a/src/lib/__tests__/kanvibeProjectState.test.ts
+++ b/src/lib/__tests__/kanvibeProjectState.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { TaskStatus } from "@/entities/KanbanTask";
+import { TaskPriority } from "@/entities/TaskPriority";
 
 const { mockReadTextFile, mockReadTextFiles, mockWriteTextFile, mockWriteTextFileIfAbsent } = vi.hoisted(() => ({
   mockReadTextFile: vi.fn(),
@@ -27,6 +28,7 @@ import {
   hasKanvibeHookTarget,
   parseKanvibeTargets,
   parseKanvibeTaskDescription,
+  parseKanvibeProjectState,
   parseKanvibeTaskState,
   parseProjectColor,
   parseTaskStatus,
@@ -36,7 +38,8 @@ import {
   upsertKanvibeHookTarget,
   writeKanvibeProjectColor,
   writeKanvibeProjectColorIfAbsent,
-  writeKanvibeTaskDescription,
+  writeKanvibeProjectPriority,
+  writeKanvibeTaskMetadata,
   writeKanvibeTaskStatus,
 } from "@/lib/kanvibeProjectState";
 
@@ -78,6 +81,23 @@ describe("kanvibeProjectState", () => {
     expect(JSON.parse(buildKanvibeProjectStateContent("#65D08A"))).toEqual({
       schemaVersion: 1,
       projectColor: "#65D08A",
+      updatedAt: expect.any(String),
+    });
+  });
+
+  it("프로젝트 priority는 project.json에 저장하고 기존 색상과 함께 읽는다", () => {
+    const content = buildKanvibeProjectStateContent("#65D08A", TaskPriority.HIGH);
+
+    expect(JSON.parse(content)).toEqual({
+      schemaVersion: 1,
+      projectColor: "#65D08A",
+      priority: TaskPriority.HIGH,
+      updatedAt: expect.any(String),
+    });
+    expect(parseKanvibeProjectState(content)).toEqual({
+      schemaVersion: 1,
+      projectColor: "#65D08A",
+      priority: TaskPriority.HIGH,
       updatedAt: expect.any(String),
     });
   });
@@ -177,6 +197,24 @@ describe("kanvibeProjectState", () => {
     expect(mockReadTextFile).toHaveBeenCalledWith("/remote/repo/.kanvibe/project.json", "ssh-host");
 
     expect(getKanvibeProjectStatePath("/local/repo")).toBe("/local/repo/.kanvibe/project.json");
+  });
+
+  it("project.json의 색상과 priority를 각각 바꿔도 다른 값을 보존한다", async () => {
+    mockReadTextFile
+      .mockResolvedValueOnce(JSON.stringify({ projectColor: "#65D08A", priority: "low" }))
+      .mockResolvedValueOnce(JSON.stringify({ projectColor: "#0064FF", priority: "low" }));
+
+    await writeKanvibeProjectColor("/local/repo", "#0064FF");
+    expect(JSON.parse(getLastWrittenContent())).toEqual(expect.objectContaining({
+      projectColor: "#0064FF",
+      priority: TaskPriority.LOW,
+    }));
+
+    await writeKanvibeProjectPriority("/local/repo", TaskPriority.HIGH);
+    expect(JSON.parse(getLastWrittenContent())).toEqual(expect.objectContaining({
+      projectColor: "#0064FF",
+      priority: TaskPriority.HIGH,
+    }));
   });
 
   it("형식이 잘못된 색상은 기록하지 않는다", async () => {
@@ -282,7 +320,9 @@ describe("kanvibeProjectState", () => {
   });
 
   it("task 설명을 status.json이 아닌 task.json에 기록한다", async () => {
-    await writeKanvibeTaskDescription("/local/repo", "결제 실패 로그 원인 추적");
+    await writeKanvibeTaskMetadata("/local/repo", {
+      description: "결제 실패 로그 원인 추적",
+    });
 
     expect(mockWriteTextFile).toHaveBeenCalledWith(
       "/local/repo/.kanvibe/task.json",
@@ -296,6 +336,26 @@ describe("kanvibeProjectState", () => {
     });
     expect(getKanvibeTaskDescriptionPath("/local/repo")).toBe("/local/repo/.kanvibe/task.json");
     expect(getKanvibeTaskDescriptionPath("/remote/repo", "build-host")).toBe("/remote/repo/.kanvibe/task.json");
+  });
+
+  it("task priority를 task.json에 설명과 함께 기록한다", () => {
+    const content = buildKanvibeTaskDescriptionContent(
+      "결제 실패 로그 원인 추적",
+      TaskPriority.LOW,
+    );
+
+    expect(JSON.parse(content)).toEqual({
+      schemaVersion: 1,
+      description: "결제 실패 로그 원인 추적",
+      priority: TaskPriority.LOW,
+      updatedAt: expect.any(String),
+    });
+    expect(parseKanvibeTaskDescription(content)).toEqual({
+      schemaVersion: 1,
+      description: "결제 실패 로그 원인 추적",
+      priority: TaskPriority.LOW,
+      updatedAt: expect.any(String),
+    });
   });
 
   it("설명을 지우면 null을 기록해 다른 기기에서도 지워지게 한다", () => {
@@ -328,9 +388,45 @@ describe("kanvibeProjectState", () => {
     expect(syncState.description?.description).toBe("결제 실패 로그 원인 추적");
     expect(mockReadTextFiles).toHaveBeenCalledTimes(1);
     expect(mockReadTextFiles).toHaveBeenCalledWith(
-      ["/local/repo/.kanvibe/status.json", "/local/repo/.kanvibe/task.json"],
+      [
+        "/local/repo/.kanvibe/status.json",
+        "/local/repo/.kanvibe/task.json",
+        "/local/repo/.kanvibe/project.json",
+      ],
       undefined,
     );
+  });
+
+  it("task priority를 우선하고 없으면 project priority를 사용한다", async () => {
+    mockReadTextFiles
+      .mockResolvedValueOnce(new Map([
+        ["/local/repo/.kanvibe/status.json", { exists: false, content: "" }],
+        ["/local/repo/.kanvibe/task.json", { exists: true, content: JSON.stringify({ priority: "low" }) }],
+        ["/project/repo/.kanvibe/project.json", { exists: true, content: JSON.stringify({ priority: "high" }) }],
+      ]))
+      .mockResolvedValueOnce(new Map([
+        ["/local/repo/.kanvibe/status.json", { exists: false, content: "" }],
+        ["/local/repo/.kanvibe/task.json", { exists: true, content: JSON.stringify({ description: null }) }],
+        ["/project/repo/.kanvibe/project.json", { exists: true, content: JSON.stringify({ priority: "high" }) }],
+      ]))
+      .mockResolvedValueOnce(new Map([
+        ["/local/repo/.kanvibe/status.json", { exists: false, content: "" }],
+        ["/local/repo/.kanvibe/task.json", { exists: true, content: JSON.stringify({ priority: null }) }],
+        ["/project/repo/.kanvibe/project.json", { exists: true, content: JSON.stringify({ priority: "high" }) }],
+      ]));
+
+    await expect(readKanvibeTaskSyncState("/local/repo", undefined, "/project/repo"))
+      .resolves.toEqual(expect.objectContaining({
+        priority: TaskPriority.LOW,
+        projectPriority: TaskPriority.HIGH,
+      }));
+    await expect(readKanvibeTaskSyncState("/local/repo", undefined, "/project/repo"))
+      .resolves.toEqual(expect.objectContaining({ projectPriority: TaskPriority.HIGH }));
+    await expect(readKanvibeTaskSyncState("/local/repo", undefined, "/project/repo"))
+      .resolves.toEqual(expect.objectContaining({
+        priority: null,
+        projectPriority: TaskPriority.HIGH,
+      }));
   });
 
   it("상태나 설명 파일이 없으면 각각 기록 없음으로 돌려준다", async () => {

--- a/src/lib/kanvibeProjectState.ts
+++ b/src/lib/kanvibeProjectState.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import { TaskStatus } from "@/entities/KanbanTask";
+import { TaskPriority } from "@/entities/TaskPriority";
 import { readTextFile, readTextFiles, writeTextFile, writeTextFileIfAbsent } from "@/lib/hostFileAccess";
 
 export const KANVIBE_DIR_NAME = ".kanvibe";
@@ -18,30 +19,34 @@ export interface KanvibeTaskState {
 }
 
 /**
- * 프로젝트 단위 공유 상태. task 상태와 파일을 분리해 hook(status.json 기록)과
+ * 프로젝트 단위 공유 상태. root task priority와 색상을 task 상태 파일에서 분리해 hook(status.json 기록)과
  * KanVibe client(project.json 기록)가 서로의 값을 덮어쓸 수 없게 한다.
  */
 export interface KanvibeProjectState {
   schemaVersion: 1;
-  projectColor: string;
+  projectColor?: string;
+  priority?: TaskPriority | null;
   updatedAt?: string;
 }
 
 /**
- * task 설명 공유 상태. hook이 통째로 재작성하는 status.json과 파일을 분리해
- * agent가 상태를 기록해도 사용자가 남긴 설명이 지워지지 않게 한다.
+ * task 메타데이터 공유 상태. hook이 통째로 재작성하는 status.json과 파일을 분리해
+ * agent가 상태를 기록해도 사용자가 남긴 설명과 priority가 지워지지 않게 한다.
  * description이 null이면 다른 기기에서도 설명을 지우라는 뜻이다.
  */
 export interface KanvibeTaskDescription {
   schemaVersion: 1;
-  description: string | null;
+  description?: string | null;
+  priority?: TaskPriority | null;
   updatedAt?: string;
 }
 
-/** 다른 기기의 상태를 한 번에 반영하기 위해 함께 읽는 값들. 각 항목의 null은 "기록 없음"이다 */
+/** 다른 기기의 상태를 한 번에 반영하기 위해 함께 읽는 값들 */
 export interface KanvibeTaskSyncState {
   status: TaskStatus | null;
   description: KanvibeTaskDescription | null;
+  priority?: TaskPriority | null;
+  projectPriority?: TaskPriority | null;
 }
 
 export interface KanvibeHookTarget {
@@ -95,14 +100,24 @@ export async function readKanvibeProjectColor(
 export async function readKanvibeTaskSyncState(
   repoPath: string,
   sshHost?: string | null,
+  projectRepoPath = repoPath,
 ): Promise<KanvibeTaskSyncState> {
   const taskStatePath = getKanvibeTaskStatePath(repoPath, sshHost);
   const taskDescriptionPath = getKanvibeTaskDescriptionPath(repoPath, sshHost);
-  const files = await readTextFiles([taskStatePath, taskDescriptionPath], sshHost);
+  const projectStatePath = getKanvibeProjectStatePath(projectRepoPath, sshHost);
+  const files = await readTextFiles([taskStatePath, taskDescriptionPath, projectStatePath], sshHost);
+  const taskMetadata = parseKanvibeTaskDescription(files.get(taskDescriptionPath)?.content ?? "");
+  const projectState = parseKanvibeProjectState(files.get(projectStatePath)?.content ?? "");
 
   return {
     status: parseKanvibeTaskState(files.get(taskStatePath)?.content ?? "")?.status ?? null,
-    description: parseKanvibeTaskDescription(files.get(taskDescriptionPath)?.content ?? ""),
+    description: taskMetadata && Object.hasOwn(taskMetadata, "description") ? taskMetadata : null,
+    ...(taskMetadata && Object.hasOwn(taskMetadata, "priority")
+      ? { priority: taskMetadata.priority ?? null }
+      : {}),
+    ...(projectState && Object.hasOwn(projectState, "priority")
+      ? { projectPriority: projectState.priority ?? null }
+      : {}),
   };
 }
 
@@ -118,14 +133,14 @@ export async function writeKanvibeTaskStatus(
   );
 }
 
-export async function writeKanvibeTaskDescription(
+export async function writeKanvibeTaskMetadata(
   repoPath: string,
-  description: string | null,
+  task: Pick<KanvibeTaskDescription, "description" | "priority">,
   sshHost?: string | null,
 ): Promise<void> {
   await writeTextFile(
     getKanvibeTaskDescriptionPath(repoPath, sshHost),
-    buildKanvibeTaskDescriptionContent(description),
+    buildKanvibeTaskDescriptionContent(task.description, task.priority),
     sshHost,
   );
 }
@@ -140,9 +155,26 @@ export async function writeKanvibeProjectColor(
     return;
   }
 
+  const currentState = parseKanvibeProjectState(
+    await readTextFile(getKanvibeProjectStatePath(repoPath, sshHost), sshHost),
+  );
   await writeTextFile(
     getKanvibeProjectStatePath(repoPath, sshHost),
-    buildKanvibeProjectStateContent(normalizedColor),
+    buildKanvibeProjectStateContent(normalizedColor, currentState?.priority),
+    sshHost,
+  );
+}
+
+export async function writeKanvibeProjectPriority(
+  repoPath: string,
+  priority: TaskPriority | null,
+  sshHost?: string | null,
+): Promise<void> {
+  const projectStatePath = getKanvibeProjectStatePath(repoPath, sshHost);
+  const currentState = parseKanvibeProjectState(await readTextFile(projectStatePath, sshHost));
+  await writeTextFile(
+    projectStatePath,
+    buildKanvibeProjectStateContent(currentState?.projectColor, priority),
     sshHost,
   );
 }
@@ -213,20 +245,28 @@ export function buildKanvibeTaskStateContent(
   return JSON.stringify(payload, null, 2) + "\n";
 }
 
-export function buildKanvibeTaskDescriptionContent(description: string | null): string {
+export function buildKanvibeTaskDescriptionContent(
+  description: string | null | undefined,
+  priority?: TaskPriority | null,
+): string {
   const payload: KanvibeTaskDescription = {
     schemaVersion: 1,
-    description,
+    ...(description !== undefined ? { description } : {}),
+    ...(priority !== undefined ? { priority } : {}),
     updatedAt: new Date().toISOString(),
   };
 
   return JSON.stringify(payload, null, 2) + "\n";
 }
 
-export function buildKanvibeProjectStateContent(projectColor: string): string {
+export function buildKanvibeProjectStateContent(
+  projectColor: string | undefined,
+  priority?: TaskPriority | null,
+): string {
   const payload: KanvibeProjectState = {
     schemaVersion: 1,
-    projectColor,
+    ...(projectColor !== undefined ? { projectColor } : {}),
+    ...(priority !== undefined ? { priority } : {}),
     updatedAt: new Date().toISOString(),
   };
 
@@ -280,14 +320,19 @@ export function parseKanvibeTaskDescription(content: string): KanvibeTaskDescrip
   }
 
   try {
-    const parsed = JSON.parse(content) as { description?: unknown; updatedAt?: unknown };
-    if (typeof parsed.description !== "string" && parsed.description !== null) {
+    const parsed = JSON.parse(content) as { description?: unknown; priority?: unknown; updatedAt?: unknown };
+    const hasDescription = Object.hasOwn(parsed, "description")
+      && (typeof parsed.description === "string" || parsed.description === null);
+    const hasPriority = Object.hasOwn(parsed, "priority")
+      && (parsed.priority === null || parseTaskPriority(parsed.priority) !== null);
+    if (!hasDescription && !hasPriority) {
       return null;
     }
 
     return {
       schemaVersion: 1,
-      description: parsed.description,
+      ...(hasDescription ? { description: parsed.description as string | null } : {}),
+      ...(hasPriority ? { priority: parsed.priority === null ? null : parseTaskPriority(parsed.priority)! } : {}),
       ...(isNonEmptyString(parsed.updatedAt) ? { updatedAt: parsed.updatedAt } : {}),
     };
   } catch {
@@ -301,15 +346,18 @@ export function parseKanvibeProjectState(content: string): KanvibeProjectState |
   }
 
   try {
-    const parsed = JSON.parse(content) as { projectColor?: unknown; updatedAt?: unknown };
+    const parsed = JSON.parse(content) as { projectColor?: unknown; priority?: unknown; updatedAt?: unknown };
     const projectColor = parseProjectColor(parsed.projectColor);
-    if (!projectColor) {
+    const hasPriority = Object.hasOwn(parsed, "priority")
+      && (parsed.priority === null || parseTaskPriority(parsed.priority) !== null);
+    if (!projectColor && !hasPriority) {
       return null;
     }
 
     return {
       schemaVersion: 1,
-      projectColor,
+      ...(projectColor ? { projectColor } : {}),
+      ...(hasPriority ? { priority: parsed.priority === null ? null : parseTaskPriority(parsed.priority)! } : {}),
       ...(isNonEmptyString(parsed.updatedAt) ? { updatedAt: parsed.updatedAt } : {}),
     };
   } catch {
@@ -351,6 +399,14 @@ export function parseProjectColor(value: unknown): string | null {
 
   const normalized = value.trim();
   return PROJECT_COLOR_PATTERN.test(normalized) ? normalized : null;
+}
+
+export function parseTaskPriority(value: unknown): TaskPriority | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  return Object.values(TaskPriority).includes(value as TaskPriority) ? value as TaskPriority : null;
 }
 
 function isNonEmptyString(value: unknown): value is string {


### PR DESCRIPTION
## 어떤 작업인가요?

- 프로젝트(root task)와 개별 task의 priority를 `.kanvibe` 공유 상태로 동기화합니다.
- task priority를 우선 적용하고, 명시적인 task priority가 없으면 project priority를 상속합니다.

## 어떻게 해결했나요?

### priority 저장 책임 분리

- 프로젝트 priority는 `.kanvibe/project.json`에 저장합니다.
- task override는 `.kanvibe/task.json`에 저장하고, hook URL 및 task ID 레지스트리인 `targets.json`의 기존 책임은 유지합니다.
- project color와 priority를 read-modify-write 방식으로 보존해 서로 덮어쓰지 않도록 했습니다.

### 상속 의미 보존

- task override가 있으면 이를 우선하고, `null` 또는 미지정이면 project priority를 사용합니다.
- 상속된 project priority를 하위 task DB 값으로 구체화하지 않아 이후 project priority 변경도 계속 반영됩니다.
- root task DB 동기화에는 project priority를, 하위 task DB 동기화에는 명시적인 task override만 사용합니다.

### 동기화와 호환성

- worktree 생성·동기화 시 project priority를 함께 전파합니다.
- 기존 공유 상태 파일과 설명·색상 필드를 유지하면서 priority 필드를 확장했습니다.

## 중요한 변경 사항 또는 리뷰 시 참고사항

- `task.json`의 priority는 명시적 override이며, 값이 없을 때만 `project.json`의 priority로 fallback합니다.
- 전체 테스트 1,121개, 타입 검사, renderer/main 빌드가 통과했습니다.
- lint는 성공했으며 이번 diff 밖의 기존 warning 11개만 남아 있습니다.
