### PR TITLE
chore(release): publish KanVibe 1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Publish KanVibe 1.2.4. This branch carries only the version bump; the shipped code is `origin/dev` at `bb521ef`.

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.2.4
- DMG asset: `dist/KanVibe-1.2.4.dmg` (171,154,485 bytes)
- SHA-256: `0e5b75108ec8bdd40c5547b2a62c3c95c6ea210407c113c0e1b6818cc94f7028`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@04d1ec9` — version and sha256 updated on `main`

## Test Plan

- `pnpm run deploy` completed with the `pm=npm` dependency collector and `packaged node_modules verified: 278 packages`.
- Notarization returned `status: Accepted`; `xcrun stapler staple` and `xcrun stapler validate` both succeeded.
- Smoke test on the published bundle, launched against a throwaway `KANVIBE_APP_DATA_DIR`:
  - `spctl -a -t exec` → `accepted`, `source=Notarized Developer ID`
  - process still alive after startup
  - module errors in the isolated diagnostics log: `0`
  - `invoke-succeeded` entries: `17`
- `curl -I -L` against the release asset URL returned `HTTP/2 200`.
- `curl -sL <asset> | shasum -a 256` matched the checksum written into the cask.
