### PR TITLE
fix(task): Done 처리 후 상세 흐름 유지

### DIFF
--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -2404,7 +2404,7 @@ describe("kanbanService.getSearchableTasks", () => {
     vi.clearAllMocks();
   });
 
-  it("빠른 검색용 task 목록에서 done 상태를 조회하지 않는다", async () => {
+  it("빠른 검색용 task 목록에 done 상태를 포함한다", async () => {
     // Given
     const updatedAt = new Date("2026-05-02T00:00:00.000Z");
     mocks.taskRepo.find.mockResolvedValue([
@@ -2418,6 +2418,16 @@ describe("kanbanService.getSearchableTasks", () => {
         status: "progress",
         updatedAt,
       },
+      {
+        id: "task-done",
+        title: "Done task",
+        branchName: "feat/done-search",
+        projectId: "project-kanvibe",
+        project: { name: "kanvibe", sshHost: null },
+        sshHost: null,
+        status: "done",
+        updatedAt,
+      },
     ]);
 
     const { getSearchableTasks } = await import("@/desktop/main/services/kanbanService");
@@ -2426,16 +2436,10 @@ describe("kanbanService.getSearchableTasks", () => {
     const result = await getSearchableTasks();
 
     // Then
-    expect(mocks.taskRepo.find).toHaveBeenCalledWith(expect.objectContaining({
-      where: expect.objectContaining({
-        status: expect.objectContaining({
-          _type: "not",
-          _value: "done",
-        }),
-      }),
+    expect(mocks.taskRepo.find).toHaveBeenCalledWith({
       relations: ["project"],
       order: { updatedAt: "DESC", createdAt: "DESC" },
-    }));
+    });
     expect(result).toEqual([
       {
         id: "task-active",
@@ -2445,6 +2449,16 @@ describe("kanbanService.getSearchableTasks", () => {
         projectName: "kanvibe",
         sshHost: null,
         status: "progress",
+        updatedAt: "2026-05-02T00:00:00.000Z",
+      },
+      {
+        id: "task-done",
+        title: "Done task",
+        branchName: "feat/done-search",
+        projectId: "project-kanvibe",
+        projectName: "kanvibe",
+        sshHost: null,
+        status: "done",
         updatedAt: "2026-05-02T00:00:00.000Z",
       },
     ]);

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -474,7 +474,6 @@ export async function getTaskById(taskId: string): Promise<KanbanTask | null> {
 export async function getSearchableTasks(): Promise<SearchableTask[]> {
   const repo = await getTaskRepository();
   const tasks = await repo.find({
-    where: { status: Not(TaskStatus.DONE) },
     relations: ["project"],
     order: { updatedAt: "DESC", createdAt: "DESC" },
   });

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -1384,11 +1384,6 @@ export default function TaskDetailRoute() {
   async function handleStatusChange(formData: FormData) {
     const newStatus = formData.get("status") as TaskStatus;
     const updatedTask = await updateTaskStatus(id, newStatus);
-    if (newStatus === TaskStatus.DONE) {
-      router.push("/");
-      return;
-    }
-
     if (updatedTask) {
       setState((current) => current
         ? {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -192,7 +192,18 @@ vi.mock("@/components/DeleteTaskButton", () => ({
 }));
 
 vi.mock("@/components/DoneStatusButton", () => ({
-  default: () => <button type="button">done</button>,
+  default: ({ statusChangeAction }: { statusChangeAction: (formData: FormData) => Promise<void> }) => (
+    <button
+      type="button"
+      onClick={() => {
+        const formData = new FormData();
+        formData.set("status", "done");
+        void statusChangeAction(formData);
+      }}
+    >
+      done
+    </button>
+  ),
 }));
 
 vi.mock("@/components/HooksStatusCard", () => ({
@@ -1354,6 +1365,39 @@ describe("TaskDetailRoute", () => {
 
     expect(await screen.findByTestId("hooks-status-card")).toBeTruthy();
     expect(screen.getByText("done")).toBeTruthy();
+  });
+
+  it("Done 상태로 변경해도 상세 화면을 유지한다", async () => {
+    const task = {
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/stay-on-detail",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/stay-on-detail",
+    };
+    mocks.getTaskById.mockResolvedValue(task);
+    mocks.updateTaskStatus.mockResolvedValue({ ...task, status: "done" });
+
+    render(<TaskDetailRoute />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "actions · hooksStatus" }));
+    fireEvent.click(screen.getByRole("button", { name: "done" }));
+
+    await waitFor(() => {
+      expect(mocks.updateTaskStatus).toHaveBeenCalledWith("task-1", "done");
+      expect(screen.queryByRole("button", { name: "done" })).toBeNull();
+    });
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "moveToTodo" })).toBeTruthy();
   });
 
   it("AI 세션 로드가 느려도 hooks 상태는 먼저 갱신한다", async () => {


### PR DESCRIPTION
## 어떤 작업인가요?
- Done 상태 전환 이후에도 태스크 상세 작업 흐름을 유지하고, 빠른 검색에서 Done 태스크를 다시 찾을 수 있도록 수정합니다.

## 어떻게 해결했나요?
**Done 전환 후 상세 화면 유지**
- Done 상태만 대시보드로 강제 이동하던 분기를 제거했습니다.
- 상태 변경 응답을 현재 상세 화면의 task 상태에 반영하도록 기존 공통 흐름을 재사용했습니다.

**Done 태스크 빠른 검색 지원**
- 빠른 검색용 task 조회에서 Done 제외 조건을 제거했습니다.
- active task와 Done task가 함께 반환되는 서비스 회귀 테스트를 추가했습니다.

## 중요한 변경 사항은 무엇인가요?
### 상세 화면 상태 전환

**Done 전환 후 route 유지**
- **변경 이유**: 상태를 완료로 바꿔도 현재 터미널과 상세 작업 맥락을 유지하기 위해서입니다.
- **수정 파일**: `src/desktop/renderer/routes/TaskDetailRoute.tsx`, `src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx`

### 빠른 검색 조회 범위

**Done 상태 포함**
- **변경 이유**: `Cmd+Shift+O` 빠른 검색으로 완료된 태스크도 다시 열 수 있어야 하기 때문입니다.
- **수정 파일**: `src/desktop/main/services/kanbanService.ts`, `src/desktop/main/services/__tests__/kanbanService.test.ts`

Co-authored-by: Codex <codex@openai.com>

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙입니다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.