### PR TITLE
fix(ai-usage): 두 번째 Claude 계정의 이메일이 뜨지 않던 문제 수정

### DIFF
--- a/src/lib/aiUsage/__tests__/accountDiscovery.test.ts
+++ b/src/lib/aiUsage/__tests__/accountDiscovery.test.ts
@@ -156,6 +156,49 @@ describe("discoverProviderAccounts(claude)", () => {
     expect(await discoverProviderAccounts("claude")).toHaveLength(1);
   });
 
+  it("기본 루트의 설정 파일에 계정 정보가 없으면 홈 설정에서 계정을 읽는다", async () => {
+    vi.stubEnv("CLAUDE_CONFIG_DIR", "");
+    const configDir = path.join(fakeHome, ".claude");
+    await mkdir(configDir, { recursive: true });
+    // CLAUDE_CONFIG_DIR를 얹어 CLI를 부르면 Claude Code가 로그인 정보 없는 설정 파일을 여기에 만든다
+    await writeFile(path.join(configDir, ".claude.json"), JSON.stringify({ numStartups: 1 }), "utf-8");
+    await writeFile(
+      path.join(fakeHome, ".claude.json"),
+      JSON.stringify({ oauthAccount: { accountUuid: "uuid-mac", emailAddress: "mac@example.com" } }),
+      "utf-8",
+    );
+    mockReadClaudeKeychainCredentials.mockResolvedValue({
+      outcome: "found",
+      credentials: JSON.stringify({ claudeAiOauth: { accessToken: "keychain-token" } }),
+    });
+
+    const accounts = await discoverProviderAccounts("claude");
+
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].accountId).toBe("uuid-mac");
+    expect(accounts[0].label).toBe("mac@example.com");
+  });
+
+  it("형제 루트는 계정 정보가 없어도 홈 계정의 신원을 물려받지 않는다", async () => {
+    vi.stubEnv("CLAUDE_CONFIG_DIR", "");
+    await writeClaudeConfigDir(".claude", { accountUuid: "uuid-home", emailAddress: "home@example.com" });
+    const workDir = path.join(fakeHome, ".claude-work");
+    await mkdir(workDir, { recursive: true });
+    await writeFile(
+      path.join(workDir, ".credentials.json"),
+      JSON.stringify({ claudeAiOauth: { accessToken: "token" } }),
+      "utf-8",
+    );
+    await writeFile(path.join(workDir, ".claude.json"), JSON.stringify({ numStartups: 1 }), "utf-8");
+
+    const accounts = await discoverProviderAccounts("claude");
+
+    expect(accounts).toHaveLength(2);
+    const workAccount = accounts.find((account) => account.accountRoot === workDir);
+    expect(workAccount?.accountId).toBe(workDir);
+    expect(workAccount?.label).toBe("work");
+  });
+
   it("파일에서 이미 찾은 계정이 있으면 Keychain을 다시 묻지 않는다", async () => {
     vi.stubEnv("CLAUDE_CONFIG_DIR", "");
     await writeClaudeConfigDir(".claude", { accountUuid: "uuid-file", emailAddress: "file@example.com" });

--- a/src/lib/aiUsage/__tests__/providerCli.test.ts
+++ b/src/lib/aiUsage/__tests__/providerCli.test.ts
@@ -50,14 +50,49 @@ describe("createProviderCliEnvironment", () => {
 
     const environment = createProviderCliEnvironment(
       AI_PROVIDER_CONFIG_DIR_SPECS.claude,
-      "/home/tester/.claude",
+      "/home/tester/.claude-work",
     );
 
     expect(environment.PORT).toBeUndefined();
     expect(environment.HOST).toBeUndefined();
     expect(environment.NODE_ENV).toBeUndefined();
     expect(environment.KANVIBE_INTERNAL_TOKEN).toBeUndefined();
-    expect(environment.CLAUDE_CONFIG_DIR).toBe("/home/tester/.claude");
+    expect(environment.CLAUDE_CONFIG_DIR).toBe("/home/tester/.claude-work");
+  });
+
+  // 기본 루트를 지정하면 Claude Code가 설정 파일을 config dir 안에 새로 만들어 계정 신원이 갈린다
+  it("기본 루트에는 계정 위치 변수를 얹지 않는다", () => {
+    vi.stubEnv("HOME", "/home/tester");
+
+    const environment = createProviderCliEnvironment(
+      AI_PROVIDER_CONFIG_DIR_SPECS.claude,
+      "/home/tester/.claude",
+    );
+
+    expect(environment.CLAUDE_CONFIG_DIR).toBeUndefined();
+  });
+
+  it("셸에서 물려받은 계정 위치 변수도 기본 루트 호출에서는 지운다", () => {
+    vi.stubEnv("HOME", "/home/tester");
+    vi.stubEnv("CLAUDE_CONFIG_DIR", "/home/tester/.claude-work");
+
+    const environment = createProviderCliEnvironment(
+      AI_PROVIDER_CONFIG_DIR_SPECS.claude,
+      "/home/tester/.claude",
+    );
+
+    expect(environment.CLAUDE_CONFIG_DIR).toBeUndefined();
+  });
+
+  it("홈 자체가 기본 루트인 provider도 변수를 얹지 않는다", () => {
+    vi.stubEnv("HOME", "/home/tester");
+
+    const environment = createProviderCliEnvironment(
+      AI_PROVIDER_CONFIG_DIR_SPECS.gemini,
+      "/home/tester",
+    );
+
+    expect(environment.GEMINI_CLI_HOME).toBeUndefined();
   });
 });
 

