### PR TITLE
fix(terminal): OSC 52 복사를 메인 프로세스 클립보드로 처리한다

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -7,7 +7,7 @@ const os = require("node:os");
 const path = require("node:path");
 const process = require("node:process");
 const { pathToFileURL } = require("node:url");
-const { app, BrowserWindow, ipcMain, session, shell } = require("electron");
+const { app, BrowserWindow, clipboard, ipcMain, session, shell } = require("electron");
 const { createDesktopDiagnostics, resolveDesktopLogPath, serializeErrorForLog } = require("./diagnostics");
 const { applyAppDataDirectoryOverride } = require("./runtimeEnvironment");
 
@@ -855,6 +855,15 @@ function registerDesktopHandlers() {
 
   ipcMain.on("kanvibe:terminal-close", (event, taskId, tabId) => {
     closeTerminal(event.sender.id, taskId, tabId);
+  });
+
+  /**
+   * 터미널 안 프로그램이 OSC 52로 보낸 복사 요청을 시스템 클립보드에 반영한다.
+   * 렌더러의 navigator.clipboard는 문서 포커스를 요구하고, 포커스가 있어도 성공을 반환한 채
+   * 클립보드를 그대로 두는 경우가 있어, 터미널 출력이 촉발하는 복사는 메인 프로세스에서 처리한다.
+   */
+  ipcMain.handle("kanvibe:clipboard-write", (_event, text) => {
+    clipboard.writeText(String(text));
   });
 
   ipcMain.handle("kanvibe:ai-login-open", async (event, provider, accountRoot, cols, rows) => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -75,6 +75,9 @@ contextBridge.exposeInMainWorld("kanvibeDesktop", {
   closeTerminal(taskId, tabId) {
     ipcRenderer.send("kanvibe:terminal-close", taskId, tabId);
   },
+  writeSystemClipboard(text) {
+    return ipcRenderer.invoke("kanvibe:clipboard-write", text);
+  },
   openAiAccountLogin(provider, accountRoot, cols, rows) {
     return ipcRenderer.invoke("kanvibe:ai-login-open", provider, accountRoot, cols, rows);
   },

--- a/src/desktop/main/__tests__/terminalClipboardBridge.test.ts
+++ b/src/desktop/main/__tests__/terminalClipboardBridge.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * OSC 52 복사는 메인 프로세스 클립보드를 거쳐야 문서 포커스와 무관하게 반영된다.
+ * 두 파일 중 한쪽만 남으면 복사가 조용히 사라지므로, 채널 양끝이 이어져 있는지 확인한다.
+ */
+describe("terminal clipboard bridge", () => {
+  const CLIPBOARD_CHANNEL = "kanvibe:clipboard-write";
+
+  function readElectronSource(fileName: string): string {
+    return readFileSync(path.join(process.cwd(), "electron", fileName), "utf8");
+  }
+
+  it("should write to the main process clipboard when the renderer requests a copy", () => {
+    // Given
+    const source = readElectronSource("main.js");
+
+    // When
+    const handler = source.match(
+      /ipcMain\.handle\("kanvibe:clipboard-write",[\s\S]*?\n {2}\}\);/,
+    )?.[0];
+
+    // Then
+    expect(handler).toBeDefined();
+    expect(handler).toMatch(/clipboard\.writeText\(/);
+  });
+
+  it("should expose the clipboard write on the desktop bridge", () => {
+    // Given
+    const source = readElectronSource("preload.js");
+
+    // When
+    const bridgeMethod = source.match(/writeSystemClipboard\(text\) \{[\s\S]*?\n {2}\},/)?.[0];
+
+    // Then
+    expect(bridgeMethod).toBeDefined();
+    expect(bridgeMethod).toContain(CLIPBOARD_CHANNEL);
+  });
+});

--- a/src/desktop/renderer/components/AiAccountLoginTerminal.tsx
+++ b/src/desktop/renderer/components/AiAccountLoginTerminal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { createTerminalOptions } from "@/lib/terminalMouseSelection";
+import { installOsc52ClipboardHandler } from "@/lib/terminalClipboard";
 import type { AiUsageProvider } from "@/lib/aiUsage/types";
 
 interface AiAccountLoginTerminalProps {
@@ -42,6 +43,7 @@ export default function AiAccountLoginTerminal({
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
     terminal.open(containerRef.current);
+    const osc52ClipboardHandler = installOsc52ClipboardHandler(terminal);
 
     const isThisSession = (event: { accountRoot: string }) => event.accountRoot === accountRoot;
 
@@ -80,6 +82,7 @@ export default function AiAccountLoginTerminal({
     if (!loginReady?.ok) {
       terminal.writeln(`\r\n\x1b[31m${loginReady?.error || "로그인 명령을 실행하지 못했습니다."}\x1b[0m`);
       return () => {
+        osc52ClipboardHandler.dispose();
         unsubscribeData?.();
         unsubscribeExit?.();
         terminal.dispose();
@@ -100,6 +103,7 @@ export default function AiAccountLoginTerminal({
 
     return () => {
       resizeObserver.disconnect();
+      osc52ClipboardHandler.dispose();
       unsubscribeData?.();
       unsubscribeExit?.();
       window.kanvibeDesktop?.closeAiAccountLogin?.(accountRoot);

--- a/src/desktop/renderer/components/__tests__/AiAccountLoginTerminal.test.tsx
+++ b/src/desktop/renderer/components/__tests__/AiAccountLoginTerminal.test.tsx
@@ -1,0 +1,100 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AiAccountLoginTerminal from "../AiAccountLoginTerminal";
+
+const { mockRegisterOscHandler, mockDisposeOscHandler, mockFit } = vi.hoisted(() => ({
+  mockRegisterOscHandler: vi.fn(),
+  mockDisposeOscHandler: vi.fn(),
+  mockFit: vi.fn(),
+}));
+
+class MockXTerm {
+  cols = 80;
+  rows = 24;
+
+  loadAddon = vi.fn();
+  open = vi.fn();
+  write = vi.fn();
+  writeln = vi.fn();
+  dispose = vi.fn();
+  focus = vi.fn();
+  onData = vi.fn();
+  parser = { registerOscHandler: mockRegisterOscHandler };
+}
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: MockXTerm,
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit = mockFit;
+  },
+}));
+
+vi.mock("@/lib/terminalMouseSelection", () => ({
+  createTerminalOptions: () => ({}),
+}));
+
+describe("AiAccountLoginTerminal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegisterOscHandler.mockReturnValue({ dispose: mockDisposeOscHandler });
+
+    vi.stubGlobal("ResizeObserver", class {
+      observe = vi.fn();
+      disconnect = vi.fn();
+    });
+
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      openAiAccountLogin: vi.fn().mockResolvedValue({ ok: true }),
+      writeAiAccountLogin: vi.fn(),
+      resizeAiAccountLogin: vi.fn(),
+      closeAiAccountLogin: vi.fn(),
+      onAiAccountLoginData: vi.fn().mockReturnValue(vi.fn()),
+      onAiAccountLoginExit: vi.fn().mockReturnValue(vi.fn()),
+    } as unknown as Window["kanvibeDesktop"];
+  });
+
+  it("should handle OSC 52 so a login code copied inside the terminal reaches the system clipboard", async () => {
+    // Given
+    const OSC_CLIPBOARD_IDENTIFIER = 52;
+
+    // When
+    render(
+      <AiAccountLoginTerminal provider="claude" accountRoot="/tmp/account" onExit={vi.fn()} />,
+    );
+
+    // Then
+    await waitFor(() => {
+      expect(mockRegisterOscHandler).toHaveBeenCalledWith(
+        OSC_CLIPBOARD_IDENTIFIER,
+        expect.any(Function),
+      );
+    });
+  });
+
+  it("should unregister the OSC 52 handler when the login terminal closes", async () => {
+    // Given
+    const { unmount } = render(
+      <AiAccountLoginTerminal provider="claude" accountRoot="/tmp/account" onExit={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(mockRegisterOscHandler).toHaveBeenCalled();
+    });
+
+    // When
+    unmount();
+
+    // Then
+    await waitFor(() => {
+      expect(mockDisposeOscHandler).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -27,6 +27,8 @@ declare global {
       resizeTerminal: (taskId: string, tabId: string | null, cols: number, rows: number) => void;
       focusTerminal: (taskId: string) => void;
       closeTerminal: (taskId: string, tabId: string | null) => void;
+      /** OSC 52 복사를 메인 프로세스에서 처리한다. 렌더러 클립보드 API는 문서 포커스에 묶여 있어 터미널 출력이 촉발하는 복사를 놓친다 */
+      writeSystemClipboard?: (text: string) => Promise<void>;
       onTerminalData: (listener: (event: { taskId: string; tabId: string | null; data: string }) => void) => () => void;
       onTerminalClose: (listener: (event: { taskId: string; tabId: string | null; reason: string | null }) => void) => () => void;
       /** AI 계정 로그인 세션은 태스크에 묶이지 않으므로 계정 루트가 식별자다 */

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -27,8 +27,6 @@ declare global {
       resizeTerminal: (taskId: string, tabId: string | null, cols: number, rows: number) => void;
       focusTerminal: (taskId: string) => void;
       closeTerminal: (taskId: string, tabId: string | null) => void;
-      /** OSC 52 복사를 메인 프로세스에서 처리한다. 렌더러 클립보드 API는 문서 포커스에 묶여 있어 터미널 출력이 촉발하는 복사를 놓친다 */
-      writeSystemClipboard?: (text: string) => Promise<void>;
       onTerminalData: (listener: (event: { taskId: string; tabId: string | null; data: string }) => void) => () => void;
       onTerminalClose: (listener: (event: { taskId: string; tabId: string | null; reason: string | null }) => void) => () => void;
       /** AI 계정 로그인 세션은 태스크에 묶이지 않으므로 계정 루트가 식별자다 */

--- a/src/lib/__tests__/terminalClipboard.test.ts
+++ b/src/lib/__tests__/terminalClipboard.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { installOsc52ClipboardHandler, readOsc52ClipboardText } from "@/lib/terminalClipboard";
 
+/** navigator를 클립보드 스텁으로 갈아끼우는 테스트가 있어, 실제 xterm.js를 쓰는 테스트를 위해 원본을 잡아 둔다 */
+const jsdomNavigator = globalThis.navigator;
+
 function encodeBase64Utf8(value: string): string {
   const bytes = new TextEncoder().encode(value);
   return btoa(String.fromCharCode(...bytes));
@@ -88,13 +91,18 @@ describe("readOsc52ClipboardText", () => {
 describe("installOsc52ClipboardHandler", () => {
   const writeText = vi.fn();
 
+  const writeSystemClipboard = vi.fn();
+
   beforeEach(() => {
     writeText.mockReset();
     writeText.mockResolvedValue(undefined);
+    writeSystemClipboard.mockReset();
+    writeSystemClipboard.mockResolvedValue(undefined);
     Object.defineProperty(globalThis, "navigator", {
       value: { clipboard: { writeText } },
       configurable: true,
     });
+    delete window.kanvibeDesktop;
   });
 
   function createTerminalStub() {
@@ -160,6 +168,40 @@ describe("installOsc52ClipboardHandler", () => {
     warn.mockRestore();
   });
 
+  it("should copy through the desktop bridge, which is not bound to renderer document focus", async () => {
+    // Given
+    window.kanvibeDesktop = { writeSystemClipboard } as unknown as Window["kanvibeDesktop"];
+    const stub = createTerminalStub();
+    installOsc52ClipboardHandler(stub.terminal as never);
+
+    // When
+    stub.invoke(`c;${encodeBase64Utf8("데스크톱 복사")}`);
+    await Promise.resolve();
+
+    // Then
+    expect(writeSystemClipboard).toHaveBeenCalledWith("데스크톱 복사");
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("should keep the terminal usable when the desktop bridge write is rejected", async () => {
+    // Given
+    window.kanvibeDesktop = { writeSystemClipboard } as unknown as Window["kanvibeDesktop"];
+    writeSystemClipboard.mockRejectedValue(new Error("bridge unavailable"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stub = createTerminalStub();
+    installOsc52ClipboardHandler(stub.terminal as never);
+
+    // When
+    const handled = stub.invoke(`c;${encodeBase64Utf8("kanvibe")}`);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Then
+    expect(handled).toBe(true);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("should return a disposable that unregisters the handler", () => {
     // Given
     const stub = createTerminalStub();
@@ -169,5 +211,56 @@ describe("installOsc52ClipboardHandler", () => {
 
     // Then
     expect(stub.dispose).toHaveBeenCalled();
+  });
+});
+
+/**
+ * 위 describe는 parser를 스텁으로 대신해 xterm.js가 실제로 OSC 52를 넘겨주는지는 확인하지 못한다.
+ * 실제 터미널이 받는 바이트열을 그대로 흘려 보내, 시퀀스 해석부터 복사까지가 끊기지 않는지 확인한다.
+ */
+describe("OSC 52 over a real xterm.js terminal", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "navigator", {
+      value: jsdomNavigator,
+      configurable: true,
+    });
+  });
+
+  const ESCAPE = String.fromCharCode(27);
+  const BELL = String.fromCharCode(7);
+  const STRING_TERMINATOR = `${ESCAPE}\\`;
+
+  async function writeToRealTerminal(terminalOutput: string): Promise<ReturnType<typeof vi.fn>> {
+    const writeSystemClipboard = vi.fn().mockResolvedValue(undefined);
+    window.kanvibeDesktop = { writeSystemClipboard } as unknown as Window["kanvibeDesktop"];
+
+    const { Terminal } = await import("@xterm/xterm");
+    const terminal = new Terminal();
+    installOsc52ClipboardHandler(terminal);
+    await new Promise<void>((resolve) => terminal.write(terminalOutput, resolve));
+
+    return writeSystemClipboard;
+  }
+
+  it("should copy a bell-terminated sequence, which is what a plain printf sends", async () => {
+    // Given
+    const terminalOutput = `${ESCAPE}]52;c;${encodeBase64Utf8("OSC52-OK")}${BELL}`;
+
+    // When
+    const writeSystemClipboard = await writeToRealTerminal(terminalOutput);
+
+    // Then
+    expect(writeSystemClipboard).toHaveBeenCalledWith("OSC52-OK");
+  });
+
+  it("should copy a string-terminated sequence, which is what tmux forwards", async () => {
+    // Given
+    const terminalOutput = `${ESCAPE}]52;c;${encodeBase64Utf8("tmux 복사")}${STRING_TERMINATOR}`;
+
+    // When
+    const writeSystemClipboard = await writeToRealTerminal(terminalOutput);
+
+    // Then
+    expect(writeSystemClipboard).toHaveBeenCalledWith("tmux 복사");
   });
 });

--- a/src/lib/terminalClipboard.ts
+++ b/src/lib/terminalClipboard.ts
@@ -63,6 +63,15 @@ function decodeBase64Utf8(encodedText: string): string | null {
 }
 
 /**
+ * 데스크톱 렌더러에만 주입되는 클립보드 브리지.
+ * 이 모듈은 `src/lib` 아래라 Electron 메인 프로세스 빌드에도 함께 컴파일되는데, 그 빌드는 렌더러 전역 선언을
+ * 포함하지 않는다. 그래서 렌더러의 `Window` 타입에 기대지 않고 실제로 쓰는 기능만 좁게 선언한다.
+ */
+interface DesktopClipboardBridge {
+  writeSystemClipboard?: (clipboardText: string) => Promise<void>;
+}
+
+/**
  * 복사 요청을 시스템 클립보드에 반영한다.
  * 데스크톱에서는 Electron 메인 프로세스를 거친다. 렌더러의 `navigator.clipboard`는 문서 포커스를 요구하고,
  * 포커스가 있어도 성공을 반환한 채 클립보드를 그대로 두는 경우가 있어 터미널 출력이 촉발하는 복사를 놓친다.
@@ -70,7 +79,8 @@ function decodeBase64Utf8(encodedText: string): string | null {
  */
 async function writeSystemClipboard(clipboardText: string): Promise<void> {
   try {
-    const writeDesktopClipboard = window.kanvibeDesktop?.writeSystemClipboard;
+    const { kanvibeDesktop } = globalThis as { kanvibeDesktop?: DesktopClipboardBridge };
+    const writeDesktopClipboard = kanvibeDesktop?.writeSystemClipboard;
     if (writeDesktopClipboard) {
       await writeDesktopClipboard(clipboardText);
       return;

--- a/src/lib/terminalClipboard.ts
+++ b/src/lib/terminalClipboard.ts
@@ -62,8 +62,20 @@ function decodeBase64Utf8(encodedText: string): string | null {
   }
 }
 
+/**
+ * 복사 요청을 시스템 클립보드에 반영한다.
+ * 데스크톱에서는 Electron 메인 프로세스를 거친다. 렌더러의 `navigator.clipboard`는 문서 포커스를 요구하고,
+ * 포커스가 있어도 성공을 반환한 채 클립보드를 그대로 두는 경우가 있어 터미널 출력이 촉발하는 복사를 놓친다.
+ * 데스크톱 브리지가 없는 웹 터미널에서는 렌더러 클립보드 API가 유일한 경로다.
+ */
 async function writeSystemClipboard(clipboardText: string): Promise<void> {
   try {
+    const writeDesktopClipboard = window.kanvibeDesktop?.writeSystemClipboard;
+    if (writeDesktopClipboard) {
+      await writeDesktopClipboard(clipboardText);
+      return;
+    }
+
     await navigator.clipboard.writeText(clipboardText);
   } catch (error) {
     console.warn("터미널 클립보드 복사 실패:", error);


### PR DESCRIPTION
## 관련 자료
- 이슈 : #373

## 어떤 작업인가요?
- SSH 원격 세션에서 보낸 OSC 52 복사가 로컬 클립보드에 반영되지 않던 문제를 고칩니다. 끊긴 지점은 이슈에 적힌 "핸들러 미등록"이 아니라 **복사를 실제로 쓰는 단계**였습니다.

## 어떻게 해결했나요?
**OSC 52 복사를 메인 프로세스 클립보드로 넘김**
- 렌더러의 `navigator.clipboard`는 문서 포커스에 묶여 있어, 터미널 출력이 촉발하는 복사를 놓칩니다.
- `kanvibe:clipboard-write` IPC를 뚫어 메인 프로세스 `clipboard.writeText`로 처리합니다. 데스크톱 브리지가 없는 웹 터미널은 기존 경로를 그대로 씁니다.

**AI 계정 로그인 터미널에도 핸들러 적용**
- 이슈가 지목한 세 번째 터미널로, 로그인 화면의 코드·URL을 터미널 밖으로 꺼낼 방법이 없었습니다.
- 나머지 두 터미널과 같은 핸들러를 걸고 정리 시 dispose 합니다.

**실제 xterm.js를 통과하는 테스트 추가**
- 기존 테스트는 `parser`를 스텁으로 대신해, xterm.js가 정말 OSC 52를 넘겨주는지 확인하지 못했습니다.
- 실제 터미널에 바이트열을 그대로 흘려 BEL 종결과 ST 종결 두 형태를 모두 확인합니다.

## 중요한 변경 사항은 무엇인가요?
### 진단 근거

Electron 32 + `file://` 렌더러 실측 결과입니다.

| 조건 | `navigator.clipboard.writeText` | 클립보드 실제 변경 |
|---|---|---|
| 창 비포커스 | `NotAllowedError: Document is not focused` | ❌ |
| 창 포커스 | **resolve** (에러 없음) | ❌ |
| 메인 프로세스 `clipboard.writeText` | — | ✅ |

성공을 반환하고도 클립보드가 그대로였고, 실패는 `console.warn`으로만 남아 사용자에게는 조용히 사라졌습니다. 이슈에 적힌 "실제: 클립보드가 바뀌지 않음"과 정확히 일치합니다.

수정 후 같은 환경에서 비포커스 창으로 IPC 경로를 태워 클립보드가 `BEFORE-PROBE` → `OSC52-OK`로 바뀌는 것을 확인했습니다.

### 복사 경로 변경

**메인 프로세스에서 클립보드를 쓴다**
- **변경 이유**: 렌더러 클립보드 API는 문서 포커스라는 전제를 요구하는데, OSC 52는 사용자 조작이 아니라 터미널 출력이 촉발한다.
- **수정 파일**: `electron/main.js`, `electron/preload.js`, `src/desktop/renderer/global.d.ts`

**데스크톱 브리지가 있으면 그쪽으로, 없으면 기존 경로로**
- **변경 이유**: `src/lib/terminalClipboard.ts`는 데스크톱과 웹 터미널이 함께 쓴다. 웹에는 브리지가 없다.
- **수정 파일**: `src/lib/terminalClipboard.ts`

### 터미널 적용 범위

**AI 계정 로그인 터미널에 핸들러 설치**
- **변경 이유**: 이슈가 적용 대상으로 지목한 세 파일 중 유일하게 빠져 있었다.
- **수정 파일**: `src/desktop/renderer/components/AiAccountLoginTerminal.tsx`

### 채택하지 않은 방안

`@xterm/addon-clipboard`은 쓰지 않았습니다. peer가 `@xterm/xterm@^5.4.0`이라 현재 v6와 충돌하고, 애드온 역시 `navigator.clipboard`를 쓰기 때문에 같은 문제를 다시 만납니다.

Closes #373

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
