### PR TITLE
chore(release): publish KanVibe 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Publish KanVibe 1.2.1. This PR carries only the version bump (`package.json`, `package-lock.json`); the shipped changes are PR #362, already merged into `dev`.

The release adds in-app AI account management: register an account, log in through the app's own terminal with each provider's official command, and see subscription tier and remaining usage per account. Expired Claude authentication is now refreshed by the CLI that owns the Keychain entry rather than by KanVibe, and Gemini multi-account discovery is fixed (it watched `GEMINI_CONFIG_DIR`, which does not exist; the real variable is `GEMINI_CLI_HOME`).

## Test Plan

- `pnpm install --frozen-lockfile` → clean, native rebuild of `better-sqlite3` completed
- `pnpm run deploy` → collector `pm=npm` → manual traversal; packaging guard `278 packages verified`
- Notarization `Accepted`; `xcrun stapler staple` and `stapler validate` both passed
- `app.asar` node_modules: top-level 232 / flattened 278, matching the known-good 1.1.0 and 1.2.0 builds
- Smoke test against the published DMG, run with an isolated `KANVIBE_APP_DATA_DIR`:
  - `spctl -a -t exec` → `accepted`, `source=Notarized Developer ID`
  - process alive after launch
  - module errors: **0**
  - `invoke-succeeded`: **20**
- `curl -sL <release asset> | shasum -a 256` matches the cask `sha256` exactly
- `brew fetch --cask rookedsysc/kanvibe/kanvibe` → `✔︎ Cask kanvibe (1.2.1)`

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.2.1
- DMG asset: `dist/KanVibe-1.2.1.dmg` (171161137 bytes)
- SHA-256: `1fd77f93271d882abb4344029d0ff558bebbbc6ba3b6fab4fb37fb0963293be7`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@f43abdb`, verified through the tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
