### PR TITLE
docs(release): 릴리스 스킬 문서를 실제 절차와 맞춘다

### DIFF
--- a/.claude/skills/kanvibe-release-deploy/SKILL.md
+++ b/.claude/skills/kanvibe-release-deploy/SKILL.md
@@ -143,6 +143,8 @@ The same script also keeps the tracked `package-lock.json` in sync, because its 
 
 Both files contain several `"version"` lines, and only three of them belong to the release. The replacement therefore anchors on **whole-line exact matches** and, inside `package-lock.json`, on the `packages[""]` block boundary. It never matches substrings and never treats indentation as optional.
 
+Every anchor is resolved in memory before the first `writeFileSync`, so a failed anchor leaves both files untouched. That ordering matters: a partial bump would leave `package.json` on the new version while `package-lock.json` stayed on the old one, and the `already at ${version}` guard would then reject the retry until someone manually ran `git checkout -- package.json`.
+
 ```bash
 TARGET_VERSION="<version supplied by user>"
 node -e '
@@ -172,10 +174,11 @@ const findExactlyOneLine = (label, lines, needle) => {
 // devEngines.packageManager.version is indented deeper and must survive untouched.
 const packageLines = fs.readFileSync("package.json", "utf8").split("\n");
 packageLines[findExactlyOneLine("package.json top-level version", packageLines, rootNeedle)] = rootReplacement;
-fs.writeFileSync("package.json", packageLines.join("\n"));
 
-if (fs.existsSync("package-lock.json")) {
-  const lockLines = fs.readFileSync("package-lock.json", "utf8").split("\n");
+const hasLock = fs.existsSync("package-lock.json");
+let lockLines = null;
+if (hasLock) {
+  lockLines = fs.readFileSync("package-lock.json", "utf8").split("\n");
   lockLines[findExactlyOneLine("package-lock.json top-level version", lockLines, rootNeedle)] = rootReplacement;
 
   // packages[""] is the root package block. Its six-space version line is textually identical
@@ -198,7 +201,13 @@ if (fs.existsSync("package-lock.json")) {
     throw new Error("package-lock.json: packages[\"\"].version line not found inside the root package block");
   }
   lockLines[innerIndex] = `      "version": "${version}",`;
+}
 
+// Every anchor is resolved by this point, so the writes happen together or not at all.
+// Writing package.json before the lock anchors were checked used to leave a half-bumped
+// tree on a lock failure, and the "already at" guard above then refused the retry.
+fs.writeFileSync("package.json", packageLines.join("\n"));
+if (hasLock) {
   fs.writeFileSync("package-lock.json", lockLines.join("\n"));
 }
 ' "$TARGET_VERSION"
@@ -325,9 +334,12 @@ Read the counts from `$LOG` inside `$SMOKE_DATA`, never from `~/Library/Applicat
 If the smoke test fails, stop. Do not publish, do not update the cask, and do not open PRs. Diagnose the bundle first; `app.asar` contents can be listed from its header:
 
 ```bash
+# Run this twice: once for the candidate bundle, once for a build known to be good.
+ASAR_PATH="dist/mac-arm64/KanVibe.app/Contents/Resources/app.asar"
+# ASAR_PATH="/Applications/KanVibe.app/Contents/Resources/app.asar"
 node -e '
 const fs=require("fs");
-const p=process.argv[1] ?? "dist/mac-arm64/KanVibe.app/Contents/Resources/app.asar";
+const p=process.argv[1] || "dist/mac-arm64/KanVibe.app/Contents/Resources/app.asar";
 const fd=fs.openSync(p,"r");
 const b=Buffer.alloc(16); fs.readSync(fd,b,0,16,0);
 const hb=Buffer.alloc(b.readUInt32LE(12)); fs.readSync(fd,hb,0,hb.length,16);
@@ -342,7 +354,7 @@ console.log(`${expanded} packages with scopes expanded  <-- matches the build gu
 
 The two numbers are both correct and they are not interchangeable. The build guard line `packaged node_modules verified: N packages` comes from `readAsarNodeModuleNames()` in `scripts/dist-deploy.cjs`, which expands `@scope/name` into one entry per scoped package, so it always reports the larger number. Counting the top-level keys instead reports the smaller one. Reading the smaller number as if it were the guard's makes a healthy build look like the 1.0.4 dependency-loss failure.
 
