### PR TITLE
Release: promote KanVibe 1.1.0 to main

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -385,7 +385,7 @@
     "aiSessions": {
       "title": "AI Sessions",
       "inlineChat": "AI Chat",
-      "remoteBadge": "Remote unsupported",
+      "remoteBadge": "No remote sessions to display.",
       "noPreview": "No preview is available.",
       "loadMoreSessions": "Load more chats",
       "loadOlderMessages": "Load older messages",
@@ -396,6 +396,9 @@
       "selectSession": "Select an AI session from the list.",
       "loadingDetail": "Loading messages...",
       "detailError": "Failed to load session details.",
+      "copyMessage": "Copy",
+      "copiedMessage": "Copied",
+      "copyFailed": "Copy failed",
       "roles": {
         "user": "User input",
         "assistant": "AI answer",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -385,7 +385,7 @@
     "aiSessions": {
       "title": "AI 세션",
       "inlineChat": "AI 채팅",
-      "remoteBadge": "원격 미지원",
+      "remoteBadge": "표시할 원격 세션이 없습니다.",
       "noPreview": "표시할 미리보기가 없습니다.",
       "loadMoreSessions": "채팅 더 불러오기",
       "loadOlderMessages": "이전 메시지 더 보기",
@@ -396,6 +396,9 @@
       "selectSession": "왼쪽 목록에서 AI 세션을 선택하세요.",
       "loadingDetail": "메시지를 불러오는 중...",
       "detailError": "세션 상세를 불러오지 못했습니다.",
+      "copyMessage": "복사",
+      "copiedMessage": "복사됨",
+      "copyFailed": "복사 실패",
       "roles": {
         "user": "사용자 입력",
         "assistant": "AI 답변",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -384,7 +384,7 @@
     "aiSessions": {
       "title": "AI 会话",
       "inlineChat": "AI 聊天",
-      "remoteBadge": "不支持远程",
+      "remoteBadge": "没有可显示的远程会话。",
       "noPreview": "没有可显示的预览。",
       "loadMoreSessions": "加载更多聊天",
       "loadOlderMessages": "加载更早消息",
@@ -395,6 +395,9 @@
       "selectSession": "从左侧列表选择 AI 会话。",
       "loadingDetail": "正在加载消息...",
       "detailError": "加载会话详情失败。",
+      "copyMessage": "复制",
+      "copiedMessage": "已复制",
+      "copyFailed": "复制失败",
       "roles": {
         "user": "用户输入",
         "assistant": "AI 回复",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.0.10",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "qa:task-kind-filter": "pnpm exec vitest run src/components/__tests__/Board.test.tsx src/desktop/renderer/hooks/__tests__/useTaskKindFilterParams.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-task-kind-filter-video.sh",
     "qa:terminal-tab": "pnpm exec vitest run src/lib/__tests__/terminalTabs.test.ts src/lib/__tests__/terminalSessionLifecycle.test.ts src/desktop/main/services/__tests__/terminalTabService.test.ts src/desktop/renderer/components/__tests__/TerminalTabBar.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-electron-flow-video.sh terminal-tab",
     "qa:project-registry-search": "pnpm exec vitest run src/components/__tests__/ProjectRegistryDialog.test.tsx src/components/__tests__/ProjectSelector.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-electron-flow-video.sh project-registry-search",
+    "qa:terminal-task-context-badge": "pnpm exec vitest run src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx src/components/__tests__/ProjectIcon.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-electron-flow-video.sh terminal-task-context-badge",
     "qa:ai-session-history": "pnpm exec vitest run src/lib/aiSessions && pnpm exec vitest run src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx && pnpm qa:electron:prepare && bash scripts/qa-ai-session-history-video.sh",
     "qa:pr275-pr276": "bash scripts/qa-pr275-pr276.sh",
     "pretest": "node scripts/ensure-native-runtime.cjs",

--- a/qa/electron/flows/terminal-task-context-badge.cjs
+++ b/qa/electron/flows/terminal-task-context-badge.cjs
@@ -1,0 +1,480 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports */
+/**
+ * 터미널 헤더 태스크 배지 QA 플로우.
+ * 배지 배경이 프로젝트 설정 색을 그대로 쓰는지, 그리고 그 배경 위에 얹은 첫 글자 칩이
+ * 같은 색으로 묻히지 않는지를 실제 Electron 화면의 계산된 스타일로 확인한다.
+ * fixture 저장소에는 GitHub remote를 두지 않아 항상 이니셜 칩 폴백 경로를 타게 만든다.
+ */
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+const { createQaRun } = require("../lib/report.cjs");
+const { launchKanVibeElectron } = require("../lib/launchElectron.cjs");
+
+const TASK_CONTEXT_BADGE_SCOPE = "터미널 헤더 태스크 배지: 프로젝트 아이콘·이름·태스크명이 한 배지에 순서대로 나오고, 배경이 프로젝트 설정 색과 같으며, 밝은 색과 어두운 색 모두에서 첫 글자 칩과 글자가 배경 위에서 읽히는지 검증한다";
+
+/** 어두운 프로젝트 색과 밝은 프로젝트 색 양쪽에서 대비 반전이 도는지 봐야 한다 */
+const DARK_PROJECT_COLOR = "#0064FF";
+const LIGHT_PROJECT_COLOR = "#FDE047";
+
+/** WCAG 1.4.11 non-text contrast. 칩은 배경 위에 얹힌 그래픽이므로 이 선을 넘어야 보인다 */
+const MINIMUM_GRAPHIC_CONTRAST = 3;
+/** WCAG 1.4.3 large text. 배지 글자는 작으므로 여유를 두고 이 선으로 본다 */
+const MINIMUM_TEXT_CONTRAST = 4.5;
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--run-dir") args.runDir = argv[++index];
+    else if (arg === "--run-id") args.runId = argv[++index];
+    else if (arg === "--output-root") args.outputRoot = argv[++index];
+  }
+  return args;
+}
+
+function gitValue(args) {
+  try {
+    return execFileSync("git", args, { encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function execGit(args, cwd) {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function renderReport(result) {
+  const lines = [];
+  lines.push("# KanVibe Terminal Task Context Badge Electron QA Report");
+  lines.push("");
+  lines.push(`- Run ID: \`${result.runId}\``);
+  lines.push(`- Branch: \`${result.branch || "unknown"}\``);
+  lines.push(`- Commit: \`${result.commit || "unknown"}\``);
+  lines.push(`- Scope: ${result.scope}`);
+  lines.push(`- Status: **${result.ok ? "PASS" : "FAIL"}**`);
+  lines.push("");
+  lines.push("## Checks");
+  lines.push("");
+  for (const check of result.checks) {
+    lines.push(`- ${check.ok ? "✅" : "❌"} **${check.name}**${check.detail ? ` — ${check.detail}` : ""}`);
+  }
+  lines.push("");
+  lines.push("## Console / Runtime Errors");
+  lines.push("");
+  if (result.errors.length > 0) {
+    for (const error of result.errors) lines.push(`- ${error}`);
+  } else {
+    lines.push("No blocking console/runtime errors captured.");
+  }
+  lines.push("");
+  lines.push("## Evidence");
+  lines.push("");
+  for (const shot of result.screenshots) {
+    lines.push(`- ${shot.label}: \`${shot.path}\``);
+  }
+  if (result.videoPath) lines.push(`- Video: \`${result.videoPath}\``);
+  if (result.tracePath) lines.push(`- Playwright trace: \`${result.tracePath}\``);
+  lines.push("");
+  lines.push("## Notes");
+  lines.push("");
+  for (const note of result.notes) lines.push(`- ${note}`);
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeReport(run, result) {
+  const fullResult = { ...result, runId: run.runId };
+  writeJson(run.jsonPath, fullResult);
+  fs.writeFileSync(run.reportPath, renderReport(fullResult), "utf8");
+}
+
+async function optionalStep(checks, name, fn) {
+  try {
+    const detail = await fn();
+    checks.push({ name, ok: true, detail: detail || "ok" });
+    return detail;
+  } catch (error) {
+    checks.push({ name, ok: false, detail: error instanceof Error ? error.message : String(error) });
+    return null;
+  }
+}
+
+async function takeScreenshot(page, run, label, screenshots) {
+  const fileName = `${String(screenshots.length + 1).padStart(2, "0")}-${label}.png`;
+  const shotPath = path.join(run.screenshotsDir, fileName);
+  await page.screenshot({ path: shotPath, fullPage: true });
+  screenshots.push({ label, path: shotPath });
+}
+
+async function invokeDesktop(page, namespace, method, ...args) {
+  return page.evaluate(
+    async ({ namespace: serviceNamespace, method: serviceMethod, args: serviceArgs }) => (
+      window.kanvibeDesktop.invoke(serviceNamespace, serviceMethod, serviceArgs)
+    ),
+    { namespace, method, args },
+  );
+}
+
+async function dismissUpdateDialogIfPresent(page) {
+  const closeButton = page.getByRole("button", { name: /닫기|Close/i }).first();
+  try {
+    await closeButton.click({ timeout: 2500 });
+    await page.waitForTimeout(500);
+  } catch {
+    // Optional release/update dialog is not always present.
+  }
+}
+
+/** GitHub remote가 없어야 아이콘 대신 이니셜 칩 폴백이 그려진다 */
+function createLocalFixtureRepository(run) {
+  const projectDir = path.join(run.runDir, "fixtures", `task-context-badge-${run.runId}`);
+  const projectName = `Quasar Badge QA ${run.runId}`;
+  const defaultBranch = "main";
+  fs.rmSync(projectDir, { recursive: true, force: true });
+  ensureDir(projectDir);
+
+  try {
+    execGit(["init", "--initial-branch", defaultBranch], projectDir);
+  } catch {
+    execGit(["init"], projectDir);
+    execGit(["checkout", "-B", defaultBranch], projectDir);
+  }
+  execGit(["config", "user.email", "qa@kanvibe.local"], projectDir);
+  execGit(["config", "user.name", "KanVibe QA"], projectDir);
+  fs.writeFileSync(path.join(projectDir, "README.md"), `# ${projectName}\n`, "utf8");
+  execGit(["add", "README.md"], projectDir);
+  execGit(["commit", "-m", "Initial QA fixture"], projectDir);
+
+  return { projectDir, projectName, defaultBranch };
+}
+
+/** 기본으로 열리는 작업 정보 패널은 터미널 크롬을 덮으므로 패널 밖 본문을 눌러 닫는다 */
+async function dismissDetailPanel(page) {
+  const viewport = page.viewportSize() || { width: 1500, height: 950 };
+  await page.mouse.click(Math.round(viewport.width * 0.75), Math.round(viewport.height * 0.6));
+  await page.waitForTimeout(500);
+}
+
+async function openTaskDetail(page, taskId) {
+  await page.evaluate((id) => {
+    window.location.hash = `#/ko/task/${id}`;
+  }, taskId);
+  await page.getByTestId("terminal-task-context").waitFor({ state: "visible", timeout: 20000 });
+  await dismissDetailPanel(page);
+  await page.waitForTimeout(1000);
+}
+
+/** 색을 바꾼 뒤 라우트가 태스크를 다시 읽게 만든다 */
+async function reopenTaskDetail(page, taskId) {
+  await page.evaluate(() => {
+    window.location.hash = "#/ko";
+  });
+  await page.waitForTimeout(800);
+  await openTaskDetail(page, taskId);
+}
+
+function parseRgb(cssColor) {
+  const matched = String(cssColor).match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!matched) throw new Error(`계산된 색을 읽을 수 없다: ${cssColor}`);
+  return [Number(matched[1]), Number(matched[2]), Number(matched[3])];
+}
+
+function toLinearChannel(channel) {
+  const normalized = channel / 255;
+  return normalized <= 0.03928 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(rgb) {
+  const weights = [0.2126, 0.7152, 0.0722];
+  return rgb.reduce((total, channel, index) => total + toLinearChannel(channel) * weights[index], 0);
+}
+
+/** WCAG 대비율. 프로덕션이 고른 색을 그대로 믿지 않고 결과를 독립적으로 재는 데 쓴다 */
+function contrastRatio(foreground, background) {
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function hexToRgb(hexColor) {
+  const value = Number.parseInt(hexColor.replace("#", ""), 16);
+  return [(value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff];
+}
+
+function isSameColor(a, b) {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+}
+
+/** 배지 한 덩어리에서 판정에 필요한 텍스트와 계산된 색을 한 번에 읽어 온다 */
+async function readBadgeAppearance(page) {
+  return page.evaluate(() => {
+    const badge = document.querySelector('[data-testid="terminal-task-context"]');
+    if (!badge) return null;
+
+    const badgeStyle = window.getComputedStyle(badge);
+    const projectNameNode = badge.querySelector('[data-testid="terminal-task-context-project"]');
+    const initialChip = badge.querySelector('[data-testid="project-initial-icon"]');
+    const githubIcon = badge.querySelector('[data-testid="project-github-icon"]');
+    const chipStyle = initialChip ? window.getComputedStyle(initialChip) : null;
+
+    return {
+      text: badge.textContent,
+      title: badge.getAttribute("title"),
+      backgroundColor: badgeStyle.backgroundColor,
+      textColor: badgeStyle.color,
+      projectName: projectNameNode ? projectNameNode.textContent : null,
+      hasInitialChip: Boolean(initialChip),
+      hasGitHubIcon: Boolean(githubIcon),
+      chipBackgroundColor: chipStyle ? chipStyle.backgroundColor : null,
+      chipTextColor: chipStyle ? chipStyle.color : null,
+      /** 배지 안에서 실제로 보이는 순서를 확인하려고 자식 노드를 순서대로 남긴다 */
+      childOrder: [...badge.childNodes].map((node) => (
+        node.nodeType === Node.TEXT_NODE
+          ? `#text:${node.textContent.trim()}`
+          : `${node.tagName.toLowerCase()}:${node.getAttribute?.("data-testid") || node.textContent.trim()}`
+      )),
+    };
+  });
+}
+
+/** 색 변경이 라우트에 반영될 때까지 기다린다 */
+async function waitForBadgeBackground(page, expectedHex, timeoutMs = 20000) {
+  const expected = hexToRgb(expectedHex);
+  const deadline = Date.now() + timeoutMs;
+  let lastAppearance = null;
+
+  while (Date.now() < deadline) {
+    lastAppearance = await readBadgeAppearance(page);
+    if (lastAppearance && isSameColor(parseRgb(lastAppearance.backgroundColor), expected)) {
+      return lastAppearance;
+    }
+    await page.waitForTimeout(400);
+  }
+
+  throw new Error(`배지 배경이 ${expectedHex}로 바뀌지 않았다: ${JSON.stringify(lastAppearance)}`);
+}
+
+/** 배지가 밝은/어두운 프로젝트 색 어느 쪽에서도 읽히는지 한 묶음으로 판정한다 */
+function assertBadgeIsLegible(appearance, expectedHex) {
+  const background = parseRgb(appearance.backgroundColor);
+  const text = parseRgb(appearance.textColor);
+  const failures = [];
+
+  const textContrast = contrastRatio(text, background);
+  if (textContrast < MINIMUM_TEXT_CONTRAST) {
+    failures.push(`글자 대비 ${textContrast.toFixed(2)}:1 < ${MINIMUM_TEXT_CONTRAST}:1`);
+  }
+
+  if (!appearance.hasInitialChip) {
+    failures.push("이니셜 칩이 그려지지 않았다");
+  } else {
+    const chipBackground = parseRgb(appearance.chipBackgroundColor);
+    if (isSameColor(chipBackground, background)) {
+      failures.push("이니셜 칩 배경이 배지 배경과 같아 묻힌다");
+    }
+    const chipContrast = contrastRatio(chipBackground, background);
+    if (chipContrast < MINIMUM_GRAPHIC_CONTRAST) {
+      failures.push(`칩 대비 ${chipContrast.toFixed(2)}:1 < ${MINIMUM_GRAPHIC_CONTRAST}:1`);
+    }
+    const chipTextContrast = contrastRatio(parseRgb(appearance.chipTextColor), chipBackground);
+    if (chipTextContrast < MINIMUM_TEXT_CONTRAST) {
+      failures.push(`칩 글자 대비 ${chipTextContrast.toFixed(2)}:1 < ${MINIMUM_TEXT_CONTRAST}:1`);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`${expectedHex} 배경에서 배지가 읽히지 않는다: ${failures.join(", ")}`);
+  }
+
+  const chipBackground = parseRgb(appearance.chipBackgroundColor);
+  return [
+    `bg=${appearance.backgroundColor}`,
+    `text=${appearance.textColor} (${contrastRatio(text, background).toFixed(2)}:1)`,
+    `chip=${appearance.chipBackgroundColor} (${contrastRatio(chipBackground, background).toFixed(2)}:1)`,
+  ].join(", ");
+}
+
+async function seedBadgeFixture(page, fixture, runId) {
+  const projectResult = await invokeDesktop(page, "project", "registerProject", fixture.projectName, fixture.projectDir);
+  if (!projectResult.success || !projectResult.project) {
+    throw new Error(projectResult.error || "QA project registration failed");
+  }
+
+  const project = projectResult.project;
+  const task = await invokeDesktop(page, "kanban", "createTask", {
+    title: `qa-badge-project-marker-${runId}`,
+    description: "Electron QA task for the terminal header project marker badge.",
+    projectId: project.id,
+    baseBranch: fixture.defaultBranch,
+  });
+
+  const connected = await invokeDesktop(page, "kanban", "connectTerminalSession", task.id, "terminal");
+  if (!connected || connected.sessionType !== "terminal") {
+    throw new Error(`connectTerminalSession failed: ${JSON.stringify(connected)}`);
+  }
+
+  return { project, taskId: task.id, taskTitle: task.title };
+}
+
+async function main() {
+  const options = parseArgs(process.argv);
+  const run = createQaRun({ ...options, rootDir: process.cwd() });
+  const fixture = createLocalFixtureRepository(run);
+  const checks = [];
+  const screenshots = [];
+  const consoleErrors = [];
+  const notes = [];
+  let app = null;
+  let page = null;
+  let traceStarted = false;
+
+  try {
+    const launched = await launchKanVibeElectron({
+      rootDir: run.rootDir,
+      outputDir: run.runDir,
+      appDataDir: path.join(run.runDir, "app-data"),
+      viewport: { width: 1500, height: 950 },
+      actionTimeoutMs: 15000,
+    });
+    app = launched.app;
+    page = launched.page;
+
+    page.on("console", (message) => {
+      if (["error", "warning"].includes(message.type())) {
+        consoleErrors.push(`${message.type()}: ${message.text()}`);
+      }
+    });
+    page.on("pageerror", (error) => consoleErrors.push(`pageerror: ${error.message}`));
+
+    await page.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
+    traceStarted = true;
+
+    await optionalStep(checks, "Electron 창이 KanVibe 보드로 열린다", async () => {
+      await page.waitForLoadState("domcontentloaded");
+      await page.locator("body").waitFor({ state: "visible", timeout: 20000 });
+      await dismissUpdateDialogIfPresent(page);
+      return page.url();
+    });
+
+    let seeded = null;
+    await optionalStep(checks, "GitHub remote 없는 QA 프로젝트와 터미널 태스크를 준비한다", async () => {
+      seeded = await seedBadgeFixture(page, fixture, run.runId);
+      if (seeded.project.iconDataUrl) {
+        throw new Error("fixture 프로젝트에 GitHub 아이콘이 붙어 이니셜 칩 폴백을 검증할 수 없다");
+      }
+      return `project=${seeded.project.name}, task=${seeded.taskId}`;
+    });
+    if (!seeded) throw new Error("QA seed 실패로 배지 플로우를 진행할 수 없다");
+
+    await optionalStep(checks, "어두운 프로젝트 색을 지정하면 배지 배경이 그 색과 같아진다", async () => {
+      await invokeDesktop(page, "kanban", "updateProjectColor", seeded.project.id, DARK_PROJECT_COLOR);
+      await openTaskDetail(page, seeded.taskId);
+      const appearance = await waitForBadgeBackground(page, DARK_PROJECT_COLOR);
+      await takeScreenshot(page, run, "badge-dark-project-color", screenshots);
+      return `expected=${DARK_PROJECT_COLOR}, actual=${appearance.backgroundColor}`;
+    });
+
+    await optionalStep(checks, "배지가 아이콘·프로젝트명·구분자·태스크명 순서로 나온다", async () => {
+      const appearance = await readBadgeAppearance(page);
+      if (appearance.projectName !== seeded.project.name) {
+        throw new Error(`프로젝트명이 배지에 없다: ${JSON.stringify(appearance.projectName)}`);
+      }
+      if (!appearance.text.includes(seeded.taskTitle)) {
+        throw new Error(`태스크명이 배지에 없다: ${appearance.text}`);
+      }
+      if (appearance.title !== `${seeded.project.name} | ${seeded.taskTitle}`) {
+        throw new Error(`tooltip이 프로젝트명과 태스크명을 함께 담지 않았다: ${appearance.title}`);
+      }
+      const chipIndex = appearance.childOrder.findIndex((entry) => entry.includes("project-initial-icon"));
+      const nameIndex = appearance.childOrder.findIndex((entry) => entry.includes("terminal-task-context-project"));
+      if (chipIndex === -1 || nameIndex === -1 || chipIndex > nameIndex) {
+        throw new Error(`아이콘이 프로젝트명 왼쪽에 있지 않다: ${JSON.stringify(appearance.childOrder)}`);
+      }
+      return `order=${appearance.childOrder.join(" > ")}`;
+    });
+
+    await optionalStep(checks, "어두운 프로젝트 색 위에서 글자와 이니셜 칩이 모두 읽힌다", async () => {
+      const appearance = await readBadgeAppearance(page);
+      return assertBadgeIsLegible(appearance, DARK_PROJECT_COLOR);
+    });
+
+    await optionalStep(checks, "밝은 프로젝트 색으로 바꾸면 배경이 따라가고 대비가 반전된다", async () => {
+      const darkAppearance = await readBadgeAppearance(page);
+      await invokeDesktop(page, "kanban", "updateProjectColor", seeded.project.id, LIGHT_PROJECT_COLOR);
+      await reopenTaskDetail(page, seeded.taskId);
+      const lightAppearance = await waitForBadgeBackground(page, LIGHT_PROJECT_COLOR);
+      await takeScreenshot(page, run, "badge-light-project-color", screenshots);
+
+      if (lightAppearance.textColor === darkAppearance.textColor) {
+        throw new Error(`밝은 색으로 바꿔도 글자색이 그대로다: ${lightAppearance.textColor}`);
+      }
+      const legibility = assertBadgeIsLegible(lightAppearance, LIGHT_PROJECT_COLOR);
+      return `${legibility}, 어두운 색일 때 글자=${darkAppearance.textColor}`;
+    });
+
+    await optionalStep(checks, "차단성 콘솔 에러가 없다", async () => {
+      const blocking = consoleErrors.filter((line) => !/favicon|DevTools|Electron Security Warning|Insecure Content-Security-Policy/i.test(line));
+      if (blocking.length > 0) throw new Error(blocking.join("\n"));
+      return "none";
+    });
+  } catch (error) {
+    checks.push({ name: "Electron 터미널 배지 QA 플로우", ok: false, detail: error instanceof Error ? error.stack || error.message : String(error) });
+  } finally {
+    if (page && traceStarted) {
+      await page.context().tracing.stop({ path: run.tracePath }).catch((error) => {
+        checks.push({ name: "Playwright trace artifact", ok: false, detail: error instanceof Error ? error.message : String(error) });
+      });
+    }
+    if (app) await app.close().catch(() => {});
+  }
+
+  await optionalStep(checks, "Playwright trace artifact written", async () => {
+    if (!fs.existsSync(run.tracePath) || fs.statSync(run.tracePath).size === 0) {
+      throw new Error(`trace missing or empty: ${run.tracePath}`);
+    }
+    return run.tracePath;
+  });
+
+  const ok = checks.every((check) => check.ok);
+  const videoExists = fs.existsSync(run.videoPath) && fs.statSync(run.videoPath).size > 0;
+  notes.push(`Fixture project: ${fixture.projectName} (GitHub remote 없음 → 이니셜 칩 폴백 경로)`);
+  notes.push("QA uses an isolated KANVIBE_APP_DATA_DIR inside the run directory, not the user's app database.");
+  notes.push(videoExists ? "Actual X11 screen recording captured with ffmpeg." : "No mp4 was present when flow finished; wrapper script can synthesize one from screenshots.");
+  notes.push(`Node: ${process.version}; platform: ${process.platform}/${process.arch}; tmp: ${os.tmpdir()}`);
+
+  const result = {
+    ok,
+    scope: TASK_CONTEXT_BADGE_SCOPE,
+    branch: gitValue(["branch", "--show-current"]),
+    commit: gitValue(["rev-parse", "--short", "HEAD"]),
+    checks,
+    errors: consoleErrors,
+    screenshots,
+    videoPath: videoExists ? run.videoPath : null,
+    tracePath: fs.existsSync(run.tracePath) ? run.tracePath : null,
+    notes,
+  };
+
+  writeReport(run, result);
+  console.log(JSON.stringify({ ok, runDir: run.runDir, reportPath: run.reportPath, videoPath: run.videoPath }, null, 2));
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -2404,7 +2404,7 @@ describe("kanbanService.getSearchableTasks", () => {
     vi.clearAllMocks();
   });
 
-  it("빠른 검색용 task 목록에서 done 상태를 조회하지 않는다", async () => {
+  it("빠른 검색용 task 목록에 done 상태를 포함한다", async () => {
     // Given
     const updatedAt = new Date("2026-05-02T00:00:00.000Z");
     mocks.taskRepo.find.mockResolvedValue([
@@ -2418,6 +2418,16 @@ describe("kanbanService.getSearchableTasks", () => {
         status: "progress",
         updatedAt,
       },
+      {
+        id: "task-done",
+        title: "Done task",
+        branchName: "feat/done-search",
+        projectId: "project-kanvibe",
+        project: { name: "kanvibe", sshHost: null },
+        sshHost: null,
+        status: "done",
+        updatedAt,
+      },
     ]);
 
     const { getSearchableTasks } = await import("@/desktop/main/services/kanbanService");
@@ -2426,16 +2436,10 @@ describe("kanbanService.getSearchableTasks", () => {
     const result = await getSearchableTasks();
 
     // Then
-    expect(mocks.taskRepo.find).toHaveBeenCalledWith(expect.objectContaining({
-      where: expect.objectContaining({
-        status: expect.objectContaining({
-          _type: "not",
-          _value: "done",
-        }),
-      }),
+    expect(mocks.taskRepo.find).toHaveBeenCalledWith({
       relations: ["project"],
       order: { updatedAt: "DESC", createdAt: "DESC" },
-    }));
+    });
     expect(result).toEqual([
       {
         id: "task-active",
@@ -2445,6 +2449,16 @@ describe("kanbanService.getSearchableTasks", () => {
         projectName: "kanvibe",
         sshHost: null,
         status: "progress",
+        updatedAt: "2026-05-02T00:00:00.000Z",
+      },
+      {
+        id: "task-done",
+        title: "Done task",
+        branchName: "feat/done-search",
+        projectId: "project-kanvibe",
+        projectName: "kanvibe",
+        sshHost: null,
+        status: "done",
         updatedAt: "2026-05-02T00:00:00.000Z",
       },
     ]);

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -474,7 +474,6 @@ export async function getTaskById(taskId: string): Promise<KanbanTask | null> {
 export async function getSearchableTasks(): Promise<SearchableTask[]> {
   const repo = await getTaskRepository();
   const tasks = await repo.find({
-    where: { status: Not(TaskStatus.DONE) },
     relations: ["project"],
     order: { updatedAt: "DESC", createdAt: "DESC" },
   });

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -775,13 +775,25 @@ function InlineAiChatEmpty({ text, compact = false }: { text: string; compact?: 
 }
 
 function InlineAiChatMessage({ message, provider }: { message: AggregatedAiMessage; provider: AggregatedAiSession["provider"] }) {
+  const t = useTranslations("taskDetail");
   const isUserMessage = message.role === "user";
   const displayedText = message.fullText || message.text;
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+  const copyLabel = t(`aiSessions.${copyState === "idle" ? "copyMessage" : copyState === "copied" ? "copiedMessage" : "copyFailed"}`);
+
+  async function copyMessage() {
+    try {
+      await navigator.clipboard.writeText(displayedText);
+      setCopyState("copied");
+    } catch {
+      setCopyState("error");
+    }
+  }
 
   return (
     <div className={`flex ${isUserMessage ? "justify-end" : "justify-start"}`}>
       <div
-        className={`max-w-[74%] rounded-2xl px-4 py-3 text-sm leading-6 shadow-sm ${
+        className={`max-w-[74%] select-text rounded-2xl px-4 py-3 text-sm leading-6 shadow-sm ${
           isUserMessage
             ? "rounded-br-md bg-brand-primary text-white"
             : "rounded-bl-md border border-border-default bg-bg-surface text-text-primary"
@@ -790,6 +802,16 @@ function InlineAiChatMessage({ message, provider }: { message: AggregatedAiMessa
         <div className={`mb-2 flex items-center gap-2 text-[11px] font-semibold ${isUserMessage ? "text-white/75" : "text-text-muted"}`}>
           <AiSessionProviderIcon provider={provider} testId={false} />
           <span>{message.role}</span>
+          <button
+            type="button"
+            onClick={() => void copyMessage()}
+            className={`ml-auto select-none rounded px-2 py-0.5 transition-colors ${
+              isUserMessage ? "hover:bg-white/15 hover:text-white" : "hover:bg-bg-page hover:text-text-primary"
+            }`}
+            aria-label={copyLabel}
+          >
+            {copyLabel}
+          </button>
         </div>
         <AiSessionMessageContent text={displayedText} isUserMessage={isUserMessage} />
       </div>

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -1384,11 +1384,6 @@ export default function TaskDetailRoute() {
   async function handleStatusChange(formData: FormData) {
     const newStatus = formData.get("status") as TaskStatus;
     const updatedTask = await updateTaskStatus(id, newStatus);
-    if (newStatus === TaskStatus.DONE) {
-      router.push("/");
-      return;
-    }
-
     if (updatedTask) {
       setState((current) => current
         ? {

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -13,6 +13,7 @@ import DoneStatusButton from "@/components/DoneStatusButton";
 import HooksStatusCard from "@/components/HooksStatusCard";
 import { AiProviderIcon } from "@/components/AiProviderIcon";
 import NotificationCenterButton, { type NotificationCenterButtonHandle } from "@/components/NotificationCenterButton";
+import ProjectIcon from "@/components/ProjectIcon";
 import TaskDetailInfoCard from "@/components/TaskDetailInfoCard";
 import TaskDetailTitleCard from "@/components/TaskDetailTitleCard";
 import { Link, useRouter } from "@/desktop/renderer/navigation";
@@ -64,6 +65,7 @@ import type {
   AggregatedAiSessionDetail,
   AggregatedAiSessionsResult,
 } from "@/lib/aiSessions/types";
+import { computeProjectColor, getReadableTextColor } from "@/lib/projectColor";
 
 const STATUS_TRANSITIONS = [
   { status: TaskStatus.TODO, labelKey: "moveToTodo" },
@@ -1356,6 +1358,27 @@ export default function TaskDetailRoute() {
     [state?.task.agentType],
   );
 
+  /**
+   * 터미널 헤더 배지에 프로젝트를 함께 보여 주기 위한 표시 값.
+   * 배지 배경을 프로젝트 색으로 칠하므로, 아이콘이 없을 때 그리는 첫 글자 칩을 같은 프로젝트 색으로
+   * 두면 배경에 묻힌다. 칩에는 배경 대비로 고른 글자색을 넘겨 반전시켜 어떤 프로젝트 색에서도 읽히게 한다.
+   */
+  const taskContextProject = useMemo(() => {
+    const project = state?.task.project;
+    if (!project) {
+      return null;
+    }
+
+    const backgroundColor = project.color || computeProjectColor(project.name);
+
+    return {
+      name: project.name,
+      iconDataUrl: project.iconDataUrl,
+      backgroundColor,
+      textColor: getReadableTextColor(backgroundColor),
+    };
+  }, [state?.task.project]);
+
   useEscapeKey(() => {
     closeDetailPanel();
   }, { enabled: visiblePanel !== null });
@@ -1557,10 +1580,30 @@ export default function TaskDetailRoute() {
             <div className="bg-terminal-chrome flex items-center gap-3 px-4 py-2.5 shrink-0">
               <span
                 data-testid="terminal-task-context"
-                title={state.task.title}
-                className="max-w-64 shrink-0 truncate rounded-md bg-green-600 px-2.5 py-1 text-xs font-semibold text-white"
+                title={taskContextProject ? `${taskContextProject.name} | ${state.task.title}` : state.task.title}
+                className={`flex min-w-0 max-w-96 shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-semibold ${
+                  taskContextProject ? "" : "bg-green-600 text-white"
+                }`}
+                style={
+                  taskContextProject
+                    ? { backgroundColor: taskContextProject.backgroundColor, color: taskContextProject.textColor }
+                    : undefined
+                }
               >
-                {state.task.title}
+                {taskContextProject ? (
+                  <>
+                    <ProjectIcon
+                      projectName={taskContextProject.name}
+                      iconDataUrl={taskContextProject.iconDataUrl}
+                      color={taskContextProject.textColor}
+                    />
+                    <span data-testid="terminal-task-context-project" className="max-w-32 shrink-0 truncate">
+                      {taskContextProject.name}
+                    </span>
+                    <span aria-hidden="true" className="shrink-0 opacity-50">|</span>
+                  </>
+                ) : null}
+                <span className="min-w-0 truncate">{state.task.title}</span>
               </span>
               {terminalTabs.tabs.length > 0 ? (
                 <TerminalTabBar

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -12,6 +12,7 @@ import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadin
 const TASK_DETAIL_CACHE_KEY = "kanvibe:route-cache:task-detail:task-1";
 const BOARD_FOCUS_TASK_CACHE_KEY = "kanvibe:route-cache:board-focus-task";
 const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 
 const mocks = vi.hoisted(() => ({
   getTaskById: vi.fn(),
@@ -46,6 +47,7 @@ const mocks = vi.hoisted(() => ({
   mermaidRender: vi.fn(async (_id: string, definition: string) => ({
     svg: `<svg data-testid="rendered-mermaid-svg"><g onload="alert('svg')"><script>svg-xss</script><text>${definition}</text></g></svg>`,
   })),
+  clipboardWriteText: vi.fn(),
 }));
 
 function createDeferred<T>() {
@@ -304,6 +306,11 @@ describe("TaskDetailRoute", () => {
     mocks.updateTaskStatus.mockResolvedValue(null);
     mocks.deleteTask.mockResolvedValue(true);
     mocks.fetchPrUrlWithPrompt.mockResolvedValue(null);
+    mocks.clipboardWriteText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: mocks.clipboardWriteText },
+    });
   });
 
   afterEach(() => {
@@ -318,6 +325,11 @@ describe("TaskDetailRoute", () => {
       delete (HTMLElement.prototype as Partial<HTMLElement>).scrollIntoView;
     }
     delete window.kanvibeDesktop;
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
   });
 
   it("캐시가 있으면 stale task detail을 즉시 렌더링하고 이후 최신 데이터로 갱신한다", async () => {
@@ -2193,6 +2205,57 @@ describe("TaskDetailRoute", () => {
       expect(scrollIntoView).toHaveBeenCalledWith({ block: "end" });
     });
     expect(messagePane.textContent?.indexOf("Older prompt")).toBeLessThan(messagePane.textContent?.indexOf("Newest answer") ?? -1);
+  });
+
+  it("채팅 메시지별 복사 버튼으로 원문을 clipboard에 복사한다", async () => {
+    mocks.getSidebarDefaultCollapsed.mockResolvedValue(true);
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "fix/chat-copy",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/chat-copy",
+    });
+    mocks.getTaskAiSessions.mockResolvedValue({
+      isRemote: false,
+      targetPath: "/repo__worktrees/chat-copy",
+      repoPath: "/repo",
+      sources: [],
+      nextCursor: null,
+      sessions: [
+        { id: "claude-1", provider: "claude", startedAt: null, updatedAt: "2026-01-01T00:03:00.000Z", matchedPath: "/repo__worktrees/chat-copy", matchScope: "worktree", title: "Copy chat", firstUserPrompt: "Copy prompt", messageCount: 1, sourceRef: "claude.jsonl" },
+      ],
+    });
+    mocks.getTaskAiSessionDetail.mockResolvedValue({
+      sessionId: "claude-1",
+      provider: "claude",
+      title: "Copy chat",
+      matchedPath: "/repo__worktrees/chat-copy",
+      sourceRef: "claude.jsonl",
+      nextCursor: null,
+      messages: [
+        { role: "assistant", timestamp: "2026-01-01T00:03:00.000Z", text: "preview", fullText: "Full remote answer\nwith detail", isTruncated: true },
+      ],
+    });
+
+    render(<TaskDetailRoute />);
+    fireEvent.click(await screen.findByRole("button", { name: "aiSessions.inlineChat" }));
+    fireEvent.click(await screen.findByRole("button", { name: /Copy chat/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "aiSessions.copyMessage" }));
+
+    await waitFor(() => {
+      expect(mocks.clipboardWriteText).toHaveBeenCalledWith("Full remote answer\nwith detail");
+    });
+    expect(screen.getByRole("button", { name: "aiSessions.copiedMessage" })).toBeTruthy();
   });
 
   it("채팅 화면에서 Claude/Codex/OpenCode/Gemini 세션을 한 목록에 표시하고 provider를 구분한다", async () => {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { useEffect, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -681,7 +681,7 @@ describe("TaskDetailRoute", () => {
     expect(mocks.getTaskById).toHaveBeenCalledTimes(taskLoadCountBeforeClose);
   });
 
-  it("터미널 탭 왼쪽에 태스크 이름 배지를 항상 표시한다", async () => {
+  it("터미널 탭 왼쪽 배지에 프로젝트 아이콘·이름과 태스크 이름을 함께 표시한다", async () => {
     mocks.getTaskById.mockResolvedValue({
       id: "task-1",
       title: "fix tab task name",
@@ -693,7 +693,89 @@ describe("TaskDetailRoute", () => {
       sessionName: "task-session",
       sshHost: null,
       projectId: "project-1",
-      project: { id: "project-1", name: "kanvibe" },
+      project: { id: "project-1", name: "kanvibe", color: "#86EFAC", iconDataUrl: null },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/fix-tab-task-name",
+    });
+
+    render(<TaskDetailRoute />);
+
+    const taskContextBadge = await screen.findByTestId("terminal-task-context");
+    expect(taskContextBadge.textContent).toBe("kkanvibe|fix tab task name");
+    expect(within(taskContextBadge).getByTestId("terminal-task-context-project").textContent).toBe("kanvibe");
+    expect(taskContextBadge.getAttribute("title")).toBe("kanvibe | fix tab task name");
+    expect(taskContextBadge.className).toContain("shrink-0");
+  });
+
+  it("배지 배경을 프로젝트 설정 색으로 칠하고 첫 글자 칩은 대비색으로 반전시킨다", async () => {
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "fix tab task name",
+      description: null,
+      branchName: "fix/tab-task-name",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe", color: "#86EFAC", iconDataUrl: null },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/fix-tab-task-name",
+    });
+
+    render(<TaskDetailRoute />);
+
+    const taskContextBadge = await screen.findByTestId("terminal-task-context");
+    expect(taskContextBadge.style.backgroundColor).toBe("rgb(134, 239, 172)");
+    expect(taskContextBadge.style.color).toBe("rgb(17, 24, 39)");
+    expect(taskContextBadge.className).not.toContain("bg-green-600");
+
+    /** 배지 배경이 프로젝트 색이므로 첫 글자 칩은 같은 색이 아니라 배지 글자색으로 칠해야 읽힌다 */
+    const initialChip = within(taskContextBadge).getByTestId("project-initial-icon");
+    expect(initialChip.style.backgroundColor).toBe("rgb(17, 24, 39)");
+  });
+
+  it("프로젝트에 색이 없으면 프로젝트명 해시 색으로 배지를 칠한다", async () => {
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "fix tab task name",
+      description: null,
+      branchName: "fix/tab-task-name",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe", color: null, iconDataUrl: null },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/fix-tab-task-name",
+    });
+
+    render(<TaskDetailRoute />);
+
+    const taskContextBadge = await screen.findByTestId("terminal-task-context");
+    /** computeProjectColor("kanvibe")가 고르는 프리셋 #5EEAD4. 보드 카드가 쓰는 색과 같아야 한다 */
+    expect(taskContextBadge.style.backgroundColor).toBe("rgb(94, 234, 212)");
+  });
+
+  it("프로젝트가 없는 태스크는 태스크 이름만 초록 배지로 표시한다", async () => {
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "fix tab task name",
+      description: null,
+      branchName: "fix/tab-task-name",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: null,
+      project: null,
       status: "todo",
       agentType: null,
       worktreePath: "/repo__worktrees/fix-tab-task-name",
@@ -705,8 +787,8 @@ describe("TaskDetailRoute", () => {
     expect(taskContextBadge.textContent).toBe("fix tab task name");
     expect(taskContextBadge.getAttribute("title")).toBe("fix tab task name");
     expect(taskContextBadge.className).toContain("bg-green-600");
-    expect(taskContextBadge.className).toContain("shrink-0");
-    expect(taskContextBadge.className).toContain("truncate");
+    expect(taskContextBadge.style.backgroundColor).toBe("");
+    expect(within(taskContextBadge).queryByTestId("terminal-task-context-project")).toBeNull();
   });
 
   it("사용자가 작업 정보 패널을 닫은 뒤 상세 데이터가 새로고침되어도 다시 열지 않는다", async () => {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -192,7 +192,18 @@ vi.mock("@/components/DeleteTaskButton", () => ({
 }));
 
 vi.mock("@/components/DoneStatusButton", () => ({
-  default: () => <button type="button">done</button>,
+  default: ({ statusChangeAction }: { statusChangeAction: (formData: FormData) => Promise<void> }) => (
+    <button
+      type="button"
+      onClick={() => {
+        const formData = new FormData();
+        formData.set("status", "done");
+        void statusChangeAction(formData);
+      }}
+    >
+      done
+    </button>
+  ),
 }));
 
 vi.mock("@/components/HooksStatusCard", () => ({
@@ -1354,6 +1365,39 @@ describe("TaskDetailRoute", () => {
 
     expect(await screen.findByTestId("hooks-status-card")).toBeTruthy();
     expect(screen.getByText("done")).toBeTruthy();
+  });
+
+  it("Done 상태로 변경해도 상세 화면을 유지한다", async () => {
+    const task = {
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/stay-on-detail",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/stay-on-detail",
+    };
+    mocks.getTaskById.mockResolvedValue(task);
+    mocks.updateTaskStatus.mockResolvedValue({ ...task, status: "done" });
+
+    render(<TaskDetailRoute />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "actions · hooksStatus" }));
+    fireEvent.click(screen.getByRole("button", { name: "done" }));
+
+    await waitFor(() => {
+      expect(mocks.updateTaskStatus).toHaveBeenCalledWith("task-1", "done");
+      expect(screen.queryByRole("button", { name: "done" })).toBeNull();
+    });
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "moveToTodo" })).toBeTruthy();
   });
 
   it("AI 세션 로드가 느려도 hooks 상태는 먼저 갱신한다", async () => {

--- a/src/lib/__tests__/gitOperations.test.ts
+++ b/src/lib/__tests__/gitOperations.test.ts
@@ -259,6 +259,33 @@ describe("gitOperations.resolvePathForShell", () => {
     expect(getSpawnedRemoteCommand()).toContain(REMOTE_COMMAND_EXIT_MARKER);
   });
 
+  it("원격 명령별 출력 한도를 적용한다", async () => {
+    mocks.spawn.mockImplementation(() => {
+      const child = createMockSSHProcess();
+      queueMicrotask(() => completeRemoteCommand(child, "output larger than the command limit"));
+      return child;
+    });
+
+    vi.doMock("@/lib/sshConfig", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/sshConfig")>();
+      return {
+        ...actual,
+        parseSSHConfig: vi.fn(async () => [{
+          host: "remote-host",
+          hostname: "example.com",
+          port: 2202,
+          username: "tester",
+          privateKeyPath: "/tmp/test-key",
+        }]),
+      };
+    });
+
+    const { execGit } = await import("@/lib/gitOperations");
+
+    await expect(execGit("cat chat.jsonl", "remote-host", { maxBufferBytes: 16 }))
+      .rejects.toThrow("exceeded maxBuffer");
+  });
+
   it("SSH transport 실패 직후 같은 host의 후속 명령은 새 ssh 프로세스를 만들지 않는다", async () => {
     // Given
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/lib/__tests__/hostFileAccess.test.ts
+++ b/src/lib/__tests__/hostFileAccess.test.ts
@@ -106,6 +106,31 @@ describe("hostFileAccess.readTextFiles", () => {
   });
 });
 
+describe("hostFileAccess.readTextFile", () => {
+  beforeEach(() => {
+    mocks.execGit.mockReset();
+  });
+
+  it("원격 채팅 파일은 일반 명령보다 큰 출력 한도로 읽는다", async () => {
+    mocks.execGit.mockResolvedValue("remote chat");
+    const { readTextFile } = await import("@/lib/hostFileAccess");
+
+    await expect(readTextFile("/remote/chat.jsonl", "remote-host")).resolves.toBe("remote chat");
+    expect(mocks.execGit).toHaveBeenCalledWith(
+      "test -f '/remote/chat.jsonl' && cat '/remote/chat.jsonl' || true",
+      "remote-host",
+      { maxBufferBytes: 64 * 1024 * 1024 },
+    );
+  });
+
+  it("원격 채팅 파일 읽기 실패를 빈 파일로 숨기지 않는다", async () => {
+    mocks.execGit.mockRejectedValue(new Error("SSH command output exceeded maxBuffer"));
+    const { readTextFile } = await import("@/lib/hostFileAccess");
+
+    await expect(readTextFile("/remote/chat.jsonl", "remote-host")).rejects.toThrow("exceeded maxBuffer");
+  });
+});
+
 describe("hostFileAccess.writeTextFileIfAbsent", () => {
   let tempDir: string;
 

--- a/src/lib/aiSessions/__tests__/readAiSessions.test.ts
+++ b/src/lib/aiSessions/__tests__/readAiSessions.test.ts
@@ -30,7 +30,7 @@ function claudeProjectDirectoryName(targetPath: string) {
 function setupRemoteFileSystem(files: Record<string, string>) {
   const fileMap = new Map(Object.entries(files));
   const directorySet = new Set<string>();
-  const execCalls: Array<{ command: string; sshHost?: string | null }> = [];
+  const execCalls: Array<{ command: string; sshHost?: string | null; options?: { maxBufferBytes?: number } }> = [];
 
   for (const filePath of fileMap.keys()) {
     let current = path.dirname(filePath);
@@ -50,8 +50,8 @@ function setupRemoteFileSystem(files: Record<string, string>) {
     .join("\n");
 
   vi.doMock("@/lib/gitOperations", () => ({
-    execGit: vi.fn(async (command: string, sshHost?: string | null) => {
-      execCalls.push({ command, sshHost });
+    execGit: vi.fn(async (command: string, sshHost?: string | null, options?: { maxBufferBytes?: number }) => {
+      execCalls.push({ command, sshHost, options });
       if (command === "printf '%s' \"$HOME\"") {
         return "/remote/home";
       }
@@ -70,6 +70,11 @@ function setupRemoteFileSystem(files: Record<string, string>) {
           throw new Error(`cat command path mismatch: ${command}`);
         }
         return fileMap.get(catMatch[1]) ?? "";
+      }
+
+      const tailMatch = command.match(/tail -n (\d+) '([^']+)'/);
+      if (tailMatch) {
+        return (fileMap.get(tailMatch[2]) ?? "").split("\n").slice(-Number(tailMatch[1]) - 1).join("\n");
       }
 
       const statMatch = command.match(/test -e '([^']+)' && \(stat -c %Y '([^']+)'/);
@@ -146,6 +151,9 @@ describe("AI session history readers", () => {
         message: { role: "user", content: [{ type: "tool_result", content: "file contents" }] },
       },
     ]);
+
+    const sessions = await readClaudeSessions({ worktreePath, repoPath: worktreePath });
+    expect(sessions.sessions[0]?.updatedAt).toBe("2026-01-01T00:02:00.000Z");
 
     const detail = await readClaudeSessionDetail(
       { worktreePath, repoPath: worktreePath },
@@ -281,6 +289,38 @@ describe("AI session history readers", () => {
     ]);
   });
 
+  it("uses the latest Codex user or assistant message as the session activity time", async () => {
+    const worktreePath = path.join(tempHome, "repo__worktrees", "task");
+    const sessionFile = path.join(tempHome, ".codex", "sessions", "2026", "codex-activity.jsonl");
+
+    await writeJsonLines(sessionFile, [
+      {
+        type: "session_meta",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        payload: { id: "codex-activity", cwd: worktreePath, timestamp: "2026-01-01T00:00:00.000Z" },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-01-01T00:01:00.000Z",
+        payload: { type: "message", role: "user", content: [{ type: "input_text", text: "Update the chat." }] },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-01-01T00:02:00.000Z",
+        payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "Chat updated." }] },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-01-01T00:03:00.000Z",
+        payload: { type: "reasoning", text: "Internal follow-up bookkeeping." },
+      },
+    ]);
+
+    const sessions = await readCodexSessions({ worktreePath, repoPath: worktreePath });
+
+    expect(sessions.sessions[0]?.updatedAt).toBe("2026-01-01T00:02:00.000Z");
+  });
+
   it("reads Gemini chat recordings from ~/.gemini/tmp/<project>/chats and classifies responses, thoughts, and tool calls", async () => {
     const worktreePath = path.join(tempHome, "repo__worktrees", "task");
     const chatFile = path.join(tempHome, ".gemini", "tmp", "task", "chats", "session-2026-01-01T00-00-gemini.json");
@@ -316,6 +356,7 @@ describe("AI session history readers", () => {
       id: "gemini-session",
       provider: "gemini",
       title: "make a plan",
+      updatedAt: "2026-01-01T00:02:00.000Z",
       sourceRef: chatFile,
     });
 
@@ -370,6 +411,46 @@ describe("AI session history readers", () => {
     });
   });
 
+  it("reads the latest Claude conversation time beyond the summary head", async () => {
+    const worktreePath = path.join(tempHome, "repo__worktrees", "task");
+    const sessionFile = path.join(
+      tempHome,
+      ".claude",
+      "projects",
+      claudeProjectDirectoryName(worktreePath),
+      "long-claude-session.jsonl",
+    );
+    const toolEvents = Array.from({ length: 65 }, (_, index) => ({
+      type: "progress",
+      sessionId: "long-claude-session",
+      cwd: worktreePath,
+      timestamp: `2026-01-01T00:00:${String(index + 2).padStart(2, "0")}.000Z`,
+      message: { role: "user", content: [{ type: "tool_result", content: `tool ${index} ${"x".repeat(4096)}` }] },
+    }));
+
+    await writeJsonLines(sessionFile, [
+      {
+        type: "user",
+        sessionId: "long-claude-session",
+        cwd: worktreePath,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "Start the long task." }] },
+      },
+      {
+        type: "assistant",
+        sessionId: "long-claude-session",
+        cwd: worktreePath,
+        timestamp: "2026-01-01T00:10:00.000Z",
+        message: { role: "assistant", content: [{ type: "text", text: "The long task is complete." }] },
+      },
+      ...toolEvents,
+    ]);
+
+    const sessions = await readClaudeSessions({ worktreePath, repoPath: worktreePath });
+
+    expect(sessions.sessions[0]?.updatedAt).toBe("2026-01-01T00:10:00.000Z");
+  });
+
   it("uses Gemini CLI .project_root metadata when projects.json does not map the chat directory", async () => {
     const worktreePath = path.join(tempHome, "repo__worktrees", "task");
     const projectDir = path.join(tempHome, ".gemini", "tmp", "project-with-root-file");
@@ -421,7 +502,7 @@ CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL, title TEXT, 
 CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data TEXT NOT NULL);
 CREATE TABLE part (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, message_id TEXT NOT NULL, data TEXT NOT NULL, time_created INTEGER NOT NULL);
 """)
-cur.execute("INSERT INTO session VALUES (?, ?, ?, ?, ?)", ("local-open", directory, "Local OpenCode", 1700000000000, 1700000010000))
+cur.execute("INSERT INTO session VALUES (?, ?, ?, ?, ?)", ("local-open", directory, "Local OpenCode", 1700000000000, 1700000100000))
 for message_id, role, text, timestamp in [
     ("user-message", "user", "load local opencode history", 1700000000000),
     ("assistant-message", "assistant", "local opencode history loaded", 1700000010000),
@@ -453,6 +534,7 @@ conn.close()
       matchedPath: worktreePath,
       title: "Local OpenCode",
       firstUserPrompt: "load local opencode history",
+      updatedAt: new Date(1700000010000).toISOString(),
       sourceRef: "local-open",
     });
 
@@ -621,13 +703,13 @@ conn.close()
   it("reads remote OpenCode sessions and detail over SSH", async () => {
     const worktreePath = "/remote/repo__worktrees/task";
     const repoPath = "/remote/repo";
-    const execCalls: Array<{ command: string; sshHost?: string | null }> = [];
+    const execCalls: Array<{ command: string; sshHost?: string | null; options?: { maxBufferBytes?: number } }> = [];
     let remoteSqliteQueryCount = 0;
 
     vi.resetModules();
     vi.doMock("@/lib/gitOperations", () => ({
-      execGit: vi.fn(async (command: string, sshHost?: string | null) => {
-        execCalls.push({ command, sshHost });
+      execGit: vi.fn(async (command: string, sshHost?: string | null, options?: { maxBufferBytes?: number }) => {
+        execCalls.push({ command, sshHost, options });
         if (command === "printf '%s' \"$HOME\"") {
           return "/remote/home";
         }
@@ -707,6 +789,10 @@ conn.close()
       ["user", "fix remote chat"],
     ]);
     expect(execCalls.every((call) => call.sshHost === "remote-host")).toBe(true);
+    expect(execCalls
+      .filter((call) => call.command.includes("python3 -c"))
+      .map((call) => call.options?.maxBufferBytes))
+      .toEqual([64 * 1024 * 1024, 64 * 1024 * 1024]);
     expect(remoteSqliteQueryCount).toBe(2);
   });
 

--- a/src/lib/aiSessions/readClaudeSessions.ts
+++ b/src/lib/aiSessions/readClaudeSessions.ts
@@ -12,6 +12,7 @@ import {
   paginateItems,
   readJsonLines,
   readJsonLinesHead,
+  readJsonLinesTail,
   REMOTE_SESSION_FILE_PARSE_CONCURRENCY,
   sortMessagesDescending,
   toIsoString,
@@ -28,6 +29,7 @@ import type {
 } from "@/lib/aiSessions/types";
 
 const DEFAULT_DETAIL_LIMIT = 20;
+const CLAUDE_SUMMARY_EVENT_LIMIT = 60;
 
 interface ClaudeProjectEvent {
   type?: string;
@@ -129,7 +131,7 @@ export async function readClaudeSessionDetail(
   });
 }
 
-/** 단일 JSONL 파일에서 세션 메타데이터를 추출한다. 앞 60줄로 충분하면 조기 종료한다. */
+/** 제목은 파일 앞, 실제 최근 대화 시각은 파일 끝에서 읽어 긴 JSONL 전체 전송을 피한다. */
 async function parseClaudeSessionFromFile(
   filePath: string,
   context: AiSessionReaderContext
@@ -152,15 +154,41 @@ async function parseClaudeSessionFromFile(
 
   const headEvents = await getCachedOrParseHead(
     filePath,
-    () => readJsonLinesHead(filePath, 60, context.sshHost),
+    () => readJsonLinesHead(filePath, CLAUDE_SUMMARY_EVENT_LIMIT, context.sshHost),
     context.sshHost,
   );
 
   const headResult = await parseEvents(headEvents);
-  if (headResult?.firstUserPrompt) return headResult;
+  if (headResult?.firstUserPrompt) {
+    const tailEvents = await readJsonLinesTail(filePath, CLAUDE_SUMMARY_EVENT_LIMIT, context.sshHost);
+    const latestConversationTimestamp = findLatestClaudeConversationTimestamp(tailEvents);
+    if (!latestConversationTimestamp) {
+      const allEvents = await getCachedOrParse(filePath, () => readJsonLines(filePath, context.sshHost), context.sshHost);
+      return parseEvents(allEvents);
+    }
+
+    return {
+      ...headResult,
+      updatedAt: latestConversationTimestamp,
+    };
+  }
 
   const allEvents = await getCachedOrParse(filePath, () => readJsonLines(filePath, context.sshHost), context.sshHost);
   return parseEvents(allEvents);
+}
+
+function findLatestClaudeConversationTimestamp(events: unknown[]): string | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index] as ClaudeProjectEvent;
+    const role = resolveClaudeRole(event);
+    if (role !== "user" && role !== "assistant") continue;
+    if (!extractPlainText(event.message?.content)) continue;
+
+    const timestamp = toIsoString(event.timestamp);
+    if (timestamp) return timestamp;
+  }
+
+  return null;
 }
 
 async function findProjectFiles(context: AiSessionReaderContext): Promise<string[]> {
@@ -230,7 +258,7 @@ function consumeClaudeListEvent(
   }
 
   const normalizedTimestamp = toIsoString(event.timestamp);
-  if (normalizedTimestamp) {
+  if (normalizedTimestamp && text && (role === "user" || role === "assistant")) {
     accumulator.session.updatedAt = normalizedTimestamp;
   }
 

--- a/src/lib/aiSessions/readCodexSessions.ts
+++ b/src/lib/aiSessions/readCodexSessions.ts
@@ -119,7 +119,9 @@ async function parseCodexSessionSummary(filePath: string, context: AiSessionRead
       }
 
       messageCount += 1;
-      updatedAt = toIsoString(event.timestamp) ?? updatedAt;
+      if (message.role === "user" || message.role === "assistant") {
+        updatedAt = toIsoString(event.timestamp) ?? updatedAt;
+      }
     }
   }
 

--- a/src/lib/aiSessions/readGeminiSessions.ts
+++ b/src/lib/aiSessions/readGeminiSessions.ts
@@ -133,6 +133,9 @@ async function parseGeminiSessionSummary(
 
   const messages = flattenGeminiMessages(parsed.value.messages ?? []);
   const firstUserPrompt = messages.find((message) => message.role === "user")?.fullText ?? null;
+  const latestConversationMessageAt = sortMessagesDescending(
+    messages.filter((message) => message.role === "user" || message.role === "assistant"),
+  )[0]?.timestamp;
   const sessionId = resolveGeminiSessionId(parsed.value, filePath);
   const title = parsed.value.title ?? (firstUserPrompt ? truncateText(firstUserPrompt, 80) : null);
 
@@ -149,7 +152,8 @@ async function parseGeminiSessionSummary(
     id: sessionId,
     provider: "gemini",
     startedAt: toIsoString(parsed.value.startTime ?? parsed.value.createdAt ?? parsed.value.timestamp),
-    updatedAt: toIsoString(parsed.value.lastUpdated ?? parsed.value.updatedAt ?? parsed.value.timestamp),
+    updatedAt: latestConversationMessageAt
+      ?? toIsoString(parsed.value.lastUpdated ?? parsed.value.updatedAt ?? parsed.value.timestamp),
     matchedPath: parsed.matchedPath,
     matchScope: parsed.matchScope,
     title,

--- a/src/lib/aiSessions/readOpenCodeSessions.ts
+++ b/src/lib/aiSessions/readOpenCodeSessions.ts
@@ -20,6 +20,8 @@ import type { AggregatedAiMessage, AiMessageRole, AiSessionDetailReaderResult, A
 const execFileAsync = promisify(execFile);
 const OPEN_CODE_QUERY_LIMIT = 120;
 const DEFAULT_DETAIL_LIMIT = 20;
+// Remote detail queries return message bodies, so they need the same bounded large-session allowance as JSONL history reads.
+const OPEN_CODE_REMOTE_QUERY_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 const SQLITE_QUERY_SCRIPT = `
 import base64
 import json
@@ -42,6 +44,7 @@ interface OpenCodeSessionRow {
   title: string | null;
   time_created: number | null;
   time_updated: number | null;
+  last_message_at?: number | null;
   part_count?: number | null;
   first_user_part?: string | null;
   matching_part_count?: number | null;
@@ -70,6 +73,14 @@ export async function readOpenCodeSessions(context: AiSessionReaderContext): Pro
         s.title,
         s.time_created,
         s.time_updated,
+        (
+          SELECT MAX(p.time_created)
+          FROM part p
+          JOIN message m ON m.id = p.message_id
+          WHERE p.session_id = s.id
+            AND json_extract(m.data, '$.role') IN ('user', 'assistant')
+            AND json_extract(p.data, '$.type') = 'text'
+        ) as last_message_at,
         (SELECT COUNT(*) FROM part p WHERE p.session_id = s.id) as part_count,
         (
           SELECT p.data
@@ -85,7 +96,7 @@ export async function readOpenCodeSessions(context: AiSessionReaderContext): Pro
           ? `(SELECT COUNT(*) FROM part p WHERE p.session_id = s.id AND lower(p.data) LIKE '%' || @query || '%' ESCAPE '\\')`
           : '0'} as matching_part_count
       FROM session s
-      ORDER BY s.time_updated DESC
+      ORDER BY COALESCE(last_message_at, s.time_updated) DESC
       LIMIT ${OPEN_CODE_QUERY_LIMIT};`,
       escapedLikeQuery ? { query: escapedLikeQuery } : undefined
     );
@@ -116,7 +127,7 @@ export async function readOpenCodeSessions(context: AiSessionReaderContext): Pro
         id: row.id,
         provider: "opencode" as const,
         startedAt: toIsoString(row.time_created),
-        updatedAt: toIsoString(row.time_updated),
+        updatedAt: toIsoString(row.last_message_at ?? row.time_updated),
         matchedPath: row.directory,
         matchScope: determineMatchScope(row.directory, context)!,
         title: row.title ?? (firstUserPrompt ? truncateText(firstUserPrompt, 80) : null),
@@ -235,6 +246,7 @@ async function queryOpenCodeRows<T>(
   const output = await execGit(
     `python3 -c ${quoteShellArgument(SQLITE_QUERY_SCRIPT)} ${quoteShellArgument(encodeSqliteQueryPayload(dbPath, sql, parameters))}`,
     context.sshHost,
+    { maxBufferBytes: OPEN_CODE_REMOTE_QUERY_MAX_BUFFER_BYTES },
   );
   return parseSqliteQueryRows<T>(output);
 }

--- a/src/lib/aiSessions/shared.ts
+++ b/src/lib/aiSessions/shared.ts
@@ -1,8 +1,9 @@
 import { createReadStream } from "fs";
-import { readdir, readFile } from "fs/promises";
+import { open, readdir, readFile } from "fs/promises";
 import { createInterface } from "readline";
 import path from "path";
-import { getFileMtimeMs, readTextFile } from "@/lib/hostFileAccess";
+import { execGit } from "@/lib/gitOperations";
+import { getFileMtimeMs, quoteShellArgument, readTextFile } from "@/lib/hostFileAccess";
 import type {
   AggregatedAiMessage,
   AggregatedAiSession,
@@ -416,4 +417,34 @@ export function readJsonLinesHead(filePath: string, maxLines: number, sshHost?: 
     rl.on("error", reject);
     stream.on("error", reject);
   });
+}
+
+export async function readJsonLinesTail(filePath: string, maxLines: number, sshHost?: string | null): Promise<unknown[]> {
+  const content = sshHost
+    ? await execGit(`tail -n ${maxLines} ${quoteShellArgument(filePath)}`, sshHost)
+    : await readLocalFileTail(filePath);
+
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(-maxLines)
+    .map((line) => safeJsonParse(line))
+    .filter((value) => value !== null);
+}
+
+// Sixty recent JSONL events commonly include large tool payloads; 128 KiB bounds I/O while leaving room for that window.
+const LOCAL_TAIL_READ_BYTES = 128 * 1024;
+
+async function readLocalFileTail(filePath: string): Promise<string> {
+  const handle = await open(filePath, "r");
+  try {
+    const { size } = await handle.stat();
+    const readLength = Math.min(size, LOCAL_TAIL_READ_BYTES);
+    const buffer = Buffer.alloc(readLength);
+    await handle.read(buffer, 0, readLength, size - readLength);
+    return buffer.toString("utf-8");
+  } finally {
+    await handle.close();
+  }
 }

--- a/src/lib/gitOperations.ts
+++ b/src/lib/gitOperations.ts
@@ -64,6 +64,7 @@ interface RemoteSSHConnectionLease {
 
 export interface ExecGitOptions {
   timeoutMs?: number;
+  maxBufferBytes?: number;
 }
 
 function collectErrorOutput(error: unknown): string {
@@ -218,7 +219,11 @@ async function execRemote(
     let lastError: Error | null = null;
     for (let attempt = 1; attempt <= REMOTE_SSH_COMMAND_MAX_ATTEMPTS; attempt += 1) {
       try {
-        return await spawnSSHCommand(sshArgs, timeoutMs);
+        return await spawnSSHCommand(
+          sshArgs,
+          timeoutMs,
+          options?.maxBufferBytes ?? REMOTE_COMMAND_MAX_BUFFER_BYTES,
+        );
       } catch (error) {
         const isCommandTimeout = isSSHCommandTimeoutError(error);
         const normalizedError = normalizeSSHExecError(error, sshHost, timeoutMs, isCommandTimeout);
@@ -268,7 +273,7 @@ function isRetriableSSHExecError(error: Error, isCommandTimeout: boolean): boole
   return isCommandTimeout || isSSHTransportError(error);
 }
 
-function spawnSSHCommand(sshArgs: string[], timeoutMs: number): Promise<string> {
+function spawnSSHCommand(sshArgs: string[], timeoutMs: number, maxBufferBytes: number): Promise<string> {
   return new Promise((resolve, reject) => {
     const child = spawn("ssh", sshArgs, {
       env: createLocalShellEnvironment(),
@@ -324,7 +329,7 @@ function spawnSSHCommand(sshArgs: string[], timeoutMs: number): Promise<string> 
     });
 
     function rejectIfOutputIsTooLarge(): void {
-      if (Buffer.byteLength(stdout) + Buffer.byteLength(stderr) <= REMOTE_COMMAND_MAX_BUFFER_BYTES) {
+      if (Buffer.byteLength(stdout) + Buffer.byteLength(stderr) <= maxBufferBytes) {
         return;
       }
 

--- a/src/lib/hostFileAccess.ts
+++ b/src/lib/hostFileAccess.ts
@@ -5,6 +5,8 @@ import { execGit } from "@/lib/gitOperations";
 
 const remoteHomeDirectoryCache = new Map<string, string>();
 const REMOTE_FILE_RECORD_PREFIX = "__KANVIBE_FILE_RECORD__";
+// AI history JSONL can exceed the general 10 MiB command cap; 64 MiB keeps reads bounded while covering large sessions.
+const REMOTE_TEXT_FILE_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 
 export interface TextFileReadResult {
   exists: boolean;
@@ -55,14 +57,11 @@ export async function readTextFile(targetPath: string, sshHost?: string | null):
     }
   }
 
-  try {
-    return await execGit(
-      `test -f ${quoteShellArgument(targetPath)} && cat ${quoteShellArgument(targetPath)} || true`,
-      sshHost,
-    );
-  } catch {
-    return "";
-  }
+  return execGit(
+    `test -f ${quoteShellArgument(targetPath)} && cat ${quoteShellArgument(targetPath)} || true`,
+    sshHost,
+    { maxBufferBytes: REMOTE_TEXT_FILE_MAX_BUFFER_BYTES },
+  );
 }
 
 export async function readTextFiles(


### PR DESCRIPTION
Promote the pinned 1.1.0 release branch to main after the published DMG release and Homebrew cask update.

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.1.0
- DMG SHA-256: `7fc2182832e99069d4029d6cab24deb480f5f82d71c8d4d2fffcb2d468eb9249`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@f775402` (`brew fetch` → `✔︎ Cask kanvibe (1.1.0)`)
- Release PR into `dev`: #354 (merged)

Head is pinned to `64632f229289eaa112b57155cd8f9d328e0bb24d`, the exact commit the published DMG was built from, rather than the moving `dev` branch.