### PR TITLE
fix(chat): 원격 메시지 읽기와 최신 대화 정렬 수정

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -385,7 +385,7 @@
     "aiSessions": {
       "title": "AI Sessions",
       "inlineChat": "AI Chat",
-      "remoteBadge": "Remote unsupported",
+      "remoteBadge": "No remote sessions to display.",
       "noPreview": "No preview is available.",
       "loadMoreSessions": "Load more chats",
       "loadOlderMessages": "Load older messages",
@@ -396,6 +396,9 @@
       "selectSession": "Select an AI session from the list.",
       "loadingDetail": "Loading messages...",
       "detailError": "Failed to load session details.",
+      "copyMessage": "Copy",
+      "copiedMessage": "Copied",
+      "copyFailed": "Copy failed",
       "roles": {
         "user": "User input",
         "assistant": "AI answer",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -385,7 +385,7 @@
     "aiSessions": {
       "title": "AI 세션",
       "inlineChat": "AI 채팅",
-      "remoteBadge": "원격 미지원",
+      "remoteBadge": "표시할 원격 세션이 없습니다.",
       "noPreview": "표시할 미리보기가 없습니다.",
       "loadMoreSessions": "채팅 더 불러오기",
       "loadOlderMessages": "이전 메시지 더 보기",
@@ -396,6 +396,9 @@
       "selectSession": "왼쪽 목록에서 AI 세션을 선택하세요.",
       "loadingDetail": "메시지를 불러오는 중...",
       "detailError": "세션 상세를 불러오지 못했습니다.",
+      "copyMessage": "복사",
+      "copiedMessage": "복사됨",
+      "copyFailed": "복사 실패",
       "roles": {
         "user": "사용자 입력",
         "assistant": "AI 답변",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -384,7 +384,7 @@
     "aiSessions": {
       "title": "AI 会话",
       "inlineChat": "AI 聊天",
-      "remoteBadge": "不支持远程",
+      "remoteBadge": "没有可显示的远程会话。",
       "noPreview": "没有可显示的预览。",
       "loadMoreSessions": "加载更多聊天",
       "loadOlderMessages": "加载更早消息",
@@ -395,6 +395,9 @@
       "selectSession": "从左侧列表选择 AI 会话。",
       "loadingDetail": "正在加载消息...",
       "detailError": "加载会话详情失败。",
+      "copyMessage": "复制",
+      "copiedMessage": "已复制",
+      "copyFailed": "复制失败",
       "roles": {
         "user": "用户输入",
         "assistant": "AI 回复",

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -775,13 +775,25 @@ function InlineAiChatEmpty({ text, compact = false }: { text: string; compact?: 
 }
 
 function InlineAiChatMessage({ message, provider }: { message: AggregatedAiMessage; provider: AggregatedAiSession["provider"] }) {
+  const t = useTranslations("taskDetail");
   const isUserMessage = message.role === "user";
   const displayedText = message.fullText || message.text;
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+  const copyLabel = t(`aiSessions.${copyState === "idle" ? "copyMessage" : copyState === "copied" ? "copiedMessage" : "copyFailed"}`);
+
+  async function copyMessage() {
+    try {
+      await navigator.clipboard.writeText(displayedText);
+      setCopyState("copied");
+    } catch {
+      setCopyState("error");
+    }
+  }
 
   return (
     <div className={`flex ${isUserMessage ? "justify-end" : "justify-start"}`}>
       <div
-        className={`max-w-[74%] rounded-2xl px-4 py-3 text-sm leading-6 shadow-sm ${
+        className={`max-w-[74%] select-text rounded-2xl px-4 py-3 text-sm leading-6 shadow-sm ${
           isUserMessage
             ? "rounded-br-md bg-brand-primary text-white"
             : "rounded-bl-md border border-border-default bg-bg-surface text-text-primary"
@@ -790,6 +802,16 @@ function InlineAiChatMessage({ message, provider }: { message: AggregatedAiMessa
         <div className={`mb-2 flex items-center gap-2 text-[11px] font-semibold ${isUserMessage ? "text-white/75" : "text-text-muted"}`}>
           <AiSessionProviderIcon provider={provider} testId={false} />
           <span>{message.role}</span>
+          <button
+            type="button"
+            onClick={() => void copyMessage()}
+            className={`ml-auto select-none rounded px-2 py-0.5 transition-colors ${
+              isUserMessage ? "hover:bg-white/15 hover:text-white" : "hover:bg-bg-page hover:text-text-primary"
+            }`}
+            aria-label={copyLabel}
+          >
+            {copyLabel}
+          </button>
         </div>
         <AiSessionMessageContent text={displayedText} isUserMessage={isUserMessage} />
       </div>

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -12,6 +12,7 @@ import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadin
 const TASK_DETAIL_CACHE_KEY = "kanvibe:route-cache:task-detail:task-1";
 const BOARD_FOCUS_TASK_CACHE_KEY = "kanvibe:route-cache:board-focus-task";
 const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 
 const mocks = vi.hoisted(() => ({
   getTaskById: vi.fn(),
@@ -46,6 +47,7 @@ const mocks = vi.hoisted(() => ({
   mermaidRender: vi.fn(async (_id: string, definition: string) => ({
     svg: `<svg data-testid="rendered-mermaid-svg"><g onload="alert('svg')"><script>svg-xss</script><text>${definition}</text></g></svg>`,
   })),
+  clipboardWriteText: vi.fn(),
 }));
 
 function createDeferred<T>() {
@@ -304,6 +306,11 @@ describe("TaskDetailRoute", () => {
     mocks.updateTaskStatus.mockResolvedValue(null);
     mocks.deleteTask.mockResolvedValue(true);
     mocks.fetchPrUrlWithPrompt.mockResolvedValue(null);
+    mocks.clipboardWriteText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: mocks.clipboardWriteText },
+    });
   });
 
   afterEach(() => {
@@ -318,6 +325,11 @@ describe("TaskDetailRoute", () => {
       delete (HTMLElement.prototype as Partial<HTMLElement>).scrollIntoView;
     }
     delete window.kanvibeDesktop;
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
   });
 
   it("캐시가 있으면 stale task detail을 즉시 렌더링하고 이후 최신 데이터로 갱신한다", async () => {
@@ -2193,6 +2205,57 @@ describe("TaskDetailRoute", () => {
       expect(scrollIntoView).toHaveBeenCalledWith({ block: "end" });
     });
     expect(messagePane.textContent?.indexOf("Older prompt")).toBeLessThan(messagePane.textContent?.indexOf("Newest answer") ?? -1);
+  });
+
+  it("채팅 메시지별 복사 버튼으로 원문을 clipboard에 복사한다", async () => {
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(true);
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "fix/chat-copy",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/chat-copy",
+    });
+    mocks.getTaskAiSessions.mockResolvedValue({
+      isRemote: false,
+      targetPath: "/repo__worktrees/chat-copy",
+      repoPath: "/repo",
+      sources: [],
+      nextCursor: null,
+      sessions: [
+        { id: "claude-1", provider: "claude", startedAt: null, updatedAt: "2026-01-01T00:03:00.000Z", matchedPath: "/repo__worktrees/chat-copy", matchScope: "worktree", title: "Copy chat", firstUserPrompt: "Copy prompt", messageCount: 1, sourceRef: "claude.jsonl" },
+      ],
+    });
+    mocks.getTaskAiSessionDetail.mockResolvedValue({
+      sessionId: "claude-1",
+      provider: "claude",
+      title: "Copy chat",
+      matchedPath: "/repo__worktrees/chat-copy",
+      sourceRef: "claude.jsonl",
+      nextCursor: null,
+      messages: [
+        { role: "assistant", timestamp: "2026-01-01T00:03:00.000Z", text: "preview", fullText: "Full remote answer\nwith detail", isTruncated: true },
+      ],
+    });
+
+    render(<TaskDetailRoute />);
+    fireEvent.click(await screen.findByRole("button", { name: "aiSessions.inlineChat" }));
+    fireEvent.click(await screen.findByRole("button", { name: /Copy chat/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "aiSessions.copyMessage" }));
+
+    await waitFor(() => {
+      expect(mocks.clipboardWriteText).toHaveBeenCalledWith("Full remote answer\nwith detail");
+    });
+    expect(screen.getByRole("button", { name: "aiSessions.copiedMessage" })).toBeTruthy();
   });
 
   it("채팅 화면에서 Claude/Codex/OpenCode/Gemini 세션을 한 목록에 표시하고 provider를 구분한다", async () => {

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -259,6 +259,33 @@ describe("gitOperations.resolvePathForShell", () => {
     expect(getSpawnedRemoteCommand()).toContain(REMOTE_COMMAND_EXIT_MARKER);
   });
 
+  it("원격 명령별 출력 한도를 적용한다", async () => {
+    mocks.spawn.mockImplementation(() => {
+      const child = createMockSSHProcess();
+      queueMicrotask(() => completeRemoteCommand(child, "output larger than the command limit"));
+      return child;
+    });
+
+    vi.doMock("@/lib/sshConfig", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/sshConfig")>();
+      return {
+        ...actual,
+        parseSSHConfig: vi.fn(async () => [{
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        }]),
+      };
+    });
+
+    const { execGit } = await import("@/lib/gitOperations");
+
+    await expect(execGit("cat chat.jsonl", "remote-host", { maxBufferBytes: 16 }))
+      .rejects.toThrow("exceeded maxBuffer");
+  });
+
   it("SSH transport 실패 직후 같은 host의 후속 명령은 새 ssh 프로세스를 만들지 않는다", async () => {
     // Given
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/lib/__tests__/hostFileAccess.test.ts
+++ b/src/lib/__tests__/hostFileAccess.test.ts
@@ -106,6 +106,31 @@ describe("hostFileAccess.readTextFiles", () => {
   });
 });
 
+describe("hostFileAccess.readTextFile", () => {
+  beforeEach(() => {
+    mocks.execGit.mockReset();
+  });
+
+  it("원격 채팅 파일은 일반 명령보다 큰 출력 한도로 읽는다", async () => {
+    mocks.execGit.mockResolvedValue("remote chat");
+    const { readTextFile } = await import("@/lib/hostFileAccess");
+
+    await expect(readTextFile("/remote/chat.jsonl", "remote-host")).resolves.toBe("remote chat");
+    expect(mocks.execGit).toHaveBeenCalledWith(
+      "test -f '/remote/chat.jsonl' && cat '/remote/chat.jsonl' || true",
+      "remote-host",
+      { maxBufferBytes: 64 * 1024 * 1024 },
+    );
+  });
+
+  it("원격 채팅 파일 읽기 실패를 빈 파일로 숨기지 않는다", async () => {
+    mocks.execGit.mockRejectedValue(new Error("SSH command output exceeded maxBuffer"));
+    const { readTextFile } = await import("@/lib/hostFileAccess");
+
+    await expect(readTextFile("/remote/chat.jsonl", "remote-host")).rejects.toThrow("exceeded maxBuffer");
+  });
+});
+
 describe("hostFileAccess.writeTextFileIfAbsent", () => {
   let tempDir: string;
 

--- a/src/lib/aiSessions/__tests__/readAiSessions.test.ts
+++ b/src/lib/aiSessions/__tests__/readAiSessions.test.ts
@@ -30,7 +30,7 @@ function claudeProjectDirectoryName(targetPath: string) {
 function setupRemoteFileSystem(files: Record<string, string>) {
   const fileMap = new Map(Object.entries(files));
   const directorySet = new Set<string>();
-  const execCalls: Array<{ command: string; sshHost?: string | null }> = [];
+  const execCalls: Array<{ command: string; sshHost?: string | null; options?: { maxBufferBytes?: number } }> = [];
 
   for (const filePath of fileMap.keys()) {
     let current = path.dirname(filePath);
@@ -50,8 +50,8 @@ function setupRemoteFileSystem(files: Record<string, string>) {
     .join("\n");
 
   vi.doMock("@/lib/gitOperations", () => ({
-    execGit: vi.fn(async (command: string, sshHost?: string | null) => {
-      execCalls.push({ command, sshHost });
+    execGit: vi.fn(async (command: string, sshHost?: string | null, options?: { maxBufferBytes?: number }) => {
+      execCalls.push({ command, sshHost, options });
       if (command === "printf '%s' \"$HOME\"") {
         return "/remote/home";
       }
@@ -70,6 +70,11 @@ function setupRemoteFileSystem(files: Record<string, string>) {
           throw new Error(`cat command path mismatch: ${command}`);
         }
         return fileMap.get(catMatch[1]) ?? "";
+      }
+
+      const tailMatch = command.match(/tail -n (\d+) '([^']+)'/);
+      if (tailMatch) {
+        return (fileMap.get(tailMatch[2]) ?? "").split("\n").slice(-Number(tailMatch[1]) - 1).join("\n");
       }
 
       const statMatch = command.match(/test -e '([^']+)' && \(stat -c %Y '([^']+)'/);
@@ -146,6 +151,9 @@ describe("AI session history readers", () => {
         message: { role: "user", content: [{ type: "tool_result", content: "file contents" }] },
       },
     ]);
+
+    const sessions = await readClaudeSessions({ worktreePath, repoPath: worktreePath });
+    expect(sessions.sessions[0]?.updatedAt).toBe("2026-01-01T00:02:00.000Z");
 
     const detail = await readClaudeSessionDetail(
       { worktreePath, repoPath: worktreePath },
@@ -281,6 +289,38 @@ describe("AI session history readers", () => {
     ]);
   });
 
+  it("uses the latest Codex user or assistant message as the session activity time", async () => {
+    const worktreePath = path.join(tempHome, "repo__worktrees", "task");
+    const sessionFile = path.join(tempHome, ".codex", "sessions", "2026", "codex-activity.jsonl");
+
+    await writeJsonLines(sessionFile, [
+      {
+        type: "session_meta",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        payload: { id: "codex-activity", cwd: worktreePath, timestamp: "2026-01-01T00:00:00.000Z" },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-01-01T00:01:00.000Z",
+        payload: { type: "message", role: "user", content: [{ type: "input_text", text: "Update the chat." }] },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-01-01T00:02:00.000Z",
+        payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "Chat updated." }] },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-01-01T00:03:00.000Z",
+        payload: { type: "reasoning", text: "Internal follow-up bookkeeping." },
+      },
+    ]);
+
+    const sessions = await readCodexSessions({ worktreePath, repoPath: worktreePath });
+
+    expect(sessions.sessions[0]?.updatedAt).toBe("2026-01-01T00:02:00.000Z");
+  });
+
   it("reads Gemini chat recordings from ~/.gemini/tmp/<project>/chats and classifies responses, thoughts, and tool calls", async () => {
     const worktreePath = path.join(tempHome, "repo__worktrees", "task");
     const chatFile = path.join(tempHome, ".gemini", "tmp", "task", "chats", "session-2026-01-01T00-00-gemini.json");
@@ -316,6 +356,7 @@ describe("AI session history readers", () => {
       id: "gemini-session",
       provider: "gemini",
       title: "make a plan",
+      updatedAt: "2026-01-01T00:02:00.000Z",
       sourceRef: chatFile,
     });
 
@@ -370,6 +411,46 @@ describe("AI session history readers", () => {
     });
   });
 
+  it("reads the latest Claude conversation time beyond the summary head", async () => {
+    const worktreePath = path.join(tempHome, "repo__worktrees", "task");
+    const sessionFile = path.join(
+      tempHome,
+      ".claude",
+      "projects",
+      claudeProjectDirectoryName(worktreePath),
+      "long-claude-session.jsonl",
+    );
+    const toolEvents = Array.from({ length: 65 }, (_, index) => ({
+      type: "progress",
+      sessionId: "long-claude-session",
+      cwd: worktreePath,
+      timestamp: `2026-01-01T00:00:${String(index + 2).padStart(2, "0")}.000Z`,
+      message: { role: "user", content: [{ type: "tool_result", content: `tool ${index} ${"x".repeat(4096)}` }] },
+    }));
+
+    await writeJsonLines(sessionFile, [
+      {
+        type: "user",
+        sessionId: "long-claude-session",
+        cwd: worktreePath,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "Start the long task." }] },
+      },
+      {
+        type: "assistant",
+        sessionId: "long-claude-session",
+        cwd: worktreePath,
+        timestamp: "2026-01-01T00:10:00.000Z",
+        message: { role: "assistant", content: [{ type: "text", text: "The long task is complete." }] },
+      },
+      ...toolEvents,
+    ]);
+
+    const sessions = await readClaudeSessions({ worktreePath, repoPath: worktreePath });
+
+    expect(sessions.sessions[0]?.updatedAt).toBe("2026-01-01T00:10:00.000Z");
+  });
+
   it("uses Gemini CLI .project_root metadata when projects.json does not map the chat directory", async () => {
     const worktreePath = path.join(tempHome, "repo__worktrees", "task");
     const projectDir = path.join(tempHome, ".gemini", "tmp", "project-with-root-file");
@@ -421,7 +502,7 @@ CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL, title TEXT, 
 CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data TEXT NOT NULL);
 CREATE TABLE part (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, message_id TEXT NOT NULL, data TEXT NOT NULL, time_created INTEGER NOT NULL);
 """)
-cur.execute("INSERT INTO session VALUES (?, ?, ?, ?, ?)", ("local-open", directory, "Local OpenCode", 1700000000000, 1700000010000))
+cur.execute("INSERT INTO session VALUES (?, ?, ?, ?, ?)", ("local-open", directory, "Local OpenCode", 1700000000000, 1700000100000))
 for message_id, role, text, timestamp in [
     ("user-message", "user", "load local opencode history", 1700000000000),
     ("assistant-message", "assistant", "local opencode history loaded", 1700000010000),
@@ -453,6 +534,7 @@ conn.close()
       matchedPath: worktreePath,
       title: "Local OpenCode",
       firstUserPrompt: "load local opencode history",
+      updatedAt: new Date(1700000010000).toISOString(),
       sourceRef: "local-open",
     });
 
@@ -621,13 +703,13 @@ conn.close()
   it("reads remote OpenCode sessions and detail over SSH", async () => {
     const worktreePath = "/remote/repo__worktrees/task";
     const repoPath = "/remote/repo";
-    const execCalls: Array<{ command: string; sshHost?: string | null }> = [];
+    const execCalls: Array<{ command: string; sshHost?: string | null; options?: { maxBufferBytes?: number } }> = [];
     let remoteSqliteQueryCount = 0;
 
     vi.resetModules();
     vi.doMock("@/lib/gitOperations", () => ({
-      execGit: vi.fn(async (command: string, sshHost?: string | null) => {
-        execCalls.push({ command, sshHost });
+      execGit: vi.fn(async (command: string, sshHost?: string | null, options?: { maxBufferBytes?: number }) => {
+        execCalls.push({ command, sshHost, options });
         if (command === "printf '%s' \"$HOME\"") {
           return "/remote/home";
         }
@@ -707,6 +789,10 @@ conn.close()
       ["user", "fix remote chat"],
     ]);
     expect(execCalls.every((call) => call.sshHost === "remote-host")).toBe(true);
+    expect(execCalls
+      .filter((call) => call.command.includes("python3 -c"))
+      .map((call) => call.options?.maxBufferBytes))
+      .toEqual([64 * 1024 * 1024, 64 * 1024 * 1024]);
     expect(remoteSqliteQueryCount).toBe(2);
   });
 

--- a/src/lib/aiSessions/readClaudeSessions.ts
+++ b/src/lib/aiSessions/readClaudeSessions.ts
@@ -12,6 +12,7 @@ import {
   paginateItems,
   readJsonLines,
   readJsonLinesHead,
+  readJsonLinesTail,
   REMOTE_SESSION_FILE_PARSE_CONCURRENCY,
   sortMessagesDescending,
   toIsoString,
@@ -28,6 +29,7 @@ import type {
 } from "@/lib/aiSessions/types";
 
 const DEFAULT_DETAIL_LIMIT = 20;
+const CLAUDE_SUMMARY_EVENT_LIMIT = 60;
 
 interface ClaudeProjectEvent {
   type?: string;
@@ -129,7 +131,7 @@ export async function readClaudeSessionDetail(
   });
 }
 
-/** 단일 JSONL 파일에서 세션 메타데이터를 추출한다. 앞 60줄로 충분하면 조기 종료한다. */
+/** 제목은 파일 앞, 실제 최근 대화 시각은 파일 끝에서 읽어 긴 JSONL 전체 전송을 피한다. */
 async function parseClaudeSessionFromFile(
   filePath: string,
   context: AiSessionReaderContext
@@ -152,15 +154,41 @@ async function parseClaudeSessionFromFile(
 
   const headEvents = await getCachedOrParseHead(
     filePath,
-    () => readJsonLinesHead(filePath, 60, context.sshHost),
+    () => readJsonLinesHead(filePath, CLAUDE_SUMMARY_EVENT_LIMIT, context.sshHost),
     context.sshHost,
   );
 
   const headResult = await parseEvents(headEvents);
-  if (headResult?.firstUserPrompt) return headResult;
+  if (headResult?.firstUserPrompt) {
+    const tailEvents = await readJsonLinesTail(filePath, CLAUDE_SUMMARY_EVENT_LIMIT, context.sshHost);
+    const latestConversationTimestamp = findLatestClaudeConversationTimestamp(tailEvents);
+    if (!latestConversationTimestamp) {
+      const allEvents = await getCachedOrParse(filePath, () => readJsonLines(filePath, context.sshHost), context.sshHost);
+      return parseEvents(allEvents);
+    }
+
+    return {
+      ...headResult,
+      updatedAt: latestConversationTimestamp,
+    };
+  }
 
   const allEvents = await getCachedOrParse(filePath, () => readJsonLines(filePath, context.sshHost), context.sshHost);
   return parseEvents(allEvents);
+}
+
+function findLatestClaudeConversationTimestamp(events: unknown[]): string | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index] as ClaudeProjectEvent;
+    const role = resolveClaudeRole(event);
+    if (role !== "user" && role !== "assistant") continue;
+    if (!extractPlainText(event.message?.content)) continue;
+
+    const timestamp = toIsoString(event.timestamp);
+    if (timestamp) return timestamp;
+  }
+
+  return null;
 }
 
 async function findProjectFiles(context: AiSessionReaderContext): Promise<string[]> {
@@ -230,7 +258,7 @@ function consumeClaudeListEvent(
   }
 
   const normalizedTimestamp = toIsoString(event.timestamp);
-  if (normalizedTimestamp) {
+  if (normalizedTimestamp && text && (role === "user" || role === "assistant")) {
     accumulator.session.updatedAt = normalizedTimestamp;
   }
 

--- a/src/lib/aiSessions/readCodexSessions.ts
+++ b/src/lib/aiSessions/readCodexSessions.ts
@@ -119,7 +119,9 @@ async function parseCodexSessionSummary(filePath: string, context: AiSessionRead
       }
 
       messageCount += 1;
-      updatedAt = toIsoString(event.timestamp) ?? updatedAt;
+      if (message.role === "user" || message.role === "assistant") {
+        updatedAt = toIsoString(event.timestamp) ?? updatedAt;
+      }
     }
   }
 

--- a/src/lib/aiSessions/readGeminiSessions.ts
+++ b/src/lib/aiSessions/readGeminiSessions.ts
@@ -133,6 +133,9 @@ async function parseGeminiSessionSummary(
 
   const messages = flattenGeminiMessages(parsed.value.messages ?? []);
   const firstUserPrompt = messages.find((message) => message.role === "user")?.fullText ?? null;
+  const latestConversationMessageAt = sortMessagesDescending(
+    messages.filter((message) => message.role === "user" || message.role === "assistant"),
+  )[0]?.timestamp;
   const sessionId = resolveGeminiSessionId(parsed.value, filePath);
   const title = parsed.value.title ?? (firstUserPrompt ? truncateText(firstUserPrompt, 80) : null);
 
@@ -149,7 +152,8 @@ async function parseGeminiSessionSummary(
     id: sessionId,
     provider: "gemini",
     startedAt: toIsoString(parsed.value.startTime ?? parsed.value.createdAt ?? parsed.value.timestamp),
-    updatedAt: toIsoString(parsed.value.lastUpdated ?? parsed.value.updatedAt ?? parsed.value.timestamp),
+    updatedAt: latestConversationMessageAt
+      ?? toIsoString(parsed.value.lastUpdated ?? parsed.value.updatedAt ?? parsed.value.timestamp),
     matchedPath: parsed.matchedPath,
     matchScope: parsed.matchScope,
     title,

--- a/src/lib/aiSessions/readOpenCodeSessions.ts
+++ b/src/lib/aiSessions/readOpenCodeSessions.ts
@@ -20,6 +20,8 @@ import type { AggregatedAiMessage, AiMessageRole, AiSessionDetailReaderResult, A
 const execFileAsync = promisify(execFile);
 const OPEN_CODE_QUERY_LIMIT = 120;
 const DEFAULT_DETAIL_LIMIT = 20;
+// Remote detail queries return message bodies, so they need the same bounded large-session allowance as JSONL history reads.
+const OPEN_CODE_REMOTE_QUERY_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 const SQLITE_QUERY_SCRIPT = `
 import base64
 import json
@@ -42,6 +44,7 @@ interface OpenCodeSessionRow {
   title: string | null;
   time_created: number | null;
   time_updated: number | null;
+  last_message_at?: number | null;
   part_count?: number | null;
   first_user_part?: string | null;
   matching_part_count?: number | null;
@@ -70,6 +73,14 @@ export async function readOpenCodeSessions(context: AiSessionReaderContext): Pro
         s.title,
         s.time_created,
         s.time_updated,
+        (
+          SELECT MAX(p.time_created)
+          FROM part p
+          JOIN message m ON m.id = p.message_id
+          WHERE p.session_id = s.id
+            AND json_extract(m.data, '$.role') IN ('user', 'assistant')
+            AND json_extract(p.data, '$.type') = 'text'
+        ) as last_message_at,
         (SELECT COUNT(*) FROM part p WHERE p.session_id = s.id) as part_count,
         (
           SELECT p.data
@@ -85,7 +96,7 @@ export async function readOpenCodeSessions(context: AiSessionReaderContext): Pro
           ? `(SELECT COUNT(*) FROM part p WHERE p.session_id = s.id AND lower(p.data) LIKE '%' || @query || '%' ESCAPE '\\')`
           : '0'} as matching_part_count
       FROM session s
-      ORDER BY s.time_updated DESC
+      ORDER BY COALESCE(last_message_at, s.time_updated) DESC
       LIMIT ${OPEN_CODE_QUERY_LIMIT};`,
       escapedLikeQuery ? { query: escapedLikeQuery } : undefined
     );
@@ -116,7 +127,7 @@ export async function readOpenCodeSessions(context: AiSessionReaderContext): Pro
         id: row.id,
         provider: "opencode" as const,
         startedAt: toIsoString(row.time_created),
-        updatedAt: toIsoString(row.time_updated),
+        updatedAt: toIsoString(row.last_message_at ?? row.time_updated),
         matchedPath: row.directory,
         matchScope: determineMatchScope(row.directory, context)!,
         title: row.title ?? (firstUserPrompt ? truncateText(firstUserPrompt, 80) : null),
@@ -235,6 +246,7 @@ async function queryOpenCodeRows<T>(
   const output = await execGit(
     `python3 -c ${quoteShellArgument(SQLITE_QUERY_SCRIPT)} ${quoteShellArgument(encodeSqliteQueryPayload(dbPath, sql, parameters))}`,
     context.sshHost,
+    { maxBufferBytes: OPEN_CODE_REMOTE_QUERY_MAX_BUFFER_BYTES },
   );
   return parseSqliteQueryRows<T>(output);
 }

--- a/src/lib/aiSessions/shared.ts
+++ b/src/lib/aiSessions/shared.ts
@@ -1,8 +1,9 @@
 import { createReadStream } from "fs";
-import { readdir, readFile } from "fs/promises";
+import { open, readdir, readFile } from "fs/promises";
 import { createInterface } from "readline";
 import path from "path";
-import { getFileMtimeMs, readTextFile } from "@/lib/hostFileAccess";
+import { execGit } from "@/lib/gitOperations";
+import { getFileMtimeMs, quoteShellArgument, readTextFile } from "@/lib/hostFileAccess";
 import type {
   AggregatedAiMessage,
   AggregatedAiSession,
@@ -416,4 +417,34 @@ export function readJsonLinesHead(filePath: string, maxLines: number, sshHost?: 
     rl.on("error", reject);
     stream.on("error", reject);
   });
+}
+
+export async function readJsonLinesTail(filePath: string, maxLines: number, sshHost?: string | null): Promise<unknown[]> {
+  const content = sshHost
+    ? await execGit(`tail -n ${maxLines} ${quoteShellArgument(filePath)}`, sshHost)
+    : await readLocalFileTail(filePath);
+
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(-maxLines)
+    .map((line) => safeJsonParse(line))
+    .filter((value) => value !== null);
+}
+
+// Sixty recent JSONL events commonly include large tool payloads; 128 KiB bounds I/O while leaving room for that window.
+const LOCAL_TAIL_READ_BYTES = 128 * 1024;
+
+async function readLocalFileTail(filePath: string): Promise<string> {
+  const handle = await open(filePath, "r");
+  try {
+    const { size } = await handle.stat();
+    const readLength = Math.min(size, LOCAL_TAIL_READ_BYTES);
+    const buffer = Buffer.alloc(readLength);
+    await handle.read(buffer, 0, readLength, size - readLength);
+    return buffer.toString("utf-8");
+  } finally {
+    await handle.close();
+  }
 }

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -64,6 +64,7 @@ interface RemoteSSHConnectionLease {
 
 export interface ExecGitOptions {
   timeoutMs?: number;
+  maxBufferBytes?: number;
 }
 
 function collectErrorOutput(error: unknown): string {
@@ -218,7 +219,11 @@ async function execRemote(
     let lastError: Error | null = null;
     for (let attempt = 1; attempt <= REMOTE_SSH_COMMAND_MAX_ATTEMPTS; attempt += 1) {
       try {
-        return await spawnSSHCommand(sshArgs, timeoutMs);
+        return await spawnSSHCommand(
+          sshArgs,
+          timeoutMs,
+          options?.maxBufferBytes ?? REMOTE_COMMAND_MAX_BUFFER_BYTES,
+        );
       } catch (error) {
         const isCommandTimeout = isSSHCommandTimeoutError(error);
         const normalizedError = normalizeSSHExecError(error, sshHost, timeoutMs, isCommandTimeout);
@@ -268,7 +273,7 @@ function isRetriableSSHExecError(error: Error, isCommandTimeout: boolean): boole
   return isCommandTimeout || isSSHTransportError(error);
 }
 
-function spawnSSHCommand(sshArgs: string[], timeoutMs: number): Promise<string> {
+function spawnSSHCommand(sshArgs: string[], timeoutMs: number, maxBufferBytes: number): Promise<string> {
   return new Promise((resolve, reject) => {
     const child = spawn("ssh", sshArgs, {
       env: createLocalShellEnvironment(),
@@ -324,7 +329,7 @@ function spawnSSHCommand(sshArgs: string[], timeoutMs: number): Promise<string> 
     });
 
     function rejectIfOutputIsTooLarge(): void {
-      if (Buffer.byteLength(stdout) + Buffer.byteLength(stderr) <= REMOTE_COMMAND_MAX_BUFFER_BYTES) {
+      if (Buffer.byteLength(stdout) + Buffer.byteLength(stderr) <= maxBufferBytes) {
         return;
       }
 

--- a/src/lib/hostFileAccess.ts
+++ b/src/lib/hostFileAccess.ts
@@ -5,6 +5,8 @@ import { execGit } from "@/lib/gitOperations";
 
 const remoteHomeDirectoryCache = new Map<string, string>();
 const REMOTE_FILE_RECORD_PREFIX = "__KANVIBE_FILE_RECORD__";
+// AI history JSONL can exceed the general 10 MiB command cap; 64 MiB keeps reads bounded while covering large sessions.
+const REMOTE_TEXT_FILE_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 
 export interface TextFileReadResult {
   exists: boolean;
@@ -55,14 +57,11 @@ export async function readTextFile(targetPath: string, sshHost?: string | null):
     }
   }
 
-  try {
-    return await execGit(
-      `test -f ${quoteShellArgument(targetPath)} && cat ${quoteShellArgument(targetPath)} || true`,
-      sshHost,
-    );
-  } catch {
-    return "";
-  }
+  return execGit(
+    `test -f ${quoteShellArgument(targetPath)} && cat ${quoteShellArgument(targetPath)} || true`,
+    sshHost,
+    { maxBufferBytes: REMOTE_TEXT_FILE_MAX_BUFFER_BYTES },
+  );
 }
 
 export async function readTextFiles(


### PR DESCRIPTION
## 어떤 작업인가요?
- 원격 작업 공간의 AI 채팅 메시지를 정상적으로 읽고 복사할 수 있게 하며, 실제 최근 대화 순서대로 채팅방을 표시합니다.

## 어떻게 해결했나요?
**원격 채팅 기록 읽기 개선**
- SSH 명령별 출력 한도를 지정할 수 있게 하고 AI 기록 읽기에는 64MiB 한도를 적용했습니다.
- 원격 읽기 오류를 빈 파일로 숨기지 않고 호출자에게 전달하도록 변경했습니다.

**실제 대화 기준 정렬**
- Claude, Codex, Gemini, OpenCode에서 사용자 또는 AI의 텍스트 메시지 시각을 세션 갱신 시각으로 사용합니다.
- 긴 Claude 기록은 파일 끝을 우선 확인하고, 도구 이벤트만 남은 경우 전체 기록으로 폴백합니다.

**메시지 복사 지원**
- 채팅 말풍선마다 원문 복사 버튼과 복사 상태 피드백을 추가했습니다.
- 메시지 본문을 직접 드래그해 선택할 수 있도록 변경했습니다.

## 중요한 변경 사항은 무엇인가요?
### 원격 기록 전송 한도

**명령별 출력 한도 지원**
- **변경 이유**: 큰 JSONL 및 OpenCode SQLite 조회 결과가 공통 SSH 출력 한도에 막히지 않게 합니다.
- **수정 파일**: `src/lib/gitOperations.ts`, `src/lib/hostFileAccess.ts`, `src/lib/aiSessions/readOpenCodeSessions.ts`

### provider별 최신 대화 시각

**메타데이터와 도구 이벤트를 정렬 기준에서 제외**
- **변경 이유**: 실제로 메시지를 주고받은 채팅방이 목록 최상단에 오도록 합니다.
- **수정 파일**: `src/lib/aiSessions/readClaudeSessions.ts`, `src/lib/aiSessions/readCodexSessions.ts`, `src/lib/aiSessions/readGeminiSessions.ts`, `src/lib/aiSessions/readOpenCodeSessions.ts`

### 메시지별 복사 UI

**원문 복사와 다국어 상태 문구 추가**
- **변경 이유**: 렌더링된 채팅 메시지를 개별적으로 재사용할 수 있게 합니다.
- **수정 파일**: `src/desktop/renderer/routes/TaskDetailRoute.tsx`, `messages/*.json`

Co-Authored-By: Codex <codex@openai.com>
