### PR TITLE
Release: promote KanVibe 1.2.2 to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",

--- a/src/desktop/renderer/hooks/__tests__/useMarkTaskNotificationsReadWhenFocused.test.tsx
+++ b/src/desktop/renderer/hooks/__tests__/useMarkTaskNotificationsReadWhenFocused.test.tsx
@@ -1,0 +1,102 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useMarkTaskNotificationsReadWhenFocused } from "../useMarkTaskNotificationsReadWhenFocused";
+
+const mocks = vi.hoisted(() => ({
+  markTaskNotificationsRead: vi.fn(),
+}));
+
+vi.mock("@/desktop/renderer/actions/notifications", () => ({
+  markTaskNotificationsRead: (...args: unknown[]) => mocks.markTaskNotificationsRead(...args),
+}));
+
+function MarkReadHarness({ taskId }: { taskId: string | null }) {
+  useMarkTaskNotificationsReadWhenFocused(taskId);
+
+  return <div data-testid="harness" />;
+}
+
+function setWindowFocused(isFocused: boolean) {
+  vi.mocked(document.hasFocus).mockReturnValue(isFocused);
+}
+
+describe("useMarkTaskNotificationsReadWhenFocused", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.markTaskNotificationsRead.mockResolvedValue(0);
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("창이 활성인 상태로 상세 화면에 들어오면 그 task의 알림을 읽음 처리한다", async () => {
+    setWindowFocused(true);
+
+    render(<MarkReadHarness taskId="task-1" />);
+
+    await waitFor(() => {
+      expect(mocks.markTaskNotificationsRead).toHaveBeenCalledWith("task-1");
+    });
+  });
+
+  it("창이 비활성이면 상세 화면이 열려 있어도 읽음 처리하지 않는다", async () => {
+    setWindowFocused(false);
+
+    render(<MarkReadHarness taskId="task-1" />);
+
+    await act(async () => {});
+
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+  });
+
+  it("비활성으로 열려 있던 상세 화면이 포커스를 받으면 그때 읽음 처리한다", async () => {
+    setWindowFocused(false);
+
+    render(<MarkReadHarness taskId="task-1" />);
+
+    await act(async () => {});
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+
+    setWindowFocused(true);
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(mocks.markTaskNotificationsRead).toHaveBeenCalledWith("task-1");
+  });
+
+  it("비활성 상태에서 화면이 다시 그려져도 읽음 처리하지 않는다", async () => {
+    setWindowFocused(false);
+
+    const { rerender } = render(<MarkReadHarness taskId="task-1" />);
+    rerender(<MarkReadHarness taskId="task-1" />);
+
+    await act(async () => {});
+
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+  });
+
+  it("아직 task를 확인하지 못했으면 읽음 처리하지 않는다", async () => {
+    setWindowFocused(true);
+
+    render(<MarkReadHarness taskId={null} />);
+
+    await act(async () => {});
+
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+  });
+
+  it("읽음 처리가 실패하면 로그만 남기고 화면은 그대로 둔다", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    setWindowFocused(true);
+    mocks.markTaskNotificationsRead.mockRejectedValue(new Error("app settings write failed"));
+
+    render(<MarkReadHarness taskId="task-1" />);
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith("알림 읽음 처리 실패:", expect.any(Error));
+    });
+  });
+});

--- a/src/desktop/renderer/hooks/useIsWindowActive.ts
+++ b/src/desktop/renderer/hooks/useIsWindowActive.ts
@@ -1,18 +1,25 @@
 import { useEffect, useState } from "react";
 
