### PR TITLE
chore(release): publish KanVibe 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Publish KanVibe 1.2.2. This bumps `package.json` and `package-lock.json` from `1.2.1` to `1.2.2`; the DMG is built, signed, notarized, stapled, smoke-tested, and already published.

The release carries two bug fixes merged into `dev` after 1.2.1: notification read-marking now waits for the task detail window to receive focus (#365), and a second Claude account shows its email address in the AI usage panel again (#366).

## Test Plan

- `pnpm install --frozen-lockfile` + `pnpm run deploy` on macOS (arm64)
- Dependency collector reported `pm=npm`, guard reported `packaged node_modules verified: 278 packages`, asar top-level 232
- Notarization `Accepted`; `xcrun stapler staple` and `stapler validate` both passed
- `spctl -a -t exec` on the mounted app: `accepted` / `source=Notarized Developer ID`
- Smoke test with an isolated `KANVIBE_APP_DATA_DIR`: process stayed alive, module errors `0`, `invoke-succeeded` 21
- `curl -sL <release asset> | shasum -a 256` matched the local DMG checksum exactly

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.2.2
- DMG asset: `dist/KanVibe-1.2.2.dmg` (171153256 bytes)
- SHA-256: `b4ebcd4fcbe2b8f0fed091ee242895fa05dc0de271700584460f9881ec4b9e24`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@6a5539d` — `version` and `sha256` only