-Do not judge either number against a remembered absolute value; package counts move whenever dependencies change. Judge by comparison: run the same snippet against a build known to be good — the installed `/Applications/KanVibe.app/Contents/Resources/app.asar` is the convenient one — and compare it with the candidate bundle.
+Do not judge either number against a remembered absolute value; package counts move whenever dependencies change. Judge by comparison: rerun the same snippet with `ASAR_PATH` pointed at a build known to be good — the installed `/Applications/KanVibe.app/Contents/Resources/app.asar` is the convenient one — and compare it with the candidate bundle. The `||` fallback rather than `??` is deliberate, because an unset `ASAR_PATH` still passes an empty-string argument that `??` would accept as a path.
 
 ## 4. Create or Update the GitHub Release
 
@@ -587,10 +599,11 @@ This returns an empty list, which means `Type Check & Test` is **not** a merge g
 Because the merge does not wait, confirm the release commit's CI conclusion separately after merging:
 
 ```bash
-MERGE_SHA=$(gh pr view "$RELEASE_PR" --repo rookedsysc/kanvibe --json mergeCommit --jq .mergeCommit.oid)
 gh run list --repo rookedsysc/kanvibe --commit "$RELEASE_HEAD_SHA" --json databaseId,name,status,conclusion
 gh run view <databaseId> --repo rookedsysc/kanvibe
 ```
+
+`RELEASE_HEAD_SHA` (captured in §6.1) is the right commit to query, because it is the commit the DMG was built from. The merge commit on `dev` is a different SHA with its own runs; it answers "is `dev` green", not "did the released code pass".
 
 Every run for that commit must end with `conclusion: success`. A failed conclusion after a completed merge is a blocker: report it instead of continuing quietly.
 