--- a/src/lib/aiUsage/accountDiscovery.ts
+++ b/src/lib/aiUsage/accountDiscovery.ts
@@ -68,23 +68,48 @@ async function readJsonFile(filePath: string): Promise<Record<string, unknown> |
   }
 }
 
+const UNKNOWN_ACCOUNT_IDENTITY: ProviderAccountIdentity = { accountId: null, label: null };
+
+/** 설정 파일이 로그인한 계정을 알려줄 때만 신원으로 친다. 둘 다 비면 이 파일은 출처가 되지 못한다 */
+function readClaudeConfigIdentity(
+  config: Record<string, unknown> | null,
+): ProviderAccountIdentity | null {
+  const oauthAccount = config?.oauthAccount as Record<string, unknown> | undefined;
+  const identity: ProviderAccountIdentity = {
+    accountId: firstNonEmptyString([oauthAccount?.accountUuid]),
+    label: firstNonEmptyString([oauthAccount?.emailAddress, oauthAccount?.displayName]),
+  };
+
+  return identity.accountId || identity.label ? identity : null;
+}
+
 /**
  * Claude는 사용량 응답에 계정 정보를 담지 않아서 `.claude.json`이 유일한 식별·라벨 출처다.
  * config dir를 따로 지정한 계정은 그 안에 `.claude.json`을 함께 두고, 기본 계정만 홈 루트에 둔다.
+ *
+ * config dir 안의 `.claude.json`은 로그인 정보 없이도 만들어진다. `CLAUDE_CONFIG_DIR`를 얹어 CLI를
+ * 부르면 Claude Code가 그 자리에 설정 파일을 새로 만들기 때문이라, 파일이 있는지가 아니라
+ * 계정을 알려주는지로 갈라야 기본 계정이 홈에 둔 신원을 잃지 않는다.
+ *
+ * 홈으로 넘어가는 것은 기본 계정뿐이다. 형제 루트까지 넘기면 다른 계정의 이메일과 uuid를 물려받아
+ * 기본 계정과 같은 계정으로 합쳐진다.
  */
 async function readClaudeAccountIdentity(configDir: string): Promise<ProviderAccountIdentity> {
-  const colocatedConfig = await readJsonFile(path.join(configDir, ".claude.json"));
-  const config = colocatedConfig ?? (await readJsonFile(path.join(homedir(), ".claude.json")));
-  const oauthAccount = config?.oauthAccount as Record<string, unknown> | undefined;
+  const colocatedIdentity = readClaudeConfigIdentity(
+    await readJsonFile(path.join(configDir, ".claude.json")),
+  );
+  if (colocatedIdentity) {
+    return colocatedIdentity;
+  }
 
-  const accountUuid = oauthAccount?.accountUuid;
-  const emailAddress = oauthAccount?.emailAddress;
-  const displayName = oauthAccount?.displayName;
+  if (configDir !== toDefaultAccountRoot(AI_PROVIDER_CONFIG_DIR_SPECS.claude)) {
+    return UNKNOWN_ACCOUNT_IDENTITY;
+  }
 
-  return {
-    accountId: typeof accountUuid === "string" && accountUuid.trim() ? accountUuid : null,
-    label: firstNonEmptyString([emailAddress, displayName]),
-  };
+  const homeIdentity = readClaudeConfigIdentity(
+    await readJsonFile(path.join(homedir(), ".claude.json")),
+  );
+  return homeIdentity ?? UNKNOWN_ACCOUNT_IDENTITY;
 }
 
 async function readCodexAccountIdentity(configDir: string): Promise<ProviderAccountIdentity> {

--- a/src/lib/aiUsage/providerCli.ts
+++ b/src/lib/aiUsage/providerCli.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import {
   AI_PROVIDER_CONFIG_DIR_SPECS,
+  toDefaultAccountRoot,
   type AiProviderConfigDirSpec,
 } from "@/lib/aiUsage/providerConfigDir";
 import { createLocalShellEnvironment } from "@/lib/shellEnvironment";
@@ -104,12 +105,24 @@ const AI_PROVIDER_CLI_SPECS: Record<AiUsageProvider, AiProviderCliSpec> = {
  * 계정 위치를 알리는 변수 하나만 얹은 자식 프로세스 환경을 만든다.
  *
  * 서버 런타임 값이 CLI로 새지 않도록 로컬 셸 환경 규칙을 그대로 쓰고, 그 위에 provider 변수만 더한다.
+ *
+ * 기본 루트일 때는 그 변수를 얹는 대신 지운다. CLI가 스스로 고르는 자리와 같은 값이지만, Claude Code는
+ * `CLAUDE_CONFIG_DIR`가 있으면 설정 파일을 홈이 아니라 config dir 안에 새로 만든다.
+ * 그러면 같은 계정의 신원이 홈과 config dir 두 곳으로 갈려, 탐색이 계정 이메일을 잃는다.
+ * 사용자가 셸에서 내보낸 값이 그대로 상속돼 있을 수 있으므로, 얹지 않는 것으로는 모자라고 지워야
+ * 이 호출이 겨냥한 계정과 CLI가 여는 계정이 어긋나지 않는다.
  */
 export function createProviderCliEnvironment(
   spec: AiProviderConfigDirSpec,
   accountRoot: string,
 ): Record<string, string> {
-  return { ...createLocalShellEnvironment(), [spec.homeEnvVar]: accountRoot };
+  const environment = createLocalShellEnvironment();
+  if (accountRoot === toDefaultAccountRoot(spec)) {
+    delete environment[spec.homeEnvVar];
+    return environment;
+  }
+
+  return { ...environment, [spec.homeEnvVar]: accountRoot };
 }
 
 /** 로그인 세션이 띄울 명령. PTY를 다루는 쪽이 실행 방식을 정하므로 여기서는 이름과 인자만 준다 */


### PR DESCRIPTION
## 관련 자료
- 이슈 : 없음

## 어떤 작업인가요?
- AI 사용량 패널에 Claude 계정이 두 개 떠 있는데 두 번째 계정의 이메일 주소가 표시되지 않던 문제를 고칩니다. 계정 라벨이 provider 이름(`Claude`)으로 떨어지면 패널이 카드 제목과 같은 말이라 판단해 줄 자체를 지우기 때문에, 두 계정이 화면에서 구분되지 않았습니다.

## 어떻게 해결했나요?
**기본 계정에는 계정 위치 변수를 얹지 않는다**
- 작업 목적: KanVibe가 스스로 만든 그림자 설정 파일 때문에 계정 신원이 두 곳으로 갈리는 것을 막습니다.
- 작업 내용 요약: `createProviderCliEnvironment()`가 기본 루트를 대상으로 할 때는 provider 환경변수를 얹지 않고, 셸에서 상속된 값까지 지웁니다.

**설정 파일 폴백을 "계정 정보 존재" 기준으로 바꾼다**
- 작업 목적: 이미 만들어진 그림자 설정 파일이 있는 환경에서도 계정 이메일을 되찾습니다.
- 작업 내용 요약: `readClaudeAccountIdentity()`가 파일 존재 여부가 아니라 `oauthAccount`가 계정을 알려주는지로 폴백을 가르고, 홈 설정 폴백은 기본 계정에만 허용합니다.

## 중요한 변경 사항은 무엇인가요?
### 기본 계정에는 CLAUDE_CONFIG_DIR을 얹지 않는다

**기본 루트 호출에서는 환경변수를 지운다**
- **변경 이유**: `CLAUDE_CONFIG_DIR`가 있으면 Claude Code는 `.claude.json`을 홈이 아니라 config dir 안에 새로 만듭니다. 기본 루트에까지 변수를 얹어 CLI를 부른 탓에 KanVibe가 `~/.claude/.claude.json`을 만들어, 홈에 있던 기본 계정의 신원과 갈라졌습니다.
- **수정 파일**: `src/lib/aiUsage/providerCli.ts`

**얹지 않는 것이 아니라 지운다**
- **변경 이유**: `createLocalShellEnvironment()`는 `PORT`/`HOST`/`NODE_ENV`/`KANVIBE_*` 외의 프로세스 환경을 그대로 통과시킵니다. 사용자가 셸에서 `CLAUDE_CONFIG_DIR`를 내보낸 채 앱을 띄웠다면, 변수를 얹지 않는 것만으로는 기본 계정을 겨냥한 호출이 상속된 다른 루트를 열게 됩니다.
- **수정 파일**: `src/lib/aiUsage/providerCli.ts`, `src/lib/aiUsage/__tests__/providerCli.test.ts`

### 설정 파일에 계정 정보가 없으면 홈 설정에서 신원을 읽는다

**폴백 기준을 파일 존재에서 계정 정보 존재로**
- **변경 이유**: config dir 안의 `.claude.json`은 로그인 정보 없이도 만들어집니다. 폴백이 "파일을 읽지 못했을 때"만 걸려, 계정 정보가 없는 그 파일에서 멈추고 이메일이 든 홈 설정까지 가지 못했습니다.
- **수정 파일**: `src/lib/aiUsage/accountDiscovery.ts`

**홈 설정 폴백은 기본 계정에만 허용**
- **변경 이유**: 위 변경이 폴백 경로를 넓히기 때문에, 형제 루트가 홈 계정의 이메일과 `accountUuid`를 물려받게 됩니다. 그러면 라벨이 틀릴 뿐 아니라 `deduplicateAccounts()`가 두 계정을 한 계정으로 합쳐 카드가 사라집니다.
- **수정 파일**: `src/lib/aiUsage/accountDiscovery.ts`, `src/lib/aiUsage/__tests__/accountDiscovery.test.ts`

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
