### PR TITLE
fix(notification): 상세 화면에 포커스가 올 때만 알림을 읽음 처리한다

### DIFF
--- a/src/desktop/renderer/hooks/__tests__/useMarkTaskNotificationsReadWhenFocused.test.tsx
+++ b/src/desktop/renderer/hooks/__tests__/useMarkTaskNotificationsReadWhenFocused.test.tsx
@@ -1,0 +1,102 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useMarkTaskNotificationsReadWhenFocused } from "../useMarkTaskNotificationsReadWhenFocused";
+
+const mocks = vi.hoisted(() => ({
+  markTaskNotificationsRead: vi.fn(),
+}));
+
+vi.mock("@/desktop/renderer/actions/notifications", () => ({
+  markTaskNotificationsRead: (...args: unknown[]) => mocks.markTaskNotificationsRead(...args),
+}));
+
+function MarkReadHarness({ taskId }: { taskId: string | null }) {
+  useMarkTaskNotificationsReadWhenFocused(taskId);
+
+  return <div data-testid="harness" />;
+}
+
+function setWindowFocused(isFocused: boolean) {
+  vi.mocked(document.hasFocus).mockReturnValue(isFocused);
+}
+
+describe("useMarkTaskNotificationsReadWhenFocused", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.markTaskNotificationsRead.mockResolvedValue(0);
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("창이 활성인 상태로 상세 화면에 들어오면 그 task의 알림을 읽음 처리한다", async () => {
+    setWindowFocused(true);
+
+    render(<MarkReadHarness taskId="task-1" />);
+
+    await waitFor(() => {
+      expect(mocks.markTaskNotificationsRead).toHaveBeenCalledWith("task-1");
+    });
+  });
+
+  it("창이 비활성이면 상세 화면이 열려 있어도 읽음 처리하지 않는다", async () => {
+    setWindowFocused(false);
+
+    render(<MarkReadHarness taskId="task-1" />);
+
+    await act(async () => {});
+
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+  });
+
+  it("비활성으로 열려 있던 상세 화면이 포커스를 받으면 그때 읽음 처리한다", async () => {
+    setWindowFocused(false);
+
+    render(<MarkReadHarness taskId="task-1" />);
+
+    await act(async () => {});
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+
+    setWindowFocused(true);
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(mocks.markTaskNotificationsRead).toHaveBeenCalledWith("task-1");
+  });
+
+  it("비활성 상태에서 화면이 다시 그려져도 읽음 처리하지 않는다", async () => {
+    setWindowFocused(false);
+
+    const { rerender } = render(<MarkReadHarness taskId="task-1" />);
+    rerender(<MarkReadHarness taskId="task-1" />);
+
+    await act(async () => {});
+
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+  });
+
+  it("아직 task를 확인하지 못했으면 읽음 처리하지 않는다", async () => {
+    setWindowFocused(true);
+
+    render(<MarkReadHarness taskId={null} />);
+
+    await act(async () => {});
+
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+  });
+
+  it("읽음 처리가 실패하면 로그만 남기고 화면은 그대로 둔다", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    setWindowFocused(true);
+    mocks.markTaskNotificationsRead.mockRejectedValue(new Error("app settings write failed"));
+
+    render(<MarkReadHarness taskId="task-1" />);
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith("알림 읽음 처리 실패:", expect.any(Error));
+    });
+  });
+});

--- a/src/desktop/renderer/hooks/useIsWindowActive.ts
+++ b/src/desktop/renderer/hooks/useIsWindowActive.ts
@@ -1,18 +1,25 @@
 import { useEffect, useState } from "react";
 