+function isWindowCurrentlyActive(): boolean {
+  return document.visibilityState !== "hidden" && document.hasFocus();
+}
+
 /**
  * 창이 뒤에 가려져 있으면 화면이 바뀌어도 볼 사람이 없으므로 폴링을 멈춘다.
  * 창을 여러 개 띄우는 사용 방식이라 창 수만큼 곱해지는 비용이고,
  * 원격에서는 SSH ControlMaster lease를 점유해 실제 git 작업과 경합한다.
  *
  * Electron은 창이 다른 창에 가려진 것만으로는 `visibilitychange`를 내지 않아 포커스도 함께 본다.
+ *
+ * 첫 값도 실제 창 상태에서 읽는다. 활성으로 가정해 두면 뒤에 가려진 창이 마운트되는 첫 렌더에서만
+ * 활성으로 보여, 포커스가 왔을 때만 해야 하는 일이 백그라운드에서도 한 번 실행된다.
  */
 export function useIsWindowActive(): boolean {
-  const [isWindowActive, setIsWindowActive] = useState(true);
+  const [isWindowActive, setIsWindowActive] = useState(isWindowCurrentlyActive);
 
   useEffect(() => {
     const syncWindowActive = () => {
-      setIsWindowActive(document.visibilityState !== "hidden" && document.hasFocus());
+      setIsWindowActive(isWindowCurrentlyActive());
     };
 
     syncWindowActive();

--- a/src/desktop/renderer/hooks/useMarkTaskNotificationsReadWhenFocused.ts
+++ b/src/desktop/renderer/hooks/useMarkTaskNotificationsReadWhenFocused.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { markTaskNotificationsRead } from "@/desktop/renderer/actions/notifications";
+import { useIsWindowActive } from "@/desktop/renderer/hooks/useIsWindowActive";
+
+/**
+ * 상세 화면으로 포커스가 옮겨온 시점에만 그 task의 알림을 확인한 것으로 본다.
+ * 창을 여러 개 띄워 두는 사용 방식이라, 뒤에 가려진 상세 창이 열려 있다는 이유만으로 읽음 처리하면
+ * 사용자가 보지 못한 알림이 조용히 사라진다. 창이 활성으로 바뀌는 순간에만 읽음 처리하고,
+ * 비활성인 동안 도착한 알림은 다시 포커스를 받을 때까지 안읽음으로 남긴다.
+ */
+export function useMarkTaskNotificationsReadWhenFocused(taskId: string | null) {
+  const isWindowActive = useIsWindowActive();
+
+  useEffect(() => {
+    if (!taskId || !isWindowActive) {
+      return;
+    }
+
+    void markTaskNotificationsRead(taskId).catch((error) => {
+      console.error("알림 읽음 처리 실패:", error);
+    });
+  }, [taskId, isWindowActive]);
+}

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -22,7 +22,6 @@ import { Link, useRouter } from "@/desktop/renderer/navigation";
 import { getDefaultSessionType, getDoneAlertDismissed, getSidebarDefaultCollapsed } from "@/desktop/renderer/actions/appSettings";
 import { getGitDiffFiles } from "@/desktop/renderer/actions/diff";
 import { deleteTask, getTaskById, getTaskIdByProjectAndBranch, updateTaskStatus } from "@/desktop/renderer/actions/kanban";
-import { markTaskNotificationsRead } from "@/desktop/renderer/actions/notifications";
 import {
   getTaskAiSessions,
   getTaskAiSessionDetail,
@@ -43,6 +42,7 @@ import { AgentCallGraphPanel } from "@/desktop/renderer/components/AgentCallGrap
 import { LiveAiSessionPanel } from "@/desktop/renderer/components/LiveAiSessionPanel";
 import TerminalLoader from "@/desktop/renderer/components/TerminalLoader";
 import TerminalTabBar from "@/desktop/renderer/components/TerminalTabBar";
+import { useMarkTaskNotificationsReadWhenFocused } from "@/desktop/renderer/hooks/useMarkTaskNotificationsReadWhenFocused";
 import { useTaskAgentCallGraph, useTaskLiveAiSessions } from "@/desktop/renderer/hooks/useLiveAiSessions";
 import { useTerminalTabs } from "@/desktop/renderer/hooks/useTerminalTabs";
 import type { TerminalTabShortcutCommand } from "@/desktop/shared/terminalTabs";
@@ -866,6 +866,7 @@ export default function TaskDetailRoute() {
     isRemote: !!state?.task.sshHost,
     isVisible: hasTerminal && mainView === "terminal",
   });
+  useMarkTaskNotificationsReadWhenFocused(state?.task.id ?? null);
   const shortcutPlatform = getCurrentShortcutPlatform();
   const statusPanelLabel = `${t("actions")} · ${t("hooksStatus")}`;
   currentTaskRef.current = state?.task ?? null;
@@ -1332,11 +1333,6 @@ export default function TaskDetailRoute() {
         if (cancelled) {
           return;
         }
-
-        /** 상세 화면에 들어온 시점에 이 task로 쌓인 알림은 이미 확인한 것으로 본다 */
-        void markTaskNotificationsRead(task.id).catch((error) => {
-          console.error("알림 읽음 처리 실패:", error);
-        });
 
         setResolvedSidebarDefaultCollapsed(sidebarDefaultCollapsed);
         setState((current) => current && current.task.id === task.id

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -502,7 +502,8 @@ describe("TaskDetailRoute", () => {
     worktreePath: "/repo__worktrees/detail-notifications",
   };
 
-  it("상세 화면에 진입하면 해당 task의 알림을 모두 읽음 처리한다", async () => {
+  it("창이 활성인 상태로 상세 화면에 진입하면 해당 task의 알림을 모두 읽음 처리한다", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
     mocks.getTaskById.mockResolvedValue(notificationReadTargetTask);
 
     render(<TaskDetailRoute />);
@@ -512,8 +513,48 @@ describe("TaskDetailRoute", () => {
     expect(mocks.markTaskNotificationsRead).toHaveBeenCalledWith("task-1");
   });
 
+  it("창이 비활성이면 상세 화면이 새로고침돼도 알림을 읽음 처리하지 않는다", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    let refreshSignal = 0;
+    mocks.useRefreshSignal.mockImplementation(() => refreshSignal);
+    mocks.getTaskById.mockResolvedValue(notificationReadTargetTask);
+
+    const { rerender } = render(<TaskDetailRoute />);
+
+    await screen.findByTestId("task-title");
+
+    refreshSignal = 1;
+    rerender(<TaskDetailRoute />);
+
+    await waitFor(() => {
+      expect(mocks.getTaskById).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+  });
+
+  it("비활성으로 열려 있던 상세 화면이 포커스를 받으면 그때 알림을 읽음 처리한다", async () => {
+    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    mocks.getTaskById.mockResolvedValue(notificationReadTargetTask);
+
+    render(<TaskDetailRoute />);
+
+    await screen.findByTestId("task-title");
+    expect(mocks.markTaskNotificationsRead).not.toHaveBeenCalled();
+
+    hasFocusSpy.mockReturnValue(true);
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() => {
+      expect(mocks.markTaskNotificationsRead).toHaveBeenCalledWith("task-1");
+    });
+  });
+
   it("알림 읽음 처리가 실패하면 로그를 남기고 상세 화면 렌더는 계속한다", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
     mocks.getTaskById.mockResolvedValue(notificationReadTargetTask);
     mocks.markTaskNotificationsRead.mockRejectedValue(new Error("app settings write failed"));
 
@@ -529,6 +570,7 @@ describe("TaskDetailRoute", () => {
   });
 
   it("존재하지 않는 task로 진입하면 알림을 읽음 처리하지 않는다", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
     mocks.getTaskById.mockResolvedValue(null);
 
     render(<TaskDetailRoute />);

--- a/src/lib/aiUsage/__tests__/accountDiscovery.test.ts
+++ b/src/lib/aiUsage/__tests__/accountDiscovery.test.ts
@@ -156,6 +156,49 @@ describe("discoverProviderAccounts(claude)", () => {
     expect(await discoverProviderAccounts("claude")).toHaveLength(1);
   });
 
+  it("기본 루트의 설정 파일에 계정 정보가 없으면 홈 설정에서 계정을 읽는다", async () => {
+    vi.stubEnv("CLAUDE_CONFIG_DIR", "");
+    const configDir = path.join(fakeHome, ".claude");
+    await mkdir(configDir, { recursive: true });
+    // CLAUDE_CONFIG_DIR를 얹어 CLI를 부르면 Claude Code가 로그인 정보 없는 설정 파일을 여기에 만든다
+    await writeFile(path.join(configDir, ".claude.json"), JSON.stringify({ numStartups: 1 }), "utf-8");
+    await writeFile(
+      path.join(fakeHome, ".claude.json"),
+      JSON.stringify({ oauthAccount: { accountUuid: "uuid-mac", emailAddress: "mac@example.com" } }),
+      "utf-8",
+    );
+    mockReadClaudeKeychainCredentials.mockResolvedValue({
+      outcome: "found",
+      credentials: JSON.stringify({ claudeAiOauth: { accessToken: "keychain-token" } }),
+    });
+
+    const accounts = await discoverProviderAccounts("claude");
+
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].accountId).toBe("uuid-mac");
+    expect(accounts[0].label).toBe("mac@example.com");
+  });
+
+  it("형제 루트는 계정 정보가 없어도 홈 계정의 신원을 물려받지 않는다", async () => {
+    vi.stubEnv("CLAUDE_CONFIG_DIR", "");
+    await writeClaudeConfigDir(".claude", { accountUuid: "uuid-home", emailAddress: "home@example.com" });
+    const workDir = path.join(fakeHome, ".claude-work");
+    await mkdir(workDir, { recursive: true });
+    await writeFile(
+      path.join(workDir, ".credentials.json"),
+      JSON.stringify({ claudeAiOauth: { accessToken: "token" } }),
+      "utf-8",
+    );
+    await writeFile(path.join(workDir, ".claude.json"), JSON.stringify({ numStartups: 1 }), "utf-8");
+
+    const accounts = await discoverProviderAccounts("claude");
+
+    expect(accounts).toHaveLength(2);
+    const workAccount = accounts.find((account) => account.accountRoot === workDir);
+    expect(workAccount?.accountId).toBe(workDir);
+    expect(workAccount?.label).toBe("work");
+  });
+
   it("파일에서 이미 찾은 계정이 있으면 Keychain을 다시 묻지 않는다", async () => {
     vi.stubEnv("CLAUDE_CONFIG_DIR", "");
     await writeClaudeConfigDir(".claude", { accountUuid: "uuid-file", emailAddress: "file@example.com" });

--- a/src/lib/aiUsage/__tests__/providerCli.test.ts
+++ b/src/lib/aiUsage/__tests__/providerCli.test.ts
@@ -50,14 +50,49 @@ describe("createProviderCliEnvironment", () => {
 
     const environment = createProviderCliEnvironment(
       AI_PROVIDER_CONFIG_DIR_SPECS.claude,
-      "/home/tester/.claude",
+      "/home/tester/.claude-work",
     );
 
     expect(environment.PORT).toBeUndefined();
     expect(environment.HOST).toBeUndefined();
     expect(environment.NODE_ENV).toBeUndefined();
     expect(environment.KANVIBE_INTERNAL_TOKEN).toBeUndefined();
-    expect(environment.CLAUDE_CONFIG_DIR).toBe("/home/tester/.claude");
+    expect(environment.CLAUDE_CONFIG_DIR).toBe("/home/tester/.claude-work");
+  });
+
+  // 기본 루트를 지정하면 Claude Code가 설정 파일을 config dir 안에 새로 만들어 계정 신원이 갈린다
+  it("기본 루트에는 계정 위치 변수를 얹지 않는다", () => {
+    vi.stubEnv("HOME", "/home/tester");
+
+    const environment = createProviderCliEnvironment(
+      AI_PROVIDER_CONFIG_DIR_SPECS.claude,
+      "/home/tester/.claude",
+    );
+
+    expect(environment.CLAUDE_CONFIG_DIR).toBeUndefined();
+  });
+
+  it("셸에서 물려받은 계정 위치 변수도 기본 루트 호출에서는 지운다", () => {
+    vi.stubEnv("HOME", "/home/tester");
+    vi.stubEnv("CLAUDE_CONFIG_DIR", "/home/tester/.claude-work");
+
+    const environment = createProviderCliEnvironment(
+      AI_PROVIDER_CONFIG_DIR_SPECS.claude,
+      "/home/tester/.claude",
+    );
+
+    expect(environment.CLAUDE_CONFIG_DIR).toBeUndefined();
+  });
+
+  it("홈 자체가 기본 루트인 provider도 변수를 얹지 않는다", () => {
+    vi.stubEnv("HOME", "/home/tester");
+
+    const environment = createProviderCliEnvironment(
+      AI_PROVIDER_CONFIG_DIR_SPECS.gemini,
+      "/home/tester",
+    );
+
+    expect(environment.GEMINI_CLI_HOME).toBeUndefined();
   });
 });
 

--- a/src/lib/aiUsage/accountDiscovery.ts
+++ b/src/lib/aiUsage/accountDiscovery.ts
@@ -68,23 +68,48 @@ async function readJsonFile(filePath: string): Promise<Record<string, unknown> |
   }
 }
 
+const UNKNOWN_ACCOUNT_IDENTITY: ProviderAccountIdentity = { accountId: null, label: null };
+
+/** 설정 파일이 로그인한 계정을 알려줄 때만 신원으로 친다. 둘 다 비면 이 파일은 출처가 되지 못한다 */
+function readClaudeConfigIdentity(
+  config: Record<string, unknown> | null,
+): ProviderAccountIdentity | null {
+  const oauthAccount = config?.oauthAccount as Record<string, unknown> | undefined;
+  const identity: ProviderAccountIdentity = {
+    accountId: firstNonEmptyString([oauthAccount?.accountUuid]),
+    label: firstNonEmptyString([oauthAccount?.emailAddress, oauthAccount?.displayName]),
+  };
+
+  return identity.accountId || identity.label ? identity : null;
+}
+
 /**
  * Claude는 사용량 응답에 계정 정보를 담지 않아서 `.claude.json`이 유일한 식별·라벨 출처다.
  * config dir를 따로 지정한 계정은 그 안에 `.claude.json`을 함께 두고, 기본 계정만 홈 루트에 둔다.
+ *
+ * config dir 안의 `.claude.json`은 로그인 정보 없이도 만들어진다. `CLAUDE_CONFIG_DIR`를 얹어 CLI를
+ * 부르면 Claude Code가 그 자리에 설정 파일을 새로 만들기 때문이라, 파일이 있는지가 아니라
+ * 계정을 알려주는지로 갈라야 기본 계정이 홈에 둔 신원을 잃지 않는다.
+ *
+ * 홈으로 넘어가는 것은 기본 계정뿐이다. 형제 루트까지 넘기면 다른 계정의 이메일과 uuid를 물려받아
+ * 기본 계정과 같은 계정으로 합쳐진다.
  */
 async function readClaudeAccountIdentity(configDir: string): Promise<ProviderAccountIdentity> {
-  const colocatedConfig = await readJsonFile(path.join(configDir, ".claude.json"));
-  const config = colocatedConfig ?? (await readJsonFile(path.join(homedir(), ".claude.json")));
-  const oauthAccount = config?.oauthAccount as Record<string, unknown> | undefined;
+  const colocatedIdentity = readClaudeConfigIdentity(
+    await readJsonFile(path.join(configDir, ".claude.json")),
+  );
+  if (colocatedIdentity) {
+    return colocatedIdentity;
+  }
 
-  const accountUuid = oauthAccount?.accountUuid;
-  const emailAddress = oauthAccount?.emailAddress;
-  const displayName = oauthAccount?.displayName;
+  if (configDir !== toDefaultAccountRoot(AI_PROVIDER_CONFIG_DIR_SPECS.claude)) {
+    return UNKNOWN_ACCOUNT_IDENTITY;
+  }
 
-  return {
-    accountId: typeof accountUuid === "string" && accountUuid.trim() ? accountUuid : null,
-    label: firstNonEmptyString([emailAddress, displayName]),
-  };
+  const homeIdentity = readClaudeConfigIdentity(
+    await readJsonFile(path.join(homedir(), ".claude.json")),
+  );
+  return homeIdentity ?? UNKNOWN_ACCOUNT_IDENTITY;
 }
 
 async function readCodexAccountIdentity(configDir: string): Promise<ProviderAccountIdentity> {

--- a/src/lib/aiUsage/providerCli.ts
+++ b/src/lib/aiUsage/providerCli.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import {
   AI_PROVIDER_CONFIG_DIR_SPECS,
+  toDefaultAccountRoot,
   type AiProviderConfigDirSpec,
 } from "@/lib/aiUsage/providerConfigDir";
 import { createLocalShellEnvironment } from "@/lib/shellEnvironment";
@@ -104,12 +105,24 @@ const AI_PROVIDER_CLI_SPECS: Record<AiUsageProvider, AiProviderCliSpec> = {
  * 계정 위치를 알리는 변수 하나만 얹은 자식 프로세스 환경을 만든다.
  *
  * 서버 런타임 값이 CLI로 새지 않도록 로컬 셸 환경 규칙을 그대로 쓰고, 그 위에 provider 변수만 더한다.
+ *
+ * 기본 루트일 때는 그 변수를 얹는 대신 지운다. CLI가 스스로 고르는 자리와 같은 값이지만, Claude Code는
+ * `CLAUDE_CONFIG_DIR`가 있으면 설정 파일을 홈이 아니라 config dir 안에 새로 만든다.
+ * 그러면 같은 계정의 신원이 홈과 config dir 두 곳으로 갈려, 탐색이 계정 이메일을 잃는다.
+ * 사용자가 셸에서 내보낸 값이 그대로 상속돼 있을 수 있으므로, 얹지 않는 것으로는 모자라고 지워야
+ * 이 호출이 겨냥한 계정과 CLI가 여는 계정이 어긋나지 않는다.
  */
 export function createProviderCliEnvironment(
   spec: AiProviderConfigDirSpec,
   accountRoot: string,
 ): Record<string, string> {
-  return { ...createLocalShellEnvironment(), [spec.homeEnvVar]: accountRoot };
+  const environment = createLocalShellEnvironment();
+  if (accountRoot === toDefaultAccountRoot(spec)) {
+    delete environment[spec.homeEnvVar];
+    return environment;
+  }
+
+  return { ...environment, [spec.homeEnvVar]: accountRoot };
 }
 
 /** 로그인 세션이 띄울 명령. PTY를 다루는 쪽이 실행 방식을 정하므로 여기서는 이름과 인자만 준다 */


### PR DESCRIPTION
Promote the pinned 1.2.2 release branch to main after the published DMG release and Homebrew cask update.

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.2.2
- Pinned head SHA: `bf8d9ba`
- SHA-256: `b4ebcd4fcbe2b8f0fed091ee242895fa05dc0de271700584460f9881ec4b9e24`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@6a5539d` — `brew fetch` returns `✔︎ Cask kanvibe (1.2.2)`