### PR TITLE
chore(release): publish KanVibe 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.10",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Publishes KanVibe 1.1.0. This branch carries only the version bump; the shipped changes are the three commits already merged into `dev` since 1.0.10 (terminal header badge project markers, remote chat message reading and conversation ordering, and the Done-transition detail flow fix).

Version bumped from `1.0.10` to `1.1.0` in `package.json` and `package-lock.json`.

## Test Plan

- `pnpm install --frozen-lockfile` under pnpm 10.34.5; native `better-sqlite3` rebuild completed.
- `pnpm run deploy` completed: dependency collector reported `pm=npm`, and the packaging guard reported `packaged node_modules verified: 278 packages`.
- `app.asar` contents compared against the known-good installed 1.0.10 build using the same method: 232 top-level keys / 278 flattened packages on both. No missing transitive dependencies.
- Signed with `Developer ID Application: Jong In Baek (3SDH4HX6H8)`; `codesign --verify --deep --strict` reported `valid on disk` and `satisfies its Designated Requirement`.
- Notarization `status: Accepted`; `xcrun stapler staple` and `xcrun stapler validate` both succeeded on the DMG.
- Smoke test on the exact published DMG (all four gates passed):
  - `spctl -a -t exec` → `accepted`, `source=Notarized Developer ID`
  - process still alive 20s after `open -n`
  - module errors (`cannot find module` / `MODULE_NOT_FOUND` / `unhandled rejection`): `0`
  - `invoke-succeeded`: `13`
  - Run isolated via `open --env KANVIBE_APP_DATA_DIR=<temp>` so userData, database, and diagnostics log were separated from the running instance.
- Release asset re-downloaded from GitHub and hashed; the served bytes match the local artifact exactly.

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.1.0
- DMG asset: `dist/KanVibe-1.1.0.dmg` (uploaded as `KanVibe-1.1.0.dmg`, 171062941 bytes)
- SHA-256: `7fc2182832e99069d4029d6cab24deb480f5f82d71c8d4d2fffcb2d468eb9249`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@f775402` — `version` and `sha256` updated, URL shape unchanged.
