### PR TITLE
chore(release): publish KanVibe 1.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

- Bump the KanVibe desktop package version from `1.0.9` to `1.0.10`.
- Publish the signed, notarized, stapled DMG and update the Homebrew cask to the same artifact checksum.

## Test Plan

- `pnpm install --frozen-lockfile`
- `pnpm run deploy`
- Packaging collector: `pm=npm`
- Packaged dependency guard: `278 packages`
- Gatekeeper: accepted, Notarized Developer ID
- Smoke test: app alive, module errors `0`, `invoke-succeeded` `14`
- `xcrun stapler validate dist/KanVibe-1.0.10.dmg`
- `brew fetch --cask rookedsysc/kanvibe/kanvibe`

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.0.10
- DMG: `dist/KanVibe-1.0.10.dmg`
- SHA-256: `b1c40a9678be6aeb125be7a99ca7ce9b61bc34241f5291e53e88e2aab6312b89`
- Homebrew cask commit: `12f7e3556e389ece97626e1ce7bd84184cb6d085`
- Homebrew status: `Cask kanvibe (1.0.10)` fetched successfully
