### PR TITLE
modify(task-card): 보드 카드 배지를 여러 줄로 흘려 잘리지 않게 한다

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -397,7 +397,7 @@ export default function TaskCard({
             </div>
           </div>
 
-          <div className="mt-1.5 flex items-center gap-1.5 overflow-hidden">
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5" data-testid="task-card-badges">
             {task.prUrl && (
               <span
                 role="link"
@@ -439,7 +439,7 @@ export default function TaskCard({
             />
 
             {task.sshHost && (
-              <span className={`${badgeClassName} min-w-0 truncate bg-tag-ssh-bg text-tag-ssh-text`}>
+              <span className={`${badgeClassName} break-all bg-tag-ssh-bg text-tag-ssh-text`}>
                 {task.sshHost}
               </span>
             )}

--- a/src/components/__tests__/TaskCard.test.tsx
+++ b/src/components/__tests__/TaskCard.test.tsx
@@ -146,6 +146,69 @@ describe("TaskCard - Priority Badge", () => {
     expect(badge.className).toContain("ml-auto");
   });
 
+  describe("배지 줄바꿈", () => {
+    const crowdedTask = createTask({
+      prUrl: "https://github.com/org/repo/pull/1",
+      agentType: "claude",
+      sessionType: SessionType.TMUX,
+      sshHost: "very-long-remote-development-host.example.com",
+      worktreePath: "/repo/task",
+      priority: TaskPriority.HIGH,
+    });
+    const runningPane = {
+      provider: "claude" as const,
+      worktreePath: "/repo/task",
+      sessionName: "kanvibe-task",
+      windowId: "@7",
+      windowName: "claude",
+    };
+
+    it("배지 행이 넘치는 배지를 잘라내지 않고 다음 줄로 흘린다", () => {
+      // Given
+      // When
+      render(<TaskCard task={crowdedTask} index={0} onContextMenu={onContextMenu} />);
+
+      // Then
+      const badgeRow = screen.getByTestId("task-card-badges");
+      expect(badgeRow.className).toContain("flex-wrap");
+      expect(badgeRow.className).not.toContain("overflow-hidden");
+    });
+
+    it("배지가 많아도 어느 하나 생략하지 않고 모두 그린다", () => {
+      // Given
+      // When
+      render(
+        <TaskCard
+          task={crowdedTask}
+          index={0}
+          onContextMenu={onContextMenu}
+          diffStats={{ fileCount: 3, additions: 12, deletions: 4 }}
+          runningAgentPanes={[runningPane]}
+        />,
+      );
+
+      // Then
+      expect(screen.getByText("PR")).toBeTruthy();
+      expect(screen.getByText("claude")).toBeTruthy();
+      expect(screen.getByText("tmux")).toBeTruthy();
+      expect(screen.getByTestId("task-card-diff-stats")).toBeTruthy();
+      expect(screen.getByTestId("task-card-running-agents")).toBeTruthy();
+      expect(screen.getByText("very-long-remote-development-host.example.com")).toBeTruthy();
+      expect(screen.getByTestId("task-priority-badge").textContent).toBe("P1");
+    });
+
+    it("긴 remote 호스트는 말줄임 대신 배지 안에서 줄바꿈해 전체를 보여준다", () => {
+      // Given
+      // When
+      render(<TaskCard task={crowdedTask} index={0} onContextMenu={onContextMenu} />);
+
+      // Then
+      const remoteBadge = screen.getByText("very-long-remote-development-host.example.com");
+      expect(remoteBadge.className).toContain("break-all");
+      expect(remoteBadge.className).not.toContain("truncate");
+    });
+  });
+
   it("should render session and remote badges with PR-aligned badge treatment", () => {
     const task = createTask({
       sessionType: SessionType.TMUX,


### PR DESCRIPTION
## 관련 자료
- 이슈 : 없음

## 어떤 작업인가요?
- 보드 카드 하단의 배지 행이 한 줄로 고정돼 있어, 배지가 많은 카드에서는 뒤쪽 배지가 잘려 보이지 않던 문제를 고칩니다.

## 어떻게 해결했나요?
**배지 행 줄바꿈 허용**
- 작업 목적: PR·에이전트·세션·diff·실행중 AI·remote·우선순위 배지를 하나도 빠뜨리지 않고 보여준다
- 작업 내용 요약: 배지 행을 `flex-wrap`으로 바꿔 카드 폭을 넘는 배지가 다음 줄로 흐르게 하고, 잘라내던 `overflow-hidden`을 없앴습니다

**긴 remote 호스트 전체 노출**
- 작업 목적: 호스트명이 말줄임으로 잘리지 않게 한다
- 작업 내용 요약: sshHost 배지의 `min-w-0 truncate`를 `break-all`로 바꿔, 긴 호스트명이 배지 안에서 줄바꿈되며 전부 보이게 했습니다

## 중요한 변경 사항은 무엇인가요?
### 배지 행 줄바꿈 허용

**배지 행을 한 줄 고정에서 여러 줄로 변경**
- **변경 이유**: 기존 `flex items-center gap-1.5 overflow-hidden`은 줄바꿈이 없어 카드 폭을 넘는 배지가 그대로 잘려 나갔습니다. `gap-1.5`는 flexbox에서 행 간격에도 적용되므로 줄바꿈 시 세로 간격 6px이 자동으로 붙습니다.
- **수정 파일**: `src/components/TaskCard.tsx`

**우선순위 배지의 오른쪽 정렬 유지**
- **변경 이유**: `ml-auto`를 그대로 두어, 한 줄에 다 들어가면 기존과 동일하게 보이고 줄바꿈되면 마지막 줄 오른쪽 끝에 붙습니다.
- **수정 파일**: `src/components/TaskCard.tsx` (변경 없음, 의도적으로 유지)

### 긴 remote 호스트 전체 노출

**sshHost 배지의 말줄임 제거**
- **변경 이유**: `truncate`만 없애면 긴 호스트명이 카드 폭을 밀어내 다시 잘리기 때문에, `break-all`로 배지 내부에서 줄바꿈되도록 했습니다.
- **수정 파일**: `src/components/TaskCard.tsx`

### 검증

- `pnpm exec vitest run` — 142 files / 1430 tests 전부 통과
- `pnpm exec tsc --noEmit` — 통과
- `pnpm exec eslint` (변경 파일) — 통과
- 신규 테스트 3건 추가 (`src/components/__tests__/TaskCard.test.tsx`). 변경을 되돌리고 재실행해 그중 2건이 실제로 실패하는 것을 확인했습니다.

> 참고: jsdom은 레이아웃을 계산하지 않으므로 테스트는 className 계약과 배지 존재만 검증합니다. 시각적 줄바꿈 자체는 실제 앱에서 확인이 필요합니다.

## 스크린샷 및 시연 영상 (optional)

없음

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vr9WLPwCLumhuc31f22mYc
