### PR TITLE
Release: promote KanVibe 1.2.4 to main

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -7,7 +7,7 @@ const os = require("node:os");
 const path = require("node:path");
 const process = require("node:process");
 const { pathToFileURL } = require("node:url");
-const { app, BrowserWindow, ipcMain, session, shell } = require("electron");
+const { app, BrowserWindow, clipboard, ipcMain, session, shell } = require("electron");
 const { createDesktopDiagnostics, resolveDesktopLogPath, serializeErrorForLog } = require("./diagnostics");
 const { applyAppDataDirectoryOverride } = require("./runtimeEnvironment");
 
@@ -855,6 +855,15 @@ function registerDesktopHandlers() {
 
   ipcMain.on("kanvibe:terminal-close", (event, taskId, tabId) => {
     closeTerminal(event.sender.id, taskId, tabId);
+  });
+
+  /**
+   * 터미널 안 프로그램이 OSC 52로 보낸 복사 요청을 시스템 클립보드에 반영한다.
+   * 렌더러의 navigator.clipboard는 문서 포커스를 요구하고, 포커스가 있어도 성공을 반환한 채
+   * 클립보드를 그대로 두는 경우가 있어, 터미널 출력이 촉발하는 복사는 메인 프로세스에서 처리한다.
+   */
+  ipcMain.handle("kanvibe:clipboard-write", (_event, text) => {
+    clipboard.writeText(String(text));
   });
 
   ipcMain.handle("kanvibe:ai-login-open", async (event, provider, accountRoot, cols, rows) => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -75,6 +75,9 @@ contextBridge.exposeInMainWorld("kanvibeDesktop", {
   closeTerminal(taskId, tabId) {
     ipcRenderer.send("kanvibe:terminal-close", taskId, tabId);
   },
+  writeSystemClipboard(text) {
+    return ipcRenderer.invoke("kanvibe:clipboard-write", text);
+  },
   openAiAccountLogin(provider, accountRoot, cols, rows) {
     return ipcRenderer.invoke("kanvibe:ai-login-open", provider, accountRoot, cols, rows);
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -420,7 +420,13 @@
     "dismissHint": "Don't show again",
     "viewDiff": "View Diff",
     "diffFiles": "Diff",
-    "diffFileCount": "{count}",
+    "diffStats": {
+      "summary": "{files} files changed · {additions} lines added · {deletions} lines removed",
+      "additions": "{count} lines added",
+      "deletions": "{count} lines removed",
+      "expand": "Show changed files",
+      "collapse": "Hide changed files"
+    },
     "terminalTabs": "Terminal tabs",
     "newTerminalTab": "New tab",
     "closeTerminalTab": "Close {name} tab",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -420,7 +420,13 @@
     "dismissHint": "다시 보지 않기",
     "viewDiff": "Diff 보기",
     "diffFiles": "변경 파일",
-    "diffFileCount": "{count}개",
+    "diffStats": {
+      "summary": "{files}개 파일 변경 · {additions}줄 추가 · {deletions}줄 삭제",
+      "additions": "{count}줄 추가",
+      "deletions": "{count}줄 삭제",
+      "expand": "변경 파일 목록 펼치기",
+      "collapse": "변경 파일 목록 접기"
+    },
     "terminalTabs": "터미널 탭",
     "newTerminalTab": "새 탭",
     "closeTerminalTab": "{name} 탭 닫기",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -419,7 +419,13 @@
     "dismissHint": "不再显示",
     "viewDiff": "查看差异",
     "diffFiles": "变更文件",
-    "diffFileCount": "{count}个",
+    "diffStats": {
+      "summary": "{files} 个文件变更 · 新增 {additions} 行 · 删除 {deletions} 行",
+      "additions": "新增 {count} 行",
+      "deletions": "删除 {count} 行",
+      "expand": "展开变更文件列表",
+      "collapse": "收起变更文件列表"
+    },
     "terminalTabs": "终端标签页",
     "newTerminalTab": "新建标签页",
     "closeTerminalTab": "关闭 {name} 标签页",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -64,9 +64,6 @@ const COLUMNS: { status: TaskStatus; labelKey: string; colorClass: string }[] = 
   { status: TaskStatus.DONE, labelKey: "done", colorClass: "bg-status-done" },
 ];
 
-/** 변경 집계를 띄우는 칸. Todo는 아직 손대기 전이고 Done은 더 바뀌지 않아, 카드마다 git을 돌려도 새로 나올 값이 없다 */
-const DIFF_STATS_STATUSES = [TaskStatus.PROGRESS, TaskStatus.PENDING, TaskStatus.REVIEW];
-
 const TASK_CARD_SELECTOR = "[data-kanban-task-card='true']";
 const BOARD_ARROW_TASK_FOCUS_KEYS = new Set([
   "ArrowUp",
@@ -684,14 +681,17 @@ export default function Board({
     return sorted;
   }, [boardSortContext, filteredTasks, sortPreference]);
 
-  /** 집계를 조회할 태스크. worktree와 브랜치가 있어야 baseBranch와 견줄 변경이 존재한다 */
-  const changingTaskIds = useMemo(
-    () => DIFF_STATS_STATUSES.flatMap((status) => displayedTasks[status]
+  /**
+   * git을 다시 돌릴 태스크. 지금 손대고 있는 칸만 새로 집계하고 나머지 칸은 마지막으로 저장된 값을 보여준다.
+   * worktree와 브랜치가 있어야 baseBranch와 견줄 변경이 존재한다.
+   */
+  const taskIdsToRefresh = useMemo(
+    () => displayedTasks[TaskStatus.PROGRESS]
       .filter((task) => task.branchName && task.worktreePath)
-      .map((task) => task.id)),
+      .map((task) => task.id),
     [displayedTasks],
   );
-  const diffStatsByTaskId = useBoardTaskDiffStats(changingTaskIds, isMounted);
+  const diffStatsByTaskId = useBoardTaskDiffStats(taskIdsToRefresh, isMounted);
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     isOpen: false,

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -23,6 +23,7 @@ import type { Project } from "@/entities/Project";
 import { useAutoRefresh } from "@/desktop/renderer/hooks/useAutoRefresh";
 import { useProjectFilterParams } from "@/desktop/renderer/hooks/useProjectFilterParams";
 import { useRunningAgentPanes } from "@/desktop/renderer/hooks/useLiveAiSessions";
+import { useBoardTaskDiffStats } from "@/desktop/renderer/hooks/useTaskDiffStats";
 import { useUnreadNotificationCountByTask } from "@/desktop/renderer/hooks/useUnreadNotificationCountByTask";
 import {
   TASK_KIND_FILTER_VALUES,
@@ -62,6 +63,9 @@ const COLUMNS: { status: TaskStatus; labelKey: string; colorClass: string }[] = 
   { status: TaskStatus.REVIEW, labelKey: "review", colorClass: "bg-status-review" },
   { status: TaskStatus.DONE, labelKey: "done", colorClass: "bg-status-done" },
 ];
+
+/** 변경 집계를 띄우는 칸. Todo는 아직 손대기 전이고 Done은 더 바뀌지 않아, 카드마다 git을 돌려도 새로 나올 값이 없다 */
+const DIFF_STATS_STATUSES = [TaskStatus.PROGRESS, TaskStatus.PENDING, TaskStatus.REVIEW];
 
 const TASK_CARD_SELECTOR = "[data-kanban-task-card='true']";
 const BOARD_ARROW_TASK_FOCUS_KEYS = new Set([
@@ -680,6 +684,15 @@ export default function Board({
     return sorted;
   }, [boardSortContext, filteredTasks, sortPreference]);
 
+  /** 집계를 조회할 태스크. worktree와 브랜치가 있어야 baseBranch와 견줄 변경이 존재한다 */
+  const changingTaskIds = useMemo(
+    () => DIFF_STATS_STATUSES.flatMap((status) => displayedTasks[status]
+      .filter((task) => task.branchName && task.worktreePath)
+      .map((task) => task.id)),
+    [displayedTasks],
+  );
+  const diffStatsByTaskId = useBoardTaskDiffStats(changingTaskIds, isMounted);
+
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     isOpen: false,
     x: 0,
@@ -1247,6 +1260,7 @@ export default function Board({
                   rootPriorityByProjectId={rootPriorityByProjectId}
                   vimModeEnabled={vimModeEnabled}
                   runningAgentPanes={runningAgentPanes}
+                  diffStatsByTaskId={diffStatsByTaskId}
                   {...(col.status === TaskStatus.DONE && {
                     totalCount: doneTotal,
                     hasMore: doneOffset < doneTotal,

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -10,6 +10,7 @@ import type { UnreadNotificationCountByTask } from "@/desktop/renderer/hooks/use
 import type { KanbanTask, TaskStatus } from "@/entities/KanbanTask";
 import type { TaskPriority } from "@/entities/TaskPriority";
 import type { RunningAgentPane } from "@/lib/aiSessions/types";
+import type { TaskDiffStats } from "@/desktop/shared/taskDiffStats";
 
 interface ColumnProps {
   status: TaskStatus;
@@ -29,6 +30,8 @@ interface ColumnProps {
   vimModeEnabled?: boolean;
   /** 보드가 한 번만 조회해 모든 카드가 나눠 쓰는 실행중 에이전트 목록 */
   runningAgentPanes?: RunningAgentPane[];
+  /** 보드가 한 번만 조회해 카드마다 나눠 쓰는 태스크별 변경 집계 */
+  diffStatsByTaskId?: Record<string, TaskDiffStats>;
 }
 
 interface TaskGroup {
@@ -95,6 +98,7 @@ export default function Column({
   isLoadingMore,
   vimModeEnabled = true,
   runningAgentPanes,
+  diffStatsByTaskId,
 }: ColumnProps) {
   const t = useTranslations("board");
   const columnRef = useFlipReflow<HTMLDivElement>(tasks.map((task) => task.id).join(","));
@@ -161,6 +165,7 @@ export default function Column({
                         rootPriorityByProjectId={rootPriorityByProjectId}
                         vimModeEnabled={vimModeEnabled}
                         runningAgentPanes={runningAgentPanes}
+                        diffStats={diffStatsByTaskId?.[task.id]}
                       />
                     ))}
                   </Fragment>
@@ -191,6 +196,7 @@ export default function Column({
                       rootPriorityByProjectId={rootPriorityByProjectId}
                       vimModeEnabled={vimModeEnabled}
                       runningAgentPanes={runningAgentPanes}
+                      diffStats={diffStatsByTaskId?.[task.id]}
                     />
                   ))}
                 </ProjectTaskGroup>

--- a/src/components/CountUpNumber.tsx
+++ b/src/components/CountUpNumber.tsx
@@ -38,10 +38,13 @@ export function CountUpNumber({ value, className, testId }: CountUpNumberProps) 
       return;
     }
 
-    const startedAt = performance.now();
     setIsCounting(true);
 
+    // 경과 시간은 프레임 타임스탬프끼리만 빼서 잰다. 다른 시계(performance.now 등)와 섞으면
+    // 두 시계의 기준점이 다른 환경에서 경과 시간이 음수로 시작해 굴러가기가 그만큼 늦게 끝난다.
+    let startedAt: number | null = null;
     let frameId = window.requestAnimationFrame(function advanceToNextFrame(now: number) {
+      startedAt ??= now;
       const progress = Math.min((now - startedAt) / COUNT_UP_DURATION_MS, 1);
       const easedProgress = 1 - (1 - progress) ** 3;
       setDisplayedValue(Math.round(startValue + (value - startValue) * easedProgress));

--- a/src/components/CountUpNumber.tsx
+++ b/src/components/CountUpNumber.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/** 한 번 굴러가는 데 걸리는 시간. 폴링 주기보다 훨씬 짧아 다음 값이 오기 전에 항상 멈춘다 */
+const COUNT_UP_DURATION_MS = 420;
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+}
+
+interface CountUpNumberProps {
+  value: number;
+  className?: string;
+  testId?: string;
+}
+
+/**
+ * 숫자를 이전 값에서 새 값으로 굴린다.
+ *
+ * 스스로 갱신되는 화면에서는 어느 자리가 방금 바뀌었는지 눈이 놓치기 쉬워, 움직임으로 그 자리를 가리킨다.
+ * 움직임을 줄이도록 설정한 사용자에게는 굴리지 않고 새 값으로 바로 건너뛴다.
+ */
+export function CountUpNumber({ value, className, testId }: CountUpNumberProps) {
+  const [displayedValue, setDisplayedValue] = useState(value);
+  const [isCounting, setIsCounting] = useState(false);
+  const displayedValueRef = useRef(value);
+  displayedValueRef.current = displayedValue;
+
+  useEffect(() => {
+    const startValue = displayedValueRef.current;
+    if (startValue === value) {
+      return;
+    }
+
+    if (prefersReducedMotion() || typeof window.requestAnimationFrame !== "function") {
+      setDisplayedValue(value);
+      return;
+    }
+
+    const startedAt = performance.now();
+    setIsCounting(true);
+
+    let frameId = window.requestAnimationFrame(function advanceToNextFrame(now: number) {
+      const progress = Math.min((now - startedAt) / COUNT_UP_DURATION_MS, 1);
+      const easedProgress = 1 - (1 - progress) ** 3;
+      setDisplayedValue(Math.round(startValue + (value - startValue) * easedProgress));
+
+      if (progress < 1) {
+        frameId = window.requestAnimationFrame(advanceToNextFrame);
+        return;
+      }
+
+      setIsCounting(false);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      setIsCounting(false);
+    };
+  }, [value]);
+
+  return (
+    <span
+      className={`kv-count-up tabular-nums${className ? ` ${className}` : ""}`}
+      data-counting={isCounting || undefined}
+      data-testid={testId}
+    >
+      {displayedValue}
+    </span>
+  );
+}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -16,7 +16,9 @@ import {
 } from "@/desktop/renderer/utils/boardTaskSort";
 import ProjectIcon from "@/components/ProjectIcon";
 import { TaskCardLiveSessions } from "@/components/TaskCardLiveSessions";
+import { TaskDiffStatsBadge } from "@/components/TaskDiffStats";
 import type { RunningAgentPane } from "@/lib/aiSessions/types";
+import type { TaskDiffStats } from "@/desktop/shared/taskDiffStats";
 
 interface ContextMenuPosition {
   x: number;
@@ -37,6 +39,8 @@ interface TaskCardProps {
   vimModeEnabled?: boolean;
   /** 보드 전체가 한 번만 조회한 실행중 에이전트 목록 */
   runningAgentPanes?: RunningAgentPane[];
+  /** 보드 전체가 한 번만 조회한 집계 중 이 태스크의 몫 */
+  diffStats?: TaskDiffStats;
 }
 
 const agentTagColors: Record<string, string> = {
@@ -201,6 +205,7 @@ export default function TaskCard({
   rootPriorityByProjectId = EMPTY_ROOT_PRIORITY_MAP,
   vimModeEnabled = true,
   runningAgentPanes = EMPTY_RUNNING_AGENT_PANES,
+  diffStats,
 }: TaskCardProps) {
   const [isLiveSessionPanelOpen, setIsLiveSessionPanelOpen] = useState(false);
   const livePanelOpenTimeoutRef = useRef<number | null>(null);
@@ -423,6 +428,8 @@ export default function TaskCard({
                 {task.sessionType}
               </span>
             )}
+
+            <TaskDiffStatsBadge stats={diffStats} />
 
             <TaskCardLiveSessions
               taskId={task.id}

--- a/src/components/TaskDetailInfoCard.tsx
+++ b/src/components/TaskDetailInfoCard.tsx
@@ -5,19 +5,23 @@ import type { KanbanTask } from "@/entities/KanbanTask";
 import PriorityEditor from "@/components/PriorityEditor";
 import { Link } from "@/desktop/renderer/navigation";
 import ProjectColorEditor from "@/components/ProjectColorEditor";
+import { TaskDiffSummary } from "@/components/TaskDiffStats";
+import type { DiffFile } from "@/desktop/renderer/actions/diff";
+
+const EMPTY_DIFF_FILES: DiffFile[] = [];
 
 interface TaskDetailInfoCardProps {
   task: KanbanTask;
   agentTagStyle: string | null;
   baseBranchTaskId: string | null;
-  diffFileCount?: number;
+  diffFiles?: DiffFile[];
 }
 
 export default function TaskDetailInfoCard({
   task,
   agentTagStyle,
   baseBranchTaskId,
-  diffFileCount,
+  diffFiles = EMPTY_DIFF_FILES,
 }: TaskDetailInfoCardProps) {
   const t = useTranslations("taskDetail");
 
@@ -83,28 +87,7 @@ export default function TaskDetailInfoCard({
               />
             </dd>
           </div>
-          {task.branchName && (
-            <div className="flex items-center justify-between gap-2">
-              <dt className="text-xs text-text-muted">{t("diffFiles")}</dt>
-              <dd>
-                <Link
-                  href={`/task/${task.id}/diff`}
-                  className="inline-flex items-center gap-1.5 text-xs bg-tag-branch-bg text-tag-branch-text px-2 py-0.5 rounded hover:opacity-80 transition-opacity"
-                  title={t("viewDiff")}
-                >
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <circle cx="6" cy="6" r="2.5" />
-                    <circle cx="18" cy="18" r="2.5" />
-                    <path d="M6 8.5v4c0 2 1.5 3.5 3.5 3.5H14" />
-                    <path d="M15 13l3 3-3 3" />
-                  </svg>
-                  {diffFileCount !== undefined && diffFileCount > 0 && (
-                    <span className="font-medium">{t("diffFileCount", { count: diffFileCount })}</span>
-                  )}
-                </Link>
-              </dd>
-            </div>
-          )}
+          {task.branchName && <TaskDiffSummary taskId={task.id} files={diffFiles} />}
           {task.agentType && (
             <div className="flex items-center justify-between gap-2">
               <dt className="text-xs text-text-muted">{t("agent")}</dt>

--- a/src/components/TaskDiffStats.tsx
+++ b/src/components/TaskDiffStats.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { CountUpNumber } from "@/components/CountUpNumber";
+import { Link } from "@/desktop/renderer/navigation";
+import type { DiffFile } from "@/desktop/renderer/actions/diff";
+import { summarizeDiffFiles, type TaskDiffStats } from "@/desktop/shared/taskDiffStats";
+
+/** 파일 상태를 한 글자로 줄인 표시. 좁은 목록에서 경로를 밀어내지 않으려고 약어를 쓴다 */
+const STATUS_LABELS: Record<DiffFile["status"], string> = {
+  added: "A",
+  modified: "M",
+  deleted: "D",
+  renamed: "R",
+};
+
+const STATUS_COLORS: Record<DiffFile["status"], string> = {
+  added: "text-status-success",
+  modified: "text-status-warning",
+  deleted: "text-status-error",
+  renamed: "text-status-info",
+};
+
+function FileDiffIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="6" cy="6" r="2.5" />
+      <circle cx="18" cy="18" r="2.5" />
+      <path d="M6 8.5v4c0 2 1.5 3.5 3.5 3.5H14" />
+      <path d="M15 13l3 3-3 3" />
+    </svg>
+  );
+}
+
+/** 파일 수와 추가·삭제 줄 수. 보드 카드와 상세 패널이 같은 숫자를 같은 배치로 보여준다 */
+function DiffStatCounts({ stats }: { stats: TaskDiffStats }) {
+  const t = useTranslations("taskDetail.diffStats");
+
+  return (
+    <>
+      <CountUpNumber value={stats.fileCount} className="font-semibold text-text-secondary" testId="task-diff-file-count" />
+      <span className="text-status-success" title={t("additions", { count: stats.additions })}>
+        +<CountUpNumber value={stats.additions} testId="task-diff-additions" />
+      </span>
+      <span className="text-status-error" title={t("deletions", { count: stats.deletions })}>
+        -<CountUpNumber value={stats.deletions} testId="task-diff-deletions" />
+      </span>
+    </>
+  );
+}
+
+/**
+ * 보드 카드에 그 태스크의 변경 규모를 띄운다.
+ * 아직 아무것도 바뀌지 않은 태스크는 배지를 그리지 않는다. 0만 늘어놓으면 카드가 볼 것 없는 값으로 채워진다.
+ */
+export function TaskDiffStatsBadge({ stats }: { stats?: TaskDiffStats }) {
+  const t = useTranslations("taskDetail.diffStats");
+
+  if (!stats || stats.fileCount === 0) {
+    return null;
+  }
+
+  const summaryText = t("summary", {
+    files: stats.fileCount,
+    additions: stats.additions,
+    deletions: stats.deletions,
+  });
+
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded border border-border-subtle px-1.5 py-0.5 text-[10px] leading-none"
+      title={summaryText}
+      aria-label={summaryText}
+      data-testid="task-card-diff-stats"
+    >
+      <FileDiffIcon />
+      <DiffStatCounts stats={stats} />
+    </span>
+  );
+}
+
+/** 추가와 삭제의 비율을 한 줄 막대로 보여준다. 숫자를 읽기 전에 변경의 성격부터 눈에 들어오게 한다 */
+function ChangeRatioBar({ stats }: { stats: TaskDiffStats }) {
+  const changedLineCount = stats.additions + stats.deletions;
+  const additionPercent = changedLineCount === 0 ? 0 : Math.round((stats.additions / changedLineCount) * 100);
+
+  return (
+    <div
+      className="flex h-1 w-full overflow-hidden rounded-full bg-border-subtle"
+      aria-hidden="true"
+      data-testid="task-diff-ratio-bar"
+    >
+      <div className="kv-diff-ratio-fill bg-status-success" style={{ width: `${additionPercent}%` }} />
+      <div className="kv-diff-ratio-fill bg-status-error" style={{ width: `${100 - additionPercent}%` }} />
+    </div>
+  );
+}
+
+function ChangedFileList({ files }: { files: DiffFile[] }) {
+  return (
+    <ul className="max-h-48 w-full space-y-0.5 overflow-y-auto" data-testid="task-diff-file-list">
+      {files.map((file) => (
+        <li key={file.path} className="flex items-center gap-1.5 text-[11px] leading-4">
+          <span className={`w-2.5 shrink-0 font-mono font-semibold ${STATUS_COLORS[file.status]}`}>
+            {STATUS_LABELS[file.status]}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-text-secondary" title={file.path}>
+            {file.path}
+          </span>
+          <span className="shrink-0 tabular-nums text-status-success">+{file.additions}</span>
+          <span className="shrink-0 tabular-nums text-status-error">-{file.deletions}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * 태스크 상세의 작업 정보에서 변경 규모를 보여준다.
+ * 파일 목록은 접어 두고 집계만 남긴다. 정보 패널은 다른 항목과 자리를 나눠 써야 해서 목록이 항상 펼쳐져 있으면 나머지를 밀어낸다.
+ */
+export function TaskDiffSummary({ taskId, files }: { taskId: string; files: DiffFile[] }) {
+  const t = useTranslations("taskDetail");
+  const [isExpanded, setIsExpanded] = useState(false);
+  const stats = useMemo(() => summarizeDiffFiles(files), [files]);
+  const hasChanges = stats.fileCount > 0;
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-y-1.5" data-testid="task-diff-summary">
+      <dt className="text-xs text-text-muted">{t("diffFiles")}</dt>
+      <dd className="flex items-center gap-1.5">
+        {hasChanges && (
+          <button
+            type="button"
+            onClick={() => setIsExpanded((current) => !current)}
+            aria-expanded={isExpanded}
+            aria-label={t(isExpanded ? "diffStats.collapse" : "diffStats.expand")}
+            className="inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs transition-colors hover:bg-bg-page"
+            data-testid="task-diff-summary-toggle"
+          >
+            <DiffStatCounts stats={stats} />
+          </button>
+        )}
+        <Link
+          href={`/task/${taskId}/diff`}
+          className="inline-flex items-center gap-1.5 rounded bg-tag-branch-bg px-2 py-0.5 text-xs text-tag-branch-text transition-opacity hover:opacity-80"
+          title={t("viewDiff")}
+        >
+          <FileDiffIcon />
+        </Link>
+      </dd>
+
+      {hasChanges && <ChangeRatioBar stats={stats} />}
+      {hasChanges && isExpanded && <ChangedFileList files={files} />}
+    </div>
+  );
+}

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -83,6 +83,13 @@ vi.mock("@/desktop/renderer/actions/backgroundTaskSync", () => ({
   runBackgroundTaskSyncNow: vi.fn().mockResolvedValue({ reviewNeeded: false, boardUpdated: false }),
 }));
 
+const diffStatsMock = vi.hoisted(() => vi.fn().mockResolvedValue({}));
+
+vi.mock("@/desktop/renderer/actions/diff", () => ({
+  getTaskDiffStats: (...args: unknown[]) => diffStatsMock(...args),
+  getGitDiffFiles: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("@/desktop/renderer/hooks/useAutoRefresh", () => ({
   useAutoRefresh: vi.fn(),
 }));
@@ -101,7 +108,11 @@ vi.mock("@/desktop/renderer/hooks/useBoardSortPreference", () => ({
 }));
 
 vi.mock("../Column", () => ({
-  default: ({ status, tasks }: { status: TaskStatus; tasks: KanbanTask[] }) => (
+  default: ({ status, tasks, diffStatsByTaskId }: {
+    status: TaskStatus;
+    tasks: KanbanTask[];
+    diffStatsByTaskId?: Record<string, { fileCount: number; additions: number; deletions: number }>;
+  }) => (
     <div data-testid="column">
       {tasks.map((task, index) => (
         <a
@@ -111,6 +122,7 @@ vi.mock("../Column", () => ({
           data-kanban-task-id={task.id}
           data-kanban-status={status}
           data-kanban-index={index}
+          data-diff-stats={diffStatsByTaskId?.[task.id] ? JSON.stringify(diffStatsByTaskId[task.id]) : undefined}
         >
           {task.title}
         </a>
@@ -1690,5 +1702,69 @@ describe("Board defaultSessionType sync", () => {
       expect(readTodoCardIds()).toEqual(["root-task", "inheriting-task", "medium-task"]);
     });
 
+  });
+});
+
+describe("Board 변경 집계 배지", () => {
+  function createTasksWithProgressAndReview(): TasksByStatus {
+    const tasks = createEmptyTasks();
+    tasks[TaskStatus.PROGRESS] = [createTask({
+      id: "task-progress",
+      title: "진행 중 작업",
+      status: TaskStatus.PROGRESS,
+      branchName: "feat/progress",
+      worktreePath: "/repo__worktrees/progress",
+    })];
+    tasks[TaskStatus.REVIEW] = [createTask({
+      id: "task-review",
+      title: "리뷰 대기 작업",
+      status: TaskStatus.REVIEW,
+      branchName: "feat/review",
+      worktreePath: "/repo__worktrees/review",
+    })];
+    return tasks;
+  }
+
+  function renderBoardWithDiffStats() {
+    return render(
+      <Board
+        initialTasks={createTasksWithProgressAndReview()}
+        initialDoneTotal={0}
+        initialDoneLimit={20}
+        sshHosts={[]}
+        projects={[createProject()]}
+        sidebarDefaultCollapsed={false}
+        doneAlertDismissed={false}
+        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+        defaultSessionType={SessionType.TMUX}
+        taskSearchShortcut="Mod+Shift+O"
+      />,
+    );
+  }
+
+  it("진행 중 카드만 다시 집계 대상으로 넘긴다", async () => {
+    diffStatsMock.mockResolvedValue({});
+
+    renderBoardWithDiffStats();
+
+    await waitFor(() => {
+      expect(diffStatsMock).toHaveBeenCalledWith(["task-progress"]);
+    });
+  });
+
+  it("진행 중이 아닌 카드에도 저장된 집계가 전달된다", async () => {
+    diffStatsMock.mockResolvedValue({
+      "task-progress": { fileCount: 2, additions: 12, deletions: 3 },
+      "task-review": { fileCount: 4, additions: 40, deletions: 8 },
+    });
+
+    renderBoardWithDiffStats();
+
+    await waitFor(() => {
+      const reviewCard = document.querySelector('[data-kanban-task-id="task-review"]');
+      expect(reviewCard?.getAttribute("data-diff-stats")).toBe(
+        JSON.stringify({ fileCount: 4, additions: 40, deletions: 8 }),
+      );
+    });
   });
 });

--- a/src/components/__tests__/CountUpNumber.test.tsx
+++ b/src/components/__tests__/CountUpNumber.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { CountUpNumber } from "@/components/CountUpNumber";
+
+function mockReducedMotion(prefersReduced: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: prefersReduced && query === "(prefers-reduced-motion: reduce)",
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+describe("CountUpNumber", () => {
+  beforeEach(() => {
+    mockReducedMotion(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("첫 렌더에서는 굴리지 않고 받은 값을 그대로 보여준다", () => {
+    render(<CountUpNumber value={348} testId="count" />);
+
+    expect(screen.getByTestId("count").textContent).toBe("348");
+    expect(screen.getByTestId("count").getAttribute("data-counting")).toBeNull();
+  });
+
+  it("값이 바뀌면 굴러가는 동안 표시하고 결국 새 값에 도달한다", async () => {
+    const { rerender } = render(<CountUpNumber value={340} testId="count" />);
+
+    rerender(<CountUpNumber value={348} testId="count" />);
+
+    expect(screen.getByTestId("count").getAttribute("data-counting")).toBe("true");
+    await waitFor(() => {
+      expect(screen.getByTestId("count").textContent).toBe("348");
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("count").getAttribute("data-counting")).toBeNull();
+    });
+  });
+
+  it("움직임을 줄이도록 설정했으면 굴리지 않고 새 값으로 바로 바꾼다", () => {
+    mockReducedMotion(true);
+    const { rerender } = render(<CountUpNumber value={340} testId="count" />);
+
+    rerender(<CountUpNumber value={348} testId="count" />);
+
+    expect(screen.getByTestId("count").textContent).toBe("348");
+    expect(screen.getByTestId("count").getAttribute("data-counting")).toBeNull();
+  });
+});

--- a/src/components/__tests__/CountUpNumber.test.tsx
+++ b/src/components/__tests__/CountUpNumber.test.tsx
@@ -33,12 +33,13 @@ describe("CountUpNumber", () => {
     rerender(<CountUpNumber value={348} testId="count" />);
 
     expect(screen.getByTestId("count").getAttribute("data-counting")).toBe("true");
+    // 굴러가는 시간(420ms)보다 넉넉히 기다린다. 느린 CI 러너에서 기본 1초는 프레임 지연을 흡수하지 못한다
     await waitFor(() => {
       expect(screen.getByTestId("count").textContent).toBe("348");
-    });
+    }, { timeout: 3_000 });
     await waitFor(() => {
       expect(screen.getByTestId("count").getAttribute("data-counting")).toBeNull();
-    });
+    }, { timeout: 3_000 });
   });
 
   it("움직임을 줄이도록 설정했으면 굴리지 않고 새 값으로 바로 바꾼다", () => {

--- a/src/components/__tests__/TaskDiffStats.test.tsx
+++ b/src/components/__tests__/TaskDiffStats.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TaskDiffStatsBadge, TaskDiffSummary } from "@/components/TaskDiffStats";
+import type { DiffFile } from "@/desktop/renderer/actions/diff";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => (
+    values ? `${key}:${JSON.stringify(values)}` : key
+  ),
+}));
+
+vi.mock("@/desktop/renderer/navigation", () => ({
+  Link: ({ children, href, title }: { children: React.ReactNode; href: string; title?: string }) => (
+    <a href={href} title={title}>{children}</a>
+  ),
+}));
+
+const changedFiles: DiffFile[] = [
+  { path: "src/components/TaskCard.tsx", status: "modified", additions: 12, deletions: 3 },
+  { path: "src/hooks/useTaskDiffStats.ts", status: "added", additions: 88, deletions: 0 },
+];
+
+describe("TaskDiffStatsBadge", () => {
+  it("파일 수와 추가·삭제 줄 수를 보여준다", () => {
+    render(<TaskDiffStatsBadge stats={{ fileCount: 12, additions: 348, deletions: 76 }} />);
+
+    expect(screen.getByTestId("task-diff-file-count").textContent).toBe("12");
+    expect(screen.getByTestId("task-diff-additions").textContent).toBe("348");
+    expect(screen.getByTestId("task-diff-deletions").textContent).toBe("76");
+  });
+
+  it("변경이 없는 태스크에는 배지를 그리지 않는다", () => {
+    render(<TaskDiffStatsBadge stats={{ fileCount: 0, additions: 0, deletions: 0 }} />);
+
+    expect(screen.queryByTestId("task-card-diff-stats")).toBeNull();
+  });
+
+  it("아직 집계를 받지 못한 태스크에도 배지를 그리지 않는다", () => {
+    render(<TaskDiffStatsBadge stats={undefined} />);
+
+    expect(screen.queryByTestId("task-card-diff-stats")).toBeNull();
+  });
+});
+
+describe("TaskDiffSummary", () => {
+  it("파일 목록을 접은 채로 집계와 비율 막대를 보여준다", () => {
+    render(<TaskDiffSummary taskId="task-1" files={changedFiles} />);
+
+    expect(screen.getByTestId("task-diff-file-count").textContent).toBe("2");
+    expect(screen.getByTestId("task-diff-additions").textContent).toBe("100");
+    expect(screen.getByTestId("task-diff-deletions").textContent).toBe("3");
+    expect(screen.getByTestId("task-diff-ratio-bar")).toBeTruthy();
+    expect(screen.queryByTestId("task-diff-file-list")).toBeNull();
+  });
+
+  it("집계를 누르면 변경된 파일 목록을 펼친다", () => {
+    render(<TaskDiffSummary taskId="task-1" files={changedFiles} />);
+
+    fireEvent.click(screen.getByTestId("task-diff-summary-toggle"));
+
+    const fileList = screen.getByTestId("task-diff-file-list");
+    expect(fileList.textContent).toContain("src/components/TaskCard.tsx");
+    expect(fileList.textContent).toContain("src/hooks/useTaskDiffStats.ts");
+    expect(screen.getByTestId("task-diff-summary-toggle").getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("변경이 없으면 집계 없이 전체 diff 링크만 남긴다", () => {
+    render(<TaskDiffSummary taskId="task-1" files={[]} />);
+
+    expect(screen.queryByTestId("task-diff-summary-toggle")).toBeNull();
+    expect(screen.queryByTestId("task-diff-ratio-bar")).toBeNull();
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/task/task-1/diff");
+  });
+});

--- a/src/desktop/main/__tests__/terminalClipboardBridge.test.ts
+++ b/src/desktop/main/__tests__/terminalClipboardBridge.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * OSC 52 복사는 메인 프로세스 클립보드를 거쳐야 문서 포커스와 무관하게 반영된다.
+ * 두 파일 중 한쪽만 남으면 복사가 조용히 사라지므로, 채널 양끝이 이어져 있는지 확인한다.
+ */
+describe("terminal clipboard bridge", () => {
+  const CLIPBOARD_CHANNEL = "kanvibe:clipboard-write";
+
+  function readElectronSource(fileName: string): string {
+    return readFileSync(path.join(process.cwd(), "electron", fileName), "utf8");
+  }
+
+  it("should write to the main process clipboard when the renderer requests a copy", () => {
+    // Given
+    const source = readElectronSource("main.js");
+
+    // When
+    const handler = source.match(
+      /ipcMain\.handle\("kanvibe:clipboard-write",[\s\S]*?\n {2}\}\);/,
+    )?.[0];
+
+    // Then
+    expect(handler).toBeDefined();
+    expect(handler).toMatch(/clipboard\.writeText\(/);
+  });
+
+  it("should expose the clipboard write on the desktop bridge", () => {
+    // Given
+    const source = readElectronSource("preload.js");
+
+    // When
+    const bridgeMethod = source.match(/writeSystemClipboard\(text\) \{[\s\S]*?\n {2}\},/)?.[0];
+
+    // Then
+    expect(bridgeMethod).toBeDefined();
+    expect(bridgeMethod).toContain(CLIPBOARD_CHANNEL);
+  });
+});

--- a/src/desktop/main/services/__tests__/diffService.test.ts
+++ b/src/desktop/main/services/__tests__/diffService.test.ts
@@ -4,6 +4,10 @@ const mocks = vi.hoisted(() => ({
   taskRepo: {
     findOne: vi.fn(),
   },
+  taskDiffStatsRepo: {
+    find: vi.fn(),
+    save: vi.fn(),
+  },
   execGit: vi.fn(),
   readTextFile: vi.fn(),
   writeTextFile: vi.fn(),
@@ -11,6 +15,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/lib/database", () => ({
   getTaskRepository: vi.fn(async () => mocks.taskRepo),
+  getTaskDiffStatsRepository: vi.fn(async () => mocks.taskDiffStatsRepo),
 }));
 
 vi.mock("@/lib/gitOperations", () => ({
@@ -99,9 +104,8 @@ describe("getTaskDiffStats", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-  });
-
-  it("여러 태스크의 변경 집계를 한 번에 돌려준다", async () => {
+    mocks.taskDiffStatsRepo.find.mockResolvedValue([]);
+    mocks.taskDiffStatsRepo.save.mockResolvedValue(undefined);
     mocks.taskRepo.findOne.mockImplementation(async ({ where }: { where: { id: string } }) => ({
       id: where.id,
       worktreePath: `/repo__worktrees/${where.id}`,
@@ -109,61 +113,92 @@ describe("getTaskDiffStats", () => {
       baseBranch: "main",
       sshHost: null,
     }));
-    mocks.execGit.mockImplementation(async (command: string) => {
-      const isFirstTask = command.includes("/repo__worktrees/task-1");
-      return isFirstTask
-        ? [
-            "__KANVIBE_DIFF_NAME_STATUS__",
-            "M\tsrc/app.ts",
-            "A\tsrc/new.ts",
-            "__KANVIBE_DIFF_NUMSTAT__",
-            "12\t3\tsrc/app.ts",
-            "88\t0\tsrc/new.ts",
-            "__KANVIBE_DIFF_WORKING_TREE__",
-          ].join("\n")
-        : [
-            "__KANVIBE_DIFF_NAME_STATUS__",
-            "D\tscripts/old.cjs",
-            "__KANVIBE_DIFF_NUMSTAT__",
-            "0\t41\tscripts/old.cjs",
-            "__KANVIBE_DIFF_WORKING_TREE__",
-          ].join("\n");
-    });
-
-    const { getTaskDiffStats } = await import("@/desktop/main/services/diffService");
-
-    await expect(getTaskDiffStats(["task-1", "task-2"])).resolves.toEqual({
-      "task-1": { fileCount: 2, additions: 100, deletions: 3 },
-      "task-2": { fileCount: 1, additions: 0, deletions: 41 },
-    });
   });
 
-  it("조회에 실패한 태스크는 빈 집계로 남기고 나머지는 그대로 돌려준다", async () => {
-    mocks.taskRepo.findOne.mockImplementation(async ({ where }: { where: { id: string } }) => (
-      where.id === "task-without-worktree"
-        ? { id: where.id, worktreePath: null, branchName: null, baseBranch: "main", sshHost: null }
-        : { id: where.id, worktreePath: "/repo__worktrees/ok", branchName: "feat/ok", baseBranch: "main", sshHost: null }
-    ));
-    mocks.execGit.mockResolvedValue([
+  function buildDiffOutput(additions: number, deletions: number) {
+    return [
       "__KANVIBE_DIFF_NAME_STATUS__",
       "M\tsrc/app.ts",
       "__KANVIBE_DIFF_NUMSTAT__",
-      "5\t2\tsrc/app.ts",
+      `${additions}\t${deletions}\tsrc/app.ts`,
       "__KANVIBE_DIFF_WORKING_TREE__",
-    ].join("\n"));
+    ].join("\n");
+  }
+
+  it("넘긴 태스크만 git을 돌리고 그 집계를 저장한다", async () => {
+    mocks.execGit.mockResolvedValue(buildDiffOutput(12, 3));
 
     const { getTaskDiffStats } = await import("@/desktop/main/services/diffService");
 
-    await expect(getTaskDiffStats(["task-without-worktree", "task-ok"])).resolves.toEqual({
-      "task-without-worktree": { fileCount: 0, additions: 0, deletions: 0 },
-      "task-ok": { fileCount: 1, additions: 5, deletions: 2 },
+    await expect(getTaskDiffStats(["task-progress"])).resolves.toEqual({
+      "task-progress": { fileCount: 1, additions: 12, deletions: 3 },
+    });
+    expect(mocks.execGit).toHaveBeenCalledTimes(1);
+    expect(mocks.taskDiffStatsRepo.save).toHaveBeenCalledWith({
+      taskId: "task-progress",
+      fileCount: 1,
+      additions: 12,
+      deletions: 3,
     });
   });
 
-  it("조회할 태스크가 없으면 git을 돌리지 않는다", async () => {
+  it("git을 돌리지 않은 태스크는 저장돼 있던 집계로 채운다", async () => {
+    mocks.taskDiffStatsRepo.find.mockResolvedValue([
+      { taskId: "task-review", fileCount: 4, additions: 40, deletions: 8 },
+      { taskId: "task-progress", fileCount: 1, additions: 1, deletions: 1 },
+    ]);
+    mocks.execGit.mockResolvedValue(buildDiffOutput(12, 3));
+
     const { getTaskDiffStats } = await import("@/desktop/main/services/diffService");
 
-    await expect(getTaskDiffStats([])).resolves.toEqual({});
+    await expect(getTaskDiffStats(["task-progress"])).resolves.toEqual({
+      "task-review": { fileCount: 4, additions: 40, deletions: 8 },
+      "task-progress": { fileCount: 1, additions: 12, deletions: 3 },
+    });
+    expect(mocks.execGit).toHaveBeenCalledTimes(1);
+  });
+
+  it("다시 돌릴 태스크가 없으면 git 없이 저장된 집계만 돌려준다", async () => {
+    mocks.taskDiffStatsRepo.find.mockResolvedValue([
+      { taskId: "task-review", fileCount: 4, additions: 40, deletions: 8 },
+    ]);
+
+    const { getTaskDiffStats } = await import("@/desktop/main/services/diffService");
+
+    await expect(getTaskDiffStats([])).resolves.toEqual({
+      "task-review": { fileCount: 4, additions: 40, deletions: 8 },
+    });
     expect(mocks.execGit).not.toHaveBeenCalled();
+    expect(mocks.taskDiffStatsRepo.save).not.toHaveBeenCalled();
+  });
+
+  it("조회에 실패한 태스크는 저장된 집계를 덮어쓰지 않는다", async () => {
+    mocks.taskDiffStatsRepo.find.mockResolvedValue([
+      { taskId: "task-progress", fileCount: 4, additions: 40, deletions: 8 },
+    ]);
+    mocks.execGit.mockRejectedValue(new Error("git 실행 실패"));
+
+    const { getTaskDiffStats } = await import("@/desktop/main/services/diffService");
+
+    await expect(getTaskDiffStats(["task-progress"])).resolves.toEqual({
+      "task-progress": { fileCount: 4, additions: 40, deletions: 8 },
+    });
+    expect(mocks.taskDiffStatsRepo.save).not.toHaveBeenCalled();
+  });
+
+  it("상세에서 파일 목록을 읽으면 그 태스크의 집계도 갱신된다", async () => {
+    mocks.execGit.mockResolvedValue(buildDiffOutput(7, 2));
+
+    const { getGitDiffFiles } = await import("@/desktop/main/services/diffService");
+
+    await expect(getGitDiffFiles("task-review")).resolves.toEqual([
+      { path: "src/app.ts", status: "modified", additions: 7, deletions: 2 },
+    ]);
+    expect(mocks.taskDiffStatsRepo.save).toHaveBeenCalledWith({
+      taskId: "task-review",
+      fileCount: 1,
+      additions: 7,
+      deletions: 2,
+    });
   });
 });

--- a/src/desktop/main/services/__tests__/diffService.test.ts
+++ b/src/desktop/main/services/__tests__/diffService.test.ts
@@ -94,3 +94,76 @@ describe("diffService remote task support", () => {
     expect(mocks.writeTextFile).toHaveBeenCalledWith("/remote/worktrees/fix-qa/src/app.ts", "updated", "remote-host");
   });
 });
+
+describe("getTaskDiffStats", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("여러 태스크의 변경 집계를 한 번에 돌려준다", async () => {
+    mocks.taskRepo.findOne.mockImplementation(async ({ where }: { where: { id: string } }) => ({
+      id: where.id,
+      worktreePath: `/repo__worktrees/${where.id}`,
+      branchName: `feat/${where.id}`,
+      baseBranch: "main",
+      sshHost: null,
+    }));
+    mocks.execGit.mockImplementation(async (command: string) => {
+      const isFirstTask = command.includes("/repo__worktrees/task-1");
+      return isFirstTask
+        ? [
+            "__KANVIBE_DIFF_NAME_STATUS__",
+            "M\tsrc/app.ts",
+            "A\tsrc/new.ts",
+            "__KANVIBE_DIFF_NUMSTAT__",
+            "12\t3\tsrc/app.ts",
+            "88\t0\tsrc/new.ts",
+            "__KANVIBE_DIFF_WORKING_TREE__",
+          ].join("\n")
+        : [
+            "__KANVIBE_DIFF_NAME_STATUS__",
+            "D\tscripts/old.cjs",
+            "__KANVIBE_DIFF_NUMSTAT__",
+            "0\t41\tscripts/old.cjs",
+            "__KANVIBE_DIFF_WORKING_TREE__",
+          ].join("\n");
+    });
+
+    const { getTaskDiffStats } = await import("@/desktop/main/services/diffService");
+
+    await expect(getTaskDiffStats(["task-1", "task-2"])).resolves.toEqual({
+      "task-1": { fileCount: 2, additions: 100, deletions: 3 },
+      "task-2": { fileCount: 1, additions: 0, deletions: 41 },
+    });
+  });
+
+  it("조회에 실패한 태스크는 빈 집계로 남기고 나머지는 그대로 돌려준다", async () => {
+    mocks.taskRepo.findOne.mockImplementation(async ({ where }: { where: { id: string } }) => (
+      where.id === "task-without-worktree"
+        ? { id: where.id, worktreePath: null, branchName: null, baseBranch: "main", sshHost: null }
+        : { id: where.id, worktreePath: "/repo__worktrees/ok", branchName: "feat/ok", baseBranch: "main", sshHost: null }
+    ));
+    mocks.execGit.mockResolvedValue([
+      "__KANVIBE_DIFF_NAME_STATUS__",
+      "M\tsrc/app.ts",
+      "__KANVIBE_DIFF_NUMSTAT__",
+      "5\t2\tsrc/app.ts",
+      "__KANVIBE_DIFF_WORKING_TREE__",
+    ].join("\n"));
+
+    const { getTaskDiffStats } = await import("@/desktop/main/services/diffService");
+
+    await expect(getTaskDiffStats(["task-without-worktree", "task-ok"])).resolves.toEqual({
+      "task-without-worktree": { fileCount: 0, additions: 0, deletions: 0 },
+      "task-ok": { fileCount: 1, additions: 5, deletions: 2 },
+    });
+  });
+
+  it("조회할 태스크가 없으면 git을 돌리지 않는다", async () => {
+    const { getTaskDiffStats } = await import("@/desktop/main/services/diffService");
+
+    await expect(getTaskDiffStats([])).resolves.toEqual({});
+    expect(mocks.execGit).not.toHaveBeenCalled();
+  });
+});

--- a/src/desktop/main/services/diffService.ts
+++ b/src/desktop/main/services/diffService.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { getTaskRepository } from "@/lib/database";
+import { getTaskDiffStatsRepository, getTaskRepository } from "@/lib/database";
 import { execGit } from "@/lib/gitOperations";
 import { quoteShellArgument, readTextFile, writeTextFile } from "@/lib/hostFileAccess";
 import { summarizeDiffFiles, type TaskDiffStats } from "@/desktop/shared/taskDiffStats";
@@ -140,13 +140,10 @@ function parseWorkingTreeStatus(
 }
 
 /**
- * baseBranch와 현재 브랜치 사이에서 변경된 파일 목록을 조회한다.
- * 커밋된 브랜치 차이뿐 아니라 working directory의
- * untracked/unstaged/staged 파일도 포함한다.
+ * 변경 파일 목록을 조회하되 실패를 `null`로 구분해 돌려준다.
+ * 조회에 실패한 것과 정말 아무것도 바뀌지 않은 것을 같은 빈 배열로 뭉치면 캐시를 0으로 덮어쓰게 된다.
  */
-export async function getGitDiffFiles(
-  taskId: string
-): Promise<DiffFile[]> {
+async function readGitDiffFiles(taskId: string): Promise<DiffFile[] | null> {
   try {
     const { worktreePath, branchName, baseBranch, sshHost } =
       await getTaskWorktreeInfo(taskId);
@@ -218,8 +215,28 @@ export async function getGitDiffFiles(
     return Array.from(fileMap.values());
   } catch (error) {
     console.error("git diff 파일 목록 조회 실패:", error);
+    return null;
+  }
+}
+
+/**
+ * baseBranch와 현재 브랜치 사이에서 변경된 파일 목록을 조회한다.
+ * 커밋된 브랜치 차이뿐 아니라 working directory의
+ * untracked/unstaged/staged 파일도 포함한다.
+ *
+ * 조회한 김에 집계 캐시도 갱신한다. 보드는 진행 중이 아닌 태스크의 배지를 이 캐시로 그리므로,
+ * 사용자가 상세를 열어 본 태스크는 그 시점 값으로 최신화된다.
+ */
+export async function getGitDiffFiles(
+  taskId: string
+): Promise<DiffFile[]> {
+  const files = await readGitDiffFiles(taskId);
+  if (!files) {
     return [];
   }
+
+  await saveTaskDiffStats(taskId, summarizeDiffFiles(files));
+  return files;
 }
 
 /** baseBranch 기준의 원본 파일 내용을 조회한다. 파일이 존재하지 않으면 빈 문자열을 반환한다 */
@@ -282,21 +299,57 @@ export async function saveFileContent(
   }
 }
 
+/** 집계 하나를 캐시에 덮어쓴다. 저장에 실패해도 조회 결과는 그대로 쓰이도록 삼킨다 */
+async function saveTaskDiffStats(taskId: string, stats: TaskDiffStats): Promise<void> {
+  try {
+    const repo = await getTaskDiffStatsRepository();
+    await repo.save({ taskId, ...stats });
+  } catch (error) {
+    console.error("변경 집계 저장 실패:", error);
+  }
+}
+
+/** 저장돼 있는 집계 전부. 보드가 진행 중이 아닌 카드의 배지를 그리는 값이다 */
+async function loadCachedTaskDiffStats(): Promise<Record<string, TaskDiffStats>> {
+  try {
+    const repo = await getTaskDiffStatsRepository();
+    const records = await repo.find();
+
+    return Object.fromEntries(records.map((record) => [
+      record.taskId,
+      { fileCount: record.fileCount, additions: record.additions, deletions: record.deletions },
+    ]));
+  } catch (error) {
+    console.error("변경 집계 캐시 조회 실패:", error);
+    return {};
+  }
+}
+
 /**
- * 여러 태스크의 변경 집계를 한 번에 접어 준다.
+ * 태스크별 변경 집계를 돌려준다. `taskIdsToRefresh`에 담긴 태스크만 git을 다시 돌리고 그 결과를 캐시에 남긴다.
  *
- * 보드는 카드 수만큼 조회가 필요한데 카드마다 IPC를 열면 왕복이 그 수만큼 쌓인다.
- * 조회하지 못한 태스크는 집계를 비워 두어, 한 태스크의 실패가 나머지 카드까지 지우지 않게 한다.
+ * 보드는 진행 중인 태스크만 새로 집계하고 나머지 칸은 마지막으로 저장된 값을 보여주므로,
+ * 반환값에는 방금 계산한 집계와 저장돼 있던 집계가 함께 담긴다.
+ * 카드마다 IPC를 열면 왕복이 카드 수만큼 쌓이므로 조회는 이 한 번으로 끝낸다.
+ *
+ * 다시 돌린 조회가 실패한 태스크는 캐시를 건드리지 않는다. 일시적인 실패로 배지가 0으로 주저앉지 않게 한다.
  */
 export async function getTaskDiffStats(
-  taskIds: string[]
+  taskIdsToRefresh: string[]
 ): Promise<Record<string, TaskDiffStats>> {
-  const statsEntries = await Promise.all(
-    taskIds.map(async (taskId) => {
-      const files = await getGitDiffFiles(taskId);
-      return [taskId, summarizeDiffFiles(files)] as const;
+  const refreshedEntries = await Promise.all(
+    taskIdsToRefresh.map(async (taskId) => {
+      const files = await readGitDiffFiles(taskId);
+      if (!files) {
+        return null;
+      }
+
+      const stats = summarizeDiffFiles(files);
+      await saveTaskDiffStats(taskId, stats);
+      return [taskId, stats] as const;
     })
   );
 
-  return Object.fromEntries(statsEntries);
+  const cachedStats = await loadCachedTaskDiffStats();
+  return { ...cachedStats, ...Object.fromEntries(refreshedEntries.filter((entry) => entry !== null)) };
 }

--- a/src/desktop/main/services/diffService.ts
+++ b/src/desktop/main/services/diffService.ts
@@ -2,6 +2,7 @@ import path from "path";
 import { getTaskRepository } from "@/lib/database";
 import { execGit } from "@/lib/gitOperations";
 import { quoteShellArgument, readTextFile, writeTextFile } from "@/lib/hostFileAccess";
+import { summarizeDiffFiles, type TaskDiffStats } from "@/desktop/shared/taskDiffStats";
 
 export interface DiffFile {
   path: string;
@@ -279,4 +280,23 @@ export async function saveFileContent(
     console.error("파일 저장 실패:", error);
     return { success: false, error: message };
   }
+}
+
+/**
+ * 여러 태스크의 변경 집계를 한 번에 접어 준다.
+ *
+ * 보드는 카드 수만큼 조회가 필요한데 카드마다 IPC를 열면 왕복이 그 수만큼 쌓인다.
+ * 조회하지 못한 태스크는 집계를 비워 두어, 한 태스크의 실패가 나머지 카드까지 지우지 않게 한다.
+ */
+export async function getTaskDiffStats(
+  taskIds: string[]
+): Promise<Record<string, TaskDiffStats>> {
+  const statsEntries = await Promise.all(
+    taskIds.map(async (taskId) => {
+      const files = await getGitDiffFiles(taskId);
+      return [taskId, summarizeDiffFiles(files)] as const;
+    })
+  );
+
+  return Object.fromEntries(statsEntries);
 }

--- a/src/desktop/renderer/actions/diff.ts
+++ b/src/desktop/renderer/actions/diff.ts
@@ -1,10 +1,16 @@
 import { invokeDesktop } from "@/desktop/renderer/ipc";
 import type { DiffFile } from "@/desktop/main/services/diffService";
+import type { TaskDiffStats } from "@/desktop/shared/taskDiffStats";
 
 export type { DiffFile };
 
 export function getGitDiffFiles(taskId: string): Promise<DiffFile[]> {
   return invokeDesktop("diff", "getGitDiffFiles", taskId);
+}
+
+/** 보드 카드가 나눠 쓸 태스크별 변경 집계. 카드마다 부르지 않고 보드가 한 번에 조회한다 */
+export function getTaskDiffStats(taskIds: string[]): Promise<Record<string, TaskDiffStats>> {
+  return invokeDesktop("diff", "getTaskDiffStats", taskIds);
 }
 
 export function getOriginalFileContent(taskId: string, filePath: string): Promise<string> {

--- a/src/desktop/renderer/actions/diff.ts
+++ b/src/desktop/renderer/actions/diff.ts
@@ -8,9 +8,12 @@ export function getGitDiffFiles(taskId: string): Promise<DiffFile[]> {
   return invokeDesktop("diff", "getGitDiffFiles", taskId);
 }
 
-/** 보드 카드가 나눠 쓸 태스크별 변경 집계. 카드마다 부르지 않고 보드가 한 번에 조회한다 */
-export function getTaskDiffStats(taskIds: string[]): Promise<Record<string, TaskDiffStats>> {
-  return invokeDesktop("diff", "getTaskDiffStats", taskIds);
+/**
+ * 보드 카드가 나눠 쓸 태스크별 변경 집계. 카드마다 부르지 않고 보드가 한 번에 조회한다.
+ * 넘긴 태스크만 git을 다시 돌리고, 나머지는 저장돼 있던 집계가 함께 실려 온다.
+ */
+export function getTaskDiffStats(taskIdsToRefresh: string[]): Promise<Record<string, TaskDiffStats>> {
+  return invokeDesktop("diff", "getTaskDiffStats", taskIdsToRefresh);
 }
 
 export function getOriginalFileContent(taskId: string, filePath: string): Promise<string> {

--- a/src/desktop/renderer/components/AiAccountLoginTerminal.tsx
+++ b/src/desktop/renderer/components/AiAccountLoginTerminal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { createTerminalOptions } from "@/lib/terminalMouseSelection";
+import { installOsc52ClipboardHandler } from "@/lib/terminalClipboard";
 import type { AiUsageProvider } from "@/lib/aiUsage/types";
 
 interface AiAccountLoginTerminalProps {
@@ -42,6 +43,7 @@ export default function AiAccountLoginTerminal({
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
     terminal.open(containerRef.current);
+    const osc52ClipboardHandler = installOsc52ClipboardHandler(terminal);
 
     const isThisSession = (event: { accountRoot: string }) => event.accountRoot === accountRoot;
 
@@ -80,6 +82,7 @@ export default function AiAccountLoginTerminal({
     if (!loginReady?.ok) {
       terminal.writeln(`\r\n\x1b[31m${loginReady?.error || "로그인 명령을 실행하지 못했습니다."}\x1b[0m`);
       return () => {
+        osc52ClipboardHandler.dispose();
         unsubscribeData?.();
         unsubscribeExit?.();
         terminal.dispose();
@@ -100,6 +103,7 @@ export default function AiAccountLoginTerminal({
 
     return () => {
       resizeObserver.disconnect();
+      osc52ClipboardHandler.dispose();
       unsubscribeData?.();
       unsubscribeExit?.();
       window.kanvibeDesktop?.closeAiAccountLogin?.(accountRoot);

--- a/src/desktop/renderer/components/__tests__/AiAccountLoginTerminal.test.tsx
+++ b/src/desktop/renderer/components/__tests__/AiAccountLoginTerminal.test.tsx
@@ -1,0 +1,100 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AiAccountLoginTerminal from "../AiAccountLoginTerminal";
+
+const { mockRegisterOscHandler, mockDisposeOscHandler, mockFit } = vi.hoisted(() => ({
+  mockRegisterOscHandler: vi.fn(),
+  mockDisposeOscHandler: vi.fn(),
+  mockFit: vi.fn(),
+}));
+
+class MockXTerm {
+  cols = 80;
+  rows = 24;
+
+  loadAddon = vi.fn();
+  open = vi.fn();
+  write = vi.fn();
+  writeln = vi.fn();
+  dispose = vi.fn();
+  focus = vi.fn();
+  onData = vi.fn();
+  parser = { registerOscHandler: mockRegisterOscHandler };
+}
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: MockXTerm,
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit = mockFit;
+  },
+}));
+
+vi.mock("@/lib/terminalMouseSelection", () => ({
+  createTerminalOptions: () => ({}),
+}));
+
+describe("AiAccountLoginTerminal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegisterOscHandler.mockReturnValue({ dispose: mockDisposeOscHandler });
+
+    vi.stubGlobal("ResizeObserver", class {
+      observe = vi.fn();
+      disconnect = vi.fn();
+    });
+
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      openAiAccountLogin: vi.fn().mockResolvedValue({ ok: true }),
+      writeAiAccountLogin: vi.fn(),
+      resizeAiAccountLogin: vi.fn(),
+      closeAiAccountLogin: vi.fn(),
+      onAiAccountLoginData: vi.fn().mockReturnValue(vi.fn()),
+      onAiAccountLoginExit: vi.fn().mockReturnValue(vi.fn()),
+    } as unknown as Window["kanvibeDesktop"];
+  });
+
+  it("should handle OSC 52 so a login code copied inside the terminal reaches the system clipboard", async () => {
+    // Given
+    const OSC_CLIPBOARD_IDENTIFIER = 52;
+
+    // When
+    render(
+      <AiAccountLoginTerminal provider="claude" accountRoot="/tmp/account" onExit={vi.fn()} />,
+    );
+
+    // Then
+    await waitFor(() => {
+      expect(mockRegisterOscHandler).toHaveBeenCalledWith(
+        OSC_CLIPBOARD_IDENTIFIER,
+        expect.any(Function),
+      );
+    });
+  });
+
+  it("should unregister the OSC 52 handler when the login terminal closes", async () => {
+    // Given
+    const { unmount } = render(
+      <AiAccountLoginTerminal provider="claude" accountRoot="/tmp/account" onExit={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(mockRegisterOscHandler).toHaveBeenCalled();
+    });
+
+    // When
+    unmount();
+
+    // Then
+    await waitFor(() => {
+      expect(mockDisposeOscHandler).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -27,6 +27,8 @@ declare global {
       resizeTerminal: (taskId: string, tabId: string | null, cols: number, rows: number) => void;
       focusTerminal: (taskId: string) => void;
       closeTerminal: (taskId: string, tabId: string | null) => void;
+      /** OSC 52 복사를 메인 프로세스에서 처리한다. 렌더러 클립보드 API는 문서 포커스에 묶여 있어 터미널 출력이 촉발하는 복사를 놓친다 */
+      writeSystemClipboard?: (text: string) => Promise<void>;
       onTerminalData: (listener: (event: { taskId: string; tabId: string | null; data: string }) => void) => () => void;
       onTerminalClose: (listener: (event: { taskId: string; tabId: string | null; reason: string | null }) => void) => () => void;
       /** AI 계정 로그인 세션은 태스크에 묶이지 않으므로 계정 루트가 식별자다 */

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -27,8 +27,6 @@ declare global {
       resizeTerminal: (taskId: string, tabId: string | null, cols: number, rows: number) => void;
       focusTerminal: (taskId: string) => void;
       closeTerminal: (taskId: string, tabId: string | null) => void;
-      /** OSC 52 복사를 메인 프로세스에서 처리한다. 렌더러 클립보드 API는 문서 포커스에 묶여 있어 터미널 출력이 촉발하는 복사를 놓친다 */
-      writeSystemClipboard?: (text: string) => Promise<void>;
       onTerminalData: (listener: (event: { taskId: string; tabId: string | null; data: string }) => void) => () => void;
       onTerminalClose: (listener: (event: { taskId: string; tabId: string | null; reason: string | null }) => void) => () => void;
       /** AI 계정 로그인 세션은 태스크에 묶이지 않으므로 계정 루트가 식별자다 */

--- a/src/desktop/renderer/hooks/__tests__/useTaskDiffStats.test.tsx
+++ b/src/desktop/renderer/hooks/__tests__/useTaskDiffStats.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { useBoardTaskDiffStats } from "@/desktop/renderer/hooks/useTaskDiffStats";
+
+const mocks = vi.hoisted(() => ({
+  getTaskDiffStats: vi.fn(),
+  getGitDiffFiles: vi.fn(),
+}));
+
+vi.mock("@/desktop/renderer/actions/diff", () => ({
+  getTaskDiffStats: (...args: unknown[]) => mocks.getTaskDiffStats(...args),
+  getGitDiffFiles: (...args: unknown[]) => mocks.getGitDiffFiles(...args),
+}));
+
+function BoardDiffStatsProbe({ taskIds, isEnabled }: { taskIds: string[]; isEnabled: boolean }) {
+  const statsByTaskId = useBoardTaskDiffStats(taskIds, isEnabled);
+
+  return <span data-testid="additions">{statsByTaskId["task-1"]?.additions ?? "none"}</span>;
+}
+
+describe("useBoardTaskDiffStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    mocks.getTaskDiffStats.mockResolvedValue({
+      "task-1": { fileCount: 2, additions: 340, deletions: 76 },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("보드에 떠 있는 태스크들을 한 번의 조회로 읽는다", async () => {
+    render(<BoardDiffStatsProbe taskIds={["task-1", "task-2"]} isEnabled />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("additions").textContent).toBe("340");
+    });
+    expect(mocks.getTaskDiffStats).toHaveBeenCalledTimes(1);
+    expect(mocks.getTaskDiffStats).toHaveBeenCalledWith(["task-1", "task-2"]);
+  });
+
+  it("주기가 돌 때마다 집계를 새로 읽어 화면 값이 따라간다", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    render(<BoardDiffStatsProbe taskIds={["task-1"]} isEnabled />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("additions").textContent).toBe("340");
+    });
+
+    mocks.getTaskDiffStats.mockResolvedValue({
+      "task-1": { fileCount: 3, additions: 348, deletions: 76 },
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(mocks.getTaskDiffStats).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(screen.getByTestId("additions").textContent).toBe("348");
+    });
+  });
+
+  it("보드를 보고 있지 않으면 조회하지 않는다", () => {
+    render(<BoardDiffStatsProbe taskIds={["task-1"]} isEnabled={false} />);
+
+    expect(mocks.getTaskDiffStats).not.toHaveBeenCalled();
+  });
+
+  it("조회할 태스크가 없으면 조회하지 않는다", () => {
+    render(<BoardDiffStatsProbe taskIds={[]} isEnabled />);
+
+    expect(mocks.getTaskDiffStats).not.toHaveBeenCalled();
+  });
+
+  it("호출자가 매 렌더 새 배열을 넘겨도 같은 목록이면 다시 조회하지 않는다", async () => {
+    const { rerender } = render(<BoardDiffStatsProbe taskIds={["task-1"]} isEnabled />);
+
+    await waitFor(() => {
+      expect(mocks.getTaskDiffStats).toHaveBeenCalledTimes(1);
+    });
+    rerender(<BoardDiffStatsProbe taskIds={["task-1"]} isEnabled />);
+
+    expect(mocks.getTaskDiffStats).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/desktop/renderer/hooks/__tests__/useTaskDiffStats.test.tsx
+++ b/src/desktop/renderer/hooks/__tests__/useTaskDiffStats.test.tsx
@@ -32,7 +32,7 @@ describe("useBoardTaskDiffStats", () => {
     vi.restoreAllMocks();
   });
 
-  it("보드에 떠 있는 태스크들을 한 번의 조회로 읽는다", async () => {
+  it("다시 돌릴 태스크 목록을 한 번의 조회로 넘긴다", async () => {
     render(<BoardDiffStatsProbe taskIds={["task-1", "task-2"]} isEnabled />);
 
     await waitFor(() => {
@@ -69,10 +69,13 @@ describe("useBoardTaskDiffStats", () => {
     expect(mocks.getTaskDiffStats).not.toHaveBeenCalled();
   });
 
-  it("조회할 태스크가 없으면 조회하지 않는다", () => {
+  it("다시 돌릴 태스크가 없어도 저장된 집계를 받아 온다", async () => {
     render(<BoardDiffStatsProbe taskIds={[]} isEnabled />);
 
-    expect(mocks.getTaskDiffStats).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mocks.getTaskDiffStats).toHaveBeenCalledWith([]);
+    });
+    expect(screen.getByTestId("additions").textContent).toBe("340");
   });
 
   it("호출자가 매 렌더 새 배열을 넘겨도 같은 목록이면 다시 조회하지 않는다", async () => {

--- a/src/desktop/renderer/hooks/useLiveAiSessions.ts
+++ b/src/desktop/renderer/hooks/useLiveAiSessions.ts
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import {
   getRunningAgentPanes,
   getTaskAgentCallGraph,
   getTaskLiveAiSessions,
 } from "@/desktop/renderer/actions/project";
-import { useIsWindowActive } from "@/desktop/renderer/hooks/useIsWindowActive";
+import { usePolledValue } from "@/desktop/renderer/hooks/usePolledValue";
 import type { AgentCallGraph, LiveAiSession, RunningAgentPane } from "@/lib/aiSessions/types";
 
 /** 세션 패널은 서브태스크가 뜨고 지는 것을 눈으로 따라갈 수 있어야 해서 짧게 돈다 */
@@ -12,69 +12,6 @@ const LIVE_SESSION_POLL_INTERVAL_MS = 2_000;
 
 /** 보드 배지는 provider가 붙었는지만 보여주므로 더 느리게 돌아도 된다 */
 const RUNNING_PANE_POLL_INTERVAL_MS = 5_000;
-
-/**
- * 조회 결과를 주기적으로 새로 읽는다.
- * 앞선 조회가 아직 안 끝났으면 건너뛰어, 원격처럼 느린 호출에서 요청이 쌓이지 않게 한다.
- *
- * 창이 가려져 있으면 주기 조회는 멈추되 첫 조회는 한 번 한다.
- * 그래야 창이 다시 앞으로 나왔을 때 빈 화면부터 보여주지 않는다.
- */
-function usePolledValue<T>(
-  read: () => Promise<T>,
-  emptyValue: T,
-  intervalMs: number,
-  isEnabled: boolean,
-): T {
-  const [value, setValue] = useState<T>(emptyValue);
-  const isWindowActive = useIsWindowActive();
-
-  useEffect(() => {
-    if (!isEnabled) {
-      return;
-    }
-
-    let isCancelled = false;
-    let isReading = false;
-
-    const readOnce = async () => {
-      if (isReading) {
-        return;
-      }
-
-      isReading = true;
-      try {
-        const nextValue = await read();
-        if (!isCancelled) {
-          setValue(nextValue);
-        }
-      } catch {
-        // 폴링 실패는 다음 주기에 다시 시도한다. 화면을 오류로 덮지 않는다.
-      } finally {
-        isReading = false;
-      }
-    };
-
-    void readOnce();
-
-    if (!isWindowActive) {
-      return () => {
-        isCancelled = true;
-      };
-    }
-
-    const pollIntervalId = window.setInterval(() => {
-      void readOnce();
-    }, intervalMs);
-
-    return () => {
-      isCancelled = true;
-      window.clearInterval(pollIntervalId);
-    };
-  }, [intervalMs, isEnabled, isWindowActive, read]);
-
-  return value;
-}
 
 const EMPTY_SESSIONS: LiveAiSession[] = [];
 const EMPTY_PANES: RunningAgentPane[] = [];

--- a/src/desktop/renderer/hooks/usePolledValue.ts
+++ b/src/desktop/renderer/hooks/usePolledValue.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { useIsWindowActive } from "@/desktop/renderer/hooks/useIsWindowActive";
+
+/**
+ * 조회 결과를 주기적으로 새로 읽는다.
+ * 앞선 조회가 아직 안 끝났으면 건너뛰어, 원격처럼 느린 호출에서 요청이 쌓이지 않게 한다.
+ *
+ * 창이 가려져 있으면 주기 조회는 멈추되 첫 조회는 한 번 한다.
+ * 그래야 창이 다시 앞으로 나왔을 때 빈 화면부터 보여주지 않는다.
+ */
+export function usePolledValue<T>(
+  read: () => Promise<T>,
+  emptyValue: T,
+  intervalMs: number,
+  isEnabled: boolean,
+): T {
+  const [value, setValue] = useState<T>(emptyValue);
+  const isWindowActive = useIsWindowActive();
+
+  useEffect(() => {
+    if (!isEnabled) {
+      return;
+    }
+
+    let isCancelled = false;
+    let isReading = false;
+
+    const readOnce = async () => {
+      if (isReading) {
+        return;
+      }
+
+      isReading = true;
+      try {
+        const nextValue = await read();
+        if (!isCancelled) {
+          setValue(nextValue);
+        }
+      } catch {
+        // 폴링 실패는 다음 주기에 다시 시도한다. 화면을 오류로 덮지 않는다.
+      } finally {
+        isReading = false;
+      }
+    };
+
+    void readOnce();
+
+    if (!isWindowActive) {
+      return () => {
+        isCancelled = true;
+      };
+    }
+
+    const pollIntervalId = window.setInterval(() => {
+      void readOnce();
+    }, intervalMs);
+
+    return () => {
+      isCancelled = true;
+      window.clearInterval(pollIntervalId);
+    };
+  }, [intervalMs, isEnabled, isWindowActive, read]);
+
+  return value;
+}

--- a/src/desktop/renderer/hooks/useTaskDiffStats.ts
+++ b/src/desktop/renderer/hooks/useTaskDiffStats.ts
@@ -13,26 +13,23 @@ const EMPTY_STATS_BY_TASK_ID: Record<string, TaskDiffStats> = {};
 const EMPTY_DIFF_FILES: DiffFile[] = [];
 
 /**
- * 보드에 떠 있는 태스크들의 변경 집계를 한 번의 조회로 받아 온다.
+ * 보드 카드에 그릴 변경 집계를 한 번의 조회로 받아 온다.
+ * `taskIdsToRefresh`에 넘긴 태스크만 git을 다시 돌리고, 나머지 카드 몫은 저장돼 있던 집계로 채워져 온다.
  *
  * 호출자가 매 렌더 새 배열을 만들어도 조회가 다시 돌지 않도록, 목록 자체가 아니라 목록의 내용으로 조회를 묶는다.
+ * 다시 돌릴 태스크가 하나도 없어도 조회는 계속한다. 저장된 집계는 다른 창이 갱신할 수 있다.
  */
 export function useBoardTaskDiffStats(
-  taskIds: string[],
+  taskIdsToRefresh: string[],
   isEnabled: boolean,
 ): Record<string, TaskDiffStats> {
-  const taskIdsKey = taskIds.join(",");
+  const taskIdsKey = taskIdsToRefresh.join(",");
   const read = useCallback(
-    () => (taskIdsKey ? getTaskDiffStats(taskIdsKey.split(",")) : Promise.resolve(EMPTY_STATS_BY_TASK_ID)),
+    () => getTaskDiffStats(taskIdsKey ? taskIdsKey.split(",") : []),
     [taskIdsKey],
   );
 
-  return usePolledValue(
-    read,
-    EMPTY_STATS_BY_TASK_ID,
-    BOARD_DIFF_STATS_POLL_INTERVAL_MS,
-    isEnabled && taskIdsKey.length > 0,
-  );
+  return usePolledValue(read, EMPTY_STATS_BY_TASK_ID, BOARD_DIFF_STATS_POLL_INTERVAL_MS, isEnabled);
 }
 
 /** 태스크 하나의 변경 파일 목록. 목록을 보여주는 패널이 열려 있는 동안에만 폴링한다 */

--- a/src/desktop/renderer/hooks/useTaskDiffStats.ts
+++ b/src/desktop/renderer/hooks/useTaskDiffStats.ts
@@ -1,0 +1,51 @@
+import { useCallback } from "react";
+import { getGitDiffFiles, getTaskDiffStats, type DiffFile } from "@/desktop/renderer/actions/diff";
+import { usePolledValue } from "@/desktop/renderer/hooks/usePolledValue";
+import type { TaskDiffStats } from "@/desktop/shared/taskDiffStats";
+
+/** 보드는 카드마다 git을 돌려야 해서, 변경을 눈으로 따라갈 수 있는 선에서 가장 느리게 잡는다 */
+const BOARD_DIFF_STATS_POLL_INTERVAL_MS = 5_000;
+
+/** 상세는 한 태스크만 보므로 보드보다 촘촘히 읽어 저장 직후의 변화를 바로 보여준다 */
+const TASK_DIFF_FILES_POLL_INTERVAL_MS = 3_000;
+
+const EMPTY_STATS_BY_TASK_ID: Record<string, TaskDiffStats> = {};
+const EMPTY_DIFF_FILES: DiffFile[] = [];
+
+/**
+ * 보드에 떠 있는 태스크들의 변경 집계를 한 번의 조회로 받아 온다.
+ *
+ * 호출자가 매 렌더 새 배열을 만들어도 조회가 다시 돌지 않도록, 목록 자체가 아니라 목록의 내용으로 조회를 묶는다.
+ */
+export function useBoardTaskDiffStats(
+  taskIds: string[],
+  isEnabled: boolean,
+): Record<string, TaskDiffStats> {
+  const taskIdsKey = taskIds.join(",");
+  const read = useCallback(
+    () => (taskIdsKey ? getTaskDiffStats(taskIdsKey.split(",")) : Promise.resolve(EMPTY_STATS_BY_TASK_ID)),
+    [taskIdsKey],
+  );
+
+  return usePolledValue(
+    read,
+    EMPTY_STATS_BY_TASK_ID,
+    BOARD_DIFF_STATS_POLL_INTERVAL_MS,
+    isEnabled && taskIdsKey.length > 0,
+  );
+}
+
+/** 태스크 하나의 변경 파일 목록. 목록을 보여주는 패널이 열려 있는 동안에만 폴링한다 */
+export function useTaskDiffFiles(taskId: string | null, isEnabled: boolean): DiffFile[] {
+  const read = useCallback(
+    () => (taskId ? getGitDiffFiles(taskId) : Promise.resolve(EMPTY_DIFF_FILES)),
+    [taskId],
+  );
+
+  return usePolledValue(
+    read,
+    EMPTY_DIFF_FILES,
+    TASK_DIFF_FILES_POLL_INTERVAL_MS,
+    isEnabled && Boolean(taskId),
+  );
+}

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -20,7 +20,6 @@ import TaskDetailInfoCard from "@/components/TaskDetailInfoCard";
 import TaskDetailTitleCard from "@/components/TaskDetailTitleCard";
 import { Link, useRouter } from "@/desktop/renderer/navigation";
 import { getDefaultSessionType, getDoneAlertDismissed, getSidebarDefaultCollapsed } from "@/desktop/renderer/actions/appSettings";
-import { getGitDiffFiles } from "@/desktop/renderer/actions/diff";
 import { deleteTask, getTaskById, getTaskIdByProjectAndBranch, updateTaskStatus } from "@/desktop/renderer/actions/kanban";
 import {
   getTaskAiSessions,
@@ -44,6 +43,7 @@ import TerminalLoader from "@/desktop/renderer/components/TerminalLoader";
 import TerminalTabBar from "@/desktop/renderer/components/TerminalTabBar";
 import { useMarkTaskNotificationsReadWhenFocused } from "@/desktop/renderer/hooks/useMarkTaskNotificationsReadWhenFocused";
 import { useTaskAgentCallGraph, useTaskLiveAiSessions } from "@/desktop/renderer/hooks/useLiveAiSessions";
+import { useTaskDiffFiles } from "@/desktop/renderer/hooks/useTaskDiffStats";
 import { useTerminalTabs } from "@/desktop/renderer/hooks/useTerminalTabs";
 import type { TerminalTabShortcutCommand } from "@/desktop/shared/terminalTabs";
 import { fetchPrUrlWithPrompt } from "@/desktop/renderer/utils/fetchPrUrlWithPrompt";
@@ -156,7 +156,6 @@ function AntennaSignalIcon({ testId }: { testId?: string }) {
 interface TaskDetailState {
   task: NonNullable<Awaited<ReturnType<typeof getTaskById>>>;
   baseBranchTaskId: string | null;
-  diffFiles: Awaited<ReturnType<typeof getGitDiffFiles>>;
   claudeHooksStatus: Awaited<ReturnType<typeof getTaskHooksStatus>>;
   geminiHooksStatus: Awaited<ReturnType<typeof getTaskGeminiHooksStatus>>;
   codexHooksStatus: Awaited<ReturnType<typeof getTaskCodexHooksStatus>>;
@@ -178,7 +177,6 @@ interface NormalizedTaskDetailRouteCache {
 
 const DEFAULT_DETAIL_STATE: Omit<TaskDetailState, "task"> = {
   baseBranchTaskId: null,
-  diffFiles: [],
   claudeHooksStatus: null,
   geminiHooksStatus: null,
   codexHooksStatus: null,
@@ -212,11 +210,13 @@ function normalizeCachedTaskDetailRouteCache(cachedRoute: TaskDetailRouteCache |
   const routeState = { ...cachedRoute } as TaskDetailRouteCache & {
     sidebarHintDismissed?: boolean;
     aiSessions?: unknown;
+    diffFiles?: unknown;
   };
   const defaultPanelDismissed = routeState.defaultPanelDismissed === true;
   delete routeState.sidebarHintDismissed;
   delete routeState.defaultPanelDismissed;
   delete routeState.aiSessions;
+  delete routeState.diffFiles;
   return {
     state: {
       ...DEFAULT_DETAIL_STATE,
@@ -893,6 +893,10 @@ export default function TaskDetailRoute() {
 
   const liveSessions = useTaskLiveAiSessions(id ?? null, visiblePanel === "liveSessions");
 
+  /** 변경 파일은 작업 정보를 열어 둔 동안에만 읽는다. 조회 한 번이 worktree에서 git을 돌리는 값이라 닫힌 패널을 위해 돌릴 이유가 없다 */
+  const hasWorktreeBranch = Boolean(state?.task.branchName && state?.task.worktreePath);
+  const diffFiles = useTaskDiffFiles(hasWorktreeBranch ? (id ?? null) : null, visiblePanel === "overview");
+
   /** 호출 그래프를 펼쳐 둔 세션. 목록과 그래프는 같은 dock 자리를 번갈아 쓴다 */
   const [graphSession, setGraphSession] = useState<LiveAiSession | null>(null);
   const agentCallGraph = useTaskAgentCallGraph(id ?? null, graphSession);
@@ -1389,9 +1393,8 @@ export default function TaskDetailRoute() {
         void (async () => {
           try {
             const baseBranchName = task.baseBranch ?? "main";
-            const [foundTaskId, diffFiles, projects, defaultSessionType, doneAlertDismissed] = await Promise.all([
+            const [foundTaskId, projects, defaultSessionType, doneAlertDismissed] = await Promise.all([
               task.projectId ? getTaskIdByProjectAndBranch(task.projectId, baseBranchName) : Promise.resolve(null),
-              task.branchName && task.worktreePath ? getGitDiffFiles(id) : Promise.resolve([]),
               getAllProjects(),
               getDefaultSessionType(),
               getDoneAlertDismissed(),
@@ -1400,7 +1403,6 @@ export default function TaskDetailRoute() {
 
             applySupplementalState({
               baseBranchTaskId,
-              diffFiles,
               projects,
               defaultSessionType,
               doneAlertDismissed,
@@ -1625,7 +1627,7 @@ export default function TaskDetailRoute() {
                 task={state.task}
                 agentTagStyle={agentTagStyle}
                 baseBranchTaskId={state.baseBranchTaskId}
-                diffFileCount={state.diffFiles.length}
+                diffFiles={diffFiles}
               />
             </div>
           ) : null}

--- a/src/desktop/shared/__tests__/taskDiffStats.test.ts
+++ b/src/desktop/shared/__tests__/taskDiffStats.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { summarizeDiffFiles } from "@/desktop/shared/taskDiffStats";
+import type { DiffFile } from "@/desktop/main/services/diffService";
+
+function createDiffFile(overrides: Partial<DiffFile> = {}): DiffFile {
+  return {
+    path: "src/app.ts",
+    status: "modified",
+    additions: 0,
+    deletions: 0,
+    ...overrides,
+  };
+}
+
+describe("summarizeDiffFiles", () => {
+  it("파일 수와 추가·삭제 줄 수를 합산한다", () => {
+    const files = [
+      createDiffFile({ path: "src/a.ts", additions: 12, deletions: 3 }),
+      createDiffFile({ path: "src/b.ts", status: "added", additions: 88, deletions: 0 }),
+      createDiffFile({ path: "scripts/old.cjs", status: "deleted", additions: 0, deletions: 41 }),
+    ];
+
+    expect(summarizeDiffFiles(files)).toEqual({
+      fileCount: 3,
+      additions: 100,
+      deletions: 44,
+    });
+  });
+
+  it("변경이 없으면 모든 값이 0이다", () => {
+    expect(summarizeDiffFiles([])).toEqual({
+      fileCount: 0,
+      additions: 0,
+      deletions: 0,
+    });
+  });
+
+  it("줄 수를 세지 못한 파일도 파일 수에는 포함한다", () => {
+    const files = [createDiffFile({ path: "assets/logo.png", status: "added" })];
+
+    expect(summarizeDiffFiles(files)).toEqual({
+      fileCount: 1,
+      additions: 0,
+      deletions: 0,
+    });
+  });
+});

--- a/src/desktop/shared/taskDiffStats.ts
+++ b/src/desktop/shared/taskDiffStats.ts
@@ -1,0 +1,30 @@
+import type { DiffFile } from "@/desktop/main/services/diffService";
+
+export interface TaskDiffStats {
+  fileCount: number;
+  additions: number;
+  deletions: number;
+}
+
+export const EMPTY_TASK_DIFF_STATS: TaskDiffStats = {
+  fileCount: 0,
+  additions: 0,
+  deletions: 0,
+};
+
+/**
+ * 변경 파일 목록을 카드와 패널이 함께 쓰는 집계로 접는다.
+ *
+ * 보드는 카드가 많아 main이 접어 둔 값만 받고, 태스크 상세는 목록 자체를 이미 들고 있어 직접 접는다.
+ * 두 화면이 같은 숫자를 보여야 해서 셈은 양쪽이 공유하는 이 자리에 둔다.
+ */
+export function summarizeDiffFiles(files: DiffFile[]): TaskDiffStats {
+  return files.reduce<TaskDiffStats>(
+    (stats, file) => ({
+      fileCount: stats.fileCount + 1,
+      additions: stats.additions + file.additions,
+      deletions: stats.deletions + file.deletions,
+    }),
+    EMPTY_TASK_DIFF_STATS,
+  );
+}

--- a/src/entities/TaskDiffStats.ts
+++ b/src/entities/TaskDiffStats.ts
@@ -1,0 +1,32 @@
+import "reflect-metadata";
+import { Entity, Column, PrimaryColumn, UpdateDateColumn, ManyToOne, JoinColumn } from "typeorm";
+import { KanbanTask } from "./KanbanTask";
+
+/**
+ * 태스크의 마지막 변경 집계를 보관한다.
+ *
+ * 보드는 진행 중인 태스크만 git을 다시 돌리고 나머지 칸은 여기 저장된 값을 보여준다.
+ * 태스크 행이 아니라 별도 테이블에 두는 이유는 두 가지다. 집계는 태스크가 바뀌지 않아도 갱신되는 파생값이고,
+ * 태스크 행에 쓰면 `updatedAt`이 밀려 그 값으로 정렬하는 보드가 매 갱신마다 카드를 재배열한다.
+ */
+@Entity("task_diff_stats")
+export class TaskDiffStatsRecord {
+  @PrimaryColumn({ name: "task_id", type: "varchar", length: 36 })
+  taskId!: string;
+
+  @ManyToOne(() => KanbanTask, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "task_id" })
+  task!: KanbanTask;
+
+  @Column({ name: "file_count", type: "integer" })
+  fileCount!: number;
+
+  @Column({ type: "integer" })
+  additions!: number;
+
+  @Column({ type: "integer" })
+  deletions!: number;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt!: Date;
+}

--- a/src/lib/__tests__/databaseMigrations.test.ts
+++ b/src/lib/__tests__/databaseMigrations.test.ts
@@ -195,7 +195,7 @@ describe("database migrations", () => {
         { id: "task-1", branch_name: "main" },
         { id: "task-2", branch_name: "main" },
       ]);
-      expect(migrations).toHaveLength(16);
+      expect(migrations).toHaveLength(17);
       expect(migrations[0]).toEqual({ name: "InitialSchema1770854400000" });
     } finally {
       await dataSource.destroy();
@@ -234,7 +234,7 @@ describe("database migrations", () => {
           priority: null,
         },
       ]);
-      expect(migrations).toHaveLength(16);
+      expect(migrations).toHaveLength(17);
     } finally {
       await dataSource.destroy();
     }
@@ -259,12 +259,12 @@ describe("database migrations", () => {
       const migrations = await dataSource.query(`SELECT name FROM migrations ORDER BY timestamp`);
 
       expect(tables.map((row: { name: string }) => row.name)).toEqual(
-        expect.arrayContaining(["app_settings", "kanban_tasks", "migrations", "pane_layout_configs", "projects"]),
+        expect.arrayContaining(["app_settings", "kanban_tasks", "migrations", "pane_layout_configs", "projects", "task_diff_stats"]),
       );
       expect(indexes.map((row: { name: string }) => row.name)).not.toContain(
         "UQ_kanban_tasks_branch_name",
       );
-      expect(migrations).toHaveLength(16);
+      expect(migrations).toHaveLength(17);
 
       await dataSource.query(`
         INSERT INTO projects (id, name, repo_path, ssh_host)

--- a/src/lib/__tests__/terminalClipboard.test.ts
+++ b/src/lib/__tests__/terminalClipboard.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { installOsc52ClipboardHandler, readOsc52ClipboardText } from "@/lib/terminalClipboard";
 
+/** navigator를 클립보드 스텁으로 갈아끼우는 테스트가 있어, 실제 xterm.js를 쓰는 테스트를 위해 원본을 잡아 둔다 */
+const jsdomNavigator = globalThis.navigator;
+
 function encodeBase64Utf8(value: string): string {
   const bytes = new TextEncoder().encode(value);
   return btoa(String.fromCharCode(...bytes));
@@ -88,13 +91,18 @@ describe("readOsc52ClipboardText", () => {
 describe("installOsc52ClipboardHandler", () => {
   const writeText = vi.fn();
 
+  const writeSystemClipboard = vi.fn();
+
   beforeEach(() => {
     writeText.mockReset();
     writeText.mockResolvedValue(undefined);
+    writeSystemClipboard.mockReset();
+    writeSystemClipboard.mockResolvedValue(undefined);
     Object.defineProperty(globalThis, "navigator", {
       value: { clipboard: { writeText } },
       configurable: true,
     });
+    delete window.kanvibeDesktop;
   });
 
   function createTerminalStub() {
@@ -160,6 +168,40 @@ describe("installOsc52ClipboardHandler", () => {
     warn.mockRestore();
   });
 
+  it("should copy through the desktop bridge, which is not bound to renderer document focus", async () => {
+    // Given
+    window.kanvibeDesktop = { writeSystemClipboard } as unknown as Window["kanvibeDesktop"];
+    const stub = createTerminalStub();
+    installOsc52ClipboardHandler(stub.terminal as never);
+
+    // When
+    stub.invoke(`c;${encodeBase64Utf8("데스크톱 복사")}`);
+    await Promise.resolve();
+
+    // Then
+    expect(writeSystemClipboard).toHaveBeenCalledWith("데스크톱 복사");
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("should keep the terminal usable when the desktop bridge write is rejected", async () => {
+    // Given
+    window.kanvibeDesktop = { writeSystemClipboard } as unknown as Window["kanvibeDesktop"];
+    writeSystemClipboard.mockRejectedValue(new Error("bridge unavailable"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stub = createTerminalStub();
+    installOsc52ClipboardHandler(stub.terminal as never);
+
+    // When
+    const handled = stub.invoke(`c;${encodeBase64Utf8("kanvibe")}`);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Then
+    expect(handled).toBe(true);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("should return a disposable that unregisters the handler", () => {
     // Given
     const stub = createTerminalStub();
@@ -169,5 +211,56 @@ describe("installOsc52ClipboardHandler", () => {
 
     // Then
     expect(stub.dispose).toHaveBeenCalled();
+  });
+});
+
+/**
+ * 위 describe는 parser를 스텁으로 대신해 xterm.js가 실제로 OSC 52를 넘겨주는지는 확인하지 못한다.
+ * 실제 터미널이 받는 바이트열을 그대로 흘려 보내, 시퀀스 해석부터 복사까지가 끊기지 않는지 확인한다.
+ */
+describe("OSC 52 over a real xterm.js terminal", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "navigator", {
+      value: jsdomNavigator,
+      configurable: true,
+    });
+  });
+
+  const ESCAPE = String.fromCharCode(27);
+  const BELL = String.fromCharCode(7);
+  const STRING_TERMINATOR = `${ESCAPE}\\`;
+
+  async function writeToRealTerminal(terminalOutput: string): Promise<ReturnType<typeof vi.fn>> {
+    const writeSystemClipboard = vi.fn().mockResolvedValue(undefined);
+    window.kanvibeDesktop = { writeSystemClipboard } as unknown as Window["kanvibeDesktop"];
+
+    const { Terminal } = await import("@xterm/xterm");
+    const terminal = new Terminal();
+    installOsc52ClipboardHandler(terminal);
+    await new Promise<void>((resolve) => terminal.write(terminalOutput, resolve));
+
+    return writeSystemClipboard;
+  }
+
+  it("should copy a bell-terminated sequence, which is what a plain printf sends", async () => {
+    // Given
+    const terminalOutput = `${ESCAPE}]52;c;${encodeBase64Utf8("OSC52-OK")}${BELL}`;
+
+    // When
+    const writeSystemClipboard = await writeToRealTerminal(terminalOutput);
+
+    // Then
+    expect(writeSystemClipboard).toHaveBeenCalledWith("OSC52-OK");
+  });
+
+  it("should copy a string-terminated sequence, which is what tmux forwards", async () => {
+    // Given
+    const terminalOutput = `${ESCAPE}]52;c;${encodeBase64Utf8("tmux 복사")}${STRING_TERMINATOR}`;
+
+    // When
+    const writeSystemClipboard = await writeToRealTerminal(terminalOutput);
+
+    // Then
+    expect(writeSystemClipboard).toHaveBeenCalledWith("tmux 복사");
   });
 });

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -5,6 +5,7 @@ import { KanbanTask } from "@/entities/KanbanTask";
 import { Project } from "@/entities/Project";
 import { PaneLayoutConfig } from "@/entities/PaneLayoutConfig";
 import { AppSettings } from "@/entities/AppSettings";
+import { TaskDiffStatsRecord } from "@/entities/TaskDiffStats";
 import { ensureRuntimeDatabaseFile, getRuntimeDatabasePath } from "@/lib/databasePaths";
 import { ensureSqliteDatabaseReady } from "@/lib/sqliteSchema";
 import { InitialSchema1770854400000 } from "@/migrations/1770854400000-InitialSchema";
@@ -23,6 +24,7 @@ import { AddIconDataUrlToProjects1771500000000 } from "@/migrations/177150000000
 import { RescopeProjectNamesPerHost1771600000000 } from "@/migrations/1771600000000-RescopeProjectNamesPerHost";
 import { AddTerminalSessionType1771700000000 } from "@/migrations/1771700000000-AddTerminalSessionType";
 import { DropDisplayOrderFromKanbanTasks1771800000000 } from "@/migrations/1771800000000-DropDisplayOrderFromKanbanTasks";
+import { AddTaskDiffStats1771900000000 } from "@/migrations/1771900000000-AddTaskDiffStats";
 
 /** TypeORM DataSource 싱글턴. Vite HMR 시 재연결을 방지하기 위해 globalThis에 캐싱한다. */
 const globalForDb = globalThis as unknown as {
@@ -46,6 +48,7 @@ const MIGRATIONS = [
   RescopeProjectNamesPerHost1771600000000,
   AddTerminalSessionType1771700000000,
   DropDisplayOrderFromKanbanTasks1771800000000,
+  AddTaskDiffStats1771900000000,
 ];
 
 interface MigrationRecord {
@@ -140,7 +143,7 @@ function createDataSource(): DataSource {
   return new DataSource({
     type: "better-sqlite3",
     database: databasePath,
-    entities: [KanbanTask, Project, PaneLayoutConfig, AppSettings],
+    entities: [KanbanTask, Project, PaneLayoutConfig, AppSettings, TaskDiffStatsRecord],
     migrations: MIGRATIONS,
     synchronize: false,
     logging: shouldLogSql,
@@ -204,4 +207,9 @@ export async function getPaneLayoutConfigRepository(): Promise<Repository<PaneLa
 export async function getAppSettingsRepository(): Promise<Repository<AppSettings>> {
   const ds = await getDataSource();
   return getRepositoryByTable<AppSettings>(ds, "app_settings");
+}
+
+export async function getTaskDiffStatsRepository(): Promise<Repository<TaskDiffStatsRecord>> {
+  const ds = await getDataSource();
+  return getRepositoryByTable<TaskDiffStatsRecord>(ds, "task_diff_stats");
 }

--- a/src/lib/terminalClipboard.ts
+++ b/src/lib/terminalClipboard.ts
@@ -63,6 +63,15 @@ function decodeBase64Utf8(encodedText: string): string | null {
 }
 
 /**
+ * 데스크톱 렌더러에만 주입되는 클립보드 브리지.
+ * 이 모듈은 `src/lib` 아래라 Electron 메인 프로세스 빌드에도 함께 컴파일되는데, 그 빌드는 렌더러 전역 선언을
+ * 포함하지 않는다. 그래서 렌더러의 `Window` 타입에 기대지 않고 실제로 쓰는 기능만 좁게 선언한다.
+ */
+interface DesktopClipboardBridge {
+  writeSystemClipboard?: (clipboardText: string) => Promise<void>;
+}
+
+/**
  * 복사 요청을 시스템 클립보드에 반영한다.
  * 데스크톱에서는 Electron 메인 프로세스를 거친다. 렌더러의 `navigator.clipboard`는 문서 포커스를 요구하고,
  * 포커스가 있어도 성공을 반환한 채 클립보드를 그대로 두는 경우가 있어 터미널 출력이 촉발하는 복사를 놓친다.
@@ -70,7 +79,8 @@ function decodeBase64Utf8(encodedText: string): string | null {
  */
 async function writeSystemClipboard(clipboardText: string): Promise<void> {
   try {
-    const writeDesktopClipboard = window.kanvibeDesktop?.writeSystemClipboard;
+    const { kanvibeDesktop } = globalThis as { kanvibeDesktop?: DesktopClipboardBridge };
+    const writeDesktopClipboard = kanvibeDesktop?.writeSystemClipboard;
     if (writeDesktopClipboard) {
       await writeDesktopClipboard(clipboardText);
       return;

--- a/src/lib/terminalClipboard.ts
+++ b/src/lib/terminalClipboard.ts
@@ -62,8 +62,20 @@ function decodeBase64Utf8(encodedText: string): string | null {
   }
 }
 
+/**
+ * 복사 요청을 시스템 클립보드에 반영한다.
+ * 데스크톱에서는 Electron 메인 프로세스를 거친다. 렌더러의 `navigator.clipboard`는 문서 포커스를 요구하고,
+ * 포커스가 있어도 성공을 반환한 채 클립보드를 그대로 두는 경우가 있어 터미널 출력이 촉발하는 복사를 놓친다.
+ * 데스크톱 브리지가 없는 웹 터미널에서는 렌더러 클립보드 API가 유일한 경로다.
+ */
 async function writeSystemClipboard(clipboardText: string): Promise<void> {
   try {
+    const writeDesktopClipboard = window.kanvibeDesktop?.writeSystemClipboard;
+    if (writeDesktopClipboard) {
+      await writeDesktopClipboard(clipboardText);
+      return;
+    }
+
     await navigator.clipboard.writeText(clipboardText);
   } catch (error) {
     console.warn("터미널 클립보드 복사 실패:", error);

--- a/src/migrations/1771900000000-AddTaskDiffStats.ts
+++ b/src/migrations/1771900000000-AddTaskDiffStats.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * task_diff_stats 테이블을 생성한다.
+ * 태스크가 지워지면 그 집계도 함께 사라져야 하므로 FK를 CASCADE로 건다.
+ */
+export class AddTaskDiffStats1771900000000 implements MigrationInterface {
+  name = "AddTaskDiffStats1771900000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "task_diff_stats" (
+        "task_id" TEXT PRIMARY KEY NOT NULL,
+        "file_count" INTEGER NOT NULL DEFAULT 0,
+        "additions" INTEGER NOT NULL DEFAULT 0,
+        "deletions" INTEGER NOT NULL DEFAULT 0,
+        "updated_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY ("task_id") REFERENCES "kanban_tasks"("id") ON DELETE CASCADE
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "task_diff_stats"`);
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -539,6 +539,39 @@ textarea {
 }
 
 /**
+ * 스스로 갱신되는 숫자가 굴러가는 동안 옅은 배경을 깔아, 어느 값이 방금 움직였는지 눈이 따라가게 한다.
+ * 굴러가기가 끝나면 배경만 천천히 빠져 잔광처럼 남는다.
+ */
+.kv-count-up {
+  border-radius: 3px;
+  padding: 0 1px;
+  background-color: transparent;
+  transition: background-color 600ms ease-out;
+}
+
+.kv-count-up[data-counting] {
+  background-color: color-mix(in srgb, var(--color-brand-primary) 22%, transparent);
+  transition-duration: 120ms;
+}
+
+/** 추가와 삭제의 비율 막대. 폴링으로 값이 바뀔 때 폭이 튀지 않고 이어지게 한다 */
+.kv-diff-ratio-fill {
+  transition: width 480ms ease-out;
+}
+
+/** 움직임을 줄이도록 설정한 사용자에게는 잔광과 폭 전환 없이 결과값만 남긴다 */
+@media (prefers-reduced-motion: reduce) {
+  .kv-count-up,
+  .kv-diff-ratio-fill {
+    transition: none;
+  }
+
+  .kv-count-up[data-counting] {
+    background-color: transparent;
+  }
+}
+
+/**
  * 세션 행 왼쪽의 provider 색띠.
  * 아이콘 하나만으로는 목록을 훑을 때 소속이 눈에 안 잡혀서, 행 전체 높이를 쓰는 띠를 따로 둔다.
  */


### PR DESCRIPTION
Promote the pinned 1.2.4 release branch to main after the published DMG release and Homebrew cask update.

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.2.4
- SHA-256: `0e5b75108ec8bdd40c5547b2a62c3c95c6ea210407c113c0e1b6818cc94f7028`
- Homebrew cask: rookedsysc/homebrew-kanvibe@04d1ec9 (`brew fetch` → `✔︎ Cask kanvibe (1.2.4)`)
- Release PR into dev: #376