### PR TITLE
chore(release): publish KanVibe 1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Publish KanVibe 1.2.3. This branch carries only the version bump; `origin/dev` at `828ed6f` is the release source.

The release ships the AI usage panel fixes from #369: KanVibe no longer stays locked on an expired credential file when the Keychain holds a fresher one, and a usage value that only a re-login can refresh is no longer carried forward as if it were current.

## Test Plan

- `pnpm install --frozen-lockfile` under pnpm 10.34.5 — native rebuild of `better-sqlite3` succeeded.
- `pnpm run deploy` — dependency collector reported `pm=npm`, packaging guard reported `packaged node_modules verified: 278 packages`, notarization accepted, staple + `xcrun stapler validate` passed.
- Smoke test against an isolated `KANVIBE_APP_DATA_DIR`: `spctl -a -t exec` → `accepted` / `source=Notarized Developer ID`; process alive after launch; module-error count `0`; `invoke-succeeded` count `18`.
- `app.asar` top-level entries: 232, identical to the installed known-good build.
- SHA-256 of the bytes GitHub serves matches the local DMG exactly.

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.2.3
- DMG asset: `dist/KanVibe-1.2.3.dmg` (171155707 bytes)
- SHA-256: `cbdbd1e71ad31cce0e46f5778b75e257be17e5d8bcc268c10062a4a54fdf7d60`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@1d287ab` — `version` and `sha256` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