@@ -654,10 +667,17 @@ MAIN_VERSION=$(git show origin/main:package.json | node -p "JSON.parse(require('
 test "$MAIN_VERSION" = "$VERSION"
 
 # Clean up the release branch only after the main promotion is merged and the release commit's
-# workflow runs have reached a conclusion. Deleting the branch cancels runs still in progress.
+# workflow runs have reached a conclusion. Deleting the branch cancels runs still in progress,
+# so the pending-run count below is the gate, not just something to read.
 if [ "$PROMOTION_STATE" = "MERGED" ]; then
   gh run list --repo rookedsysc/kanvibe --commit "$RELEASE_HEAD_SHA" --json name,status,conclusion
-  git push origin --delete "$PROMOTION_BRANCH" || true
+  PENDING_RUNS=$(gh run list --repo rookedsysc/kanvibe --commit "$RELEASE_HEAD_SHA" \
+    --json status --jq '[.[] | select(.status != "completed")] | length')
+  if [ "$PENDING_RUNS" != "0" ]; then
+    echo "release commit runs still in progress ($PENDING_RUNS); skip branch cleanup" >&2
+  else
+    git push origin --delete "$PROMOTION_BRANCH" || true
+  fi
 fi
 ```
 

--- a/.claude/skills/kanvibe-release-deploy/SKILL.md
+++ b/.claude/skills/kanvibe-release-deploy/SKILL.md
@@ -139,7 +139,9 @@ If the release worktree path or branch already exists, re-read its status and PR
 
 After the user chooses the target version, update `package.json` before running the build. Use a deterministic script instead of manually editing JSON punctuation.
 
-The same script also keeps the tracked `package-lock.json` in sync, because its top-level `version` and root `packages[""].version` fields otherwise keep advertising the previous release and npm-based install/packaging paths would see conflicting metadata. The regex rejects prerelease/build suffixes so the published tag always matches the desktop update checker.
+The same script also keeps the tracked `package-lock.json` in sync, because its top-level `version` and root `packages[""].version` fields otherwise keep advertising the previous release and npm-based install/packaging paths would see conflicting metadata. The format check rejects prerelease/build suffixes so the published tag always matches the desktop update checker.
+
+Both files contain several `"version"` lines, and only three of them belong to the release. The replacement therefore anchors on **whole-line exact matches** and, inside `package-lock.json`, on the `packages[""]` block boundary. It never matches substrings and never treats indentation as optional.
 
 ```bash
 TARGET_VERSION="<version supplied by user>"
@@ -149,23 +151,84 @@ const version = process.argv[1];
 if (!/^\d+\.\d+\.\d+$/.test(version)) {
   throw new Error(`Invalid release version (expected plain x.y.z, no v/prerelease): ${version}`);
 }
-const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
-packageJson.version = version;
-fs.writeFileSync("package.json", `${JSON.stringify(packageJson, null, 2)}\n`);
+
+const current = JSON.parse(fs.readFileSync("package.json", "utf8")).version;
+if (current === version) {
+  throw new Error(`package.json is already at ${version}; pick a different target version`);
+}
+
+const rootNeedle = `  "version": "${current}",`;
+const rootReplacement = `  "version": "${version}",`;
+
+const findExactlyOneLine = (label, lines, needle) => {
+  const matches = lines.reduce((indexes, line, index) => (line === needle ? [...indexes, index] : indexes), []);
+  if (matches.length !== 1) {
+    throw new Error(`${label}: expected exactly 1 line matching ${JSON.stringify(needle)}, got ${matches.length}`);
+  }
+  return matches[0];
+};
+
+// package.json: the release version is the only two-space-indented version line.
+// devEngines.packageManager.version is indented deeper and must survive untouched.
+const packageLines = fs.readFileSync("package.json", "utf8").split("\n");
+packageLines[findExactlyOneLine("package.json top-level version", packageLines, rootNeedle)] = rootReplacement;
+fs.writeFileSync("package.json", packageLines.join("\n"));
+
 if (fs.existsSync("package-lock.json")) {
-  const lock = JSON.parse(fs.readFileSync("package-lock.json", "utf8"));
-  lock.version = version;
-  if (lock.packages && lock.packages[""]) lock.packages[""].version = version;
-  fs.writeFileSync("package-lock.json", `${JSON.stringify(lock, null, 2)}\n`);
+  const lockLines = fs.readFileSync("package-lock.json", "utf8").split("\n");
+  lockLines[findExactlyOneLine("package-lock.json top-level version", lockLines, rootNeedle)] = rootReplacement;
+
+  // packages[""] is the root package block. Its six-space version line is textually identical
+  // to the one in every dependency that happens to sit on the same version, so scan only
+  // between the block opener and its closing brace.
+  const blockStart = lockLines.indexOf(`    "": {`);
+  if (blockStart === -1) {
+    throw new Error("package-lock.json: packages[\"\"] block opener not found");
+  }
+  const innerNeedle = `      "version": "${current}",`;
+  let innerIndex = -1;
+  for (let i = blockStart + 1; i < lockLines.length; i++) {
+    if (lockLines[i] === "    },") break;
+    if (lockLines[i] === innerNeedle) {
+      innerIndex = i;
+      break;
+    }
+  }
+  if (innerIndex === -1) {
+    throw new Error("package-lock.json: packages[\"\"].version line not found inside the root package block");
+  }
+  lockLines[innerIndex] = `      "version": "${version}",`;
+
+  fs.writeFileSync("package-lock.json", lockLines.join("\n"));
 }
 ' "$TARGET_VERSION"
 
 node -p "require('./package.json').version"
-test -f package-lock.json && node -p "require('./package-lock.json').version"
-git diff -- package.json package-lock.json
+node -p "require('./package.json').devEngines.packageManager.version"
+test -f package-lock.json && node -e 'const lock = require("./package-lock.json"); console.log(lock.version, lock.packages[""].version);'
+git diff --numstat -- package.json package-lock.json
 ```
 
-Verify the printed `package.json` and `package-lock.json` versions both match the user-selected target version. Commit the version bump (including `package-lock.json`) with the release changes or ensure the release tag targets a commit that already contains the updated files.
+The bump is correct only when all four hold:
+
+1. `package.json` version and both `package-lock.json` versions print the user-selected target version. Re-reading them through `require` also proves the files still parse as JSON.
+2. `devEngines.packageManager.version` still prints the pnpm pin, not the release version.
+3. `git diff --numstat` reports `1 1 package.json` and `2 2 package-lock.json`. Any other count means the edit escaped its anchors.
+4. Nothing else appears in `git status`.
+
+Commit the version bump (including `package-lock.json`) with the release changes or ensure the release tag targets a commit that already contains the updated files.
+
+### Why the anchors look like this
+
+Three earlier approaches were tried and discarded. Do not reintroduce them.
+
+| Approach | Used in | Defect |
+| --- | --- | --- |
+| `JSON.parse` → `JSON.stringify` round-trip | up to 1.0.8 | Reserializes the whole file, so unrelated lines land in the release diff. |
+| `^(\s*)"version": "\d+\.\d+\.\d+"` regex | 1.0.8 | `\s*` also matches the deeper indentation of `devEngines.packageManager.version`, which rewrites the **pnpm pin** to the release version. |
+| `text.split(<literal indented needle>)` | 1.1.0 | `split` has no concept of line boundaries. A six-space dependency line *contains* the two-space needle as a substring, so the anchor is not isolated. |
+
+The third defect stayed invisible in 1.1.0 only by luck: the then-current version `1.0.10` happened to match no dependency. In 1.2.0 the current version was `1.1.0`, a common value that twenty dependencies in `package-lock.json` also carried, and the two-space needle matched 22 places. The safety of that anchor depended on how rare the current version string happened to be — which is not a property a release procedure may rely on.
 
 ## 3. Build the Versioned DMG
 
@@ -218,12 +281,12 @@ If a previous release notarized successfully with the same key and team, the con
 
 **Do not publish a release without this step.** Code signing, notarization, stapling, and checksum verification all pass on a bundle whose app cannot start. KanVibe 1.0.4 shipped exactly that way: the DMG was signed, notarized, stapled, and its checksum matched, but `app.asar` was missing seven transitive dependencies and the app died on launch with `Cannot find module 'ms'`.
 
-Mount the DMG you are about to publish, copy the app out, launch it, and read the app's own diagnostics log:
+Mount the DMG you are about to publish, copy the app out, launch it against a throwaway data directory, and read that run's own diagnostics log:
 
 ```bash
 VERSION=$(node -p "require('./package.json').version")
-LOG="$HOME/Library/Application Support/kanvibe/logs/kanvibe-desktop.log"
-rm -f "$LOG"
+SMOKE_DATA=$(mktemp -d /tmp/kanvibe-smoke-XXXXXX)
+LOG="$SMOKE_DATA/logs/kanvibe-desktop.log"
 
 hdiutil attach "dist/KanVibe-${VERSION}.dmg" -nobrowse -readonly -quiet
 MOUNT="/Volumes/KanVibe ${VERSION}-arm64"
@@ -232,15 +295,16 @@ rm -rf /tmp/KanVibe-smoke.app
 cp -R "$MOUNT/KanVibe.app" /tmp/KanVibe-smoke.app
 hdiutil detach "$MOUNT" -quiet
 
-open -a /tmp/KanVibe-smoke.app
+open -n --env "KANVIBE_APP_DATA_DIR=$SMOKE_DATA" -a /tmp/KanVibe-smoke.app
 sleep 15
 
 pgrep -f "KanVibe-smoke.app/Contents/MacOS/KanVibe" >/dev/null || { echo "app exited during startup" >&2; exit 1; }
+wc -l "$LOG"
 grep -icE "cannot find module|MODULE_NOT_FOUND|unhandled rejection" "$LOG"
 grep -c "invoke-succeeded" "$LOG"
 
 pkill -f "KanVibe-smoke.app"
-rm -rf /tmp/KanVibe-smoke.app
+rm -rf /tmp/KanVibe-smoke.app "$SMOKE_DATA"
 ```
 
 The release may proceed only when all four hold:
@@ -250,22 +314,35 @@ The release may proceed only when all four hold:
 3. The module-error count is `0`.
 4. The `invoke-succeeded` count is greater than zero, which proves the database and IPC layer actually came up rather than the window merely opening.
 
-Launch the app with `open -a`, not by executing the binary directly. Running the binary as a child of the terminal makes macOS attribute the app's file-access prompts to the terminal process, and a denial there revokes the whole process tree's access to `~/Documents` — which blocks the rest of the release.
+Read the counts from `$LOG` inside `$SMOKE_DATA`, never from `~/Library/Application Support/kanvibe`. Do not delete the user's log to get a clean read.
+
+### Why the smoke run is isolated
+
+`electron/main.js` calls `applyAppDataDirectoryOverride(app, process.env)` at module load, well before `app.whenReady()`. That helper (`electron/runtimeEnvironment.js`) turns `KANVIBE_APP_DATA_DIR` into `app.setPath("userData", ...)`, and the diagnostics log path is derived from `userData` (`electron/diagnostics.js`), so the smoke run's database **and** its log both follow the temporary directory. The user's installed instance, its data, and its existing log are left alone — during the 1.2.0 smoke the verdict came from a 43-line isolated log while `/Applications/KanVibe.app` kept running untouched.
+
+`open --env` applies the variable to the launched app only and does not touch the shell, so this stays inside the repository's runtime-environment safety rules. `open -n` is required: without it macOS just focuses an already-running instance instead of starting the copy under test.
 
 If the smoke test fails, stop. Do not publish, do not update the cask, and do not open PRs. Diagnose the bundle first; `app.asar` contents can be listed from its header:
 
 ```bash
 node -e '
 const fs=require("fs");
-const p="dist/mac-arm64/KanVibe.app/Contents/Resources/app.asar";
+const p=process.argv[1] ?? "dist/mac-arm64/KanVibe.app/Contents/Resources/app.asar";
 const fd=fs.openSync(p,"r");
 const b=Buffer.alloc(16); fs.readSync(fd,b,0,16,0);
 const hb=Buffer.alloc(b.readUInt32LE(12)); fs.readSync(fd,hb,0,hb.length,16);
 const h=JSON.parse(hb.toString("utf8").replace(/\0+$/,""));
-console.log(Object.keys(h.files.node_modules.files).length, "top-level packages");
 fs.closeSync(fd);
-'
+const entries=Object.entries(h.files.node_modules.files);
+const expanded=entries.reduce((n,[name,entry])=>n+(name.startsWith("@")?Object.keys(entry.files??{}).length:1),0);
+console.log(`${entries.length} top-level entries (scopes counted once)`);
+console.log(`${expanded} packages with scopes expanded  <-- matches the build guard`);
+' "$ASAR_PATH"
 ```
+
+The two numbers are both correct and they are not interchangeable. The build guard line `packaged node_modules verified: N packages` comes from `readAsarNodeModuleNames()` in `scripts/dist-deploy.cjs`, which expands `@scope/name` into one entry per scoped package, so it always reports the larger number. Counting the top-level keys instead reports the smaller one. Reading the smaller number as if it were the guard's makes a healthy build look like the 1.0.4 dependency-loss failure.
+
+Do not judge either number against a remembered absolute value; package counts move whenever dependencies change. Judge by comparison: run the same snippet against a build known to be good — the installed `/Applications/KanVibe.app/Contents/Resources/app.asar` is the convenient one — and compare it with the candidate bundle.
 
 ## 4. Create or Update the GitHub Release
 
@@ -472,7 +549,7 @@ UNRESOLVED_THREADS=$(gh api graphql \
 test "$UNRESOLVED_THREADS" = "0"
 ```
 
-Merge automatically when checks are green. If checks are still pending but the PR is otherwise mergeable, enable auto-merge and keep watching until the PR becomes `MERGED` before starting the promotion PR. Never enable auto-merge after a failed, cancelled, timed-out, or action-required check.
+Merge automatically when checks are green. If checks are still pending but the PR is otherwise mergeable, enable auto-merge and keep watching until the PR becomes `MERGED` before starting the promotion PR. Never enable auto-merge after a failed, cancelled, timed-out, or action-required check. Auto-merge on this repository can land the PR before the pending checks finish; see the note below.
 
 ```bash
 CHECK_STATE=$(gh pr checks "$RELEASE_PR" --repo rookedsysc/kanvibe --json state --jq '
@@ -496,6 +573,28 @@ esac
 
 gh pr view "$RELEASE_PR" --repo rookedsysc/kanvibe --json state,mergeCommit,mergedBy,headRefName
 ```
+
+#### A pending check does not hold the merge
+
+`dev` has no required status checks:
+
+```bash
+gh api repos/rookedsysc/kanvibe/branches/dev/protection --jq '.required_status_checks.contexts'
+```
+
+This returns an empty list, which means `Type Check & Test` is **not** a merge gate. `gh pr merge --auto` has nothing to wait for, so a PR whose checks read `pending` can merge immediately. Do not read a pending line in `gh pr checks` as "waiting to merge"; it only says the workflow has not finished yet. In the 1.2.0 release, PR #359 merged while this check was still `in_progress` — that followed the procedure, but the merge landed ahead of the CI conclusion.
+
+Because the merge does not wait, confirm the release commit's CI conclusion separately after merging:
+
+```bash
+MERGE_SHA=$(gh pr view "$RELEASE_PR" --repo rookedsysc/kanvibe --json mergeCommit --jq .mergeCommit.oid)
+gh run list --repo rookedsysc/kanvibe --commit "$RELEASE_HEAD_SHA" --json databaseId,name,status,conclusion
+gh run view <databaseId> --repo rookedsysc/kanvibe
+```
+
+Every run for that commit must end with `conclusion: success`. A failed conclusion after a completed merge is a blocker: report it instead of continuing quietly.
+
+Delete release branches only after that conclusion exists. Deleting a branch cancels workflow runs still in progress on it, which destroys the evidence this step depends on.
 
 ### 6.2 Promote the pinned release branch to `main`
 
@@ -554,8 +653,10 @@ git fetch origin main
 MAIN_VERSION=$(git show origin/main:package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
 test "$MAIN_VERSION" = "$VERSION"
 
-# Clean up the release branch only after the main promotion is actually merged.
+# Clean up the release branch only after the main promotion is merged and the release commit's
+# workflow runs have reached a conclusion. Deleting the branch cancels runs still in progress.
 if [ "$PROMOTION_STATE" = "MERGED" ]; then
+  gh run list --repo rookedsysc/kanvibe --commit "$RELEASE_HEAD_SHA" --json name,status,conclusion
   git push origin --delete "$PROMOTION_BRANCH" || true
 fi
 ```
@@ -567,7 +668,7 @@ Before reporting success, collect real output for:
 - dev-only preflight evidence: current branch `dev`, clean status, and local `HEAD` matching `origin/dev` before the release branch was cut;
 - `pnpm --version` showing 10.x and `package.json` carrying no `packageManager` field;
 - current version printed before the bump and the user-selected target version;
-- `git diff -- package.json package-lock.json` or commit evidence showing the version bump in both files;
+- `git diff --numstat -- package.json package-lock.json` showing `1 1 package.json` and `2 2 package-lock.json`, plus `devEngines.packageManager.version` still on the pnpm pin;
 - `pnpm run deploy` completion, including the `pm=npm` collector line and the `packaged node_modules verified: N packages` guard line;
 - **smoke-test evidence from step 3.5**: `spctl` verdict, process alive after launch, module-error count `0`, and a non-zero `invoke-succeeded` count;
 - `test -f dist/KanVibe-<version>.dmg` and `shasum -a 256`;
@@ -577,6 +678,7 @@ Before reporting success, collect real output for:
 - Homebrew cask diff showing only `version` and `sha256` changes, plus the cask repository push result or exact blocker;
 - release branch commit SHA and pushed branch name;
 - release PR URL, file list, check result, unresolved review-thread count, and merge or auto-merge result into `dev`;
+- the release commit's workflow conclusion from `gh run list --commit <sha>`, collected after the merge because a pending check does not hold it;
 - promotion PR URL, check result, unresolved review-thread count, and merge or auto-merge result into `main`;
 - `git show origin/main:package.json` confirming `main` now contains the release version, or the exact blocker if auto-merge is still pending.
 
@@ -595,6 +697,7 @@ Final handoff format:
 - GitHub release: <release URL>
 - Homebrew cask: <commit SHA or branch/status>
 - Release PR: <URL> → <merged/auto-merge/blocker>
+- Release commit CI: <workflow conclusion for the release commit>
 - Promotion PR: <URL> → <merged/auto-merge/blocker>
 - main version: <confirmed version or pending reason>
 - Verification:


### PR DESCRIPTION
## Summary

`kanvibe-release-deploy` 스킬 문서가 실제 릴리스 절차와 어긋나 있던 네 지점을 고칩니다. 1.0.8·1.1.0·1.2.0 세 번의 릴리스에서 매번 실행 중에 임시로 고치고 문서에는 남기지 않아, 다음 담당자가 문서대로 하면 같은 곳에서 다시 막히는 상태였습니다.

Resolves #361

### 1. §2 버전 범프 — 줄 단위 정확 비교 + 블록 경계 제한

기존 JSON 왕복 방식과, 그 뒤 제안됐던 두 대안 모두 결함이 있었습니다.

| 방식 | 출처 | 결함 |
| --- | --- | --- |
| JSON 왕복 | 기존 `SKILL.md` §2 | 무관한 줄이 릴리스 diff에 섞임 |
| `^(\s*)"version": "\d+\.\d+\.\d+"` | 1.0.8 | `\s*`가 `devEngines.packageManager.version`까지 매칭해 pnpm 핀을 파괴 |
| `text.split(<리터럴 들여쓰기 needle>)` | 1.1.0 | `split`은 줄 경계를 모름 — 6칸 줄이 2칸 needle을 부분 문자열로 포함 |

세 번째 결함은 1.1.0에서 드러나지 않았습니다. 당시 버전 `1.0.10`이 우연히 어느 의존성과도 겹치지 않았기 때문입니다. 1.2.0에서는 현재 버전이 `1.1.0`이라 의존성 20개가 같은 값이었고 2칸 needle이 22곳을 잡았습니다. **앵커의 안전성이 현재 버전 문자열의 희소성에 의존하고 있었습니다.**

새 방식은 줄 전체 정확 일치(`line === needle`) + `packages[""]` 블록 경계 제한 + 개수 단언을 겹칩니다. 폐기된 세 대안의 이력표도 함께 남겨 재제안을 막습니다.

### 2. §3.5 스모크 테스트 격리

`rm -f "$LOG"`(사용자 진단 로그 삭제)와 비격리 `open -a`를 `open -n --env "KANVIBE_APP_DATA_DIR=$SMOKE_DATA"`로 교체했습니다. 실제로는 1.0.10·1.1.0·1.2.0 세 번 연속 격리 방식을 썼습니다.

`electron/main.js`가 `app.whenReady()` 이전에 `applyAppDataDirectoryOverride()`를 호출하고, 진단 로그 경로가 `userData`에서 파생되므로 DB와 로그가 함께 임시 디렉터리로 따라갑니다. `open --env`는 실행되는 앱에만 적용되어 저장소의 런타임 환경 안전 규약과도 맞습니다.

### 3. §3.5 asar 카운트 지표

문서 스니펫은 최상위 키만 세어 `232`를 출력하는데, 빌드 가드는 스코프를 펼친 `278`을 씁니다. 둘 다 정상값인데 구분이 없어 "278에서 46개 누락"으로 오판할 여지가 있었습니다 — 하필 1.0.4 의존성 누락 사고와 같은 실패 모드를 잘못 짚게 만듭니다. 이제 두 값을 라벨과 함께 출력하고, 판정은 절대값 암기가 아니라 정상 빌드 대조임을 명시합니다.

### 4. §6 체크 게이트

`dev`에는 required status check가 없어 `--auto --merge`가 기다릴 대상이 없습니다. 1.2.0에서 PR #359는 `Type Check & Test`가 `in_progress`인 채 머지됐습니다(절차 위반은 아니고, CI도 이후 success로 끝났습니다). pending 표시를 "머지 대기"로 읽지 않도록 명시하고, 릴리스 커밋의 CI 결론은 머지 후 `gh run list --commit`으로 따로 확인하며, 브랜치 정리는 그 결론 이후에 하도록 했습니다.

## Test Plan

문서에서 스크립트를 그대로 추출해 실행 검증했습니다.

| # | 검증 | 결과 |
| --- | --- | --- |
| A | 정상 범프 `1.2.2 → 1.3.0` | `1.3.0` / `1.3.0 1.3.0`, numstat `1 1 package.json` · `2 2 package-lock.json`, exit 0 |
| B | pnpm 핀 보존 | `devEngines.packageManager.version` → `10.34.5` 유지 |
| C | **의존성 줄 미오염** | 범프 후에도 `"version": "1.2.2"` 6줄 그대로 — 옛 `split` 방식이면 7줄 전부 변경 |
| D | 동일 버전 재실행 차단 | `Error: package.json is already at 1.3.0` |
| E | 잘못된 포맷 차단 | `Error: Invalid release version ...` (`v1.3.0`) |
| F | 중복 앵커 차단 | `expected exactly 1 line ..., got 2`, exit 1, 파일 미변경 |
| G | required check 실측 | `gh api .../branches/dev/protection --jq '.required_status_checks.contexts'` → `[]` |
| H | asar 스니펫 | 설치본 app.asar에 실행 → `232 top-level entries` / `278 packages with scopes expanded` |

C가 핵심 증거입니다. 현재 저장소에서 `1.2.2`는 `package-lock.json`의 6칸 들여쓰기 줄 7곳(루트 1 + 의존성 6)에 나타나는데, 새 방식은 루트 패키지 블록 안 1곳만 바꿉니다.

## Scope

`.claude/skills/kanvibe-release-deploy/SKILL.md` 한 파일, `+126 / -23`. 코드 변경 없음 — `scripts/dist-deploy.cjs`와 `electron/runtimeEnvironment.js`는 읽기만 했습니다. `git diff -U0` 기준 22개 hunk 전부 이슈 항목에 매핑되며 미매핑 hunk는 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