+function isWindowCurrentlyActive(): boolean {
+  return document.visibilityState !== "hidden" && document.hasFocus();
+}
+
 /**
  * 창이 뒤에 가려져 있으면 화면이 바뀌어도 볼 사람이 없으므로 폴링을 멈춘다.
  * 창을 여러 개 띄우는 사용 방식이라 창 수만큼 곱해지는 비용이고,
  * 원격에서는 SSH ControlMaster lease를 점유해 실제 git 작업과 경합한다.
  *
  * Electron은 창이 다른 창에 가려진 것만으로는 `visibilitychange`를 내지 않아 포커스도 함께 본다.
+ *
+ * 첫 값도 실제 창 상태에서 읽는다. 활성으로 가정해 두면 뒤에 가려진 창이 마운트되는 첫 렌더에서만
+ * 활성으로 보여, 포커스가 왔을 때만 해야 하는 일이 백그라운드에서도 한 번 실행된다.
  */
 export function useIsWindowActive(): boolean {
-  const [isWindowActive, setIsWindowActive] = useState(true);
+  const [isWindowActive, setIsWindowActive] = useState(isWindowCurrentlyActive);
 
   useEffect(() => {
     const syncWindowActive = () => {
-      setIsWindowActive(document.visibilityState !== "hidden" && document.hasFocus());
+      setIsWindowActive(isWindowCurrentlyActive());
     };
 
     syncWindowActive();

--- a/src/desktop/renderer/hooks/useMarkTaskNotificationsReadWhenFocused.ts
+++ b/src/desktop/renderer/hooks/useMarkTaskNotificationsReadWhenFocused.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { markTaskNotificationsRead } from "@/desktop/renderer/actions/notifications";
+import { useIsWindowActive } from "@/desktop/renderer/hooks/useIsWindowActive";
+
+/**
+ * 상세 화면으로 포커스가 옮겨온 시점에만 그 task의 알림을 확인한 것으로 본다.
+ * 창을 여러 개 띄워 두는 사용 방식이라, 뒤에 가려진 상세 창이 열려 있다는 이유만으로 읽음 처리하면
+ * 사용자가 보지 못한 알림이 조용히 사라진다. 창이 활성으로 바뀌는 순간에만 읽음 처리하고,
+ * 비활성인 동안 도착한 알림은 다시 포커스를 받을 때까지 안읽음으로 남긴다.
+ */
+export function useMarkTaskNotificationsReadWhenFocused(taskId: string | null) {
+  const isWindowActive = useIsWindowActive();
+
+  useEffect(() => {
+    if (!taskId || !isWindowActive) {
+      return;
+    }
+
+    void markTaskNotificationsRead(taskId).catch((error) => {
+      console.error("알림 읽음 처리 실패:", error);
+    });
+  }, [taskId, isWindowActive]);
+}

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -22,7 +22,6 @@ import { Link, useRouter } from "@/desktop/renderer/navigation";
 import { getDefaultSessionType, getDoneAlertDismissed, getSidebarDefaultCollapsed } from "@/desktop/renderer/actions/appSettings";
 import { getGitDiffFiles } from "@/desktop/renderer/actions/diff";
 import { deleteTask, getTaskById, getTaskIdByProjectAndBranch, updateTaskStatus } from "@/desktop/renderer/actions/kanban";
-import { markTaskNotificationsRead } from "@/desktop/renderer/actions/notifications";
 import {
   getTaskAiSessions,
   getTaskAiSessionDetail,
@@ -43,6 +42,7 @@ import { AgentCallGraphPanel } from "@/desktop/renderer/components/AgentCallGrap
 import { LiveAiSessionPanel } from "@/desktop/renderer/components/LiveAiSessionPanel";
 import TerminalLoader from "@/desktop/renderer/components/TerminalLoader";
 import TerminalTabBar from "@/desktop/renderer/components/TerminalTabBar";
+import { useMarkTaskNotificationsReadWhenFocused } from "@/desktop/renderer/hooks/useMarkTaskNotificationsReadWhenFocused";
 import { useTaskAgentCallGraph, useTaskLiveAiSessions } from "@/desktop/renderer/hooks/useLiveAiSessions";
 import { useTerminalTabs } from "@/desktop/renderer/hooks/useTerminalTabs";
 import type { TerminalTabShortcutCommand } from "@/desktop/shared/terminalTabs";
@@ -866,6 +866,7 @@ export default function TaskDetailRoute() {
     isRemote: !!state?.task.sshHost,
     isVisible: hasTerminal && mainView === "terminal",
   });
+  useMarkTaskNotificationsReadWhenFocused(state?.task.id ?? null);
   const shortcutPlatform = getCurrentShortcutPlatform();
   const statusPanelLabel = `${t("actions")} · ${t("hooksStatus")}`;
   currentTaskRef.current = state?.task ?? null;
@@ -1332,11 +1333,6 @@ export default function TaskDetailRoute() {
         if (cancelled) {
           return;
         }
-
-        /** 상세 화면에 들어온 시점에 이 task로 쌓인 알림은 이미 확인한 것으로 본다 */
-        void markTaskNotificationsRead(task.id).catch((error) => {
-          console.error("알림 읽음 처리 실패:", error);
-        });
 
         setResolvedSidebarDefaultCollapsed(sidebarDefaultCollapsed);
         setState((current) => current && current.task.id === task.id

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -502,7 +502,8 @@ describe("TaskDetailRoute", () => {
     worktreePath: "/repo__worktrees/detail-notifications",
   };
 
-  it("상세 화면에 진입하면 해당 task의 알림을 모두 읽음 처리한다", async () => {
+  it("창이 활성인 상태로 상세 화면에 진입하면 해당 task의 알림을 모두 읽음 처리한다", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
     mocks.getTaskById.mockResolvedValue(notificationReadTargetTask);
 
     render(<TaskDetailRoute />);
@@ -512,8 +513,48 @@ describe("TaskDetailRoute", () => {
     expect(mocks.markTaskNotificationsRead).toHaveBeenCalledWith("task-1");
   });
 
+  it("창이 비활성이면 상세 화면이 새로고침돼도 알림을 읽음 처리하지 않는다", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    let refreshSignal = 0;
+    mocks.useRefreshSignal.mockImplementation(() => refreshSignal);
+    mocks.getTaskById.mockResolvedValue(notificationReadTargetTask);
+
+    const { rerender } = render(<TaskDetailRoute />);
+
+    await screen.findByTestId("task-title");
+
+    refreshSignal = 1;
+    rerender(<TaskDetailRoute />);
+
+    await waitFor(() => {
+      expect(mocks.getTaskById).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+  });
+
+  it("비활성으로 열려 있던 상세 화면이 포커스를 받으면 그때 알림을 읽음 처리한다", async () => {
+    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    mocks.getTaskById.mockResolvedValue(notificationReadTargetTask);
+
+    render(<TaskDetailRoute />);
+
+    await screen.findByTestId("task-title");
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+
+    hasFocusSpy.mockReturnValue(true);
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() => {
+      expect(mocks.markTaskNotificationsRead).toHaveBeenCalledWith("task-1");
+    });
+  });
+
   it("알림 읽음 처리가 실패하면 로그를 남기고 상세 화면 렌더는 계속한다", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
     mocks.getTaskById.mockResolvedValue(notificationReadTargetTask);
     mocks.markTaskNotificationsRead.mockRejectedValue(new Error("app settings write failed"));
 
@@ -529,6 +570,7 @@ describe("TaskDetailRoute", () => {
   });
 
   it("존재하지 않는 task로 진입하면 알림을 읽음 처리하지 않는다", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
     mocks.getTaskById.mockResolvedValue(null);
 
     render(<TaskDetailRoute />);


### PR DESCRIPTION
## 관련 자료
- 이슈 : 없음

## 어떤 작업인가요?
- 상세 페이지가 열려 있기만 하면 관련 알림이 읽음 처리되던 동작을, **상세 페이지로 포커스가 옮겨온 순간**에만 읽음 처리하도록 바꿉니다. 뒤에 가려진 상세 창에서는 새 알림이 안읽음으로 쌓입니다.

## 어떻게 해결했나요?
**읽음 처리 시점을 포커스 전환으로 옮김**
- 알림 클릭으로 상세를 열거나 직접 진입하는 경우는 그대로 읽음 처리하고, 백그라운드 상세 창에서는 알림이 사라지지 않게 한다.
- 로드 이펙트 안에 있던 읽음 처리를 전용 훅으로 분리해 `(taskId, 창 활성)`이 바뀌는 순간에만 호출한다.

**창 활성 판정의 첫 값 교정**
- 포커스 게이트가 성립하려면 창 활성 여부의 초기값이 실제 창 상태여야 한다.
- `useIsWindowActive`가 초기값을 `true`로 가정하던 부분을 실제 상태에서 읽도록 바꾼다.

## 중요한 변경 사항은 무엇인가요?
### 읽음 처리 시점을 포커스 전환으로 옮김

**읽음 처리를 로드 이펙트에서 분리**
- **변경 이유**: 읽음 처리가 상세 로드 이펙트 안에 있었고 그 이펙트는 `refreshSignal`에 물려 있었다. 보드 이벤트가 올 때마다 `App.tsx`가 전역 새로고침을 쏘므로, 뒤에 가려진 상세 창까지 재로드되며 그 task의 알림을 전부 읽음 처리했다.
- **수정 파일**: `src/desktop/renderer/routes/TaskDetailRoute.tsx`

**포커스 전환 시점에만 읽음 처리하는 훅 추가**
- **변경 이유**: 기존 `useIsWindowActive`를 재사용해 창이 활성으로 바뀌는 순간에만 `markTaskNotificationsRead`를 호출한다. 비활성인 동안 도착한 알림은 다시 포커스를 받을 때까지 안읽음으로 남는다.
- **수정 파일**: `src/desktop/renderer/hooks/useMarkTaskNotificationsReadWhenFocused.ts` (신규)

### 창 활성 판정의 첫 값 교정

**초기값을 실제 창 상태에서 읽도록 변경**
- **변경 이유**: 초기값이 `true`로 고정돼 있어 백그라운드 창의 첫 렌더에서만 활성으로 보였고, 그 틈에 읽음 처리가 한 번 실행됐다. 이걸 고치지 않으면 포커스 게이트 자체가 성립하지 않는다.
- **수정 파일**: `src/desktop/renderer/hooks/useIsWindowActive.ts`

### 알려진 한계

- Electron 실기 QA flow는 실행하지 않았습니다. `qa/electron/flows`에 알림 flow가 없고, Xvfb에서 다중 창 포커스/블러를 재현하는 새 flow 작성은 이번 범위를 넘습니다. "Electron이 창을 focus하면 렌더러가 `focus` 이벤트를 받고 `document.hasFocus()`가 true가 된다"는 런타임 가정은 단위 테스트로만 검증했습니다.

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
