### PR TITLE
chore(release): publish KanVibe 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Publish KanVibe 1.2.0. This bumps `package.json` and `package-lock.json` from `1.1.0` to `1.2.0`; no other files change.

The release carries the AI usage panel in task detail, live AI session lineage with an agent call graph, provider-split running badges on the board, an unread-only notification filter, and fixes for the task detail renderer bundle error and the board card session popover swallowing clicks.

## Test Plan

- `pnpm install --frozen-lockfile` and `pnpm run deploy` on macOS (arm64).
- Dependency collector reported `pm=npm` with manual traversal; packaging guard reported `packaged node_modules verified: 278 packages`.
- `app.asar` package counts: top-level 232 / flattened 278, matching the known-good 1.1.0 build.
- Notarization `Accepted`; `xcrun stapler staple` and `xcrun stapler validate` both succeeded.
- `spctl -a -t exec` on the mounted app: `accepted`, `source=Notarized Developer ID`.
- Isolated smoke test via `open -n --env KANVIBE_APP_DATA_DIR=<temp>`: process stayed alive, module-error count `0`, `invoke-succeeded` count `18`. The user's running instance was left untouched.
- The bytes GitHub serves for the release asset hash to the same SHA-256 as the local artifact.

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.2.0
- DMG asset: `dist/KanVibe-1.2.0.dmg`
- SHA-256: `b1fe043947960d33c9ced93b1df49662d26ed44cda6e3b6654b212d7358978ce`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@e99192d` — `version` and `sha256` only.
