### PR TITLE
feat(shortcut): 단축키 재배정과 VS Code 열기를 추가하고 PR 도크 자리를 고정한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 /.claude/plan
+
+# review-resolve-loop artifacts
+/.review-resolve-loop/
+/needs-user.md

--- a/electron/main.js
+++ b/electron/main.js
@@ -45,6 +45,8 @@ let windowOpenHelpers = null;
 let keyboardShortcutHelpers = null;
 let shortcutBindingHelpers = null;
 let currentShortcutBindings = null;
+/** 단축키를 녹화 중인 창의 webContents id. 녹화 중에는 그 조합을 명령으로 가로채지 않는다 */
+const shortcutCapturingWebContentsIds = new Set();
 let stopBackgroundTaskSync = null;
 /** 앱 종료 시 KanVibe가 소유한 PTY를 정리한다. 핸들러 등록 시점에 채워진다 */
 let killAllTerminalSessionsOnQuit = null;
@@ -159,6 +161,15 @@ function broadcastNotificationsChanged() {
   for (const window of BrowserWindow.getAllWindows()) {
     if (!window.isDestroyed()) {
       window.webContents.send("kanvibe:notifications-changed");
+    }
+  }
+}
+
+/** 단축키 재배정은 저장한 창만이 아니라 열려 있는 모든 창의 렌더러 캐시에 반영돼야 한다 */
+function broadcastShortcutBindingsChanged() {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send("kanvibe:shortcut-bindings-changed");
     }
   }
 }
@@ -475,7 +486,20 @@ function registerAppWindow(browserWindow) {
     }
   });
 
+  const shortcutCapturingWebContentsId = browserWindow.webContents.id;
+
+  /**
+   * 문서가 새로 커밋되면 렌더러의 녹화 상태는 사라지지만 effect cleanup은 돌지 않는다.
+   * 표시를 여기서 지우지 않으면 그 창은 살아 있는 채로 main 단축키 가로채기를 통째로 잃는다.
+   * 해시 이동은 문서를 갈아치우지 않아 did-navigate가 오지 않으므로 녹화 중 표시가 유지된다.
+   */
+  browserWindow.webContents.on("did-navigate", () => {
+    shortcutCapturingWebContentsIds.delete(shortcutCapturingWebContentsId);
+  });
+
   browserWindow.on("closed", () => {
+    shortcutCapturingWebContentsIds.delete(shortcutCapturingWebContentsId);
+
     if (mainWindow === browserWindow) {
       mainWindow = getAvailableWindows()[0] || null;
     }
@@ -706,6 +730,14 @@ function attachWindowHandlers(browserWindow) {
       return;
     }
 
+    /**
+     * 녹화 중에는 명령을 찾지 않고 그대로 렌더러로 흘려보낸다.
+     * 여기서 가로채면 keydown이 렌더러에 닿지 않아 녹화가 실패하고, 그 조합의 원래 동작만 실행된다.
+     */
+    if (shortcutCapturingWebContentsIds.has(browserWindow.webContents.id)) {
+      return;
+    }
+
     const shortcutCommand = findShortcutCommandForElectronInput(
       getCurrentShortcutBindings(),
       input,
@@ -823,7 +855,15 @@ function registerDesktopHandlers() {
   });
 
   ipcMain.on("kanvibe:shortcut-bindings-changed", () => {
-    void refreshShortcutBindings();
+    void refreshShortcutBindings().then(broadcastShortcutBindingsChanged);
+  });
+
+  ipcMain.on("kanvibe:shortcut-capture-changed", (event, isCapturing) => {
+    if (isCapturing) {
+      shortcutCapturingWebContentsIds.add(event.sender.id);
+    } else {
+      shortcutCapturingWebContentsIds.delete(event.sender.id);
+    }
   });
 
   ipcMain.handle("kanvibe:invoke", async (event, namespace, method, args) => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -43,6 +43,8 @@ let mainWindow = null;
 let hookServer = null;
 let windowOpenHelpers = null;
 let keyboardShortcutHelpers = null;
+let shortcutBindingHelpers = null;
+let currentShortcutBindings = null;
 let stopBackgroundTaskSync = null;
 /** 앱 종료 시 KanVibe가 소유한 PTY를 정리한다. 핸들러 등록 시점에 채워진다 */
 let killAllTerminalSessionsOnQuit = null;
@@ -201,6 +203,33 @@ function getKeyboardShortcutHelpers() {
   }
 
   return keyboardShortcutHelpers;
+}
+
+function getShortcutBindingHelpers() {
+  if (!shortcutBindingHelpers) {
+    shortcutBindingHelpers = require(getRuntimeModulePath(path.join("src", "desktop", "shared", "shortcutBindings.ts")));
+  }
+
+  return shortcutBindingHelpers;
+}
+
+/**
+ * `before-input-event`는 동기라 저장된 재배정을 그때그때 읽어올 수 없다.
+ * 그래서 시작할 때 한 번 읽어 두고, 설정 화면이 바꿀 때마다 렌더러가 알려 주면 다시 읽는다.
+ */
+function getCurrentShortcutBindings() {
+  return currentShortcutBindings ?? getShortcutBindingHelpers().DEFAULT_SHORTCUT_BINDINGS;
+}
+
+async function refreshShortcutBindings() {
+  try {
+    const { getShortcutBindings } = require(getRuntimeModulePath(
+      path.join("src", "desktop", "main", "services", "appSettingsService.ts"),
+    ));
+    currentShortcutBindings = await getShortcutBindings();
+  } catch (error) {
+    logDiagnostic("shortcut:bindings-load-failed", { error: serializeErrorForLog(error) });
+  }
 }
 
 function registerRuntimeAliases() {
@@ -662,48 +691,59 @@ function attachWindowHandlers(browserWindow) {
 
   browserWindow.webContents.on("before-input-event", (event, input) => {
     const {
-      DESKTOP_SHORTCUTS,
       getShortcutPlatformFromProcessPlatform,
       isBlockedElectronShortcutInput,
-      matchElectronShortcutInput,
-      matchTaskDetailDockShortcutInput,
-      resolveTaskDetailUsageShortcutInput,
-      resolveTerminalTabShortcutCommand,
     } = getKeyboardShortcutHelpers();
+    const {
+      findShortcutCommandForElectronInput,
+      getTaskDetailDockIndexForCommand,
+      resolveTerminalTabCommand,
+    } = getShortcutBindingHelpers();
     const shortcutPlatform = getShortcutPlatformFromProcessPlatform(process.platform);
-    const isBlockedShortcut = isBlockedElectronShortcutInput(input, shortcutPlatform);
-    const isNotificationShortcut = matchElectronShortcutInput(input, DESKTOP_SHORTCUTS.notificationCenter, shortcutPlatform);
-    const isCreateTaskShortcut = matchElectronShortcutInput(input, DESKTOP_SHORTCUTS.createTask, shortcutPlatform);
-    const isNewWindowShortcut = matchElectronShortcutInput(input, DESKTOP_SHORTCUTS.newWindow, shortcutPlatform);
-    const taskDetailDockShortcutIndex = isTaskDetailRouteUrl(browserWindow.webContents.getURL())
-      ? matchTaskDetailDockShortcutInput(input, shortcutPlatform)
-      : null;
 
-    if (isBlockedShortcut) {
+    if (isBlockedElectronShortcutInput(input, shortcutPlatform)) {
       event.preventDefault();
       return;
     }
 
-    if (isNotificationShortcut) {
+    const shortcutCommand = findShortcutCommandForElectronInput(
+      getCurrentShortcutBindings(),
+      input,
+      shortcutPlatform,
+    );
+
+    if (!shortcutCommand) {
+      return;
+    }
+
+    const isTaskDetailRoute = isTaskDetailRouteUrl(browserWindow.webContents.getURL());
+
+    if (shortcutCommand === "boardNotification") {
       event.preventDefault();
 
       browserWindow.webContents.send("kanvibe:notification-shortcut");
       return;
     }
 
-    if (isCreateTaskShortcut) {
+    if (shortcutCommand === "createTask") {
       event.preventDefault();
 
       browserWindow.webContents.send("kanvibe:create-task-shortcut");
       return;
     }
 
-    if (isNewWindowShortcut) {
+    if (shortcutCommand === "newWindow") {
       event.preventDefault();
 
       const currentUrl = browserWindow.webContents.getURL() || getRendererNavigationUrl();
       void createAppWindow(currentUrl);
+      return;
     }
+
+    /** 화면 판정 없이 dock 번호를 넘기면 보드에서도 숫자 키를 삼켜 버린다 */
+    const taskDetailDockShortcutIndex = isTaskDetailRoute
+      ? getTaskDetailDockIndexForCommand(shortcutCommand)
+      : null;
 
     if (taskDetailDockShortcutIndex !== null) {
       event.preventDefault();
@@ -713,11 +753,7 @@ function attachWindowHandlers(browserWindow) {
     }
 
     /** 사용량 단축키도 dock 단축키와 같은 이유로 터미널이 입력을 먹기 전에 가로챈다 */
-    if (resolveTaskDetailUsageShortcutInput(
-      input,
-      shortcutPlatform,
-      isTaskDetailRouteUrl(browserWindow.webContents.getURL()),
-    )) {
+    if (shortcutCommand === "taskDetailUsage" && isTaskDetailRoute) {
       event.preventDefault();
 
       browserWindow.webContents.send("kanvibe:task-detail-usage-shortcut");
@@ -728,11 +764,7 @@ function attachWindowHandlers(browserWindow) {
      * 탭 단축키는 터미널이 입력을 먼저 먹기 전에 가로채야 한다.
      * xterm에 먼저 닿으면 셸이 그 키를 소비해 버려 탭 조작이 아예 일어나지 않는다.
      */
-    const terminalTabCommand = resolveTerminalTabShortcutCommand(
-      input,
-      shortcutPlatform,
-      isTaskDetailRouteUrl(browserWindow.webContents.getURL()),
-    );
+    const terminalTabCommand = resolveTerminalTabCommand(shortcutCommand, isTaskDetailRoute);
 
     if (terminalTabCommand) {
       event.preventDefault();
@@ -788,6 +820,10 @@ function registerDesktopHandlers() {
 
   ipcMain.on("kanvibe:renderer-log", (_event, payload) => {
     logDiagnostic("renderer:bridge", payload);
+  });
+
+  ipcMain.on("kanvibe:shortcut-bindings-changed", () => {
+    void refreshShortcutBindings();
   });
 
   ipcMain.handle("kanvibe:invoke", async (event, namespace, method, args) => {
@@ -1022,6 +1058,7 @@ app.whenReady().then(async () => {
   const unsubscribeBoardEvents = registerBoardEventForwarding();
   startHookServer();
   registerNotificationHandlers();
+  await refreshShortcutBindings();
 
   await createMainWindow();
   const { startBackgroundTaskSync } = require(getRuntimeModulePath(path.join("src", "desktop", "main", "services", "backgroundTaskSyncService.ts")));

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -194,4 +194,14 @@ contextBridge.exposeInMainWorld("kanvibeDesktop", {
   notifyShortcutBindingsChanged() {
     ipcRenderer.send("kanvibe:shortcut-bindings-changed");
   },
+  onShortcutBindingsChanged(listener) {
+    const handler = () => listener();
+    ipcRenderer.on("kanvibe:shortcut-bindings-changed", handler);
+    return () => {
+      ipcRenderer.removeListener("kanvibe:shortcut-bindings-changed", handler);
+    };
+  },
+  notifyShortcutCaptureChanged(isCapturing) {
+    ipcRenderer.send("kanvibe:shortcut-capture-changed", Boolean(isCapturing));
+  },
 });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -191,4 +191,7 @@ contextBridge.exposeInMainWorld("kanvibeDesktop", {
       ipcRenderer.removeListener("kanvibe:task-detail-usage-shortcut", handler);
     };
   },
+  notifyShortcutBindingsChanged() {
+    ipcRenderer.send("kanvibe:shortcut-bindings-changed");
+  },
 });

--- a/messages/en.json
+++ b/messages/en.json
@@ -264,7 +264,43 @@
     "keyboardSection": "Keyboard",
     "vimModeEnabled": "Vim-style board controls",
     "vimModeEnabledDescription": "Enable h/j/k/l focus movement, n for a new task, dd delete, and :move status commands on the board. Arrow keys stay available when this is off.",
-    "aiAccountsLink": "AI accounts"
+    "aiAccountsLink": "AI accounts",
+    "shortcutsLink": "Keyboard shortcuts",
+    "shortcuts": {
+      "title": "Keyboard shortcuts",
+      "pageDescription": "Press the key combination you want for each command to rebind it.",
+      "record": "Record",
+      "recording": "Press keys",
+      "recordHint": "The combination you press is saved immediately. Press Esc to cancel.",
+      "reset": "Default",
+      "resetAll": "Reset all to defaults",
+      "conflict": "{command} already uses this combination.",
+      "unsupported": "Only combinations with at least one modifier key can be used.",
+      "groups": {
+        "taskDetailDock": "Task detail dock",
+        "taskDetail": "Task detail",
+        "board": "Board",
+        "terminal": "Terminal"
+      },
+      "commands": {
+        "taskDetailDock": "Dock item {index}",
+        "taskDetailUsage": "AI usage panel",
+        "taskSearch": "Task quick search",
+        "boardNotification": "Notification center",
+        "boardProjectFilter": "Project filter",
+        "boardPageFind": "Find on page",
+        "createTask": "Create task",
+        "newWindow": "New window",
+        "pageBack": "Go back",
+        "pageForward": "Go forward",
+        "terminalTabNew": "New terminal tab",
+        "terminalTabClose": "Close terminal tab",
+        "terminalWindowClose": "Close window",
+        "terminalTabPrevious": "Previous terminal tab",
+        "terminalTabNext": "Next terminal tab",
+        "terminalTab": "Go to terminal tab {index}"
+      }
+    }
   },
   "taskSearch": {
     "title": "Quick Task Search",
@@ -476,7 +512,10 @@
         "fetch-failed": "Could not fetch usage."
       },
       "manageAccounts": "Manage accounts"
-    }
+    },
+    "openInVsCode": "Open in VS Code",
+    "openInVsCodeFailed": "Could not launch VS Code. Check that the `code` command is on your PATH.",
+    "pullRequestNotFound": "No pull request is linked to this branch."
   },
   "projectBranchTasks": {
     "title": "Project Tasks",

--- a/messages/en.json
+++ b/messages/en.json
@@ -285,7 +285,7 @@
         "terminal": "Terminal"
       },
       "commands": {
-        "taskDetailDock": "Dock item {index}",
+        "taskDetailDock": "Dock {index} · {item}",
         "taskDetailUsage": "AI usage panel",
         "taskSearch": "Task quick search",
         "boardNotification": "Notification center",

--- a/messages/en.json
+++ b/messages/en.json
@@ -276,6 +276,8 @@
       "resetAll": "Reset all to defaults",
       "conflict": "{command} already uses this combination.",
       "unsupported": "Only combinations with at least one modifier key can be used.",
+      "saveFailed": "Failed to save the shortcut.",
+      "loadFailed": "Failed to load saved shortcuts. Reopen this screen after the problem is fixed.",
       "groups": {
         "taskDetailDock": "Task detail dock",
         "taskDetail": "Task detail",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -285,7 +285,7 @@
         "terminal": "터미널"
       },
       "commands": {
-        "taskDetailDock": "도크 {index}번 항목",
+        "taskDetailDock": "도크 {index} · {item}",
         "taskDetailUsage": "AI 사용량 패널",
         "taskSearch": "작업 빠른 검색",
         "boardNotification": "알림 센터",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -276,6 +276,8 @@
       "resetAll": "전체 기본값으로",
       "conflict": "{command} 명령이 이미 이 조합을 쓰고 있습니다.",
       "unsupported": "수정 키를 하나 이상 포함한 조합만 쓸 수 있습니다.",
+      "saveFailed": "단축키를 저장하지 못했습니다.",
+      "loadFailed": "저장된 단축키를 불러오지 못했습니다. 문제가 해결된 뒤 이 화면을 다시 열어 주세요.",
       "groups": {
         "taskDetailDock": "작업 상세 도크",
         "taskDetail": "작업 상세",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -264,7 +264,43 @@
     "keyboardSection": "키보드",
     "vimModeEnabled": "Vim 스타일 보드 조작",
     "vimModeEnabledDescription": "보드에서 h/j/k/l 포커스 이동, n 새 작업, dd 삭제, :move status 명령을 사용합니다. 꺼도 방향키 이동은 유지됩니다.",
-    "aiAccountsLink": "AI 계정"
+    "aiAccountsLink": "AI 계정",
+    "shortcutsLink": "단축키 설정",
+    "shortcuts": {
+      "title": "단축키",
+      "pageDescription": "명령마다 원하는 키 조합을 눌러 다시 배정합니다.",
+      "record": "녹화",
+      "recording": "키를 누르세요",
+      "recordHint": "바꿀 조합을 누르면 바로 저장됩니다. Esc를 누르면 취소합니다.",
+      "reset": "기본값",
+      "resetAll": "전체 기본값으로",
+      "conflict": "{command} 명령이 이미 이 조합을 쓰고 있습니다.",
+      "unsupported": "수정 키를 하나 이상 포함한 조합만 쓸 수 있습니다.",
+      "groups": {
+        "taskDetailDock": "작업 상세 도크",
+        "taskDetail": "작업 상세",
+        "board": "보드",
+        "terminal": "터미널"
+      },
+      "commands": {
+        "taskDetailDock": "도크 {index}번 항목",
+        "taskDetailUsage": "AI 사용량 패널",
+        "taskSearch": "작업 빠른 검색",
+        "boardNotification": "알림 센터",
+        "boardProjectFilter": "프로젝트 필터",
+        "boardPageFind": "페이지 내 검색",
+        "createTask": "작업 생성",
+        "newWindow": "새 창",
+        "pageBack": "뒤로 가기",
+        "pageForward": "앞으로 가기",
+        "terminalTabNew": "터미널 탭 추가",
+        "terminalTabClose": "터미널 탭 닫기",
+        "terminalWindowClose": "창 닫기",
+        "terminalTabPrevious": "이전 터미널 탭",
+        "terminalTabNext": "다음 터미널 탭",
+        "terminalTab": "터미널 탭 {index}번으로 이동"
+      }
+    }
   },
   "taskSearch": {
     "title": "태스크 빠른 검색",
@@ -476,7 +512,10 @@
         "fetch-failed": "사용량을 가져오지 못했습니다."
       },
       "manageAccounts": "계정 관리"
-    }
+    },
+    "openInVsCode": "VS Code에서 열기",
+    "openInVsCodeFailed": "VS Code를 열지 못했습니다. `code` 명령을 PATH에서 찾을 수 있는지 확인하세요.",
+    "pullRequestNotFound": "이 브랜치에 연결된 PR을 찾지 못했습니다."
   },
   "projectBranchTasks": {
     "title": "프로젝트 작업",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -263,7 +263,43 @@
     "keyboardSection": "键盘",
     "vimModeEnabled": "Vim 风格看板控制",
     "vimModeEnabledDescription": "在看板中启用 h/j/k/l 焦点移动、n 新建任务、dd 删除和 :move status 命令。关闭后仍可使用方向键移动。",
-    "aiAccountsLink": "AI 账号"
+    "aiAccountsLink": "AI 账号",
+    "shortcutsLink": "快捷键设置",
+    "shortcuts": {
+      "title": "快捷键",
+      "pageDescription": "为每个命令按下想要的组合键即可重新绑定。",
+      "record": "录制",
+      "recording": "请按键",
+      "recordHint": "按下的组合会立即保存。按 Esc 取消。",
+      "reset": "默认值",
+      "resetAll": "全部恢复默认",
+      "conflict": "{command} 已经在使用该组合。",
+      "unsupported": "只能使用至少包含一个修饰键的组合。",
+      "groups": {
+        "taskDetailDock": "任务详情 dock",
+        "taskDetail": "任务详情",
+        "board": "看板",
+        "terminal": "终端"
+      },
+      "commands": {
+        "taskDetailDock": "Dock 第 {index} 项",
+        "taskDetailUsage": "AI 用量面板",
+        "taskSearch": "任务快速搜索",
+        "boardNotification": "通知中心",
+        "boardProjectFilter": "项目筛选",
+        "boardPageFind": "页面内查找",
+        "createTask": "创建任务",
+        "newWindow": "新窗口",
+        "pageBack": "后退",
+        "pageForward": "前进",
+        "terminalTabNew": "新建终端标签",
+        "terminalTabClose": "关闭终端标签",
+        "terminalWindowClose": "关闭窗口",
+        "terminalTabPrevious": "上一个终端标签",
+        "terminalTabNext": "下一个终端标签",
+        "terminalTab": "跳到终端标签 {index}"
+      }
+    }
   },
   "taskSearch": {
     "title": "快速任务搜索",
@@ -475,7 +511,10 @@
         "fetch-failed": "无法获取用量。"
       },
       "manageAccounts": "管理账号"
-    }
+    },
+    "openInVsCode": "在 VS Code 中打开",
+    "openInVsCodeFailed": "无法启动 VS Code。请确认 `code` 命令在 PATH 中。",
+    "pullRequestNotFound": "该分支没有关联的 PR。"
   },
   "projectBranchTasks": {
     "title": "项目任务",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -284,7 +284,7 @@
         "terminal": "终端"
       },
       "commands": {
-        "taskDetailDock": "Dock 第 {index} 项",
+        "taskDetailDock": "Dock {index} · {item}",
         "taskDetailUsage": "AI 用量面板",
         "taskSearch": "任务快速搜索",
         "boardNotification": "通知中心",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -275,6 +275,8 @@
       "resetAll": "全部恢复默认",
       "conflict": "{command} 已经在使用该组合。",
       "unsupported": "只能使用至少包含一个修饰键的组合。",
+      "saveFailed": "快捷键保存失败。",
+      "loadFailed": "无法读取已保存的快捷键。问题解决后请重新打开此页面。",
       "groups": {
         "taskDetailDock": "任务详情 dock",
         "taskDetail": "任务详情",

--- a/src/components/BoardPageFindBar.tsx
+++ b/src/components/BoardPageFindBar.tsx
@@ -3,9 +3,9 @@
 import { useCallback, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useTranslations } from "next-intl";
 import { useHasBoardShortcutBlocker } from "@/desktop/renderer/components/BoardCommandProvider";
-import { SHORTCUTS, getCurrentShortcutPlatform, matchShortcutEvent } from "@/desktop/renderer/utils/keyboardShortcut";
+import { getCurrentShortcutPlatform, matchShortcutEvent } from "@/desktop/renderer/utils/keyboardShortcut";
+import { useShortcutBindings } from "@/desktop/renderer/utils/shortcutBindings";
 
-const BOARD_PAGE_FIND_SHORTCUT = SHORTCUTS.boardPageFind;
 const BOARD_PAGE_VIM_FIND_KEY = "/";
 
 function findPageText(query: string, backwards = false) {
@@ -50,6 +50,7 @@ export default function BoardPageFindBar({ vimModeEnabled }: BoardPageFindBarPro
   const [query, setQuery] = useState("");
   const [hasMatch, setHasMatch] = useState<boolean | null>(null);
   const shortcutPlatform = getCurrentShortcutPlatform();
+  const boardPageFindShortcut = useShortcutBindings().boardPageFind;
 
   const openSearchBar = useCallback(() => {
     setIsOpen(true);
@@ -76,7 +77,7 @@ export default function BoardPageFindBar({ vimModeEnabled }: BoardPageFindBarPro
         return;
       }
 
-      const shouldOpenSearchBar = matchShortcutEvent(event, BOARD_PAGE_FIND_SHORTCUT, shortcutPlatform)
+      const shouldOpenSearchBar = matchShortcutEvent(event, boardPageFindShortcut, shortcutPlatform)
         || (vimModeEnabled && isPlainBoardPageFindKey(event));
       if (!shouldOpenSearchBar) {
         return;
@@ -90,7 +91,7 @@ export default function BoardPageFindBar({ vimModeEnabled }: BoardPageFindBarPro
     return () => {
       window.removeEventListener("keydown", handleGlobalKeyDown);
     };
-  }, [hasShortcutBlocker, openSearchBar, shortcutPlatform, vimModeEnabled]);
+  }, [boardPageFindShortcut, hasShortcutBlocker, openSearchBar, shortcutPlatform, vimModeEnabled]);
 
   function closeSearchBar() {
     setIsOpen(false);

--- a/src/components/ProjectSettings.tsx
+++ b/src/components/ProjectSettings.tsx
@@ -543,6 +543,15 @@ export default function ProjectSettings({
               />
             </button>
           </label>
+
+          <Link
+            href="/settings/shortcuts"
+            prefetch={false}
+            className="mt-4 flex items-center justify-between w-full px-3 py-2 text-sm bg-bg-page border border-border-default rounded-md text-text-primary hover:border-brand-primary transition-colors"
+          >
+            <span>{t("shortcutsLink")}</span>
+            <span className="text-text-muted">&rarr;</span>
+          </Link>
         </div>
 
         </div>

--- a/src/desktop/main/__tests__/desktopShortcutRouting.test.ts
+++ b/src/desktop/main/__tests__/desktopShortcutRouting.test.ts
@@ -37,6 +37,76 @@ describe("desktop shortcut routing", () => {
     expect(source).toContain("getCurrentShortcutBindings()");
   });
 
+  /**
+   * 녹화 화면은 main이 가로챈 조합을 영영 받지 못한다.
+   * 그러면 그 조합의 원래 동작(새 창, 창 닫기)만 실행되고 녹화는 실패한다.
+   */
+  it("녹화 중인 창에서는 명령을 찾기 전에 입력을 렌더러로 흘려보낸다", () => {
+    const source = readMainSource();
+
+    expect(source).toContain('ipcMain.on("kanvibe:shortcut-capture-changed"');
+    expect(source).toContain("shortcutCapturingWebContentsIds.add(event.sender.id)");
+    expect(source).toContain("shortcutCapturingWebContentsIds.delete(event.sender.id)");
+
+    const captureGuardIndex = source.indexOf(
+      "if (shortcutCapturingWebContentsIds.has(browserWindow.webContents.id))",
+    );
+    const commandLookupIndex = source.indexOf("const shortcutCommand = findShortcutCommandForElectronInput(");
+    expect(captureGuardIndex).toBeGreaterThan(-1);
+    /** 명령을 찾은 뒤에 검사하면 이미 preventDefault가 걸린 뒤라 늦다 */
+    expect(captureGuardIndex).toBeLessThan(commandLookupIndex);
+  });
+
+  /** 창이 녹화 중인 채로 닫히면 그 id가 남아, 나중에 같은 id를 받은 창이 단축키를 통째로 잃는다 */
+  it("창이 닫히면 녹화 중 표시를 지운다", () => {
+    const source = readMainSource();
+
+    const closeHandlerIndex = source.indexOf('browserWindow.on("closed"');
+    expect(closeHandlerIndex).toBeGreaterThan(-1);
+
+    /** 같은 정리 줄을 쓰는 did-navigate 핸들러가 대신 걸리면 이 정리가 사라져도 통과한다 */
+    const closeHandlerBody = source.slice(
+      closeHandlerIndex,
+      source.indexOf("\n}", closeHandlerIndex),
+    );
+    expect(closeHandlerBody).toContain(
+      "shortcutCapturingWebContentsIds.delete(shortcutCapturingWebContentsId)",
+    );
+  });
+
+  /**
+   * 문서를 다시 로드하면 렌더러 녹화 상태는 사라지는데 effect cleanup은 돌지 않아 해제 알림이 안 나간다.
+   * 창은 살아 있으니 closed도 오지 않아, 표시가 남은 그 창은 main 단축키 가로채기를 통째로 잃는다.
+   */
+  it("문서를 다시 로드해도 녹화 중 표시를 지운다", () => {
+    const source = readMainSource();
+
+    const navigationHandlerIndex = source.indexOf('browserWindow.webContents.on("did-navigate"');
+    expect(navigationHandlerIndex).toBeGreaterThan(-1);
+
+    const navigationHandlerBody = source.slice(
+      navigationHandlerIndex,
+      source.indexOf('browserWindow.on("closed"', navigationHandlerIndex),
+    );
+    expect(navigationHandlerBody).toContain(
+      "shortcutCapturingWebContentsIds.delete(shortcutCapturingWebContentsId)",
+    );
+  });
+
+  /** 저장한 창만 갱신하면 다른 창은 재시작 전까지 옛 조합과 새 조합이 섞인 상태로 남는다 */
+  it("단축키 재배정을 다시 읽은 뒤 열려 있는 모든 창에 알린다", () => {
+    const source = readMainSource();
+
+    expect(source).toContain("void refreshShortcutBindings().then(broadcastShortcutBindingsChanged);");
+    expect(source).toContain("function broadcastShortcutBindingsChanged()");
+
+    const broadcastBody = source.slice(
+      source.indexOf("function broadcastShortcutBindingsChanged()"),
+    );
+    expect(broadcastBody).toContain("BrowserWindow.getAllWindows()");
+    expect(broadcastBody).toContain('window.webContents.send("kanvibe:shortcut-bindings-changed")');
+  });
+
   it("blocks Cmd/Ctrl+R without registering a Kanvibe refresh shortcut", () => {
     const source = readMainSource();
 

--- a/src/desktop/main/__tests__/desktopShortcutRouting.test.ts
+++ b/src/desktop/main/__tests__/desktopShortcutRouting.test.ts
@@ -10,10 +10,10 @@ describe("desktop shortcut routing", () => {
   it("routes platform-aware shortcuts through the shared shortcut matcher", () => {
     const source = readMainSource();
 
-    expect(source).toContain("matchElectronShortcutInput");
-    expect(source).toContain("DESKTOP_SHORTCUTS.createTask");
-    expect(source).toContain("DESKTOP_SHORTCUTS.newWindow");
-    expect(source).toContain("matchTaskDetailDockShortcutInput");
+    expect(source).toContain("findShortcutCommandForElectronInput");
+    expect(source).toContain('shortcutCommand === "createTask"');
+    expect(source).toContain('shortcutCommand === "newWindow"');
+    expect(source).toContain("getTaskDetailDockIndexForCommand");
     expect(source).toContain('browserWindow.webContents.send("kanvibe:create-task-shortcut")');
     expect(source).toContain('browserWindow.webContents.send("kanvibe:task-detail-dock-shortcut"');
     expect(source).toContain("void createAppWindow(currentUrl)");
@@ -22,12 +22,19 @@ describe("desktop shortcut routing", () => {
   it("사용량 단축키를 태스크 상세 판정과 함께 공유 매처에 넘긴다", () => {
     const source = readMainSource();
 
-    expect(source).toContain("resolveTaskDetailUsageShortcutInput");
     expect(source).toContain('browserWindow.webContents.send("kanvibe:task-detail-usage-shortcut")');
     /** 화면 판정 없이 매칭하면 보드에서도 줌 초기화 키를 삼켜 버린다 */
-    expect(source).toMatch(
-      /resolveTaskDetailUsageShortcutInput\(\s*input,\s*shortcutPlatform,\s*isTaskDetailRouteUrl\(/,
-    );
+    expect(source).toContain('shortcutCommand === "taskDetailUsage" && isTaskDetailRoute');
+    expect(source).toContain("const isTaskDetailRoute = isTaskDetailRouteUrl(browserWindow.webContents.getURL());");
+  });
+
+  /** 저장된 재배정을 읽지 않으면 설정 화면에서 바꾼 단축키가 main 경로에서만 옛 조합으로 남는다 */
+  it("저장된 단축키 재배정을 읽어 두고 변경 알림에 다시 읽는다", () => {
+    const source = readMainSource();
+
+    expect(source).toContain("await refreshShortcutBindings();");
+    expect(source).toContain('ipcMain.on("kanvibe:shortcut-bindings-changed"');
+    expect(source).toContain("getCurrentShortcutBindings()");
   });
 
   it("blocks Cmd/Ctrl+R without registering a Kanvibe refresh shortcut", () => {

--- a/src/desktop/main/serviceRegistry.ts
+++ b/src/desktop/main/serviceRegistry.ts
@@ -3,6 +3,7 @@ import * as aiUsage from "@/desktop/main/services/aiUsageService";
 import * as appSettings from "@/desktop/main/services/appSettingsService";
 import { runBackgroundTaskSyncNow } from "@/desktop/main/services/backgroundTaskSyncService";
 import * as diff from "@/desktop/main/services/diffService";
+import * as editor from "@/desktop/main/services/editorService";
 import * as githubCliDependency from "@/desktop/main/services/githubCliDependencyService";
 import * as hooks from "@/desktop/main/services/hookService";
 import * as kanban from "@/desktop/main/services/kanbanService";
@@ -20,6 +21,7 @@ export const desktopServices = {
   appSettings,
   backgroundTaskSync,
   diff,
+  editor,
   githubCliDependency,
   hooks,
   kanban,

--- a/src/desktop/main/services/__tests__/appSettingsService.test.ts
+++ b/src/desktop/main/services/__tests__/appSettingsService.test.ts
@@ -129,3 +129,65 @@ describe("보드 정렬 설정", () => {
     expect(preference).toEqual({ keys: [] });
   });
 });
+
+describe("단축키 재배정 설정", () => {
+  const SHORTCUT_BINDINGS_KEY = "shortcut_bindings";
+
+  it("재배정한 단축키를 앱을 다시 켠 뒤에도 그대로 읽는다", async () => {
+    // Given
+    const { getShortcutBindings, setShortcutBindings } = await import(
+      "@/desktop/main/services/appSettingsService"
+    );
+    const { DEFAULT_SHORTCUT_BINDINGS } = await import("@/desktop/shared/shortcutBindings");
+
+    // When
+    await setShortcutBindings({ ...DEFAULT_SHORTCUT_BINDINGS, taskDetailDock4: "Mod+Shift+K" });
+
+    // Then
+    expect(await getShortcutBindings()).toEqual({
+      ...DEFAULT_SHORTCUT_BINDINGS,
+      taskDetailDock4: "Mod+Shift+K",
+    });
+  });
+
+  /** 기본값까지 통째로 저장해 두면 나중에 기본값을 바꿔도 옛 값이 남아 새 기본값이 적용되지 않는다 */
+  it("기본값과 같은 항목은 저장하지 않는다", async () => {
+    // Given
+    const { setShortcutBindings } = await import("@/desktop/main/services/appSettingsService");
+    const { DEFAULT_SHORTCUT_BINDINGS } = await import("@/desktop/shared/shortcutBindings");
+
+    // When
+    await setShortcutBindings({ ...DEFAULT_SHORTCUT_BINDINGS, createTask: "Mod+Shift+J" });
+
+    // Then
+    expect(JSON.parse(storedSettings.get(SHORTCUT_BINDINGS_KEY) ?? "{}")).toEqual({
+      createTask: "Mod+Shift+J",
+    });
+  });
+
+  it("한 번도 저장한 적이 없으면 기본 단축키를 돌려준다", async () => {
+    // Given
+    const { getShortcutBindings } = await import("@/desktop/main/services/appSettingsService");
+    const { DEFAULT_SHORTCUT_BINDINGS } = await import("@/desktop/shared/shortcutBindings");
+
+    // When
+    const bindings = await getShortcutBindings();
+
+    // Then
+    expect(bindings).toEqual(DEFAULT_SHORTCUT_BINDINGS);
+  });
+
+  it("빠른 검색 단축키도 같은 재배정 표에서 읽는다", async () => {
+    // Given
+    const { getTaskSearchShortcut, setShortcutBindings } = await import(
+      "@/desktop/main/services/appSettingsService"
+    );
+    const { DEFAULT_SHORTCUT_BINDINGS } = await import("@/desktop/shared/shortcutBindings");
+
+    // When
+    await setShortcutBindings({ ...DEFAULT_SHORTCUT_BINDINGS, taskSearch: "Mod+Shift+F" });
+
+    // Then
+    expect(await getTaskSearchShortcut()).toBe("Mod+Shift+F");
+  });
+});

--- a/src/desktop/main/services/__tests__/appSettingsService.test.ts
+++ b/src/desktop/main/services/__tests__/appSettingsService.test.ts
@@ -132,6 +132,7 @@ describe("보드 정렬 설정", () => {
 
 describe("단축키 재배정 설정", () => {
   const SHORTCUT_BINDINGS_KEY = "shortcut_bindings";
+  const LEGACY_TASK_SEARCH_SHORTCUT_KEY = "task_search_shortcut";
 
   it("재배정한 단축키를 앱을 다시 켠 뒤에도 그대로 읽는다", async () => {
     // Given
@@ -189,5 +190,103 @@ describe("단축키 재배정 설정", () => {
 
     // Then
     expect(await getTaskSearchShortcut()).toBe("Mod+Shift+F");
+  });
+
+  /** 승계하지 않으면 옛 버전에서 빠른 검색을 바꿔 둔 사용자의 단축키가 업그레이드 순간 말없이 되돌아간다 */
+  it("단축키 표가 없으면 옛 task_search_shortcut 값을 taskSearch 재배정으로 승계한다", async () => {
+    // Given
+    const { getShortcutBindings } = await import("@/desktop/main/services/appSettingsService");
+    const { DEFAULT_SHORTCUT_BINDINGS } = await import("@/desktop/shared/shortcutBindings");
+    storedSettings.set(LEGACY_TASK_SEARCH_SHORTCUT_KEY, "Mod+Shift+F");
+
+    // When
+    const bindings = await getShortcutBindings();
+
+    // Then
+    expect(bindings).toEqual({ ...DEFAULT_SHORTCUT_BINDINGS, taskSearch: "Mod+Shift+F" });
+    expect(JSON.parse(storedSettings.get(SHORTCUT_BINDINGS_KEY) ?? "{}")).toEqual({
+      taskSearch: "Mod+Shift+F",
+    });
+  });
+
+  /**
+   * 옛 UI는 platform 인자 없이 녹화해 `Mod`가 아닌 플랫폼 표기를 저장했다.
+   * 그 표기를 그대로 승계하면 실행 시에는 같은 조합인데 중복 판정만 다른 조합으로 봐서,
+   * 사용자가 같은 물리 조합을 다른 명령에 배정해도 경고 없이 저장된다.
+   */
+  it("옛 플랫폼 표기로 저장된 값은 Mod 표기로 접어 승계한다", async () => {
+    // Given
+    const { getShortcutBindings } = await import("@/desktop/main/services/appSettingsService");
+    const { DEFAULT_SHORTCUT_BINDINGS } = await import("@/desktop/shared/shortcutBindings");
+    storedSettings.set(LEGACY_TASK_SEARCH_SHORTCUT_KEY, "Ctrl+Shift+F");
+
+    // When
+    const bindings = await getShortcutBindings();
+
+    // Then
+    expect(bindings).toEqual({ ...DEFAULT_SHORTCUT_BINDINGS, taskSearch: "Mod+Shift+F" });
+    expect(JSON.parse(storedSettings.get(SHORTCUT_BINDINGS_KEY) ?? "{}")).toEqual({
+      taskSearch: "Mod+Shift+F",
+    });
+  });
+
+  /** 실질적으로 기본값인 옛 표기를 재배정으로 남기면 그 사용자만 향후 기본값 변경을 못 받는다 */
+  it("승계한 값이 플랫폼 표기만 다른 기본값이면 재배정으로 저장하지 않는다", async () => {
+    // Given
+    const { getShortcutBindings } = await import("@/desktop/main/services/appSettingsService");
+    const { DEFAULT_SHORTCUT_BINDINGS } = await import("@/desktop/shared/shortcutBindings");
+    storedSettings.set(LEGACY_TASK_SEARCH_SHORTCUT_KEY, "Ctrl+Shift+O");
+
+    // When
+    const bindings = await getShortcutBindings();
+
+    // Then
+    expect(bindings).toEqual(DEFAULT_SHORTCUT_BINDINGS);
+    expect(JSON.parse(storedSettings.get(SHORTCUT_BINDINGS_KEY) ?? "{}")).toEqual({});
+  });
+
+  /** 옛 화면은 파싱하면 키가 사라지는 값도 저장했다. 그 결과를 그대로 얹으면 빠른 검색 단축키가 통째로 사라진다 */
+  it("옛 값을 접었을 때 키가 남지 않으면 재배정으로 얹지 않는다", async () => {
+    // Given
+    const { getShortcutBindings } = await import("@/desktop/main/services/appSettingsService");
+    const { DEFAULT_SHORTCUT_BINDINGS } = await import("@/desktop/shared/shortcutBindings");
+    storedSettings.set(LEGACY_TASK_SEARCH_SHORTCUT_KEY, "Ctrl+Shift++");
+
+    // When
+    const bindings = await getShortcutBindings();
+
+    // Then
+    expect(bindings).toEqual(DEFAULT_SHORTCUT_BINDINGS);
+    expect(JSON.parse(storedSettings.get(SHORTCUT_BINDINGS_KEY) ?? "{}")).toEqual({});
+  });
+
+  /** 승계가 반복되면 사용자가 그 뒤에 되돌린 기본값을 옛 값이 다시 덮어쓴다 */
+  it("승계한 뒤 옛 값을 지워도 단축키 표에 남은 값을 그대로 읽는다", async () => {
+    // Given
+    const { getShortcutBindings, setShortcutBindings } = await import(
+      "@/desktop/main/services/appSettingsService"
+    );
+    const { DEFAULT_SHORTCUT_BINDINGS } = await import("@/desktop/shared/shortcutBindings");
+    storedSettings.set(LEGACY_TASK_SEARCH_SHORTCUT_KEY, "Mod+Shift+F");
+    await getShortcutBindings();
+
+    // When
+    await setShortcutBindings({ ...DEFAULT_SHORTCUT_BINDINGS });
+
+    // Then
+    expect(await getShortcutBindings()).toEqual(DEFAULT_SHORTCUT_BINDINGS);
+  });
+
+  it("단축키 표도 옛 값도 없으면 기본값을 저장하지 않고 돌려준다", async () => {
+    // Given
+    const { getShortcutBindings } = await import("@/desktop/main/services/appSettingsService");
+    const { DEFAULT_SHORTCUT_BINDINGS } = await import("@/desktop/shared/shortcutBindings");
+
+    // When
+    const bindings = await getShortcutBindings();
+
+    // Then
+    expect(bindings).toEqual(DEFAULT_SHORTCUT_BINDINGS);
+    expect(storedSettings.has(SHORTCUT_BINDINGS_KEY)).toBe(false);
   });
 });

--- a/src/desktop/main/services/__tests__/editorService.test.ts
+++ b/src/desktop/main/services/__tests__/editorService.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  taskRepo: { findOneBy: vi.fn() },
+  projectRepo: { findOneBy: vi.fn() },
+  execFile: vi.fn(),
+  createLocalShellEnvironment: vi.fn(() => ({ PATH: "/usr/local/bin" })),
+}));
+
+vi.mock("child_process", () => ({
+  execFile: mocks.execFile,
+  default: { execFile: mocks.execFile },
+}));
+
+vi.mock("@/lib/database", () => ({
+  getTaskRepository: vi.fn(async () => mocks.taskRepo),
+  getProjectRepository: vi.fn(async () => mocks.projectRepo),
+}));
+
+vi.mock("@/lib/shellEnvironment", () => ({
+  createLocalShellEnvironment: mocks.createLocalShellEnvironment,
+}));
+
+function resolveExecFileSuccessfully() {
+  mocks.execFile.mockImplementation((_command, _args, _options, callback) => {
+    callback(null, "", "");
+    return {} as never;
+  });
+}
+
+describe("editorService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createLocalShellEnvironment.mockReturnValue({ PATH: "/usr/local/bin" });
+    resolveExecFileSuccessfully();
+  });
+
+  it("로컬 작업은 worktree 경로만 넘겨 VS Code를 연다", async () => {
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-1",
+      projectId: "project-1",
+      worktreePath: "/workspace/repo__worktrees/feature",
+      sshHost: null,
+    });
+    mocks.projectRepo.findOneBy.mockResolvedValue({ id: "project-1", repoPath: "/workspace/repo", sshHost: null });
+
+    const { openTaskInVsCode } = await import("@/desktop/main/services/editorService");
+
+    await expect(openTaskInVsCode("task-1")).resolves.toEqual({ ok: true });
+    expect(mocks.execFile).toHaveBeenCalledWith(
+      "code",
+      ["/workspace/repo__worktrees/feature"],
+      expect.objectContaining({ env: { PATH: "/usr/local/bin" } }),
+      expect.any(Function),
+    );
+  });
+
+  /**
+   * 원격 셸에서 `code`를 부르면 그 머신에서 창을 띄우려 하므로 사용자 화면에는 아무것도 안 뜬다.
+   * 로컬 VS Code에 붙을 원격 호스트를 알려 주는 방향이어야 한다.
+   */
+  it("원격 작업은 로컬 VS Code를 Remote-SSH로 붙여서 연다", async () => {
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-2",
+      projectId: "project-remote",
+      worktreePath: "/remote/repo__worktrees/feature",
+      sshHost: null,
+    });
+    mocks.projectRepo.findOneBy.mockResolvedValue({
+      id: "project-remote",
+      repoPath: "/remote/repo",
+      sshHost: "build-box",
+    });
+
+    const { openTaskInVsCode } = await import("@/desktop/main/services/editorService");
+
+    await expect(openTaskInVsCode("task-2")).resolves.toEqual({ ok: true });
+    expect(mocks.execFile).toHaveBeenCalledWith(
+      "code",
+      ["--remote", "ssh-remote+build-box", "/remote/repo__worktrees/feature"],
+      expect.anything(),
+      expect.any(Function),
+    );
+  });
+
+  it("worktree가 없으면 프로젝트 저장소 경로를 연다", async () => {
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-3",
+      projectId: "project-1",
+      worktreePath: null,
+      sshHost: null,
+    });
+    mocks.projectRepo.findOneBy.mockResolvedValue({ id: "project-1", repoPath: "/workspace/repo", sshHost: null });
+
+    const { openTaskInVsCode } = await import("@/desktop/main/services/editorService");
+
+    await openTaskInVsCode("task-3");
+
+    expect(mocks.execFile).toHaveBeenCalledWith("code", ["/workspace/repo"], expect.anything(), expect.any(Function));
+  });
+
+  it("열 경로를 찾지 못하면 VS Code를 실행하지 않는다", async () => {
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-4",
+      projectId: null,
+      worktreePath: null,
+      sshHost: null,
+    });
+
+    const { openTaskInVsCode } = await import("@/desktop/main/services/editorService");
+
+    await expect(openTaskInVsCode("task-4")).resolves.toEqual({ ok: false, error: "no-target-path" });
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
+
+  it("code 명령을 찾지 못하면 실패 사유를 돌려준다", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-5",
+      projectId: null,
+      worktreePath: "/workspace/repo__worktrees/feature",
+      sshHost: null,
+    });
+    mocks.execFile.mockImplementation((_command, _args, _options, callback) => {
+      callback(Object.assign(new Error("spawn code ENOENT"), { code: "ENOENT" }), "", "");
+      return {} as never;
+    });
+
+    const { openTaskInVsCode } = await import("@/desktop/main/services/editorService");
+
+    await expect(openTaskInVsCode("task-5")).resolves.toEqual({ ok: false, error: "spawn code ENOENT" });
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -17,7 +17,6 @@ const mocks = vi.hoisted(() => ({
     save: vi.fn(),
     update: vi.fn(),
   },
-  execFile: vi.fn(),
   createWorktreeWithSession: vi.fn(),
   createSessionWithoutWorktree: vi.fn(),
   removeWorktreeAndBranch: vi.fn(),
@@ -35,13 +34,6 @@ const mocks = vi.hoisted(() => ({
   broadcastTaskPrMergedDetectedBatch: vi.fn(),
   writeTextFile: vi.fn(),
   readTextFile: vi.fn(),
-}));
-
-vi.mock("child_process", () => ({
-  execFile: mocks.execFile,
-  default: {
-    execFile: mocks.execFile,
-  },
 }));
 
 vi.mock("@/lib/database", () => ({
@@ -107,6 +99,29 @@ vi.mock("@/lib/hostFileAccess", () => ({
   writeTextFile: mocks.writeTextFile,
   quoteShellArgument: (value: string) => `'${value.replaceAll("'", `'\\''`)}'`,
 }));
+
+const PR_LIST_URL_ARGUMENTS_FOR = (branchName: string) => `pr list --head '${branchName}' --json url -q '.[0].url'`;
+const PR_LIST_INFO_ARGUMENTS_FOR = (branchName: string) => (
+  `pr list --head '${branchName}' --state all --json url,state,mergedAt,updatedAt`
+);
+
+function readGitHubCliCall(callIndex = -1) {
+  const call = mocks.execGit.mock.calls.at(callIndex);
+  return {
+    command: String(call?.[0] ?? ""),
+    sshHost: (call?.[1] ?? null) as string | null,
+    options: call?.[2] as { timeoutMs?: number } | undefined,
+  };
+}
+
+function expectGitHubCliCommand(command: string, repoPath: string, ghArguments: string) {
+  expect(command).toContain(`repo='${repoPath}'`);
+  /** 등록된 경로가 저장소를 감싼 상위 폴더면 바로 아래 저장소로 내려가야 조회가 성립한다 */
+  expect(command).toContain('if [ ! -e "$repo/.git" ]');
+  /** .envrc에 GitHub 인증을 심어 둔 저장소는 direnv를 태우지 않으면 권한 없이 실패한다 */
+  expect(command).toContain(`direnv exec "$repo" gh ${ghArguments}`);
+  expect(command).toContain(`else gh ${ghArguments}`);
+}
 
 describe("kanbanService.createTask", () => {
   beforeEach(() => {
@@ -1443,7 +1458,7 @@ describe("kanbanService.createTask", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it("PR URL 조회는 셸 없이 gh CLI를 직접 실행한다", async () => {
+  it("PR URL 조회는 저장소를 찾아 direnv 환경으로 gh를 실행한다", async () => {
     // Given
     mocks.taskRepo.findOneBy.mockResolvedValue({
       id: "task-4",
@@ -1456,10 +1471,7 @@ describe("kanbanService.createTask", () => {
       repoPath: "/workspace/repo",
     });
     mocks.taskRepo.save.mockImplementation(async (value) => value);
-    mocks.execFile.mockImplementation((file, args, options, callback) => {
-      callback(null, "https://github.com/kanvibe/kanvibe/pull/1\n", "");
-      return {} as never;
-    });
+    mocks.execGit.mockResolvedValue("https://github.com/kanvibe/kanvibe/pull/1\n");
 
     const { fetchAndSavePrUrl } = await import("@/desktop/main/services/kanbanService");
 
@@ -1467,12 +1479,10 @@ describe("kanbanService.createTask", () => {
     const result = await fetchAndSavePrUrl("task-4");
 
     // Then
-    expect(mocks.execFile).toHaveBeenCalledWith(
-      "gh",
-      ["pr", "list", "--head", "main", "--json", "url", "-q", ".[0].url"],
-      expect.objectContaining({ cwd: "/workspace/repo", timeout: 10_000 }),
-      expect.any(Function),
-    );
+    const githubCliCall = readGitHubCliCall();
+    expectGitHubCliCommand(githubCliCall.command, "/workspace/repo", PR_LIST_URL_ARGUMENTS_FOR("main"));
+    expect(githubCliCall.sshHost).toBeNull();
+    expect(githubCliCall.options).toEqual({ timeoutMs: 10_000 });
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
       id: "task-4",
       prUrl: "https://github.com/kanvibe/kanvibe/pull/1",
@@ -1494,16 +1504,12 @@ describe("kanbanService.createTask", () => {
       id: "project-1",
       repoPath: "/workspace/repo",
     });
-    mocks.execFile.mockImplementation((file, args, options, callback) => {
-      const error = Object.assign(new Error("spawn gh ENOENT"), {
-        code: "ENOENT",
-        errno: -2,
-        syscall: "spawn gh",
-        path: "gh",
-      });
-      callback(error, "", "");
-      return {} as never;
-    });
+    mocks.execGit.mockRejectedValue(Object.assign(new Error("spawn gh ENOENT"), {
+      code: "ENOENT",
+      errno: -2,
+      syscall: "spawn gh",
+      path: "gh",
+    }));
 
     const { fetchAndSavePrUrl } = await import("@/desktop/main/services/kanbanService");
 
@@ -1537,11 +1543,11 @@ describe("kanbanService.createTask", () => {
 
     const result = await fetchAndSavePrUrl("task-6");
 
-    expect(mocks.execGit).toHaveBeenCalledWith(
-      "cd '/remote/repo' && gh pr list --head 'feature/remote-pr' --json url -q '.[0].url'",
-      "remote-host",
-    );
-    expect(mocks.execFile).not.toHaveBeenCalled();
+    const remoteGithubCliCall = readGitHubCliCall();
+    expectGitHubCliCommand(remoteGithubCliCall.command, "/remote/repo", PR_LIST_URL_ARGUMENTS_FOR("feature/remote-pr"));
+    expect(remoteGithubCliCall.sshHost).toBe("remote-host");
+    /** 원격은 SSH 계층이 이미 제한 시간을 관리하므로 명령에 따로 걸지 않는다 */
+    expect(remoteGithubCliCall.options).toBeUndefined();
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
       id: "task-6",
       prUrl: "https://github.com/kanvibe/kanvibe/pull/99",
@@ -1567,10 +1573,13 @@ describe("kanbanService.createTask", () => {
 
     const result = await fetchAndSavePrUrl("task-7");
 
-    expect(mocks.execGit).toHaveBeenCalledWith(
-      "cd '/remote/repo__worktrees/feature-fallback-path' && gh pr list --head 'feature/fallback-path' --json url -q '.[0].url'",
-      "remote-host",
+    const fallbackGithubCliCall = readGitHubCliCall();
+    expectGitHubCliCommand(
+      fallbackGithubCliCall.command,
+      "/remote/repo__worktrees/feature-fallback-path",
+      PR_LIST_URL_ARGUMENTS_FOR("feature/fallback-path"),
     );
+    expect(fallbackGithubCliCall.sshHost).toBe("remote-host");
     expect(mocks.taskRepo.save).toHaveBeenCalledWith(expect.objectContaining({
       id: "task-7",
       prUrl: "https://github.com/kanvibe/kanvibe/pull/101",
@@ -1601,10 +1610,7 @@ describe("kanbanService.createTask", () => {
     const result = await fetchAndSavePrUrl("task-8");
 
     expect(result).toBeNull();
-    expect(mocks.execGit).toHaveBeenCalledWith(
-      "cd '/remote/repo' && gh pr list --head 'feature/no-gh' --json url -q '.[0].url'",
-      "remote-host",
-    );
+    expectGitHubCliCommand(readGitHubCliCall().command, "/remote/repo", PR_LIST_URL_ARGUMENTS_FOR("feature/no-gh"));
     expect(mocks.taskRepo.save).not.toHaveBeenCalled();
     expect(mocks.broadcastBoardUpdate).not.toHaveBeenCalled();
     expect(consoleErrorSpy).not.toHaveBeenCalled();
@@ -1631,15 +1637,12 @@ describe("kanbanService.createTask", () => {
       sshHost: null,
     });
     mocks.taskRepo.save.mockImplementation(async (value) => value);
-    mocks.execFile.mockImplementation((file, args, options, callback) => {
-      callback(null, JSON.stringify([{
-        url: prUrl,
-        state: "OPEN",
-        mergedAt: null,
-        updatedAt: "2026-04-30T01:00:00Z",
-      }]), "");
-      return {} as never;
-    });
+    mocks.execGit.mockResolvedValue(JSON.stringify([{
+      url: prUrl,
+      state: "OPEN",
+      mergedAt: null,
+      updatedAt: "2026-04-30T01:00:00Z",
+    }]));
 
     const { syncActiveTaskPullRequests } = await import("@/desktop/main/services/kanbanService");
 
@@ -1687,7 +1690,7 @@ describe("kanbanService.createTask", () => {
       mergeEventKeys: [],
       mergedPullRequests: [],
     });
-    expect(mocks.execFile).not.toHaveBeenCalled();
+    expect(mocks.execGit).not.toHaveBeenCalled();
     expect(mocks.taskRepo.save).not.toHaveBeenCalled();
     expect(mocks.broadcastTaskPrMergedDetectedBatch).not.toHaveBeenCalled();
   });
@@ -1713,10 +1716,7 @@ describe("kanbanService.createTask", () => {
       defaultBranch: "main",
       sshHost: null,
     });
-    mocks.execFile.mockImplementation((file, args, options, callback) => {
-      callback(new Error("gh auth failed"), "", "");
-      return {} as never;
-    });
+    mocks.execGit.mockRejectedValue(new Error("gh auth failed"));
 
     try {
       const { syncActiveTaskPullRequests } = await import("@/desktop/main/services/kanbanService");
@@ -1767,15 +1767,12 @@ describe("kanbanService.createTask", () => {
       sshHost: null,
     });
     mocks.taskRepo.save.mockImplementation(async (value) => value);
-    mocks.execFile.mockImplementation((file, args, options, callback) => {
-      callback(null, JSON.stringify([{
-        url: prUrl,
-        state: "MERGED",
-        mergedAt: "2026-04-30T02:00:00Z",
-        updatedAt: "2026-04-30T02:00:00Z",
-      }]), "");
-      return {} as never;
-    });
+    mocks.execGit.mockResolvedValue(JSON.stringify([{
+      url: prUrl,
+      state: "MERGED",
+      mergedAt: "2026-04-30T02:00:00Z",
+      updatedAt: "2026-04-30T02:00:00Z",
+    }]));
 
     const mergeEventKeys = new Set<string>();
     const { syncActiveTaskPullRequests } = await import("@/desktop/main/services/kanbanService");
@@ -1827,37 +1824,32 @@ describe("kanbanService.createTask", () => {
       defaultBranch: "main",
       sshHost: null,
     });
-    const callbacks: Array<(error: Error | null, stdout: string, stderr: string) => void> = [];
-    mocks.execFile.mockImplementation((file, args, options, callback) => {
-      callbacks.push(callback);
-      return {} as never;
-    });
+    const pendingLookups: Array<(output: string) => void> = [];
+    mocks.execGit.mockImplementation(() => new Promise<string>((resolve) => {
+      pendingLookups.push(resolve);
+    }));
 
     const { syncActiveTaskPullRequests } = await import("@/desktop/main/services/kanbanService");
+    const emptyPullRequestList = JSON.stringify([{
+      url: null,
+      state: null,
+      mergedAt: null,
+      updatedAt: "2026-05-02T01:00:00Z",
+    }]);
 
     // When
     const syncPromise = syncActiveTaskPullRequests(new Set());
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     // Then
-    expect(callbacks).toHaveLength(1);
+    expect(pendingLookups).toHaveLength(1);
 
-    callbacks[0](null, JSON.stringify([{
-      url: null,
-      state: null,
-      mergedAt: null,
-      updatedAt: "2026-05-02T01:00:00Z",
-    }]), "");
+    pendingLookups[0](emptyPullRequestList);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(callbacks).toHaveLength(2);
+    expect(pendingLookups).toHaveLength(2);
 
-    callbacks[1](null, JSON.stringify([{
-      url: null,
-      state: null,
-      mergedAt: null,
-      updatedAt: "2026-05-02T01:00:00Z",
-    }]), "");
+    pendingLookups[1](emptyPullRequestList);
     await syncPromise;
   });
 
@@ -1894,25 +1886,27 @@ describe("kanbanService.createTask", () => {
         defaultBranch: "main",
         sshHost: null,
       });
-      const execFileOptions: Array<{ cwd?: string; timeout?: number }> = [];
-      mocks.execFile.mockImplementation((file, args: string[], options, callback) => {
-        execFileOptions.push(options);
-        if (args.includes("feature/pr-stuck")) {
-          if (typeof options.timeout === "number") {
+      const githubCliOptions: Array<{ timeoutMs?: number } | undefined> = [];
+      mocks.execGit.mockImplementation((
+        command: string,
+        _sshHost: string | null,
+        options?: { timeoutMs?: number },
+      ) => {
+        githubCliOptions.push(options);
+        if (command.includes("feature/pr-stuck")) {
+          return new Promise((_resolve, reject) => {
             setTimeout(() => {
-              callback(Object.assign(new Error("gh pr list timed out"), { killed: true, signal: "SIGTERM" }), "", "");
-            }, options.timeout);
-          }
-          return {} as never;
+              reject(Object.assign(new Error("gh pr list timed out"), { killed: true, signal: "SIGTERM" }));
+            }, options?.timeoutMs);
+          });
         }
 
-        callback(null, JSON.stringify([{
+        return Promise.resolve(JSON.stringify([{
           url: null,
           state: null,
           mergedAt: null,
           updatedAt: "2026-05-02T01:00:00Z",
-        }]), "");
-        return {} as never;
+        }]));
       });
 
       const { syncActiveTaskPullRequests } = await import("@/desktop/main/services/kanbanService");
@@ -1922,17 +1916,17 @@ describe("kanbanService.createTask", () => {
       await vi.advanceTimersByTimeAsync(0);
 
       // Then
-      expect(execFileOptions).toEqual([
-        expect.objectContaining({ cwd: "/workspace/repo", timeout: 10_000 }),
-      ]);
+      expectGitHubCliCommand(
+        readGitHubCliCall(0).command,
+        "/workspace/repo",
+        PR_LIST_INFO_ARGUMENTS_FOR("feature/pr-stuck"),
+      );
+      expect(githubCliOptions).toEqual([{ timeoutMs: 10_000 }]);
 
       await vi.advanceTimersByTimeAsync(10_000);
       await vi.advanceTimersByTimeAsync(0);
 
-      expect(execFileOptions).toEqual([
-        expect.objectContaining({ cwd: "/workspace/repo", timeout: 10_000 }),
-        expect.objectContaining({ cwd: "/workspace/repo", timeout: 10_000 }),
-      ]);
+      expect(githubCliOptions).toEqual([{ timeoutMs: 10_000 }, { timeoutMs: 10_000 }]);
       await expect(syncPromise).resolves.toEqual({
         updatedTaskIds: [],
         mergeEventKeys: [],

--- a/src/desktop/main/services/__tests__/kanbanService.test.ts
+++ b/src/desktop/main/services/__tests__/kanbanService.test.ts
@@ -119,7 +119,8 @@ function expectGitHubCliCommand(command: string, repoPath: string, ghArguments: 
   /** 등록된 경로가 저장소를 감싼 상위 폴더면 바로 아래 저장소로 내려가야 조회가 성립한다 */
   expect(command).toContain('if [ ! -e "$repo/.git" ]');
   /** .envrc에 GitHub 인증을 심어 둔 저장소는 direnv를 태우지 않으면 권한 없이 실패한다 */
-  expect(command).toContain(`direnv exec "$repo" gh ${ghArguments}`);
+  expect(command).toContain(`if [ -f "$repo/.envrc" ] && command -v direnv`);
+  expect(command).toContain(`direnv exec "$repo" gh ${ghArguments} || gh ${ghArguments}`);
   expect(command).toContain(`else gh ${ghArguments}`);
 }
 
@@ -2586,5 +2587,213 @@ describe("kanbanService.updateTask", () => {
 
     // Then
     expect(mocks.writeTextFile).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * gh를 부르는 셸 명령은 문자열 비교만으로는 검증되지 않는다.
+ * 실제 저장소 배치를 만들어 두고 `sh -c`로 돌려, 어느 디렉터리에서 gh가 실행되는지 확인한다.
+ */
+describe("kanbanService gh 실행 셸 명령", () => {
+  const nodeFs = require("node:fs") as typeof import("node:fs");
+  const nodeOs = require("node:os") as typeof import("node:os");
+  const nodePath = require("node:path") as typeof import("node:path");
+  const { execFileSync } = require("node:child_process") as typeof import("node:child_process");
+
+  let workspaceRoot = "";
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    workspaceRoot = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), "kanvibe-gh-command-"));
+  });
+
+  /** gh와 direnv를 흉내 내는 stub을 PATH 앞에 두고, 실행된 디렉터리를 stdout으로 받는다 */
+  function createShellStubs({ direnvFails = false }: { direnvFails?: boolean } = {}) {
+    const stubDirectory = nodePath.join(workspaceRoot, "__bin");
+    nodeFs.mkdirSync(stubDirectory, { recursive: true });
+
+    nodeFs.writeFileSync(
+      nodePath.join(stubDirectory, "gh"),
+      '#!/bin/sh\nprintf "gh:%s" "$(pwd)"\n',
+      { mode: 0o755 },
+    );
+    nodeFs.writeFileSync(
+      nodePath.join(stubDirectory, "direnv"),
+      direnvFails
+        ? '#!/bin/sh\necho "direnv: .envrc is blocked" >&2\nexit 1\n'
+        : '#!/bin/sh\nshift 2\nprintf "direnv:%s" "$(pwd)"\n',
+      { mode: 0o755 },
+    );
+
+    return stubDirectory;
+  }
+
+  function runGitHubCliCommand(command: string, stubDirectory: string): string {
+    return execFileSync("sh", ["-c", command], {
+      encoding: "utf8",
+      env: { PATH: `${stubDirectory}:${process.env.PATH ?? ""}` },
+    });
+  }
+
+  async function captureGitHubCliCommand(repoPath: string): Promise<string> {
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-gh",
+      projectId: "project-gh",
+      branchName: "feat/login",
+      prUrl: null,
+    });
+    mocks.projectRepo.findOneBy.mockResolvedValue({ id: "project-gh", repoPath });
+    mocks.taskRepo.save.mockImplementation(async (value: unknown) => value);
+    mocks.execGit.mockResolvedValue("");
+
+    const { fetchAndSavePrUrl } = await import("@/desktop/main/services/kanbanService");
+    await fetchAndSavePrUrl("task-gh");
+
+    return readGitHubCliCall().command;
+  }
+
+  function createRepository(relativePath: string): string {
+    const repositoryPath = nodePath.join(workspaceRoot, relativePath);
+    nodeFs.mkdirSync(nodePath.join(repositoryPath, ".git"), { recursive: true });
+    return repositoryPath;
+  }
+
+  it("등록 경로 아래 저장소가 하나뿐이면 그 저장소에서 gh를 실행한다", async () => {
+    // Given
+    const nestedRepository = createRepository("web");
+    const command = await captureGitHubCliCommand(workspaceRoot);
+
+    // When
+    const output = runGitHubCliCommand(command, createShellStubs());
+
+    // Then
+    expect(output).toBe(`gh:${nestedRepository}`);
+  });
+
+  /** 엉뚱한 저장소의 PR을 task.prUrl로 저장하면 머지 알림까지 잘못 뜬다. 실패가 낫다 */
+  it("등록 경로 아래 저장소가 둘 이상이면 어느 쪽으로도 내려가지 않는다", async () => {
+    // Given
+    createRepository("api");
+    createRepository("web");
+    const command = await captureGitHubCliCommand(workspaceRoot);
+
+    // When
+    const output = runGitHubCliCommand(command, createShellStubs());
+
+    // Then
+    expect(output).toBe(`gh:${workspaceRoot}`);
+  });
+
+  it("등록 경로 자체가 저장소면 하위를 뒤지지 않는다", async () => {
+    // Given
+    const repositoryPath = createRepository("solo");
+    createRepository(nodePath.join("solo", "nested"));
+    const command = await captureGitHubCliCommand(repositoryPath);
+
+    // When
+    const output = runGitHubCliCommand(command, createShellStubs());
+
+    // Then
+    expect(output).toBe(`gh:${repositoryPath}`);
+  });
+
+  it(".envrc가 없으면 direnv가 깔려 있어도 평범한 gh를 부른다", async () => {
+    // Given
+    const repositoryPath = createRepository("plain");
+    const command = await captureGitHubCliCommand(repositoryPath);
+
+    // When
+    const output = runGitHubCliCommand(command, createShellStubs());
+
+    // Then
+    expect(output).toBe(`gh:${repositoryPath}`);
+  });
+
+  it(".envrc가 있으면 direnv를 태워 gh를 부른다", async () => {
+    // Given
+    const repositoryPath = createRepository("direnv-repo");
+    nodeFs.writeFileSync(nodePath.join(repositoryPath, ".envrc"), "export GH_TOKEN=token\n");
+    const command = await captureGitHubCliCommand(repositoryPath);
+
+    // When
+    const output = runGitHubCliCommand(command, createShellStubs());
+
+    // Then
+    expect(output).toBe(`direnv:${repositoryPath}`);
+  });
+
+  /** direnv allow가 안 된 .envrc면 direnv 경로가 늘 실패한다. fallback이 없으면 그 저장소는 영구히 조회 불가다 */
+  it("direnv 경로가 실패하면 평범한 gh로 되돌아간다", async () => {
+    // Given
+    const repositoryPath = createRepository("blocked-envrc");
+    nodeFs.writeFileSync(nodePath.join(repositoryPath, ".envrc"), "export GH_TOKEN=token\n");
+    const command = await captureGitHubCliCommand(repositoryPath);
+
+    // When
+    const output = runGitHubCliCommand(command, createShellStubs({ direnvFails: true }));
+
+    // Then
+    expect(output).toBe(`gh:${repositoryPath}`);
+  });
+
+  /** 경로 없음은 재시도해도 회복되지 않는다. 예외로 올리면 매 background sync마다 실패 창이 뜬다 */
+  it("저장소 경로가 사라졌으면 gh를 부르지 않고 표식만 남기고 정상 종료한다", async () => {
+    // Given
+    const command = await captureGitHubCliCommand(nodePath.join(workspaceRoot, "gone"));
+
+    // When
+    const output = runGitHubCliCommand(command, createShellStubs());
+
+    // Then
+    expect(output).toBe("kanvibe-missing-repository");
+  });
+
+  /**
+   * `shouldLogRemoteCommandFailure`가 이 패턴을 조용한 probe로 보고 원격 실패 로그를 통째로 지운다.
+   * 명령에 섞여 들어가면 SSH 원격 태스크의 PR 조회 실패가 진단 로그에 남지 않는다.
+   */
+  it("원격 실패 로그를 지우는 조용한 probe 패턴을 명령에 넣지 않는다", async () => {
+    // Given
+    const repositoryPath = createRepository("logging");
+
+    // When
+    const command = await captureGitHubCliCommand(repositoryPath);
+
+    // Then
+    expect(command).not.toContain(">/dev/null 2>&1");
+    expect(command).not.toContain("2>/dev/null");
+  });
+});
+
+describe("kanbanService PR 조회 실패 처리", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("저장소 경로 없음 표식이 오면 PR URL 조회를 조용히 건너뛴다", async () => {
+    // Given
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.taskRepo.findOneBy.mockResolvedValue({
+      id: "task-missing-repo",
+      projectId: "project-1",
+      branchName: "dev",
+      prUrl: null,
+    });
+    mocks.projectRepo.findOneBy.mockResolvedValue({ id: "project-1", repoPath: "/moved/away" });
+    mocks.execGit.mockResolvedValue("kanvibe-missing-repository");
+
+    const { fetchAndSavePrUrl } = await import("@/desktop/main/services/kanbanService");
+
+    // When
+    const result = await fetchAndSavePrUrl("task-missing-repo");
+
+    // Then
+    expect(result).toBeNull();
+    expect(mocks.taskRepo.save).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/src/desktop/main/services/appSettingsService.ts
+++ b/src/desktop/main/services/appSettingsService.ts
@@ -7,6 +7,10 @@ import {
   type ShortcutBindings,
 } from "@/desktop/shared/shortcutBindings";
 import {
+  canonicalizeShortcutForPlatform,
+  getShortcutPlatformFromProcessPlatform,
+} from "@/desktop/shared/keyboardShortcut";
+import {
   parseBoardSortPreference,
   serializeBoardSortPreference,
   type BoardSortPreference,
@@ -221,6 +225,8 @@ export async function setBackgroundSyncIntervalMs(intervalMs: number): Promise<v
 
 const DEFAULT_SESSION_TYPE_KEY = "default_session_type";
 const SHORTCUT_BINDINGS_KEY = "shortcut_bindings";
+/** 단축키 표가 생기기 전, 빠른 검색 하나만 따로 저장하던 키 */
+const LEGACY_TASK_SEARCH_SHORTCUT_KEY = "task_search_shortcut";
 const VIM_MODE_ENABLED_KEY = "vim_mode_enabled";
 
 /** 기본 세션 타입을 조회한다. 미설정이거나 모르는 값이면 "tmux"를 반환한다 */
@@ -236,14 +242,46 @@ export async function setDefaultSessionType(sessionType: SessionType): Promise<v
   await setAppSetting(DEFAULT_SESSION_TYPE_KEY, sessionType);
 }
 
-/** 사용자가 재배정한 값까지 반영한 단축키 표를 조회한다 */
+/**
+ * 사용자가 재배정한 값까지 반영한 단축키 표를 조회한다.
+ *
+ * 단축키 표가 없으면 옛 `task_search_shortcut` 값을 `taskSearch` 재배정으로 승계한다. 승계하지 않으면
+ * 그 시절에 빠른 검색을 바꿔 둔 사용자의 단축키가 업그레이드 순간 말없이 기본값으로 되돌아간다.
+ * 승계 결과를 한 번 써 두면 이 분기는 다시 타지 않으므로 옛 키는 그대로 두고 읽지 않는다.
+ */
 export async function getShortcutBindings(): Promise<ShortcutBindings> {
-  return resolveShortcutBindings(parseShortcutOverrides(await getAppSetting(SHORTCUT_BINDINGS_KEY)));
+  const shortcutPlatform = getShortcutPlatformFromProcessPlatform(process.platform);
+  const storedOverrides = await getAppSetting(SHORTCUT_BINDINGS_KEY);
+  if (storedOverrides !== null) {
+    return resolveShortcutBindings(parseShortcutOverrides(storedOverrides, shortcutPlatform));
+  }
+
+  const legacyTaskSearchShortcut = await getAppSetting(LEGACY_TASK_SEARCH_SHORTCUT_KEY);
+  if (!legacyTaskSearchShortcut) {
+    return resolveShortcutBindings({});
+  }
+
+  /** 옛 값은 Mod 없이 `Meta+…`/`Ctrl+…`로 저장돼 있어, 접지 않으면 중복 판정이 같은 조합을 못 알아본다 */
+  const migratedTaskSearchShortcut = canonicalizeShortcutForPlatform(
+    legacyTaskSearchShortcut,
+    shortcutPlatform,
+  );
+  /** 옛 값이 파싱 불가면 canonical 결과가 빈 문자열이고, 그대로 얹으면 기본값을 지워 빠른 검색이 사라진다 */
+  const migratedBindings = resolveShortcutBindings(
+    migratedTaskSearchShortcut ? { taskSearch: migratedTaskSearchShortcut } : {},
+  );
+  await setShortcutBindings(migratedBindings);
+
+  return migratedBindings;
 }
 
 /** 단축키 표를 저장한다. 기본값과 같은 항목은 빼고 재배정만 남긴다 */
 export async function setShortcutBindings(bindings: ShortcutBindings): Promise<void> {
-  await setAppSetting(SHORTCUT_BINDINGS_KEY, JSON.stringify(collectShortcutOverrides(bindings)));
+  const shortcutPlatform = getShortcutPlatformFromProcessPlatform(process.platform);
+  await setAppSetting(
+    SHORTCUT_BINDINGS_KEY,
+    JSON.stringify(collectShortcutOverrides(bindings, shortcutPlatform)),
+  );
 }
 
 /** 태스크 빠른 검색 단축키를 조회한다. 미설정 시 기본값을 반환한다 */

--- a/src/desktop/main/services/appSettingsService.ts
+++ b/src/desktop/main/services/appSettingsService.ts
@@ -1,6 +1,11 @@
 import { getAppSettingsRepository } from "@/lib/database";
 import { SessionType } from "@/entities/KanbanTask";
-import { DEFAULT_TASK_SEARCH_SHORTCUT } from "@/desktop/shared/keyboardShortcut";
+import {
+  collectShortcutOverrides,
+  parseShortcutOverrides,
+  resolveShortcutBindings,
+  type ShortcutBindings,
+} from "@/desktop/shared/shortcutBindings";
 import {
   parseBoardSortPreference,
   serializeBoardSortPreference,
@@ -215,7 +220,7 @@ export async function setBackgroundSyncIntervalMs(intervalMs: number): Promise<v
 }
 
 const DEFAULT_SESSION_TYPE_KEY = "default_session_type";
-const TASK_SEARCH_SHORTCUT_KEY = "task_search_shortcut";
+const SHORTCUT_BINDINGS_KEY = "shortcut_bindings";
 const VIM_MODE_ENABLED_KEY = "vim_mode_enabled";
 
 /** 기본 세션 타입을 조회한다. 미설정이거나 모르는 값이면 "tmux"를 반환한다 */
@@ -231,16 +236,19 @@ export async function setDefaultSessionType(sessionType: SessionType): Promise<v
   await setAppSetting(DEFAULT_SESSION_TYPE_KEY, sessionType);
 }
 
-/** 태스크 빠른 검색 단축키를 조회한다. 미설정 시 기본값을 반환한다 */
-export async function getTaskSearchShortcut(): Promise<string> {
-  const value = await getAppSetting(TASK_SEARCH_SHORTCUT_KEY);
-  return value?.trim() || DEFAULT_TASK_SEARCH_SHORTCUT;
+/** 사용자가 재배정한 값까지 반영한 단축키 표를 조회한다 */
+export async function getShortcutBindings(): Promise<ShortcutBindings> {
+  return resolveShortcutBindings(parseShortcutOverrides(await getAppSetting(SHORTCUT_BINDINGS_KEY)));
 }
 
-/** 태스크 빠른 검색 단축키를 저장한다 */
-export async function setTaskSearchShortcut(shortcut: string): Promise<void> {
-  const normalizedShortcut = shortcut.trim() || DEFAULT_TASK_SEARCH_SHORTCUT;
-  await setAppSetting(TASK_SEARCH_SHORTCUT_KEY, normalizedShortcut);
+/** 단축키 표를 저장한다. 기본값과 같은 항목은 빼고 재배정만 남긴다 */
+export async function setShortcutBindings(bindings: ShortcutBindings): Promise<void> {
+  await setAppSetting(SHORTCUT_BINDINGS_KEY, JSON.stringify(collectShortcutOverrides(bindings)));
+}
+
+/** 태스크 빠른 검색 단축키를 조회한다. 미설정 시 기본값을 반환한다 */
+export async function getTaskSearchShortcut(): Promise<string> {
+  return (await getShortcutBindings()).taskSearch;
 }
 
 /** Vim-style board navigation 활성화 여부를 조회한다. 미설정 시 활성화 상태를 반환한다 */

--- a/src/desktop/main/services/editorService.ts
+++ b/src/desktop/main/services/editorService.ts
@@ -1,0 +1,68 @@
+import { execFile } from "child_process";
+import { getProjectRepository, getTaskRepository } from "@/lib/database";
+import { createLocalShellEnvironment } from "@/lib/shellEnvironment";
+
+const VS_CODE_COMMAND = "code";
+const VS_CODE_LAUNCH_TIMEOUT_MS = 10_000;
+
+export interface EditorOpenResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * VS Code CLI 인자를 만든다.
+ * 원격 작업이라도 명령은 항상 로컬에서 돈다. 원격 셸에서 `code`를 실행하면 그 머신에서 창을 띄우려 하고,
+ * Remote-SSH의 `code` 셔틀은 이미 Remote-SSH로 붙은 통합 터미널 안에서만 로컬로 넘어오기 때문이다.
+ * 그래서 원격은 로컬 VS Code에 `--remote ssh-remote+<host>`로 붙을 곳을 알려 주는 방향으로 뒤집는다.
+ */
+export function buildVsCodeOpenArgs(targetPath: string, sshHost: string | null): string[] {
+  return sshHost ? ["--remote", `ssh-remote+${sshHost}`, targetPath] : [targetPath];
+}
+
+/**
+ * 작업을 열 경로와 호스트를 정한다.
+ * worktree가 있으면 그 작업의 실제 작업 사본이므로 프로젝트 저장소보다 먼저 쓴다.
+ */
+async function resolveTaskEditorTarget(taskId: string): Promise<{ targetPath: string; sshHost: string | null } | null> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOneBy({ id: taskId });
+  if (!task) {
+    return null;
+  }
+
+  const project = task.projectId
+    ? await (await getProjectRepository()).findOneBy({ id: task.projectId })
+    : null;
+  const targetPath = task.worktreePath || project?.repoPath || null;
+  if (!targetPath) {
+    return null;
+  }
+
+  return { targetPath, sshHost: task.sshHost || project?.sshHost || null };
+}
+
+/** 작업 폴더를 로컬 VS Code로 연다. 원격 작업이면 Remote-SSH로 붙어서 연다 */
+export async function openTaskInVsCode(taskId: string): Promise<EditorOpenResult> {
+  const target = await resolveTaskEditorTarget(taskId);
+  if (!target) {
+    return { ok: false, error: "no-target-path" };
+  }
+
+  return new Promise((resolve) => {
+    execFile(
+      VS_CODE_COMMAND,
+      buildVsCodeOpenArgs(target.targetPath, target.sshHost),
+      { env: createLocalShellEnvironment(), timeout: VS_CODE_LAUNCH_TIMEOUT_MS },
+      (error) => {
+        if (error) {
+          console.error("VS Code 실행 실패:", error);
+          resolve({ ok: false, error: error.message });
+          return;
+        }
+
+        resolve({ ok: true });
+      },
+    );
+  });
+}

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -1,4 +1,3 @@
-import { execFile } from "child_process";
 import { In, Not, Like } from "typeorm";
 import { getTaskRepository } from "@/lib/database";
 import { KanbanTask, TaskStatus, SessionType } from "@/entities/KanbanTask";
@@ -18,7 +17,7 @@ import {
   installKanvibeHookFiles,
   scheduleKanvibeHooksVerification,
 } from "@/lib/kanvibeHooksInstaller";
-import { execGit, pullCurrentBranch, remoteBranchExists } from "@/lib/gitOperations";
+import { execGit, pullCurrentBranch, remoteBranchExists, type ExecGitOptions } from "@/lib/gitOperations";
 import { detachSession } from "@/lib/terminal";
 import {
   persistTaskMetadataForTask as persistTaskMetadata,
@@ -232,43 +231,42 @@ function reportTaskHookInstallFailure(
   });
 }
 
+/**
+ * 저장소 안에서 gh를 실행할 셸 명령을 만든다.
+ *
+ * 등록된 경로가 저장소를 감싼 상위 폴더일 수 있어, `.git`이 없으면 바로 아래에서 저장소를 한 번 더 찾는다.
+ * direnv가 깔려 있으면 그 경로의 `.envrc`를 태워서 gh를 부른다. GitHub 인증을 `.envrc`에 심어 둔 경우
+ * 셸을 거치지 않고 gh를 부르면 인증이 빠진 채로 돌아 권한 없음으로 실패한다.
+ */
+function buildGitHubCliCommand(repoPath: string, ghArguments: string): string {
+  return [
+    `repo=${quoteForShell(repoPath)}`,
+    'if [ ! -e "$repo/.git" ]; then for candidate in "$repo"/*/; do if [ -e "$candidate.git" ]; then repo="${candidate%/}"; break; fi; done; fi',
+    'cd "$repo" || exit 1',
+    `if command -v direnv >/dev/null 2>&1; then direnv exec "$repo" gh ${ghArguments}; else gh ${ghArguments}; fi`,
+  ].join("; ");
+}
+
+/** 로컬만 명령 자체에 제한 시간을 걸고, 원격은 SSH 계층이 쓰는 제한 시간을 그대로 따른다 */
+function getGitHubCliExecOptions(sshHost?: string | null): ExecGitOptions | undefined {
+  return sshHost ? undefined : { timeoutMs: ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS };
+}
+
 async function getPrUrlFromGitHubCli(branchName: string, cwd: string, sshHost?: string | null): Promise<string | null> {
-  if (sshHost) {
-    try {
-      const output = await execGit(
-        `cd ${quoteForShell(cwd)} && gh pr list --head ${quoteForShell(branchName)} --json url -q '.[0].url'`,
-        sshHost,
-      );
-      return output.trim() || null;
-    } catch (error) {
-      if (isMissingGitHubCli(error)) {
-        return null;
-      }
-
-      throw error;
-    }
-  }
-
-  return new Promise((resolve, reject) => {
-    execFile(
-      "gh",
-      ["pr", "list", "--head", branchName, "--json", "url", "-q", ".[0].url"],
-      { cwd, timeout: ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS },
-      (error, stdout) => {
-        if (error) {
-          if (isMissingGitHubCli(error)) {
-            resolve(null);
-            return;
-          }
-
-          reject(error);
-          return;
-        }
-
-        resolve(stdout.trim() || null);
-      },
+  try {
+    const output = await execGit(
+      buildGitHubCliCommand(cwd, `pr list --head ${quoteForShell(branchName)} --json url -q '.[0].url'`),
+      sshHost,
+      getGitHubCliExecOptions(sshHost),
     );
-  });
+    return output.trim() || null;
+  } catch (error) {
+    if (isMissingGitHubCli(error)) {
+      return null;
+    }
+
+    throw error;
+  }
 }
 
 function parseGitHubPullRequestInfo(output: string): GitHubPullRequestInfo | null {
@@ -302,50 +300,24 @@ async function getPrInfoFromGitHubCli(
   cwd: string,
   sshHost?: string | null,
 ): Promise<GitHubPullRequestInfo | null> {
-  if (sshHost) {
-    try {
-      const output = await execGit(
-        `cd ${quoteForShell(cwd)} && gh pr list --head ${quoteForShell(branchName)} --state all --json url,state,mergedAt,updatedAt`,
-        sshHost,
-      );
-      if (!output.trim()) {
-        return null;
-      }
-      return parseGitHubPullRequestInfo(output);
-    } catch (error) {
-      if (isMissingGitHubCli(error)) {
-        return null;
-      }
-
-      throw error;
-    }
-  }
-
-  return new Promise((resolve, reject) => {
-    execFile(
-      "gh",
-      ["pr", "list", "--head", branchName, "--state", "all", "--json", "url,state,mergedAt,updatedAt"],
-      { cwd, timeout: ACTIVE_TASK_PR_GITHUB_CLI_TIMEOUT_MS },
-      (error, stdout) => {
-        if (error) {
-          if (isMissingGitHubCli(error)) {
-            resolve(null);
-            return;
-          }
-
-          reject(error);
-          return;
-        }
-
-        if (!stdout.trim()) {
-          resolve(null);
-          return;
-        }
-
-        resolve(parseGitHubPullRequestInfo(stdout));
-      },
+  try {
+    const output = await execGit(
+      buildGitHubCliCommand(cwd, `pr list --head ${quoteForShell(branchName)} --state all --json url,state,mergedAt,updatedAt`),
+      sshHost,
+      getGitHubCliExecOptions(sshHost),
     );
-  });
+    if (!output.trim()) {
+      return null;
+    }
+
+    return parseGitHubPullRequestInfo(output);
+  } catch (error) {
+    if (isMissingGitHubCli(error)) {
+      return null;
+    }
+
+    throw error;
+  }
 }
 
 function isDefaultBranchTask(

--- a/src/desktop/main/services/kanbanService.ts
+++ b/src/desktop/main/services/kanbanService.ts
@@ -232,19 +232,39 @@ function reportTaskHookInstallFailure(
 }
 
 /**
+ * 저장소 경로가 사라졌을 때 셸이 stdout으로 내보내는 표식.
+ *
+ * 경로 없음은 재시도해도 회복되지 않아 사용자에게 sync 실패로 올릴 값이 아니다. 예외로 던지면
+ * gh 인증 실패와 구분되지 않으므로, `remoteBranchExists`가 쓰는 방식대로 표식을 찍고 조용히 건너뛴다.
+ */
+const MISSING_REPOSITORY_MARKER = "kanvibe-missing-repository";
+
+/**
  * 저장소 안에서 gh를 실행할 셸 명령을 만든다.
  *
  * 등록된 경로가 저장소를 감싼 상위 폴더일 수 있어, `.git`이 없으면 바로 아래에서 저장소를 한 번 더 찾는다.
- * direnv가 깔려 있으면 그 경로의 `.envrc`를 태워서 gh를 부른다. GitHub 인증을 `.envrc`에 심어 둔 경우
- * 셸을 거치지 않고 gh를 부르면 인증이 빠진 채로 돌아 권한 없음으로 실패한다.
+ * 후보가 둘 이상이면 어느 쪽이 이 태스크의 저장소인지 알 수 없어 승격하지 않는다. 엉뚱한 저장소의 PR을
+ * 링크하는 것보다 조회가 실패하는 편이 낫다.
+ *
+ * `.envrc`가 있으면 direnv를 태워 gh를 부른다. GitHub 인증을 `.envrc`에 심어 둔 경우 셸을 거치지 않고
+ * gh를 부르면 인증이 빠진 채로 돌아 권한 없음으로 실패한다. direnv 경로 자체가 실패할 수도 있어
+ * (`direnv allow` 안 된 `.envrc` 등) 평범한 gh 호출로 되돌아간다.
+ *
+ * 명령 문자열에 `>/dev/null 2>&1`을 넣지 않는다. `shouldLogRemoteCommandFailure`가 그 패턴을 조용한
+ * probe로 보고 원격 실패 로그를 통째로 지운다.
  */
 function buildGitHubCliCommand(repoPath: string, ghArguments: string): string {
   return [
     `repo=${quoteForShell(repoPath)}`,
-    'if [ ! -e "$repo/.git" ]; then for candidate in "$repo"/*/; do if [ -e "$candidate.git" ]; then repo="${candidate%/}"; break; fi; done; fi',
-    'cd "$repo" || exit 1',
-    `if command -v direnv >/dev/null 2>&1; then direnv exec "$repo" gh ${ghArguments}; else gh ${ghArguments}; fi`,
+    'if [ ! -e "$repo/.git" ]; then nested=""; nestedCount=0; for candidate in "$repo"/*/; do if [ -e "$candidate.git" ]; then nested="${candidate%/}"; nestedCount=$((nestedCount + 1)); fi; done; if [ "$nestedCount" -eq 1 ]; then repo="$nested"; fi; fi',
+    `cd "$repo" || { printf %s ${quoteForShell(MISSING_REPOSITORY_MARKER)}; exit 0; }`,
+    `if [ -f "$repo/.envrc" ] && command -v direnv >/dev/null; then direnv exec "$repo" gh ${ghArguments} || gh ${ghArguments}; else gh ${ghArguments}; fi`,
   ].join("; ");
+}
+
+/** 저장소 경로가 없어 조회를 건너뛰어야 하는 출력인지 본다 */
+function isMissingRepositoryOutput(output: string): boolean {
+  return output.trim() === MISSING_REPOSITORY_MARKER;
 }
 
 /** 로컬만 명령 자체에 제한 시간을 걸고, 원격은 SSH 계층이 쓰는 제한 시간을 그대로 따른다 */
@@ -259,6 +279,10 @@ async function getPrUrlFromGitHubCli(branchName: string, cwd: string, sshHost?: 
       sshHost,
       getGitHubCliExecOptions(sshHost),
     );
+    if (isMissingRepositoryOutput(output)) {
+      return null;
+    }
+
     return output.trim() || null;
   } catch (error) {
     if (isMissingGitHubCli(error)) {
@@ -306,7 +330,7 @@ async function getPrInfoFromGitHubCli(
       sshHost,
       getGitHubCliExecOptions(sshHost),
     );
-    if (!output.trim()) {
+    if (!output.trim() || isMissingRepositoryOutput(output)) {
       return null;
     }
 

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -15,8 +15,13 @@ import { applyThemePreference, THEME_PREFERENCE_CHANGED_EVENT } from "@/desktop/
 import {
   getCurrentShortcutPlatform,
   isTaskDetailRouteUrl,
-  resolveTerminalTabShortcutEvent,
 } from "@/desktop/renderer/utils/keyboardShortcut";
+import {
+  isShortcutCaptureTarget,
+  loadShortcutBindings,
+  readShortcutBindings,
+} from "@/desktop/renderer/utils/shortcutBindings";
+import { findShortcutCommandForEvent, resolveTerminalTabCommand } from "@/desktop/shared/shortcutBindings";
 import type { BoardEventPayload } from "@/lib/boardNotifier";
 import type { TerminalTabShortcutCommand } from "@/desktop/shared/terminalTabs";
 
@@ -27,6 +32,7 @@ const NotFoundRoute = lazy(() => import("@/desktop/renderer/routes/NotFoundRoute
 const AiAccountsRoute = lazy(() => import("@/desktop/renderer/routes/AiAccountsRoute"));
 const PaneLayoutRoute = lazy(() => import("@/desktop/renderer/routes/PaneLayoutRoute"));
 const SettingsRoute = lazy(() => import("@/desktop/renderer/routes/SettingsRoute"));
+const ShortcutSettingsRoute = lazy(() => import("@/desktop/renderer/routes/ShortcutSettingsRoute"));
 const TaskDetailRoute = lazy(() => import("@/desktop/renderer/routes/TaskDetailRoute"));
 
 function RouteLoadingFallback() {
@@ -108,6 +114,10 @@ export default function App() {
   const boardRefreshTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
+    void loadShortcutBindings();
+  }, []);
+
+  useEffect(() => {
     const scheduleBoardRefresh = () => {
       if (boardRefreshTimerRef.current !== null) {
         return;
@@ -147,9 +157,13 @@ export default function App() {
     };
 
     function handleWindowCloseShortcut(event: KeyboardEvent) {
-      const command = resolveTerminalTabShortcutEvent(
-        event,
-        getCurrentShortcutPlatform(),
+      /** 단축키를 녹화 중이면 그 조합은 명령이 아니라 녹화할 값이다 */
+      if (isShortcutCaptureTarget(event.target)) {
+        return;
+      }
+
+      const command = resolveTerminalTabCommand(
+        findShortcutCommandForEvent(readShortcutBindings(), event, getCurrentShortcutPlatform()),
         isTaskDetailRouteUrl(window.location.href),
       );
       if (command?.type !== "close-window") {
@@ -178,6 +192,7 @@ export default function App() {
           <Route path="ai-accounts" element={<DeferredRoute><AiAccountsRoute /></DeferredRoute>} />
           <Route path="pane-layout" element={<DeferredRoute><PaneLayoutRoute /></DeferredRoute>} />
           <Route path="settings" element={<DeferredRoute><SettingsRoute /></DeferredRoute>} />
+          <Route path="settings/shortcuts" element={<DeferredRoute><ShortcutSettingsRoute /></DeferredRoute>} />
           <Route path="task/:id" element={<DeferredRoute><TaskDetailRoute /></DeferredRoute>} />
           <Route path="task/:id/diff" element={<DeferredRoute><DiffRoute /></DeferredRoute>} />
           <Route path="*" element={<DeferredRoute><NotFoundRoute /></DeferredRoute>} />

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -17,6 +17,7 @@ import {
   isTaskDetailRouteUrl,
 } from "@/desktop/renderer/utils/keyboardShortcut";
 import {
+  isShortcutCaptureActive,
   isShortcutCaptureTarget,
   loadShortcutBindings,
   readShortcutBindings,
@@ -113,8 +114,13 @@ function LocaleShell() {
 export default function App() {
   const boardRefreshTimerRef = useRef<number | null>(null);
 
+  /** 다른 창이 단축키를 바꾸면 main이 알려 준다. 그러지 않으면 이 창은 재시작 전까지 옛 조합으로 동작한다 */
   useEffect(() => {
     void loadShortcutBindings();
+
+    return window.kanvibeDesktop?.onShortcutBindingsChanged?.(() => {
+      void loadShortcutBindings();
+    });
   }, []);
 
   useEffect(() => {
@@ -151,14 +157,18 @@ export default function App() {
    */
   useEffect(() => {
     const closeWindowIfRequested = (command: TerminalTabShortcutCommand) => {
+      /** 단축키를 녹화 중이면 그 조합은 명령이 아니라 녹화할 값이다 */
+      if (isShortcutCaptureActive()) {
+        return;
+      }
+
       if (command.type === "close-window") {
         window.kanvibeDesktop?.closeCurrentWindow?.();
       }
     };
 
     function handleWindowCloseShortcut(event: KeyboardEvent) {
-      /** 단축키를 녹화 중이면 그 조합은 명령이 아니라 녹화할 값이다 */
-      if (isShortcutCaptureTarget(event.target)) {
+      if (isShortcutCaptureActive() || isShortcutCaptureTarget(event.target)) {
         return;
       }
 

--- a/src/desktop/renderer/actions/appSettings.ts
+++ b/src/desktop/renderer/actions/appSettings.ts
@@ -1,5 +1,6 @@
 import type { SessionType } from "@/entities/KanbanTask";
 import type { BoardSortPreference } from "@/desktop/shared/boardSort";
+import type { ShortcutBindings } from "@/desktop/shared/shortcutBindings";
 import { invokeDesktop } from "@/desktop/renderer/ipc";
 import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
 
@@ -87,8 +88,12 @@ export function getTaskSearchShortcut(): Promise<string> {
   return invokeDesktop("appSettings", "getTaskSearchShortcut");
 }
 
-export function setTaskSearchShortcut(shortcut: string): Promise<void> {
-  return invokeAndRefresh("setTaskSearchShortcut", shortcut);
+export function getShortcutBindings(): Promise<ShortcutBindings> {
+  return invokeDesktop("appSettings", "getShortcutBindings");
+}
+
+export function setShortcutBindings(bindings: ShortcutBindings): Promise<void> {
+  return invokeAndRefresh("setShortcutBindings", bindings);
 }
 
 export function getVimModeEnabled(): Promise<boolean> {

--- a/src/desktop/renderer/actions/editor.ts
+++ b/src/desktop/renderer/actions/editor.ts
@@ -1,0 +1,6 @@
+import { invokeDesktop } from "@/desktop/renderer/ipc";
+import type { EditorOpenResult } from "@/desktop/main/services/editorService";
+
+export function openTaskInVsCode(taskId: string): Promise<EditorOpenResult> {
+  return invokeDesktop("editor", "openTaskInVsCode", taskId);
+}

--- a/src/desktop/renderer/components/BoardCommandProvider.tsx
+++ b/src/desktop/renderer/components/BoardCommandProvider.tsx
@@ -12,17 +12,11 @@ import {
 } from "react";
 import { useRouter } from "@/desktop/renderer/navigation";
 import {
-  SHORTCUTS,
   getCurrentShortcutPlatform,
   isBlockedShortcutEvent,
-  matchShortcutEvent,
 } from "@/desktop/renderer/utils/keyboardShortcut";
-
-export const BOARD_NOTIFICATION_SHORTCUT = SHORTCUTS.boardNotification;
-export const BOARD_PROJECT_FILTER_SHORTCUT = SHORTCUTS.boardProjectFilter;
-export const CREATE_BRANCH_TODO_SHORTCUT = SHORTCUTS.createTask;
-export const PAGE_BACK_SHORTCUT = SHORTCUTS.pageBack;
-export const PAGE_FORWARD_SHORTCUT = SHORTCUTS.pageForward;
+import { useShortcutBindings } from "@/desktop/renderer/utils/shortcutBindings";
+import { findShortcutCommandForEvent } from "@/desktop/shared/shortcutBindings";
 
 export interface BranchTodoDefaults {
   projectId: string;
@@ -86,6 +80,7 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
   const [isTaskQuickSearchOpen, setIsTaskQuickSearchOpen] = useState(false);
   const [shortcutBlockerCount, setShortcutBlockerCount] = useState(0);
   const shortcutPlatform = getCurrentShortcutPlatform();
+  const shortcutBindings = useShortcutBindings();
   const hasShortcutBlocker = shortcutBlockerCount > 0;
 
   const registerBoardHandlers = useCallback((handlers: BoardCommandHandlers) => {
@@ -146,7 +141,9 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
         return;
       }
 
-      if (matchShortcutEvent(event, BOARD_NOTIFICATION_SHORTCUT, shortcutPlatform)) {
+      const shortcutCommand = findShortcutCommandForEvent(shortcutBindings, event, shortcutPlatform);
+
+      if (shortcutCommand === "boardNotification") {
         if (!notificationCenterHandlerRef.current) {
           return;
         }
@@ -156,7 +153,7 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
         return;
       }
 
-      if (matchShortcutEvent(event, BOARD_PROJECT_FILTER_SHORTCUT, shortcutPlatform)) {
+      if (shortcutCommand === "boardProjectFilter") {
         if (!handlersRef.current) {
           return;
         }
@@ -166,19 +163,19 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
         return;
       }
 
-      if (matchShortcutEvent(event, CREATE_BRANCH_TODO_SHORTCUT, shortcutPlatform)) {
+      if (shortcutCommand === "createTask") {
         event.preventDefault();
         handlersRef.current?.openCreateTaskModal();
         return;
       }
 
-      if (matchShortcutEvent(event, PAGE_BACK_SHORTCUT, shortcutPlatform)) {
+      if (shortcutCommand === "pageBack") {
         event.preventDefault();
         router.back();
         return;
       }
 
-      if (matchShortcutEvent(event, PAGE_FORWARD_SHORTCUT, shortcutPlatform)) {
+      if (shortcutCommand === "pageForward") {
         event.preventDefault();
         router.forward();
       }
@@ -188,7 +185,7 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
     return () => {
       window.removeEventListener("keydown", handleGlobalKeyDown);
     };
-  }, [hasShortcutBlocker, isTaskQuickSearchOpen, router, shortcutPlatform]);
+  }, [hasShortcutBlocker, isTaskQuickSearchOpen, router, shortcutBindings, shortcutPlatform]);
 
   useEffect(() => {
     const unsubscribe = window.kanvibeDesktop?.onCreateTaskShortcut?.(() => {

--- a/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
+++ b/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
@@ -22,10 +22,10 @@ import { requestActiveTerminalFocusAfterUiSettles } from "@/desktop/renderer/uti
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { fuzzyMatch, type FuzzyMatch } from "@/utils/fuzzySearch";
 import {
-  CREATE_BRANCH_TODO_SHORTCUT,
   useBoardCommands,
   useHasBoardShortcutBlocker,
 } from "@/desktop/renderer/components/BoardCommandProvider";
+import { useShortcutBindings } from "@/desktop/renderer/utils/shortcutBindings";
 
 interface TaskQuickSearchDialogProps {
   shortcut?: string;
@@ -223,6 +223,7 @@ export default function TaskQuickSearchDialog({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const shortcutPlatform = getCurrentShortcutPlatform();
+  const createTaskShortcut = useShortcutBindings().createTask;
 
   const effectiveShortcut = shortcut || savedShortcut;
   const results = useMemo(() => buildSearchResults(tasks, query), [query, tasks]);
@@ -391,7 +392,7 @@ export default function TaskQuickSearchDialog({
   }, [createBranchTodoFromSelection, isOpen]);
 
   function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
-    if (matchShortcutEvent(event, CREATE_BRANCH_TODO_SHORTCUT, shortcutPlatform)) {
+    if (matchShortcutEvent(event, createTaskShortcut, shortcutPlatform)) {
       event.preventDefault();
       createBranchTodoFromSelection();
       return;
@@ -433,7 +434,7 @@ export default function TaskQuickSearchDialog({
     t("hint"),
     boardCommands.canCreateBranchTodo
       ? t("branchTodoHint", {
-          shortcut: formatShortcutForDisplay(CREATE_BRANCH_TODO_SHORTCUT, shortcutPlatform),
+          shortcut: formatShortcutForDisplay(createTaskShortcut, shortcutPlatform),
         })
       : null,
   ].filter(Boolean).join(" · ");

--- a/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
+++ b/src/desktop/renderer/components/TaskQuickSearchDialog.tsx
@@ -7,12 +7,9 @@ import {
   getSearchableTasks,
   type SearchableTask,
 } from "@/desktop/renderer/actions/kanban";
-import { getTaskSearchShortcut } from "@/desktop/renderer/actions/appSettings";
 import { usePathname, useRouter } from "@/desktop/renderer/navigation";
-import { useRefreshSignal } from "@/desktop/renderer/utils/refresh";
 import { navigateToTaskDetail } from "@/desktop/renderer/utils/taskNavigation";
 import {
-  DEFAULT_TASK_SEARCH_SHORTCUT,
   formatShortcutForDisplay,
   getCurrentShortcutPlatform,
   isBlockedShortcutEvent,
@@ -213,19 +210,18 @@ export default function TaskQuickSearchDialog({
   const tc = useTranslations("common");
   const router = useRouter();
   const pathname = usePathname();
-  const refreshSignal = useRefreshSignal(["all", "settings"]);
   const inputRef = useRef<HTMLInputElement>(null);
   const resultsListRef = useRef<HTMLDivElement>(null);
-  const [savedShortcut, setSavedShortcut] = useState<string>(DEFAULT_TASK_SEARCH_SHORTCUT);
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [tasks, setTasks] = useState<SearchableTask[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const shortcutPlatform = getCurrentShortcutPlatform();
-  const createTaskShortcut = useShortcutBindings().createTask;
+  const shortcutBindings = useShortcutBindings();
+  const createTaskShortcut = shortcutBindings.createTask;
 
-  const effectiveShortcut = shortcut || savedShortcut;
+  const effectiveShortcut = shortcut || shortcutBindings.taskSearch;
   const results = useMemo(() => buildSearchResults(tasks, query), [query, tasks]);
   const selectedResultIndex = results.length === 0
     ? 0
@@ -245,24 +241,6 @@ export default function TaskQuickSearchDialog({
     setIsLoading(false);
     requestActiveTerminalFocusAfterUiSettles();
   }, []);
-
-  useEffect(() => {
-    if (shortcut) {
-      return;
-    }
-
-    let cancelled = false;
-
-    getTaskSearchShortcut().then((nextShortcut) => {
-      if (!cancelled) {
-        setSavedShortcut(nextShortcut || DEFAULT_TASK_SEARCH_SHORTCUT);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [refreshSignal, shortcut]);
 
   useEffect(() => {
     function handleGlobalKeyDown(event: KeyboardEvent) {

--- a/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
@@ -32,7 +32,6 @@ vi.mock("@/desktop/renderer/navigation", () => ({
 }));
 
 vi.mock("@/desktop/renderer/components/BoardCommandProvider", () => ({
-  CREATE_BRANCH_TODO_SHORTCUT: "Mod+N",
   useBoardCommands: () => ({
     requestCreateBranchTodo: mocks.requestCreateBranchTodo,
     setTaskQuickSearchOpen: mocks.setTaskQuickSearchOpen,

--- a/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/TaskQuickSearchDialog.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import TaskQuickSearchDialog from "@/desktop/renderer/components/TaskQuickSearchDialog";
+import { loadShortcutBindings } from "@/desktop/renderer/utils/shortcutBindings";
+import { DEFAULT_SHORTCUT_BINDINGS } from "@/desktop/shared/shortcutBindings";
 
 const mocks = vi.hoisted(() => ({
   getSearchableTasks: vi.fn(),
@@ -9,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   requestCreateBranchTodo: vi.fn(),
   scrollIntoView: vi.fn(),
   setTaskQuickSearchOpen: vi.fn(),
+  getShortcutBindings: vi.fn(),
   hasShortcutBlocker: false,
 }));
 
@@ -18,6 +21,11 @@ vi.mock("next-intl", () => ({
 
 vi.mock("@/desktop/renderer/actions/kanban", () => ({
   getSearchableTasks: (...args: unknown[]) => mocks.getSearchableTasks(...args),
+}));
+
+vi.mock("@/desktop/renderer/actions/appSettings", () => ({
+  getShortcutBindings: (...args: unknown[]) => mocks.getShortcutBindings(...args),
+  setShortcutBindings: vi.fn(),
 }));
 
 vi.mock("@/desktop/renderer/navigation", () => ({
@@ -41,9 +49,11 @@ vi.mock("@/desktop/renderer/components/BoardCommandProvider", () => ({
 }));
 
 describe("TaskQuickSearchDialog", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     mocks.hasShortcutBlocker = false;
+    mocks.getShortcutBindings.mockResolvedValue({ ...DEFAULT_SHORTCUT_BINDINGS });
+    await loadShortcutBindings();
     window.history.replaceState({}, "", "/#/en");
     window.kanvibeDesktop = {
       isDesktop: true,
@@ -95,6 +105,30 @@ describe("TaskQuickSearchDialog", () => {
         updatedAt: "2026-04-30T03:00:00.000Z",
       },
     ]);
+  });
+
+  /**
+   * 다른 창이 단축키를 바꾸면 main 알림으로 공유 스토어만 갱신된다.
+   * 이 다이얼로그가 스토어를 안 읽으면 그 창은 앱을 다시 켤 때까지 옛 조합으로 열린다.
+   */
+  it("prop이 없으면 공유 단축키 스토어에 저장된 조합으로 연다", async () => {
+    mocks.getShortcutBindings.mockResolvedValue({
+      ...DEFAULT_SHORTCUT_BINDINGS,
+      taskSearch: "Mod+Shift+J",
+    });
+    await loadShortcutBindings();
+
+    render(<TaskQuickSearchDialog />);
+
+    fireEvent.keyDown(window, {
+      key: "j",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeTruthy();
+    });
   });
 
   it("단축키를 누르면 검색 다이얼로그를 열고 태스크 목록을 불러온다", async () => {

--- a/src/desktop/renderer/navigation.tsx
+++ b/src/desktop/renderer/navigation.tsx
@@ -22,7 +22,7 @@ function getRefreshScope(pathname: string) {
     return "pane-layout" as const;
   }
 
-  if (pathname.endsWith("/settings")) {
+  if (pathname.includes("/settings")) {
     return "settings" as const;
   }
 

--- a/src/desktop/renderer/routes/ShortcutSettingsRoute.tsx
+++ b/src/desktop/renderer/routes/ShortcutSettingsRoute.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Link } from "@/desktop/renderer/navigation";
+import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
+import {
+  captureShortcutFromEvent,
+  formatShortcutForDisplay,
+  getCurrentShortcutPlatform,
+} from "@/desktop/renderer/utils/keyboardShortcut";
+import { saveShortcutBindings, useShortcutBindings } from "@/desktop/renderer/utils/shortcutBindings";
+import {
+  DEFAULT_SHORTCUT_BINDINGS,
+  SHORTCUT_COMMAND_DEFINITIONS,
+  findShortcutCommandConflict,
+  type ShortcutCommandDefinition,
+  type ShortcutCommandGroup,
+  type ShortcutCommandId,
+} from "@/desktop/shared/shortcutBindings";
+
+const SHORTCUT_GROUP_ORDER: ShortcutCommandGroup[] = ["taskDetailDock", "taskDetail", "board", "terminal"];
+
+function groupShortcutCommands(): Array<{ group: ShortcutCommandGroup; commands: ShortcutCommandDefinition[] }> {
+  return SHORTCUT_GROUP_ORDER.map((group) => ({
+    group,
+    commands: SHORTCUT_COMMAND_DEFINITIONS.filter((definition) => definition.group === group),
+  }));
+}
+
+export default function ShortcutSettingsRoute() {
+  const t = useTranslations("settings.shortcuts");
+  const bindings = useShortcutBindings();
+  const boardCommands = useBoardCommands();
+  const shortcutPlatform = getCurrentShortcutPlatform();
+  const [recordingCommandId, setRecordingCommandId] = useState<ShortcutCommandId | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const commandGroups = useMemo(groupShortcutCommands, []);
+
+  useEffect(() => {
+    document.title = "Shortcuts";
+  }, []);
+
+  const describeCommand = useCallback((definition: ShortcutCommandDefinition) => (
+    t(`commands.${definition.labelKey}`, { index: definition.labelIndex ?? 0 })
+  ), [t]);
+
+  const applyShortcut = useCallback(async (commandId: ShortcutCommandId, shortcut: string) => {
+    await saveShortcutBindings({ ...bindings, [commandId]: shortcut });
+  }, [bindings]);
+
+  /**
+   * 녹화 중에는 앱의 다른 단축키 처리를 멈춘다.
+   * 그러지 않으면 새 조합을 누르는 순간 그 조합의 원래 명령이 함께 실행된다.
+   */
+  useEffect(() => {
+    if (!recordingCommandId) {
+      return;
+    }
+
+    const targetCommandId = recordingCommandId;
+    const releaseShortcutBlocker = boardCommands.registerShortcutBlocker();
+
+    function handleRecordingKeyDown(event: KeyboardEvent) {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+
+      if (event.key === "Escape") {
+        setRecordingCommandId(null);
+        return;
+      }
+
+      const capturedShortcut = captureShortcutFromEvent(event, shortcutPlatform);
+      if (!capturedShortcut) {
+        setErrorMessage(t("unsupported"));
+        return;
+      }
+
+      const conflictingCommandId = findShortcutCommandConflict(bindings, targetCommandId, capturedShortcut);
+      const conflictingCommand = SHORTCUT_COMMAND_DEFINITIONS
+        .find((definition) => definition.id === conflictingCommandId);
+      if (conflictingCommand) {
+        setErrorMessage(t("conflict", { command: describeCommand(conflictingCommand) }));
+        return;
+      }
+
+      setErrorMessage(null);
+      setRecordingCommandId(null);
+      void applyShortcut(targetCommandId, capturedShortcut);
+    }
+
+    window.addEventListener("keydown", handleRecordingKeyDown, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", handleRecordingKeyDown, { capture: true });
+      releaseShortcutBlocker();
+    };
+  }, [applyShortcut, bindings, boardCommands, describeCommand, recordingCommandId, shortcutPlatform, t]);
+
+  return (
+    <div data-shortcut-capture="true" className="min-h-screen bg-bg-page px-6 py-8">
+      <div className="mx-auto w-full max-w-3xl">
+        <Link href="/settings" className="mb-8 inline-flex items-center gap-3 text-xs font-medium text-text-muted hover:text-text-primary">
+          <span aria-hidden="true">←</span>
+          {t("title")}
+        </Link>
+
+        <header className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-lg font-semibold text-text-primary">{t("title")}</h1>
+            <p className="mt-1 text-sm text-text-muted">{t("pageDescription")}</p>
+            <p className="mt-1 text-xs text-text-muted">{t("recordHint")}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setErrorMessage(null);
+              setRecordingCommandId(null);
+              void saveShortcutBindings({ ...DEFAULT_SHORTCUT_BINDINGS });
+            }}
+            className="shrink-0 rounded-md border border-border-default bg-button-neutral px-3 py-2 text-xs text-text-primary transition-colors hover:border-brand-primary"
+          >
+            {t("resetAll")}
+          </button>
+        </header>
+
+        {errorMessage ? (
+          <p role="alert" className="mb-4 rounded-md border border-status-warning/20 bg-status-warning/15 px-3 py-2 text-xs text-status-warning">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        {commandGroups.map(({ group, commands }) => (
+          <section key={group} className="mb-6 rounded-lg border border-border-default bg-bg-surface">
+            <h2 className="border-b border-border-default px-4 py-3 text-xs uppercase tracking-wide text-text-muted">
+              {t(`groups.${group}`)}
+            </h2>
+            <ul>
+              {commands.map((definition) => {
+                const isRecording = recordingCommandId === definition.id;
+                const isCustomized = bindings[definition.id] !== definition.defaultShortcut;
+
+                return (
+                  <li key={definition.id} className="flex items-center justify-between gap-3 border-b border-border-default px-4 py-3 last:border-b-0">
+                    <span className="text-sm text-text-primary">{describeCommand(definition)}</span>
+                    <div className="flex items-center gap-2">
+                      <code className="rounded-md border border-border-default bg-bg-page px-2 py-1 text-xs text-text-secondary">
+                        {formatShortcutForDisplay(bindings[definition.id], shortcutPlatform)}
+                      </code>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setErrorMessage(null);
+                          setRecordingCommandId(isRecording ? null : definition.id);
+                        }}
+                        className={`rounded-md border px-3 py-1 text-xs transition-colors ${
+                          isRecording
+                            ? "border-brand-primary bg-brand-subtle text-brand-primary"
+                            : "border-border-default bg-button-neutral text-text-primary hover:border-brand-primary"
+                        }`}
+                      >
+                        {isRecording ? t("recording") : t("record")}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={!isCustomized}
+                        onClick={() => {
+                          setErrorMessage(null);
+                          void applyShortcut(definition.id, definition.defaultShortcut);
+                        }}
+                        className="rounded-md border border-border-default px-3 py-1 text-xs text-text-muted transition-colors hover:border-brand-primary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        {t("reset")}
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/desktop/renderer/routes/ShortcutSettingsRoute.tsx
+++ b/src/desktop/renderer/routes/ShortcutSettingsRoute.tsx
@@ -6,12 +6,20 @@ import {
   captureShortcutFromEvent,
   formatShortcutForDisplay,
   getCurrentShortcutPlatform,
+  isShortcutModifierKey,
 } from "@/desktop/renderer/utils/keyboardShortcut";
-import { saveShortcutBindings, useShortcutBindings } from "@/desktop/renderer/utils/shortcutBindings";
+import {
+  hasLoadedShortcutBindings,
+  loadShortcutBindings,
+  saveShortcutBindings,
+  setShortcutCaptureActive,
+  useShortcutBindings,
+} from "@/desktop/renderer/utils/shortcutBindings";
 import {
   DEFAULT_SHORTCUT_BINDINGS,
   SHORTCUT_COMMAND_DEFINITIONS,
   findShortcutCommandConflict,
+  type ShortcutBindings,
   type ShortcutCommandDefinition,
   type ShortcutCommandGroup,
   type ShortcutCommandId,
@@ -33,19 +41,70 @@ export default function ShortcutSettingsRoute() {
   const shortcutPlatform = getCurrentShortcutPlatform();
   const [recordingCommandId, setRecordingCommandId] = useState<ShortcutCommandId | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isBindingsLoaded, setIsBindingsLoaded] = useState(hasLoadedShortcutBindings);
   const commandGroups = useMemo(groupShortcutCommands, []);
 
   useEffect(() => {
-    document.title = "Shortcuts";
-  }, []);
+    document.title = t("title");
+  }, [t]);
+
+  /**
+   * 앱이 뜰 때의 조회 한 번이 실패하면 이 화면은 재배정이 전부 사라진 것처럼 보인다.
+   * 그 위에서 저장하면 표가 기본값으로 치환돼 실제로도 사라지므로, 담긴 표가 없을 때만 한 번 더 읽는다.
+   * 이미 담겨 있는데도 다시 읽으면, 늦게 도착한 응답이 그 사이에 저장한 값을 되돌린다.
+   */
+  useEffect(() => {
+    if (hasLoadedShortcutBindings()) {
+      return;
+    }
+
+    void loadShortcutBindings().then((isLoaded) => {
+      setIsBindingsLoaded(isLoaded);
+      if (!isLoaded) {
+        setErrorMessage(t("loadFailed"));
+      }
+    });
+  }, [t]);
 
   const describeCommand = useCallback((definition: ShortcutCommandDefinition) => (
     t(`commands.${definition.labelKey}`, { index: definition.labelIndex ?? 0 })
   ), [t]);
 
+  /** 저장이 실패하면 화면은 옛 값 그대로다. 조용히 넘기면 사용자는 바뀐 줄 안다 */
+  const persistBindings = useCallback(async (nextBindings: ShortcutBindings) => {
+    /** 저장은 표를 통째로 치환한다. 조회하지 못한 기본값 표를 저장하면 저장돼 있던 재배정이 전부 지워진다 */
+    if (!hasLoadedShortcutBindings()) {
+      setIsBindingsLoaded(false);
+      setErrorMessage(t("loadFailed"));
+      return;
+    }
+
+    try {
+      await saveShortcutBindings(nextBindings);
+    } catch (error) {
+      console.error("단축키 저장 실패:", error);
+      setErrorMessage(t("saveFailed"));
+    }
+  }, [t]);
+
+  /** 겹치는 조합이 붙으면 정의 순서상 뒤인 명령은 렌더러와 main 양쪽에서 도달할 방법이 없어진다 */
+  const describeShortcutConflict = useCallback((commandId: ShortcutCommandId, shortcut: string) => {
+    const conflictingCommandId = findShortcutCommandConflict(bindings, commandId, shortcut, shortcutPlatform);
+    const conflictingCommand = SHORTCUT_COMMAND_DEFINITIONS
+      .find((definition) => definition.id === conflictingCommandId);
+    return conflictingCommand ? t("conflict", { command: describeCommand(conflictingCommand) }) : null;
+  }, [bindings, describeCommand, shortcutPlatform, t]);
+
+  /** 녹화든 개별 되돌리기든 같은 관문을 지나야 중복 배정이 조용히 생기지 않는다 */
   const applyShortcut = useCallback(async (commandId: ShortcutCommandId, shortcut: string) => {
-    await saveShortcutBindings({ ...bindings, [commandId]: shortcut });
-  }, [bindings]);
+    const conflictMessage = describeShortcutConflict(commandId, shortcut);
+    if (conflictMessage) {
+      setErrorMessage(conflictMessage);
+      return;
+    }
+
+    await persistBindings({ ...bindings, [commandId]: shortcut });
+  }, [bindings, describeShortcutConflict, persistBindings]);
 
   /**
    * 녹화 중에는 앱의 다른 단축키 처리를 멈춘다.
@@ -58,6 +117,8 @@ export default function ShortcutSettingsRoute() {
 
     const targetCommandId = recordingCommandId;
     const releaseShortcutBlocker = boardCommands.registerShortcutBlocker();
+    /** Electron main도 녹화 중임을 알아야 한다. 모르면 main이 가로채는 조합은 여기까지 오지 못한다 */
+    setShortcutCaptureActive(true);
 
     function handleRecordingKeyDown(event: KeyboardEvent) {
       event.preventDefault();
@@ -65,7 +126,13 @@ export default function ShortcutSettingsRoute() {
       event.stopImmediatePropagation();
 
       if (event.key === "Escape") {
+        setErrorMessage(null);
         setRecordingCommandId(null);
+        return;
+      }
+
+      /** 조합을 누르는 모든 사용자가 수식키 keydown을 먼저 흘린다. 이걸 오류로 보면 매 녹화마다 거짓 배너가 뜬다 */
+      if (isShortcutModifierKey(event.key)) {
         return;
       }
 
@@ -75,11 +142,9 @@ export default function ShortcutSettingsRoute() {
         return;
       }
 
-      const conflictingCommandId = findShortcutCommandConflict(bindings, targetCommandId, capturedShortcut);
-      const conflictingCommand = SHORTCUT_COMMAND_DEFINITIONS
-        .find((definition) => definition.id === conflictingCommandId);
-      if (conflictingCommand) {
-        setErrorMessage(t("conflict", { command: describeCommand(conflictingCommand) }));
+      const conflictMessage = describeShortcutConflict(targetCommandId, capturedShortcut);
+      if (conflictMessage) {
+        setErrorMessage(conflictMessage);
         return;
       }
 
@@ -91,9 +156,10 @@ export default function ShortcutSettingsRoute() {
     window.addEventListener("keydown", handleRecordingKeyDown, { capture: true });
     return () => {
       window.removeEventListener("keydown", handleRecordingKeyDown, { capture: true });
+      setShortcutCaptureActive(false);
       releaseShortcutBlocker();
     };
-  }, [applyShortcut, bindings, boardCommands, describeCommand, recordingCommandId, shortcutPlatform, t]);
+  }, [applyShortcut, boardCommands, describeShortcutConflict, recordingCommandId, shortcutPlatform, t]);
 
   return (
     <div data-shortcut-capture="true" className="min-h-screen bg-bg-page px-6 py-8">
@@ -111,12 +177,13 @@ export default function ShortcutSettingsRoute() {
           </div>
           <button
             type="button"
+            disabled={!isBindingsLoaded}
             onClick={() => {
               setErrorMessage(null);
               setRecordingCommandId(null);
-              void saveShortcutBindings({ ...DEFAULT_SHORTCUT_BINDINGS });
+              void persistBindings({ ...DEFAULT_SHORTCUT_BINDINGS });
             }}
-            className="shrink-0 rounded-md border border-border-default bg-button-neutral px-3 py-2 text-xs text-text-primary transition-colors hover:border-brand-primary"
+            className="shrink-0 rounded-md border border-border-default bg-button-neutral px-3 py-2 text-xs text-text-primary transition-colors hover:border-brand-primary disabled:cursor-not-allowed disabled:opacity-40"
           >
             {t("resetAll")}
           </button>
@@ -147,11 +214,12 @@ export default function ShortcutSettingsRoute() {
                       </code>
                       <button
                         type="button"
+                        disabled={!isBindingsLoaded}
                         onClick={() => {
                           setErrorMessage(null);
                           setRecordingCommandId(isRecording ? null : definition.id);
                         }}
-                        className={`rounded-md border px-3 py-1 text-xs transition-colors ${
+                        className={`rounded-md border px-3 py-1 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
                           isRecording
                             ? "border-brand-primary bg-brand-subtle text-brand-primary"
                             : "border-border-default bg-button-neutral text-text-primary hover:border-brand-primary"
@@ -161,7 +229,7 @@ export default function ShortcutSettingsRoute() {
                       </button>
                       <button
                         type="button"
-                        disabled={!isCustomized}
+                        disabled={!isCustomized || !isBindingsLoaded}
                         onClick={() => {
                           setErrorMessage(null);
                           void applyShortcut(definition.id, definition.defaultShortcut);

--- a/src/desktop/renderer/routes/ShortcutSettingsRoute.tsx
+++ b/src/desktop/renderer/routes/ShortcutSettingsRoute.tsx
@@ -24,6 +24,7 @@ import {
   type ShortcutCommandGroup,
   type ShortcutCommandId,
 } from "@/desktop/shared/shortcutBindings";
+import { resolveTaskDetailDockLabel } from "@/desktop/shared/taskDetailDock";
 
 const SHORTCUT_GROUP_ORDER: ShortcutCommandGroup[] = ["taskDetailDock", "taskDetail", "board", "terminal"];
 
@@ -36,6 +37,8 @@ function groupShortcutCommands(): Array<{ group: ShortcutCommandGroup; commands:
 
 export default function ShortcutSettingsRoute() {
   const t = useTranslations("settings.shortcuts");
+  /** 도크 항목 이름은 도크가 쓰는 그 문구를 그대로 가져온다 */
+  const tTaskDetail = useTranslations("taskDetail");
   const bindings = useShortcutBindings();
   const boardCommands = useBoardCommands();
   const shortcutPlatform = getCurrentShortcutPlatform();
@@ -67,8 +70,11 @@ export default function ShortcutSettingsRoute() {
   }, [t]);
 
   const describeCommand = useCallback((definition: ShortcutCommandDefinition) => (
-    t(`commands.${definition.labelKey}`, { index: definition.labelIndex ?? 0 })
-  ), [t]);
+    t(`commands.${definition.labelKey}`, {
+      index: definition.labelIndex ?? 0,
+      item: definition.dockItemId ? resolveTaskDetailDockLabel(tTaskDetail, definition.dockItemId) : "",
+    })
+  ), [t, tTaskDetail]);
 
   /** 저장이 실패하면 화면은 옛 값 그대로다. 조용히 넘기면 사용자는 바뀐 줄 안다 */
   const persistBindings = useCallback(async (nextBindings: ShortcutBindings) => {

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -946,7 +946,14 @@ export default function TaskDetailRoute() {
       return;
     }
 
-    const prUrl = await fetchPrUrlWithPrompt(task, commonTranslationsRef.current);
+    /** 조회가 던지면 자동 조회 경로와 같이 로그를 남긴다. 삼키면 눌러도 아무 일이 없어 보인다 */
+    let prUrl: string | null = null;
+    try {
+      prUrl = await fetchPrUrlWithPrompt(task, commonTranslationsRef.current);
+    } catch (error) {
+      console.error("PR URL 조회 실패:", error);
+    }
+
     if (!prUrl) {
       window.alert(t("pullRequestNotFound"));
       return;
@@ -964,8 +971,15 @@ export default function TaskDetailRoute() {
       return;
     }
 
-    const result = await openTaskInVsCode(task.id);
-    if (!result.ok) {
+    /** 실행 요청이 던져도 실패 알림으로 합류시킨다. 삼키면 눌러도 아무 일이 없어 보인다 */
+    let opened = false;
+    try {
+      opened = (await openTaskInVsCode(task.id)).ok;
+    } catch (error) {
+      console.error("VS Code 실행 요청 실패:", error);
+    }
+
+    if (!opened) {
       window.alert(t("openInVsCodeFailed"));
     }
   }, [t]);

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -61,6 +61,7 @@ import {
   getTaskDetailDockIndexForCommand,
   resolveTerminalTabCommand,
 } from "@/desktop/shared/shortcutBindings";
+import { resolveTaskDetailDockLabel, type TaskDetailDockItemId } from "@/desktop/shared/taskDetailDock";
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { rememberBoardFocusTask } from "@/desktop/renderer/utils/boardFocusTarget";
 import { buildRouteCacheKey, readRouteCache, removeRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
@@ -97,7 +98,7 @@ const AGENT_TAG_STYLES: Record<string, string> = {
 type DetailPanel = "overview" | "status" | "liveSessions" | "usage";
 type MainView = "terminal" | "chat";
 type TaskDetailDockItem = {
-  id: string;
+  id: TaskDetailDockItemId;
   label: string;
   isActive: boolean;
   renderIcon: () => ReactNode;
@@ -872,7 +873,7 @@ export default function TaskDetailRoute() {
   useMarkTaskNotificationsReadWhenFocused(state?.task.id ?? null);
   const shortcutPlatform = getCurrentShortcutPlatform();
   const shortcutBindings = useShortcutBindings();
-  const statusPanelLabel = `${t("actions")} · ${t("hooksStatus")}`;
+  const statusPanelLabel = resolveTaskDetailDockLabel(t, "status");
   currentTaskRef.current = state?.task ?? null;
   const shouldShowDefaultOverviewPanel = !!state
     && state !== null
@@ -992,7 +993,7 @@ export default function TaskDetailRoute() {
     const items: TaskDetailDockItem[] = [
       {
         id: "overview",
-        label: t("info"),
+        label: resolveTaskDetailDockLabel(t, "overview"),
         isActive: visiblePanel === "overview",
         renderIcon: () => (
           <HugeiconsIcon
@@ -1013,7 +1014,7 @@ export default function TaskDetailRoute() {
       },
       {
         id: "chat",
-        label: t("aiSessions.inlineChat"),
+        label: resolveTaskDetailDockLabel(t, "chat"),
         isActive: mainView === "chat",
         renderIcon: () => (
           <HugeiconsIcon
@@ -1027,7 +1028,7 @@ export default function TaskDetailRoute() {
       },
       {
         id: "live-sessions",
-        label: t("liveSessions.dock"),
+        label: resolveTaskDetailDockLabel(t, "live-sessions"),
         isActive: visiblePanel === "liveSessions",
         renderIcon: () => (
           <HugeiconsIcon
@@ -1044,7 +1045,7 @@ export default function TaskDetailRoute() {
     /** PR 자리는 링크가 아직 없어도 비워 두지 않는다. 자리가 사라지면 뒤 항목의 dock 번호가 통째로 밀린다 */
     items.splice(PR_DOCK_INSERT_INDEX, 0, {
       id: "pull-request",
-      label: "PR",
+      label: resolveTaskDetailDockLabel(t, "pull-request"),
       isActive: false,
       renderIcon: () => <PullRequestIcon />,
       onActivate: () => {
@@ -1055,7 +1056,7 @@ export default function TaskDetailRoute() {
 
     items.push({
       id: "vscode",
-      label: t("openInVsCode"),
+      label: resolveTaskDetailDockLabel(t, "vscode"),
       isActive: false,
       renderIcon: () => (
         <HugeiconsIcon

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -5,6 +5,7 @@ import {
   ChartHistogramIcon,
   Chatting01Icon,
   InformationCircleIcon,
+  SourceCodeIcon,
 } from "@hugeicons/core-free-icons";
 import { useTranslations } from "next-intl";
 import { useParams } from "react-router-dom";
@@ -47,17 +48,19 @@ import { useTaskDiffFiles } from "@/desktop/renderer/hooks/useTaskDiffStats";
 import { useTerminalTabs } from "@/desktop/renderer/hooks/useTerminalTabs";
 import type { TerminalTabShortcutCommand } from "@/desktop/shared/terminalTabs";
 import { fetchPrUrlWithPrompt } from "@/desktop/renderer/utils/fetchPrUrlWithPrompt";
+import { openTaskInVsCode } from "@/desktop/renderer/actions/editor";
 import {
-  SHORTCUTS,
   TASK_DETAIL_DOCK_SHORTCUT_INDEXES,
-  createTaskDetailDockShortcut,
   formatShortcutForDisplay,
   getCurrentShortcutPlatform,
-  matchShortcutEvent,
-  resolveTerminalTabShortcutEvent,
-  matchTaskDetailDockShortcutEvent,
-  matchTaskDetailUsageShortcutEvent,
 } from "@/desktop/renderer/utils/keyboardShortcut";
+import { useShortcutBindings } from "@/desktop/renderer/utils/shortcutBindings";
+import {
+  createTaskDetailDockCommandId,
+  findShortcutCommandForEvent,
+  getTaskDetailDockIndexForCommand,
+  resolveTerminalTabCommand,
+} from "@/desktop/shared/shortcutBindings";
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS, logDesktopInitialLoadTimeout } from "@/desktop/renderer/utils/loadingTimeout";
 import { rememberBoardFocusTask } from "@/desktop/renderer/utils/boardFocusTarget";
 import { buildRouteCacheKey, readRouteCache, removeRouteCache, writeRouteCache } from "@/desktop/renderer/utils/routeCache";
@@ -868,6 +871,7 @@ export default function TaskDetailRoute() {
   });
   useMarkTaskNotificationsReadWhenFocused(state?.task.id ?? null);
   const shortcutPlatform = getCurrentShortcutPlatform();
+  const shortcutBindings = useShortcutBindings();
   const statusPanelLabel = `${t("actions")} · ${t("hooksStatus")}`;
   currentTaskRef.current = state?.task ?? null;
   const shouldShowDefaultOverviewPanel = !!state
@@ -927,6 +931,45 @@ export default function TaskDetailRoute() {
     });
   }, [markDefaultPanelDismissed]);
 
+  /**
+   * PR 자리를 눌렀을 때 링크가 아직 없으면 그 자리에서 찾아 연다.
+   * 링크가 없다고 자리를 감추면 PR이 붙기 전까지 이 dock 번호를 쓸 수 없다.
+   */
+  const openPullRequest = useCallback(async () => {
+    const task = currentTaskRef.current;
+    if (!task) {
+      return;
+    }
+
+    if (task.prUrl) {
+      window.open(task.prUrl, "_blank", "noopener,noreferrer");
+      return;
+    }
+
+    const prUrl = await fetchPrUrlWithPrompt(task, commonTranslationsRef.current);
+    if (!prUrl) {
+      window.alert(t("pullRequestNotFound"));
+      return;
+    }
+
+    setState((current) => current && current.task.id === task.id
+      ? { ...current, task: { ...current.task, prUrl } }
+      : current);
+    window.open(prUrl, "_blank", "noopener,noreferrer");
+  }, [t]);
+
+  const openInVsCode = useCallback(async () => {
+    const task = currentTaskRef.current;
+    if (!task) {
+      return;
+    }
+
+    const result = await openTaskInVsCode(task.id);
+    if (!result.ok) {
+      window.alert(t("openInVsCodeFailed"));
+    }
+  }, [t]);
+
   const dockItems = useMemo<TaskDetailDockItem[]>(() => {
     if (!state) {
       return [];
@@ -984,21 +1027,37 @@ export default function TaskDetailRoute() {
       },
     ];
 
-    if (state.task.prUrl) {
-      items.splice(PR_DOCK_INSERT_INDEX, 0, {
-        id: "pull-request",
-        label: "PR",
-        isActive: false,
-        renderIcon: () => <PullRequestIcon />,
-        onActivate: () => {
-          window.open(state.task.prUrl!, "_blank", "noopener,noreferrer");
-        },
-        href: state.task.prUrl,
-      });
-    }
+    /** PR 자리는 링크가 아직 없어도 비워 두지 않는다. 자리가 사라지면 뒤 항목의 dock 번호가 통째로 밀린다 */
+    items.splice(PR_DOCK_INSERT_INDEX, 0, {
+      id: "pull-request",
+      label: "PR",
+      isActive: false,
+      renderIcon: () => <PullRequestIcon />,
+      onActivate: () => {
+        void openPullRequest();
+      },
+      href: state.task.prUrl ?? undefined,
+    });
+
+    items.push({
+      id: "vscode",
+      label: t("openInVsCode"),
+      isActive: false,
+      renderIcon: () => (
+        <HugeiconsIcon
+          icon={SourceCodeIcon}
+          size={17}
+          strokeWidth={1.6}
+          aria-hidden="true"
+        />
+      ),
+      onActivate: () => {
+        void openInVsCode();
+      },
+    });
 
     return items;
-  }, [mainView, state, statusPanelLabel, t, toggleChatView, toggleDetailPanel, visiblePanel]);
+  }, [mainView, openInVsCode, openPullRequest, state, statusPanelLabel, t, toggleChatView, toggleDetailPanel, visiblePanel]);
 
   // dock 항목을 렌더 시점에 ref로 넘겨두면 shortcut 구독을 다시 등록하지 않아도 항상 최신 dock을 실행한다.
   // 구독을 dock 변경마다 재등록하면 커밋과 effect flush 사이에 들어온 shortcut이 이전 dock(빈 배열)을 보고 무시된다.
@@ -1051,7 +1110,9 @@ export default function TaskDetailRoute() {
     }
 
     function handlePriorityHistoryShortcut(event: KeyboardEvent) {
-      if (matchShortcutEvent(event, SHORTCUTS.pageBack, shortcutPlatform)) {
+      const shortcutCommand = findShortcutCommandForEvent(shortcutBindings, event, shortcutPlatform);
+
+      if (shortcutCommand === "pageBack") {
         if (hasShortcutBlocker) {
           consumeHistoryShortcut(event);
           return;
@@ -1062,7 +1123,7 @@ export default function TaskDetailRoute() {
         return;
       }
 
-      if (matchShortcutEvent(event, SHORTCUTS.pageForward, shortcutPlatform)) {
+      if (shortcutCommand === "pageForward") {
         if (hasShortcutBlocker) {
           consumeHistoryShortcut(event);
           return;
@@ -1077,7 +1138,7 @@ export default function TaskDetailRoute() {
     return () => {
       window.removeEventListener("keydown", handlePriorityHistoryShortcut, { capture: true });
     };
-  }, [hasShortcutBlocker, router, shortcutPlatform]);
+  }, [hasShortcutBlocker, router, shortcutBindings, shortcutPlatform]);
 
   useEffect(() => {
     function consumeDockShortcut(event: KeyboardEvent) {
@@ -1087,7 +1148,9 @@ export default function TaskDetailRoute() {
     }
 
     function handlePriorityDockShortcut(event: KeyboardEvent) {
-      const shortcutIndex = matchTaskDetailDockShortcutEvent(event, shortcutPlatform);
+      const shortcutIndex = getTaskDetailDockIndexForCommand(
+        findShortcutCommandForEvent(shortcutBindings, event, shortcutPlatform),
+      );
       if (shortcutIndex === null) {
         return;
       }
@@ -1109,11 +1172,11 @@ export default function TaskDetailRoute() {
     return () => {
       window.removeEventListener("keydown", handlePriorityDockShortcut, { capture: true });
     };
-  }, [activateDockItem, hasShortcutBlocker, shortcutPlatform]);
+  }, [activateDockItem, hasShortcutBlocker, shortcutBindings, shortcutPlatform]);
 
   useEffect(() => {
     function handlePriorityUsageShortcut(event: KeyboardEvent) {
-      if (!matchTaskDetailUsageShortcutEvent(event, shortcutPlatform)) {
+      if (findShortcutCommandForEvent(shortcutBindings, event, shortcutPlatform) !== "taskDetailUsage") {
         return;
       }
 
@@ -1132,7 +1195,7 @@ export default function TaskDetailRoute() {
     return () => {
       window.removeEventListener("keydown", handlePriorityUsageShortcut, { capture: true });
     };
-  }, [hasShortcutBlocker, shortcutPlatform, toggleDetailPanel]);
+  }, [hasShortcutBlocker, shortcutBindings, shortcutPlatform, toggleDetailPanel]);
 
   /** 탭을 다 닫으면 남길 화면이 없으므로 창까지 닫는다. 창을 닫을지는 세션 타입을 아는 main이 정한다 */
   const closeTerminalTabOrWindow = useCallback(async (tabId: string) => {
@@ -1203,7 +1266,10 @@ export default function TaskDetailRoute() {
         return;
       }
 
-      const command = resolveTerminalTabShortcutEvent(event, shortcutPlatform, true);
+      const command = resolveTerminalTabCommand(
+        findShortcutCommandForEvent(shortcutBindings, event, shortcutPlatform),
+        true,
+      );
       if (!command) {
         return;
       }
@@ -1218,7 +1284,7 @@ export default function TaskDetailRoute() {
     return () => {
       window.removeEventListener("keydown", handleTerminalTabShortcut, { capture: true });
     };
-  }, [hasShortcutBlocker, runTerminalTabCommand, shortcutPlatform]);
+  }, [hasShortcutBlocker, runTerminalTabCommand, shortcutBindings, shortcutPlatform]);
 
   useEffect(() => (
     window.kanvibeDesktop?.onTaskDetailDockShortcut?.((shortcutIndex: number) => {
@@ -1537,7 +1603,7 @@ export default function TaskDetailRoute() {
         {dockItems.map((item, itemIndex) => {
           const shortcutIndex = TASK_DETAIL_DOCK_SHORTCUT_INDEXES[itemIndex];
           const shortcutText = shortcutIndex
-            ? formatShortcutForDisplay(createTaskDetailDockShortcut(shortcutIndex), shortcutPlatform)
+            ? formatShortcutForDisplay(shortcutBindings[createTaskDetailDockCommandId(shortcutIndex)], shortcutPlatform)
             : null;
           const title = shortcutText ? `${item.label} (${shortcutText})` : item.label;
 
@@ -1586,7 +1652,7 @@ export default function TaskDetailRoute() {
               ? "bg-brand-subtle text-text-brand"
               : "text-text-muted hover:bg-bg-page hover:text-text-primary"
           }`}
-          title={`${t("aiUsage.title")} (${formatShortcutForDisplay(SHORTCUTS.taskDetailUsage, shortcutPlatform)})`}
+          title={`${t("aiUsage.title")} (${formatShortcutForDisplay(shortcutBindings.taskDetailUsage, shortcutPlatform)})`}
           aria-label={t("aiUsage.title")}
           data-testid="task-detail-usage-button"
         >

--- a/src/desktop/renderer/routes/__tests__/ShortcutSettingsRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/ShortcutSettingsRoute.test.tsx
@@ -2,12 +2,14 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BoardCommandProvider } from "@/desktop/renderer/components/BoardCommandProvider";
 import ShortcutSettingsRoute from "@/desktop/renderer/routes/ShortcutSettingsRoute";
+import { loadShortcutBindings } from "@/desktop/renderer/utils/shortcutBindings";
 import { DEFAULT_SHORTCUT_BINDINGS } from "@/desktop/shared/shortcutBindings";
 
 const mocks = vi.hoisted(() => ({
   getShortcutBindings: vi.fn(),
   setShortcutBindings: vi.fn(),
   notifyShortcutBindingsChanged: vi.fn(),
+  notifyShortcutCaptureChanged: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
@@ -47,13 +49,15 @@ function findRecordButtonFor(commandLabel: string) {
 }
 
 describe("ShortcutSettingsRoute", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     mocks.getShortcutBindings.mockResolvedValue({ ...DEFAULT_SHORTCUT_BINDINGS });
     mocks.setShortcutBindings.mockResolvedValue(undefined);
+    await loadShortcutBindings();
     window.kanvibeDesktop = {
       isDesktop: true,
       notifyShortcutBindingsChanged: mocks.notifyShortcutBindingsChanged,
+      notifyShortcutCaptureChanged: mocks.notifyShortcutCaptureChanged,
     };
   });
 
@@ -86,6 +90,38 @@ describe("ShortcutSettingsRoute", () => {
     expect(mocks.setShortcutBindings).not.toHaveBeenCalled();
   });
 
+  /**
+   * 개별 되돌리기가 충돌 검사를 건너뛰면 되돌린 조합이 다른 명령의 조합과 같아진다.
+   * 그러면 정의 순서상 뒤인 명령은 재배정하기 전까지 실행할 방법이 없다.
+   */
+  it("개별 기본값 되돌리기가 다른 명령과 겹치면 저장하지 않고 알린다", async () => {
+    renderShortcutSettings();
+
+    const firstDockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    fireEvent.click(within(firstDockRow).getByText("record"));
+    fireEvent.keyDown(window, { key: "j", ctrlKey: true, shiftKey: true });
+    await waitFor(() => {
+      expect(mocks.setShortcutBindings).toHaveBeenCalledWith(expect.objectContaining({
+        taskDetailDock1: "Mod+Shift+J",
+      }));
+    });
+
+    const secondDockRow = findRecordButtonFor("commands.taskDetailDock:2");
+    fireEvent.click(within(secondDockRow).getByText("record"));
+    fireEvent.keyDown(window, { key: "1", ctrlKey: true });
+    await waitFor(() => {
+      expect(mocks.setShortcutBindings).toHaveBeenCalledWith(expect.objectContaining({
+        taskDetailDock2: "Mod+1",
+      }));
+    });
+
+    mocks.setShortcutBindings.mockClear();
+    fireEvent.click(within(findRecordButtonFor("commands.taskDetailDock:1")).getByText("reset"));
+
+    expect((await screen.findByRole("alert")).textContent).toBe("conflict");
+    expect(mocks.setShortcutBindings).not.toHaveBeenCalled();
+  });
+
   it("Esc를 누르면 녹화를 취소한다", async () => {
     renderShortcutSettings();
 
@@ -101,6 +137,50 @@ describe("ShortcutSettingsRoute", () => {
     expect(mocks.setShortcutBindings).not.toHaveBeenCalled();
   });
 
+  /**
+   * 조합을 누르는 사용자는 Ctrl/Cmd/Shift keydown을 먼저 흘린다.
+   * 이걸 "수정 키가 없는 조합"과 같이 다루면 모든 녹화 시도마다 사실과 반대인 오류가 뜨고,
+   * role="alert"라 스크린리더는 수식키를 누를 때마다 거짓 오류를 읽는다.
+   */
+  it("수식 키만 눌린 동안에는 오류를 띄우지 않는다", async () => {
+    renderShortcutSettings();
+
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    fireEvent.click(within(dockRow).getByText("record"));
+    fireEvent.keyDown(window, { key: "Control", ctrlKey: true });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(within(dockRow).getByText("recording")).toBeTruthy();
+  });
+
+  /** 배정할 수 없는 키를 조용히 버리면 사용자는 재배정이 됐다고 믿고 화면을 떠난다 */
+  it("담을 수 없는 조합을 녹화하면 저장하지 않고 오류를 알린다", async () => {
+    renderShortcutSettings();
+
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    fireEvent.click(within(dockRow).getByText("record"));
+    fireEvent.keyDown(window, { key: "+", ctrlKey: true, shiftKey: true });
+
+    expect((await screen.findByRole("alert")).textContent).toBe("unsupported");
+    expect(mocks.setShortcutBindings).not.toHaveBeenCalled();
+  });
+
+  /** 녹화를 끝낸 화면에 옛 오류가 남으면 사용자는 방금 한 취소가 실패한 줄 안다 */
+  it("Esc로 취소하면 남아 있던 오류 배너를 지운다", async () => {
+    renderShortcutSettings();
+
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    fireEvent.click(within(dockRow).getByText("record"));
+    fireEvent.keyDown(window, { key: "n", ctrlKey: true });
+    expect((await screen.findByRole("alert")).textContent).toBe("conflict");
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+  });
+
   it("전체 기본값으로 되돌리면 저장된 재배정을 모두 지운다", async () => {
     renderShortcutSettings();
 
@@ -108,6 +188,71 @@ describe("ShortcutSettingsRoute", () => {
 
     await waitFor(() => {
       expect(mocks.setShortcutBindings).toHaveBeenCalledWith(DEFAULT_SHORTCUT_BINDINGS);
+    });
+  });
+
+  /**
+   * main이 녹화 중임을 모르면 `before-input-event`가 조합을 가로채, 그 조합의 원래 동작만 실행되고
+   * keydown은 녹화 처리기까지 오지 못한다.
+   */
+  it("녹화를 시작하고 끝낼 때 Electron main에 알린다", async () => {
+    renderShortcutSettings();
+
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    fireEvent.click(within(dockRow).getByText("record"));
+    expect(mocks.notifyShortcutCaptureChanged).toHaveBeenLastCalledWith(true);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(mocks.notifyShortcutCaptureChanged).toHaveBeenLastCalledWith(false);
+    });
+  });
+
+  /** 저장이 실패했는데 조용하면 화면은 옛 값 그대로인 채로 사용자는 바뀐 줄 안다 */
+  it("저장이 실패하면 오류 배너로 알린다", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.setShortcutBindings.mockRejectedValue(new Error("설정 저장 실패"));
+    renderShortcutSettings();
+
+    fireEvent.click(screen.getByText("resetAll"));
+
+    expect((await screen.findByRole("alert")).textContent).toBe("saveFailed");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  /**
+   * 저장은 단축키 표를 통째로 치환한다. 조회에 실패한 창의 캐시는 기본값이라,
+   * 그 위에서 한 번만 저장해도 저장돼 있던 다른 명령의 재배정이 전부 지워진다.
+   */
+  it("단축키 조회에 실패하면 재배정을 저장하지 않고 조회 실패를 알린다", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.getShortcutBindings.mockRejectedValue(new Error("설정 조회 실패"));
+    /** 앱이 뜰 때의 조회가 실패한 창을 그대로 재현한다 */
+    await loadShortcutBindings();
+    renderShortcutSettings();
+
+    expect((await screen.findByRole("alert")).textContent).toBe("loadFailed");
+
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:4");
+    fireEvent.click(within(dockRow).getByText("record"));
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true, shiftKey: true });
+
+    await waitFor(() => {
+      expect(within(dockRow).getByText("record")).toBeTruthy();
+    });
+    expect(mocks.setShortcutBindings).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  /** 나머지 화면은 3개 로케일이 채워져 있는데 제목만 영어 리터럴이면 그 창만 번역이 빠진다 */
+  it("문서 제목을 번역 키에서 가져온다", async () => {
+    renderShortcutSettings();
+
+    await waitFor(() => {
+      expect(document.title).toBe("title");
     });
   });
 });

--- a/src/desktop/renderer/routes/__tests__/ShortcutSettingsRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/ShortcutSettingsRoute.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BoardCommandProvider } from "@/desktop/renderer/components/BoardCommandProvider";
+import ShortcutSettingsRoute from "@/desktop/renderer/routes/ShortcutSettingsRoute";
+import { DEFAULT_SHORTCUT_BINDINGS } from "@/desktop/shared/shortcutBindings";
+
+const mocks = vi.hoisted(() => ({
+  getShortcutBindings: vi.fn(),
+  setShortcutBindings: vi.fn(),
+  notifyShortcutBindingsChanged: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => Object.assign(
+    (key: string, values?: Record<string, unknown>) => (
+      values && "index" in values ? `${key}:${values.index}` : key
+    ),
+    { rich: (key: string) => key },
+  ),
+}));
+
+vi.mock("@/desktop/renderer/navigation", () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+  useRouter: () => ({ back: vi.fn(), forward: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock("@/desktop/renderer/actions/appSettings", () => ({
+  getShortcutBindings: (...args: unknown[]) => mocks.getShortcutBindings(...args),
+  setShortcutBindings: (...args: unknown[]) => mocks.setShortcutBindings(...args),
+}));
+
+function renderShortcutSettings() {
+  return render(
+    <BoardCommandProvider>
+      <ShortcutSettingsRoute />
+    </BoardCommandProvider>,
+  );
+}
+
+function findRecordButtonFor(commandLabel: string) {
+  const commandRow = screen.getByText(commandLabel).closest("li");
+  if (!commandRow) {
+    throw new Error(`단축키 행을 찾지 못했습니다: ${commandLabel}`);
+  }
+
+  return commandRow;
+}
+
+describe("ShortcutSettingsRoute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getShortcutBindings.mockResolvedValue({ ...DEFAULT_SHORTCUT_BINDINGS });
+    mocks.setShortcutBindings.mockResolvedValue(undefined);
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      notifyShortcutBindingsChanged: mocks.notifyShortcutBindingsChanged,
+    };
+  });
+
+  it("녹화한 조합을 그 명령의 새 단축키로 저장한다", async () => {
+    renderShortcutSettings();
+
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:4");
+    fireEvent.click(within(dockRow).getByText("record"));
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true, shiftKey: true });
+
+    await waitFor(() => {
+      expect(mocks.setShortcutBindings).toHaveBeenCalledWith(expect.objectContaining({
+        taskDetailDock4: "Mod+Shift+K",
+      }));
+    });
+
+    /** main도 같은 표를 들고 있어야 하므로 저장만 하고 알리지 않으면 Electron 경로가 옛 조합으로 남는다 */
+    expect(mocks.notifyShortcutBindingsChanged).toHaveBeenCalled();
+  });
+
+  /** 같은 조합이 두 명령에 붙으면 뒤 명령은 영영 실행되지 않는다 */
+  it("이미 쓰는 조합은 저장하지 않고 어떤 명령과 겹치는지 알린다", async () => {
+    renderShortcutSettings();
+
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    fireEvent.click(within(dockRow).getByText("record"));
+    fireEvent.keyDown(window, { key: "n", ctrlKey: true });
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(mocks.setShortcutBindings).not.toHaveBeenCalled();
+  });
+
+  it("Esc를 누르면 녹화를 취소한다", async () => {
+    renderShortcutSettings();
+
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    fireEvent.click(within(dockRow).getByText("record"));
+    expect(within(dockRow).getByText("recording")).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(within(dockRow).getByText("record")).toBeTruthy();
+    });
+    expect(mocks.setShortcutBindings).not.toHaveBeenCalled();
+  });
+
+  it("전체 기본값으로 되돌리면 저장된 재배정을 모두 지운다", async () => {
+    renderShortcutSettings();
+
+    fireEvent.click(screen.getByText("resetAll"));
+
+    await waitFor(() => {
+      expect(mocks.setShortcutBindings).toHaveBeenCalledWith(DEFAULT_SHORTCUT_BINDINGS);
+    });
+  });
+});

--- a/src/desktop/renderer/routes/__tests__/ShortcutSettingsRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/ShortcutSettingsRoute.test.tsx
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("next-intl", () => ({
   useTranslations: () => Object.assign(
     (key: string, values?: Record<string, unknown>) => (
-      values && "index" in values ? `${key}:${values.index}` : key
+      values && "index" in values ? `${key}:${values.index}:${values.item}` : key
     ),
     { rich: (key: string) => key },
   ),
@@ -64,7 +64,7 @@ describe("ShortcutSettingsRoute", () => {
   it("녹화한 조합을 그 명령의 새 단축키로 저장한다", async () => {
     renderShortcutSettings();
 
-    const dockRow = findRecordButtonFor("commands.taskDetailDock:4");
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:4:PR");
     fireEvent.click(within(dockRow).getByText("record"));
     fireEvent.keyDown(window, { key: "k", ctrlKey: true, shiftKey: true });
 
@@ -82,7 +82,7 @@ describe("ShortcutSettingsRoute", () => {
   it("이미 쓰는 조합은 저장하지 않고 어떤 명령과 겹치는지 알린다", async () => {
     renderShortcutSettings();
 
-    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1:info");
     fireEvent.click(within(dockRow).getByText("record"));
     fireEvent.keyDown(window, { key: "n", ctrlKey: true });
 
@@ -97,7 +97,7 @@ describe("ShortcutSettingsRoute", () => {
   it("개별 기본값 되돌리기가 다른 명령과 겹치면 저장하지 않고 알린다", async () => {
     renderShortcutSettings();
 
-    const firstDockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    const firstDockRow = findRecordButtonFor("commands.taskDetailDock:1:info");
     fireEvent.click(within(firstDockRow).getByText("record"));
     fireEvent.keyDown(window, { key: "j", ctrlKey: true, shiftKey: true });
     await waitFor(() => {
@@ -106,7 +106,7 @@ describe("ShortcutSettingsRoute", () => {
       }));
     });
 
-    const secondDockRow = findRecordButtonFor("commands.taskDetailDock:2");
+    const secondDockRow = findRecordButtonFor("commands.taskDetailDock:2:actions · hooksStatus");
     fireEvent.click(within(secondDockRow).getByText("record"));
     fireEvent.keyDown(window, { key: "1", ctrlKey: true });
     await waitFor(() => {
@@ -116,7 +116,7 @@ describe("ShortcutSettingsRoute", () => {
     });
 
     mocks.setShortcutBindings.mockClear();
-    fireEvent.click(within(findRecordButtonFor("commands.taskDetailDock:1")).getByText("reset"));
+    fireEvent.click(within(findRecordButtonFor("commands.taskDetailDock:1:info")).getByText("reset"));
 
     expect((await screen.findByRole("alert")).textContent).toBe("conflict");
     expect(mocks.setShortcutBindings).not.toHaveBeenCalled();
@@ -125,7 +125,7 @@ describe("ShortcutSettingsRoute", () => {
   it("Esc를 누르면 녹화를 취소한다", async () => {
     renderShortcutSettings();
 
-    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1:info");
     fireEvent.click(within(dockRow).getByText("record"));
     expect(within(dockRow).getByText("recording")).toBeTruthy();
 
@@ -145,7 +145,7 @@ describe("ShortcutSettingsRoute", () => {
   it("수식 키만 눌린 동안에는 오류를 띄우지 않는다", async () => {
     renderShortcutSettings();
 
-    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1:info");
     fireEvent.click(within(dockRow).getByText("record"));
     fireEvent.keyDown(window, { key: "Control", ctrlKey: true });
 
@@ -157,7 +157,7 @@ describe("ShortcutSettingsRoute", () => {
   it("담을 수 없는 조합을 녹화하면 저장하지 않고 오류를 알린다", async () => {
     renderShortcutSettings();
 
-    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1:info");
     fireEvent.click(within(dockRow).getByText("record"));
     fireEvent.keyDown(window, { key: "+", ctrlKey: true, shiftKey: true });
 
@@ -169,7 +169,7 @@ describe("ShortcutSettingsRoute", () => {
   it("Esc로 취소하면 남아 있던 오류 배너를 지운다", async () => {
     renderShortcutSettings();
 
-    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1:info");
     fireEvent.click(within(dockRow).getByText("record"));
     fireEvent.keyDown(window, { key: "n", ctrlKey: true });
     expect((await screen.findByRole("alert")).textContent).toBe("conflict");
@@ -198,7 +198,7 @@ describe("ShortcutSettingsRoute", () => {
   it("녹화를 시작하고 끝낼 때 Electron main에 알린다", async () => {
     renderShortcutSettings();
 
-    const dockRow = findRecordButtonFor("commands.taskDetailDock:1");
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:1:info");
     fireEvent.click(within(dockRow).getByText("record"));
     expect(mocks.notifyShortcutCaptureChanged).toHaveBeenLastCalledWith(true);
 
@@ -235,7 +235,7 @@ describe("ShortcutSettingsRoute", () => {
 
     expect((await screen.findByRole("alert")).textContent).toBe("loadFailed");
 
-    const dockRow = findRecordButtonFor("commands.taskDetailDock:4");
+    const dockRow = findRecordButtonFor("commands.taskDetailDock:4:PR");
     fireEvent.click(within(dockRow).getByText("record"));
     fireEvent.keyDown(window, { key: "k", ctrlKey: true, shiftKey: true });
 
@@ -245,6 +245,29 @@ describe("ShortcutSettingsRoute", () => {
     expect(mocks.setShortcutBindings).not.toHaveBeenCalled();
 
     consoleErrorSpy.mockRestore();
+  });
+
+  /**
+   * 번호만 보여 주면 "도크 4번 항목"이 무엇을 여는지 이 화면에서는 알 방법이 없고,
+   * 도크에 없는 번호까지 늘어놓으면 눌러도 아무 일이 없는 단축키를 설정하게 된다.
+   */
+  it("도크 명령을 실제 항목 이름으로 도크에 있는 자리만큼만 보여 준다", async () => {
+    renderShortcutSettings();
+
+    const dockSection = (await screen.findByText("groups.taskDetailDock")).closest("section");
+    expect(dockSection).toBeTruthy();
+
+    const dockRowLabels = Array.from(dockSection!.querySelectorAll("li")).map(
+      (row) => row.querySelector("span")?.textContent,
+    );
+    expect(dockRowLabels).toEqual([
+      "commands.taskDetailDock:1:info",
+      "commands.taskDetailDock:2:actions · hooksStatus",
+      "commands.taskDetailDock:3:aiSessions.inlineChat",
+      "commands.taskDetailDock:4:PR",
+      "commands.taskDetailDock:5:liveSessions.dock",
+      "commands.taskDetailDock:6:openInVsCode",
+    ]);
   });
 
   /** 나머지 화면은 3개 로케일이 채워져 있는데 제목만 영어 리터럴이면 그 창만 번역이 빠진다 */

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -40,6 +40,7 @@ const mocks = vi.hoisted(() => ({
   markAllNotificationsRead: vi.fn(),
   activateNotification: vi.fn(),
   fetchPrUrlWithPrompt: vi.fn(),
+  openTaskInVsCode: vi.fn(),
   renderHooksStatusCard: vi.fn(),
   useRefreshSignal: vi.fn(() => 0),
   redirect: vi.fn(),
@@ -102,6 +103,7 @@ vi.mock("@hugeicons/core-free-icons", () => ({
   ChartHistogramIcon: { __iconName: "ChartHistogramIcon" },
   Chatting01Icon: { __iconName: "Chatting01Icon" },
   InformationCircleIcon: { __iconName: "InformationCircleIcon" },
+  SourceCodeIcon: { __iconName: "SourceCodeIcon" },
 }));
 
 vi.mock("@/desktop/renderer/actions/aiUsage", () => ({
@@ -187,6 +189,10 @@ vi.mock("@/desktop/renderer/actions/notifications", () => ({
 
 vi.mock("@/desktop/renderer/utils/fetchPrUrlWithPrompt", () => ({
   fetchPrUrlWithPrompt: (...args: unknown[]) => mocks.fetchPrUrlWithPrompt(...args),
+}));
+
+vi.mock("@/desktop/renderer/actions/editor", () => ({
+  openTaskInVsCode: (...args: unknown[]) => mocks.openTaskInVsCode(...args),
 }));
 
 vi.mock("@/components/ConnectTerminalForm", () => ({
@@ -1071,6 +1077,80 @@ describe("TaskDetailRoute", () => {
 
     expect(wasNotPrevented).toBe(false);
     expect(openSpy).toHaveBeenCalledWith(prUrl, "_blank", "noopener,noreferrer");
+  });
+
+  /** PR 자리가 링크 유무로 사라지면 뒤 dock 항목의 번호가 통째로 밀려 근육기억이 깨진다 */
+  it("PR을 찾지 못한 task도 dock 4번 자리를 지키고 눌리면 다시 조회한다", async () => {
+    vi.spyOn(window, "alert").mockImplementation(() => {});
+    mocks.fetchPrUrlWithPrompt.mockResolvedValue(null);
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(
+      <BoardCommandProvider>
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    await screen.findByLabelText("terminal input");
+
+    const pullRequestDockButton = screen.getByRole("button", { name: "PR" });
+    expect(pullRequestDockButton.getAttribute("title")).toContain("Ctrl+4");
+
+    const autoLookupCallCount = mocks.fetchPrUrlWithPrompt.mock.calls.length;
+    fireEvent.keyDown(window, { key: "4", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(mocks.fetchPrUrlWithPrompt.mock.calls.length).toBe(autoLookupCallCount + 1);
+    });
+  });
+
+  it("dock 6번 shortcut은 작업 폴더를 VS Code로 연다", async () => {
+    mocks.openTaskInVsCode.mockResolvedValue({ ok: true });
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(
+      <BoardCommandProvider>
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    await screen.findByLabelText("terminal input");
+
+    fireEvent.keyDown(window, { key: "6", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(mocks.openTaskInVsCode).toHaveBeenCalledWith("task-1");
+    });
   });
 
   it("Electron main에서 전달된 dock shortcut도 같은 dock action을 실행한다", async () => {
@@ -2762,7 +2842,7 @@ describe("TaskDetailRoute", () => {
     expect(screen.getByRole("button", { name: "aiSessions.roles.tool" })).toBeTruthy();
   });
 
-  it("PR이 없는 task는 dock 4번 shortcut으로 실행중 세션 패널을 연다", async () => {
+  it("PR이 없는 task도 dock 5번 shortcut으로 실행중 세션 패널을 연다", async () => {
     mocks.getSidebarDefaultCollapsed.mockResolvedValue(true);
     mocks.getTaskLiveAiSessions.mockResolvedValue({
       taskId: "task-1",
@@ -2802,7 +2882,7 @@ describe("TaskDetailRoute", () => {
 
     await screen.findByLabelText("terminal input");
 
-    fireEvent.keyDown(window, { key: "4", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "5", ctrlKey: true });
 
     expect(await screen.findByTestId("live-ai-session-claude")).toBeTruthy();
     expect(screen.getByTestId("live-ai-session-state-running")).toBeTruthy();

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/desktop/renderer/components/BoardCommandProvider";
 import TaskDetailRoute from "@/desktop/renderer/routes/TaskDetailRoute";
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadingTimeout";
+import { TASK_DETAIL_DOCK_ITEM_IDS, resolveTaskDetailDockLabel } from "@/desktop/shared/taskDetailDock";
 
 const TASK_DETAIL_CACHE_KEY = "kanvibe:route-cache:task-detail:task-1";
 const BOARD_FOCUS_TASK_CACHE_KEY = "kanvibe:route-cache:board-focus-task";
@@ -995,6 +996,43 @@ describe("TaskDetailRoute", () => {
     expect(prLink.getAttribute("href")).toBe(prUrl);
     expect(prLink.getAttribute("target")).toBe("_blank");
     expect(screen.getByTestId("task-detail-pr-icon")).toBeTruthy();
+  });
+
+  /**
+   * dock 번호는 이 배열 순서에서 파생되므로, 순서가 공유 목록과 갈라지면
+   * 단축키 설정 화면이 실제와 다른 항목 이름을 보여 주고 근육기억도 깨진다.
+   */
+  it("dock 버튼 순서와 이름이 공유 dock 항목 목록과 일치한다", async () => {
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: "https://github.com/kanvibe/kanvibe/pull/236",
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    const { container } = render(<TaskDetailRoute />);
+    await screen.findByRole("link", { name: "PR" });
+
+    const dock = container.querySelector("aside");
+    const dockLabels = Array.from(
+      dock?.querySelectorAll(
+        ":scope > a[aria-label], :scope > button[aria-label]:not([data-testid='task-detail-usage-button'])",
+      ) ?? [],
+    ).map((dockItem) => dockItem.getAttribute("aria-label"));
+
+    expect(dockLabels).toEqual(
+      TASK_DETAIL_DOCK_ITEM_IDS.map((itemId) => resolveTaskDetailDockLabel((key) => key, itemId)),
+    );
   });
 
   it("상세 dock shortcut은 terminal 입력보다 먼저 capture 단계에서 처리한다", async () => {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -1153,6 +1153,42 @@ describe("TaskDetailRoute", () => {
     });
   });
 
+  /** IPC나 저장소 계층이 던지는 실패도 눌렀을 때 아무 일이 없어 보이면 안 된다 */
+  it("VS Code 실행 요청이 던지면 실패 알림을 띄운다", async () => {
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    mocks.openTaskInVsCode.mockRejectedValue(new Error("db down"));
+    mocks.getTaskById.mockResolvedValue({
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/detail-shortcut",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: "tmux",
+      sessionName: "task-session",
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/detail-shortcut",
+    });
+
+    render(
+      <BoardCommandProvider>
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    await screen.findByLabelText("terminal input");
+
+    fireEvent.keyDown(window, { key: "6", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+    });
+  });
+
   it("Electron main에서 전달된 dock shortcut도 같은 dock action을 실행한다", async () => {
     let dockShortcutListener: ((index: number) => void) | null = null;
     window.kanvibeDesktop = {

--- a/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
+++ b/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
@@ -11,13 +11,6 @@ import {
   isBlockedElectronShortcutInput,
   isBlockedShortcutEvent,
   matchElectronShortcutInput,
-  matchTaskDetailDockShortcutEvent,
-  matchTaskDetailUsageShortcutEvent,
-  matchTerminalTabShortcutEvent,
-  matchTerminalTabShortcutInput,
-  resolveTaskDetailUsageShortcutInput,
-  resolveTerminalTabShortcutCommand,
-  resolveTerminalTabShortcutEvent,
   matchShortcutEvent,
 } from "@/desktop/renderer/utils/keyboardShortcut";
 
@@ -116,19 +109,6 @@ describe("keyboardShortcut", () => {
     expect(matchShortcutEvent(closeWindowEvent, SHORTCUTS.terminalTabClose, "linux")).toBe(false);
   });
 
-  it("탭 번호 단축키는 일치한 번호를 반환하고 dock 단축키와 충돌하지 않는다", () => {
-    for (const shortcutIndex of TERMINAL_TAB_SHORTCUT_INDEXES) {
-      const macEvent = new KeyboardEvent("keydown", {
-        key: String(shortcutIndex),
-        metaKey: true,
-        altKey: true,
-      });
-
-      expect(matchTerminalTabShortcutEvent(macEvent, "mac")).toBe(shortcutIndex);
-      expect(matchTaskDetailDockShortcutEvent(macEvent, "mac")).toBeNull();
-    }
-  });
-
   /** macOS는 Cmd+Shift+3~5를 스크린샷으로 가져가 앱에 넘기지 않으므로 탭 단축키가 Shift를 쓰면 죽는다 */
   it("탭 번호 단축키는 macOS 스크린샷 조합인 Cmd+Shift+숫자를 쓰지 않는다", () => {
     for (const shortcutIndex of TERMINAL_TAB_SHORTCUT_INDEXES) {
@@ -142,29 +122,6 @@ describe("keyboardShortcut", () => {
         shiftKey: true,
       }), createTerminalTabShortcut(shortcutIndex), "mac")).toBe(false);
     }
-  });
-
-  it("dock 번호 입력은 탭 번호 단축키로 매칭하지 않는다", () => {
-    const dockEvent = new KeyboardEvent("keydown", { key: "1", ctrlKey: true });
-
-    expect(matchTaskDetailDockShortcutEvent(dockEvent, "linux")).toBe(1);
-    expect(matchTerminalTabShortcutEvent(dockEvent, "linux")).toBeNull();
-  });
-
-  it("macOS dock 입력은 Option이 없어 탭 번호 단축키와 갈린다", () => {
-    const dockEvent = new KeyboardEvent("keydown", { key: "1", metaKey: true });
-
-    expect(matchTaskDetailDockShortcutEvent(dockEvent, "mac")).toBe(1);
-    expect(matchTerminalTabShortcutEvent(dockEvent, "mac")).toBeNull();
-  });
-
-  it("Electron input도 탭 번호 단축키로 매칭한다", () => {
-    expect(matchTerminalTabShortcutInput({
-      type: "keyDown",
-      key: "3",
-      control: true,
-      alt: true,
-    }, "linux")).toBe(3);
   });
 
   it("추가 modifier가 있으면 단축키가 일치하지 않는다", () => {
@@ -313,21 +270,6 @@ describe("keyboardShortcut", () => {
     }), createTaskDetailDockShortcut(1), "linux")).toBe(false);
   });
 
-  it("상세 dock shortcut matcher는 일치한 dock 번호를 반환한다", () => {
-    expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
-      key: "4",
-      metaKey: true,
-    }), "mac")).toBe(4);
-    expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
-      key: "4",
-      ctrlKey: true,
-    }), "linux")).toBe(4);
-    expect(matchTaskDetailDockShortcutEvent(new KeyboardEvent("keydown", {
-      key: "4",
-      altKey: true,
-    }), "linux")).toBeNull();
-  });
-
   it("Cmd/Ctrl+R은 앱에서 차단할 shortcut으로 판별한다", () => {
     expect(isBlockedShortcutEvent(new KeyboardEvent("keydown", {
       key: "r",
@@ -369,125 +311,5 @@ describe("keyboardShortcut", () => {
     });
 
     expect(captureShortcutFromEvent(event)).toBeNull();
-  });
-});
-
-describe("터미널 탭 단축키 명령 해석", () => {
-  const macInput = (key: string, modifiers: { meta?: boolean; alt?: boolean; shift?: boolean } = {}) => ({
-    type: "keyDown",
-    isAutoRepeat: false,
-    key,
-    meta: modifiers.meta ?? false,
-    control: false,
-    alt: modifiers.alt ?? false,
-    shift: modifiers.shift ?? false,
-  });
-
-  it("태스크 상세에서 새 탭·이전·다음 명령을 만든다", () => {
-    expect(resolveTerminalTabShortcutCommand(macInput("t", { meta: true }), "mac", true))
-      .toEqual({ type: "new-tab" });
-    expect(resolveTerminalTabShortcutCommand(macInput("{", { meta: true, shift: true }), "mac", true))
-      .toEqual({ type: "previous-tab" });
-    expect(resolveTerminalTabShortcutCommand(macInput("}", { meta: true, shift: true }), "mac", true))
-      .toEqual({ type: "next-tab" });
-  });
-
-  it("숫자 단축키는 이동할 탭 위치를 담는다", () => {
-    expect(resolveTerminalTabShortcutCommand(macInput("3", { meta: true, alt: true }), "mac", true))
-      .toEqual({ type: "go-to-tab", position: 3 });
-  });
-
-  it("탭 닫기는 태스크 상세에서만 탭을 닫고 밖에서는 창을 닫는다", () => {
-    expect(resolveTerminalTabShortcutCommand(macInput("w", { meta: true }), "mac", true))
-      .toEqual({ type: "close-tab" });
-    expect(resolveTerminalTabShortcutCommand(macInput("w", { meta: true }), "mac", false))
-      .toEqual({ type: "close-window" });
-  });
-
-  it("창 닫기는 어느 화면에서나 동작한다", () => {
-    expect(resolveTerminalTabShortcutCommand(macInput("w", { meta: true, shift: true }), "mac", false))
-      .toEqual({ type: "close-window" });
-  });
-
-  it("태스크 상세가 아니면 탭 조작 명령을 만들지 않는다", () => {
-    expect(resolveTerminalTabShortcutCommand(macInput("t", { meta: true }), "mac", false)).toBeNull();
-    expect(resolveTerminalTabShortcutCommand(macInput("3", { meta: true, shift: true }), "mac", false)).toBeNull();
-  });
-
-  it("페이지 이동 단축키는 탭 명령으로 새지 않는다", () => {
-    expect(resolveTerminalTabShortcutCommand(macInput("[", { meta: true }), "mac", true)).toBeNull();
-    expect(resolveTerminalTabShortcutCommand(macInput("]", { meta: true }), "mac", true)).toBeNull();
-  });
-});
-
-describe("렌더러 keydown도 같은 탭 명령으로 해석한다", () => {
-  it("Electron 입력과 렌더러 이벤트가 같은 명령을 만든다", () => {
-    const linuxEvent = new KeyboardEvent("keydown", { key: "t", ctrlKey: true });
-    const linuxInput = { type: "keyDown", key: "t", control: true, meta: false, alt: false, shift: false };
-
-    expect(resolveTerminalTabShortcutEvent(linuxEvent, "linux", true)).toEqual({ type: "new-tab" });
-    expect(resolveTerminalTabShortcutCommand(linuxInput, "linux", true)).toEqual({ type: "new-tab" });
-  });
-
-  it("렌더러 경로도 태스크 상세 밖에서는 탭 조작을 만들지 않는다", () => {
-    const newTabEvent = new KeyboardEvent("keydown", { key: "t", ctrlKey: true });
-
-    expect(resolveTerminalTabShortcutEvent(newTabEvent, "linux", false)).toBeNull();
-  });
-
-  it("렌더러 경로에서도 탭 번호와 창 닫기를 해석한다", () => {
-    expect(resolveTerminalTabShortcutEvent(
-      new KeyboardEvent("keydown", { key: "2", ctrlKey: true, altKey: true }),
-      "linux",
-      true,
-    )).toEqual({ type: "go-to-tab", position: 2 });
-
-    expect(resolveTerminalTabShortcutEvent(
-      new KeyboardEvent("keydown", { key: "w", ctrlKey: true, shiftKey: true }),
-      "linux",
-      false,
-    )).toEqual({ type: "close-window" });
-  });
-});
-
-describe("AI 사용량 패널 단축키", () => {
-  it("Mod+0을 사용량 단축키로 인식한다", () => {
-    expect(matchTaskDetailUsageShortcutEvent(
-      new KeyboardEvent("keydown", { key: "0", ctrlKey: true }),
-      "linux",
-    )).toBe(true);
-
-    expect(matchTaskDetailUsageShortcutEvent(
-      new KeyboardEvent("keydown", { key: "0", metaKey: true }),
-      "mac",
-    )).toBe(true);
-  });
-
-  it("dock 번호와 겹치지 않는다", () => {
-    expect(matchTaskDetailUsageShortcutEvent(
-      new KeyboardEvent("keydown", { key: "1", ctrlKey: true }),
-      "linux",
-    )).toBe(false);
-
-    /** dock 번호 배열은 1~9뿐이어야 0이 dock 항목을 집으려 하지 않는다 */
-    expect(TASK_DETAIL_DOCK_SHORTCUT_INDEXES).not.toContain(0);
-    expect(matchTaskDetailDockShortcutEvent(
-      new KeyboardEvent("keydown", { key: "0", ctrlKey: true }),
-      "linux",
-    )).toBeNull();
-  });
-
-  it("터미널 탭 단축키와도 겹치지 않는다", () => {
-    expect(matchTaskDetailUsageShortcutEvent(
-      new KeyboardEvent("keydown", { key: "0", ctrlKey: true, altKey: true }),
-      "linux",
-    )).toBe(false);
-  });
-
-  it("태스크 상세 밖에서는 Electron 입력을 사용량 명령으로 해석하지 않는다", () => {
-    const usageInput = { type: "keyDown", key: "0", control: true };
-
-    expect(resolveTaskDetailUsageShortcutInput(usageInput, "linux", true)).toBe(true);
-    expect(resolveTaskDetailUsageShortcutInput(usageInput, "linux", false)).toBe(false);
   });
 });

--- a/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
+++ b/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
@@ -242,7 +242,7 @@ describe("keyboardShortcut", () => {
   });
 
   it("상세 dock shortcut은 macOS Cmd+숫자와 Linux Ctrl+숫자로 표시하고 매칭한다", () => {
-    expect(TASK_DETAIL_DOCK_SHORTCUT_INDEXES).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(TASK_DETAIL_DOCK_SHORTCUT_INDEXES).toEqual([1, 2, 3, 4, 5, 6]);
     expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "mac")).toBe("Cmd+1");
     expect(formatShortcutForDisplay(createTaskDetailDockShortcut(1), "linux")).toBe("Ctrl+1");
 

--- a/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
+++ b/src/desktop/renderer/utils/__tests__/keyboardShortcut.test.ts
@@ -304,6 +304,19 @@ describe("keyboardShortcut", () => {
     }), "linux")).toBeNull();
   });
 
+  /**
+   * `+`는 단축키 문자열의 토큰 구분자라 키 자리에 담기지 못한다.
+   * 캡처가 이 값을 통과시키면 `Mod+Shift++`가 다시 파싱될 때 키가 사라져
+   * 저장·매칭·표시가 전부 조용히 실패하고, 사용자는 배정된 줄로 안다.
+   */
+  it("문자열 포맷이 담을 수 없는 + 키는 캡처하지 않는다", () => {
+    expect(captureShortcutFromEvent(new KeyboardEvent("keydown", {
+      key: "+",
+      ctrlKey: true,
+      shiftKey: true,
+    }), "linux")).toBeNull();
+  });
+
   it("modifier만 누른 경우는 캡처하지 않는다", () => {
     const event = new KeyboardEvent("keydown", {
       key: "Meta",

--- a/src/desktop/renderer/utils/__tests__/shortcutBindings.test.ts
+++ b/src/desktop/renderer/utils/__tests__/shortcutBindings.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SHORTCUT_BINDINGS } from "@/desktop/shared/shortcutBindings";
+
+const mocks = vi.hoisted(() => ({
+  getShortcutBindings: vi.fn(),
+  setShortcutBindings: vi.fn(),
+}));
+
+vi.mock("@/desktop/renderer/actions/appSettings", () => ({
+  getShortcutBindings: (...args: unknown[]) => mocks.getShortcutBindings(...args),
+  setShortcutBindings: (...args: unknown[]) => mocks.setShortcutBindings(...args),
+}));
+
+/** 캐시는 모듈 전역이라, 테스트마다 새로 불러와야 앞 테스트가 채운 값을 보지 않는다 */
+function importShortcutBindings() {
+  vi.resetModules();
+  return import("@/desktop/renderer/utils/shortcutBindings");
+}
+
+describe("loadShortcutBindings", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  /**
+   * 저장은 단축키 표를 통째로 치환한다. 조회 실패를 성공과 구분하지 못하면 기본값 표가 그대로 저장돼
+   * 저장돼 있던 다른 명령의 재배정이 전부 지워진다.
+   */
+  it("조회에 실패하면 캐시를 채우지 않고 실패를 알린다", async () => {
+    mocks.getShortcutBindings.mockRejectedValue(new Error("설정 조회 실패"));
+    const { hasLoadedShortcutBindings, loadShortcutBindings, readShortcutBindings } = await importShortcutBindings();
+
+    expect(await loadShortcutBindings()).toBe(false);
+    expect(hasLoadedShortcutBindings()).toBe(false);
+    expect(readShortcutBindings()).toEqual(DEFAULT_SHORTCUT_BINDINGS);
+  });
+
+  it("조회에 성공하면 저장된 표를 캐시에 담는다", async () => {
+    const storedBindings = { ...DEFAULT_SHORTCUT_BINDINGS, taskSearch: "Mod+J" };
+    mocks.getShortcutBindings.mockResolvedValue(storedBindings);
+    const { hasLoadedShortcutBindings, loadShortcutBindings, readShortcutBindings } = await importShortcutBindings();
+
+    expect(await loadShortcutBindings()).toBe(true);
+    expect(hasLoadedShortcutBindings()).toBe(true);
+    expect(readShortcutBindings()).toEqual(storedBindings);
+  });
+
+  /** 다시 읽기에 실패한 캐시는 다른 창이 바꾼 값을 놓친 옛 표라, 그대로 저장하면 그 변경을 지운다 */
+  it("한 번 성공한 뒤 다시 읽기에 실패하면 캐시를 담고 있다고 하지 않는다", async () => {
+    mocks.getShortcutBindings.mockResolvedValueOnce({ ...DEFAULT_SHORTCUT_BINDINGS });
+    const { hasLoadedShortcutBindings, loadShortcutBindings } = await importShortcutBindings();
+    expect(await loadShortcutBindings()).toBe(true);
+
+    mocks.getShortcutBindings.mockRejectedValueOnce(new Error("설정 조회 실패"));
+
+    expect(await loadShortcutBindings()).toBe(false);
+    expect(hasLoadedShortcutBindings()).toBe(false);
+  });
+});

--- a/src/desktop/renderer/utils/shortcutBindings.ts
+++ b/src/desktop/renderer/utils/shortcutBindings.ts
@@ -39,13 +39,52 @@ export function isShortcutCaptureTarget(eventTarget: EventTarget | null): boolea
   return eventTarget instanceof Element && eventTarget.closest('[data-shortcut-capture="true"]') !== null;
 }
 
-/** 저장된 재배정을 캐시에 채운다. 실패해도 기본 단축키로는 계속 동작해야 한다 */
-export async function loadShortcutBindings(): Promise<void> {
+/**
+ * 녹화 화면이 열려 있는지. 녹화 중에 눌린 조합은 명령이 아니라 저장할 값이다.
+ *
+ * 녹화 화면은 입력 요소에 포커스를 두지 않아 keydown 대상이 대개 `body`다.
+ * 그래서 `isShortcutCaptureTarget`만으로는 창 닫기 같은 전역 처리기를 막지 못한다.
+ */
+let shortcutCaptureActive = false;
+
+export function isShortcutCaptureActive(): boolean {
+  return shortcutCaptureActive;
+}
+
+/** 녹화 시작/종료를 렌더러 전역과 Electron main 양쪽에 알린다 */
+export function setShortcutCaptureActive(isActive: boolean): void {
+  shortcutCaptureActive = isActive;
+  window.kanvibeDesktop?.notifyShortcutCaptureChanged?.(isActive);
+}
+
+/**
+ * 캐시가 저장된 표를 실제로 담고 있는지.
+ *
+ * 조회에 실패한 창의 캐시는 기본값이다. 저장은 표를 통째로 치환하므로, 그 캐시를 그대로 저장하면
+ * 저장돼 있던 다른 명령의 재배정이 함께 지워진다. 그래서 저장 전에 이 값을 먼저 본다.
+ */
+let shortcutBindingsLoaded = false;
+
+export function hasLoadedShortcutBindings(): boolean {
+  return shortcutBindingsLoaded;
+}
+
+/**
+ * 저장된 재배정을 캐시에 채운다. 실패해도 기본 단축키로는 계속 동작해야 한다.
+ *
+ * 다시 읽기에 실패하면 캐시는 다른 창이 바꾼 값을 놓친 옛 표다. 그 표로 저장해도 남의 재배정을
+ * 지우므로, 성공한 조회가 있었더라도 실패한 순간부터는 담고 있지 않다고 본다.
+ */
+export async function loadShortcutBindings(): Promise<boolean> {
   try {
     publishShortcutBindings(await getShortcutBindings());
+    shortcutBindingsLoaded = true;
   } catch (error) {
     console.error("단축키 설정 조회 실패:", error);
+    shortcutBindingsLoaded = false;
   }
+
+  return shortcutBindingsLoaded;
 }
 
 /** 단축키 표를 저장하고, 렌더러 캐시와 Electron main 캐시를 함께 갱신한다 */

--- a/src/desktop/renderer/utils/shortcutBindings.ts
+++ b/src/desktop/renderer/utils/shortcutBindings.ts
@@ -1,0 +1,56 @@
+import { useSyncExternalStore } from "react";
+import { getShortcutBindings, setShortcutBindings } from "@/desktop/renderer/actions/appSettings";
+import { DEFAULT_SHORTCUT_BINDINGS, type ShortcutBindings } from "@/desktop/shared/shortcutBindings";
+
+/**
+ * 키 입력 처리는 동기라 저장소를 그때 읽어올 수 없다.
+ * 그래서 앱이 뜰 때 한 번 읽어 여기에 담아 두고, 설정 화면이 바꿀 때마다 다시 채운다.
+ */
+let currentShortcutBindings: ShortcutBindings = DEFAULT_SHORTCUT_BINDINGS;
+const bindingListeners = new Set<() => void>();
+
+export function readShortcutBindings(): ShortcutBindings {
+  return currentShortcutBindings;
+}
+
+function subscribeToShortcutBindings(listener: () => void): () => void {
+  bindingListeners.add(listener);
+  return () => {
+    bindingListeners.delete(listener);
+  };
+}
+
+function publishShortcutBindings(bindings: ShortcutBindings): void {
+  currentShortcutBindings = bindings;
+  for (const listener of bindingListeners) {
+    listener();
+  }
+}
+
+export function useShortcutBindings(): ShortcutBindings {
+  return useSyncExternalStore(subscribeToShortcutBindings, readShortcutBindings, readShortcutBindings);
+}
+
+/**
+ * 단축키를 녹화 중인 UI 안에서 난 입력인지 본다.
+ * 녹화 중에는 누른 조합이 명령으로 실행되면 안 되고 새 단축키 값으로만 읽혀야 한다.
+ */
+export function isShortcutCaptureTarget(eventTarget: EventTarget | null): boolean {
+  return eventTarget instanceof Element && eventTarget.closest('[data-shortcut-capture="true"]') !== null;
+}
+
+/** 저장된 재배정을 캐시에 채운다. 실패해도 기본 단축키로는 계속 동작해야 한다 */
+export async function loadShortcutBindings(): Promise<void> {
+  try {
+    publishShortcutBindings(await getShortcutBindings());
+  } catch (error) {
+    console.error("단축키 설정 조회 실패:", error);
+  }
+}
+
+/** 단축키 표를 저장하고, 렌더러 캐시와 Electron main 캐시를 함께 갱신한다 */
+export async function saveShortcutBindings(bindings: ShortcutBindings): Promise<void> {
+  await setShortcutBindings(bindings);
+  publishShortcutBindings(bindings);
+  window.kanvibeDesktop?.notifyShortcutBindingsChanged?.();
+}

--- a/src/desktop/shared/__tests__/shortcutBindings.test.ts
+++ b/src/desktop/shared/__tests__/shortcutBindings.test.ts
@@ -18,6 +18,7 @@ import {
   resolveShortcutBindings,
   resolveTerminalTabCommand,
 } from "@/desktop/shared/shortcutBindings";
+import { TASK_DETAIL_DOCK_ITEM_IDS } from "@/desktop/shared/taskDetailDock";
 
 function dockIndexForEvent(event: KeyboardEvent, platform: ShortcutPlatformInput) {
   return getTaskDetailDockIndexForCommand(findShortcutCommandForEvent(DEFAULT_SHORTCUT_BINDINGS, event, platform));
@@ -184,7 +185,7 @@ describe("AI 사용량 패널 단축키", () => {
   });
 
   it("dock 번호와 겹치지 않는다", () => {
-    /** dock 번호 배열은 1~9뿐이어야 0이 dock 항목을 집으려 하지 않는다 */
+    /** dock 번호 배열은 1부터 시작해야 0이 dock 항목을 집으려 하지 않는다 */
     expect(TASK_DETAIL_DOCK_SHORTCUT_INDEXES).not.toContain(0);
     expect(dockIndexForEvent(new KeyboardEvent("keydown", { key: "0", ctrlKey: true }), "linux")).toBeNull();
   });
@@ -199,6 +200,26 @@ describe("AI 사용량 패널 단축키", () => {
 });
 
 describe("단축키 재배정", () => {
+  /**
+   * 도크에 없는 번호까지 명령을 만들면 설정 화면이 눌러도 아무 일이 없는 단축키를 보여 준다.
+   * 반대로 도크 항목보다 번호가 모자라면 마지막 항목을 키로 열 수 없다.
+   */
+  it("dock 명령은 도크에 실제로 있는 항목 수만큼만 있고 각 항목을 가리킨다", () => {
+    const dockDefinitions = SHORTCUT_COMMAND_DEFINITIONS.filter(
+      (definition) => definition.group === "taskDetailDock",
+    );
+
+    expect(dockDefinitions.map((definition) => definition.dockItemId)).toEqual([...TASK_DETAIL_DOCK_ITEM_IDS]);
+    expect(dockIndexForEvent(new KeyboardEvent("keydown", {
+      key: String(TASK_DETAIL_DOCK_ITEM_IDS.length),
+      ctrlKey: true,
+    }), "linux")).toBe(TASK_DETAIL_DOCK_ITEM_IDS.length);
+    expect(findShortcutCommandForEvent(DEFAULT_SHORTCUT_BINDINGS, new KeyboardEvent("keydown", {
+      key: String(TASK_DETAIL_DOCK_ITEM_IDS.length + 1),
+      ctrlKey: true,
+    }), "linux")).toBeNull();
+  });
+
   it("기본 단축키 표에는 중복 조합이 없다", () => {
     const usedShortcuts = new Set<string>();
 

--- a/src/desktop/shared/__tests__/shortcutBindings.test.ts
+++ b/src/desktop/shared/__tests__/shortcutBindings.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "vitest";
+import {
+  TASK_DETAIL_DOCK_SHORTCUT_INDEXES,
+  TERMINAL_TAB_SHORTCUT_INDEXES,
+  type ElectronShortcutInput,
+  type ShortcutPlatformInput,
+} from "@/desktop/shared/keyboardShortcut";
+import {
+  DEFAULT_SHORTCUT_BINDINGS,
+  SHORTCUT_COMMAND_DEFINITIONS,
+  collectShortcutOverrides,
+  findShortcutCommandConflict,
+  findShortcutCommandForElectronInput,
+  findShortcutCommandForEvent,
+  getTaskDetailDockIndexForCommand,
+  getTerminalTabPositionForCommand,
+  parseShortcutOverrides,
+  resolveShortcutBindings,
+  resolveTerminalTabCommand,
+} from "@/desktop/shared/shortcutBindings";
+
+function dockIndexForEvent(event: KeyboardEvent, platform: ShortcutPlatformInput) {
+  return getTaskDetailDockIndexForCommand(findShortcutCommandForEvent(DEFAULT_SHORTCUT_BINDINGS, event, platform));
+}
+
+function tabPositionForEvent(event: KeyboardEvent, platform: ShortcutPlatformInput) {
+  return getTerminalTabPositionForCommand(findShortcutCommandForEvent(DEFAULT_SHORTCUT_BINDINGS, event, platform));
+}
+
+function terminalTabCommandForInput(
+  input: ElectronShortcutInput,
+  platform: ShortcutPlatformInput,
+  isTaskDetailRoute: boolean,
+) {
+  return resolveTerminalTabCommand(
+    findShortcutCommandForElectronInput(DEFAULT_SHORTCUT_BINDINGS, input, platform),
+    isTaskDetailRoute,
+  );
+}
+
+function terminalTabCommandForEvent(
+  event: KeyboardEvent,
+  platform: ShortcutPlatformInput,
+  isTaskDetailRoute: boolean,
+) {
+  return resolveTerminalTabCommand(
+    findShortcutCommandForEvent(DEFAULT_SHORTCUT_BINDINGS, event, platform),
+    isTaskDetailRoute,
+  );
+}
+
+const macInput = (key: string, modifiers: { meta?: boolean; alt?: boolean; shift?: boolean } = {}) => ({
+  type: "keyDown",
+  isAutoRepeat: false,
+  key,
+  meta: modifiers.meta ?? false,
+  control: false,
+  alt: modifiers.alt ?? false,
+  shift: modifiers.shift ?? false,
+});
+
+describe("단축키 명령 판정", () => {
+  it("탭 번호 단축키는 일치한 번호를 반환하고 dock 단축키와 충돌하지 않는다", () => {
+    for (const shortcutIndex of TERMINAL_TAB_SHORTCUT_INDEXES) {
+      const macEvent = new KeyboardEvent("keydown", {
+        key: String(shortcutIndex),
+        metaKey: true,
+        altKey: true,
+      });
+
+      expect(tabPositionForEvent(macEvent, "mac")).toBe(shortcutIndex);
+      expect(dockIndexForEvent(macEvent, "mac")).toBeNull();
+    }
+  });
+
+  it("dock 번호 입력은 탭 번호 단축키로 매칭하지 않는다", () => {
+    const dockEvent = new KeyboardEvent("keydown", { key: "1", ctrlKey: true });
+
+    expect(dockIndexForEvent(dockEvent, "linux")).toBe(1);
+    expect(tabPositionForEvent(dockEvent, "linux")).toBeNull();
+  });
+
+  it("macOS dock 입력은 Option이 없어 탭 번호 단축키와 갈린다", () => {
+    const dockEvent = new KeyboardEvent("keydown", { key: "1", metaKey: true });
+
+    expect(dockIndexForEvent(dockEvent, "mac")).toBe(1);
+    expect(tabPositionForEvent(dockEvent, "mac")).toBeNull();
+  });
+
+  it("Electron input도 탭 번호 단축키로 매칭한다", () => {
+    expect(getTerminalTabPositionForCommand(findShortcutCommandForElectronInput(DEFAULT_SHORTCUT_BINDINGS, {
+      type: "keyDown",
+      key: "3",
+      control: true,
+      alt: true,
+    }, "linux"))).toBe(3);
+  });
+
+  it("상세 dock shortcut matcher는 일치한 dock 번호를 반환한다", () => {
+    expect(dockIndexForEvent(new KeyboardEvent("keydown", { key: "4", metaKey: true }), "mac")).toBe(4);
+    expect(dockIndexForEvent(new KeyboardEvent("keydown", { key: "4", ctrlKey: true }), "linux")).toBe(4);
+    expect(dockIndexForEvent(new KeyboardEvent("keydown", { key: "4", altKey: true }), "linux")).toBeNull();
+  });
+});
+
+describe("터미널 탭 단축키 명령 해석", () => {
+  it("태스크 상세에서 새 탭·이전·다음 명령을 만든다", () => {
+    expect(terminalTabCommandForInput(macInput("t", { meta: true }), "mac", true))
+      .toEqual({ type: "new-tab" });
+    expect(terminalTabCommandForInput(macInput("{", { meta: true, shift: true }), "mac", true))
+      .toEqual({ type: "previous-tab" });
+    expect(terminalTabCommandForInput(macInput("}", { meta: true, shift: true }), "mac", true))
+      .toEqual({ type: "next-tab" });
+  });
+
+  it("숫자 단축키는 이동할 탭 위치를 담는다", () => {
+    expect(terminalTabCommandForInput(macInput("3", { meta: true, alt: true }), "mac", true))
+      .toEqual({ type: "go-to-tab", position: 3 });
+  });
+
+  it("탭 닫기는 태스크 상세에서만 탭을 닫고 밖에서는 창을 닫는다", () => {
+    expect(terminalTabCommandForInput(macInput("w", { meta: true }), "mac", true))
+      .toEqual({ type: "close-tab" });
+    expect(terminalTabCommandForInput(macInput("w", { meta: true }), "mac", false))
+      .toEqual({ type: "close-window" });
+  });
+
+  it("창 닫기는 어느 화면에서나 동작한다", () => {
+    expect(terminalTabCommandForInput(macInput("w", { meta: true, shift: true }), "mac", false))
+      .toEqual({ type: "close-window" });
+  });
+
+  it("태스크 상세가 아니면 탭 조작 명령을 만들지 않는다", () => {
+    expect(terminalTabCommandForInput(macInput("t", { meta: true }), "mac", false)).toBeNull();
+    expect(terminalTabCommandForInput(macInput("3", { meta: true, shift: true }), "mac", false)).toBeNull();
+  });
+
+  it("페이지 이동 단축키는 탭 명령으로 새지 않는다", () => {
+    expect(terminalTabCommandForInput(macInput("[", { meta: true }), "mac", true)).toBeNull();
+    expect(terminalTabCommandForInput(macInput("]", { meta: true }), "mac", true)).toBeNull();
+  });
+
+  it("Electron 입력과 렌더러 이벤트가 같은 명령을 만든다", () => {
+    const linuxEvent = new KeyboardEvent("keydown", { key: "t", ctrlKey: true });
+    const linuxInput = { type: "keyDown", key: "t", control: true, meta: false, alt: false, shift: false };
+
+    expect(terminalTabCommandForEvent(linuxEvent, "linux", true)).toEqual({ type: "new-tab" });
+    expect(terminalTabCommandForInput(linuxInput, "linux", true)).toEqual({ type: "new-tab" });
+  });
+
+  it("렌더러 경로도 태스크 상세 밖에서는 탭 조작을 만들지 않는다", () => {
+    expect(terminalTabCommandForEvent(new KeyboardEvent("keydown", { key: "t", ctrlKey: true }), "linux", false))
+      .toBeNull();
+  });
+
+  it("렌더러 경로에서도 탭 번호와 창 닫기를 해석한다", () => {
+    expect(terminalTabCommandForEvent(
+      new KeyboardEvent("keydown", { key: "2", ctrlKey: true, altKey: true }),
+      "linux",
+      true,
+    )).toEqual({ type: "go-to-tab", position: 2 });
+
+    expect(terminalTabCommandForEvent(
+      new KeyboardEvent("keydown", { key: "w", ctrlKey: true, shiftKey: true }),
+      "linux",
+      false,
+    )).toEqual({ type: "close-window" });
+  });
+});
+
+describe("AI 사용량 패널 단축키", () => {
+  it("Mod+0을 사용량 단축키로 인식한다", () => {
+    expect(findShortcutCommandForEvent(
+      DEFAULT_SHORTCUT_BINDINGS,
+      new KeyboardEvent("keydown", { key: "0", ctrlKey: true }),
+      "linux",
+    )).toBe("taskDetailUsage");
+
+    expect(findShortcutCommandForEvent(
+      DEFAULT_SHORTCUT_BINDINGS,
+      new KeyboardEvent("keydown", { key: "0", metaKey: true }),
+      "mac",
+    )).toBe("taskDetailUsage");
+  });
+
+  it("dock 번호와 겹치지 않는다", () => {
+    /** dock 번호 배열은 1~9뿐이어야 0이 dock 항목을 집으려 하지 않는다 */
+    expect(TASK_DETAIL_DOCK_SHORTCUT_INDEXES).not.toContain(0);
+    expect(dockIndexForEvent(new KeyboardEvent("keydown", { key: "0", ctrlKey: true }), "linux")).toBeNull();
+  });
+
+  it("터미널 탭 단축키와도 겹치지 않는다", () => {
+    expect(findShortcutCommandForEvent(
+      DEFAULT_SHORTCUT_BINDINGS,
+      new KeyboardEvent("keydown", { key: "0", ctrlKey: true, altKey: true }),
+      "linux",
+    )).not.toBe("taskDetailUsage");
+  });
+});
+
+describe("단축키 재배정", () => {
+  it("기본 단축키 표에는 중복 조합이 없다", () => {
+    const usedShortcuts = new Set<string>();
+
+    for (const definition of SHORTCUT_COMMAND_DEFINITIONS) {
+      expect(usedShortcuts.has(definition.defaultShortcut)).toBe(false);
+      usedShortcuts.add(definition.defaultShortcut);
+    }
+  });
+
+  it("재배정한 조합으로 명령을 판정한다", () => {
+    const bindings = resolveShortcutBindings({ taskDetailDock4: "Mod+Shift+K" });
+
+    expect(getTaskDetailDockIndexForCommand(findShortcutCommandForEvent(
+      bindings,
+      new KeyboardEvent("keydown", { key: "k", ctrlKey: true, shiftKey: true }),
+      "linux",
+    ))).toBe(4);
+    expect(dockIndexForEvent(new KeyboardEvent("keydown", { key: "4", ctrlKey: true }), "linux")).toBe(4);
+  });
+
+  it("모르는 명령과 문자열이 아닌 값은 재배정에서 버린다", () => {
+    expect(parseShortcutOverrides(JSON.stringify({
+      taskDetailDock1: "Mod+Shift+K",
+      unknownCommand: "Mod+J",
+      taskDetailUsage: 7,
+    }))).toEqual({ taskDetailDock1: "Mod+Shift+K" });
+  });
+
+  it("저장 형식이 깨져 있으면 재배정 없이 기본값을 쓴다", () => {
+    expect(parseShortcutOverrides("{not json")).toEqual({});
+    expect(resolveShortcutBindings(parseShortcutOverrides(null))).toEqual(DEFAULT_SHORTCUT_BINDINGS);
+  });
+
+  it("기본값과 같아진 항목은 저장하지 않는다", () => {
+    expect(collectShortcutOverrides({
+      ...DEFAULT_SHORTCUT_BINDINGS,
+      taskDetailDock1: "Mod+Shift+K",
+    })).toEqual({ taskDetailDock1: "Mod+Shift+K" });
+  });
+
+  it("이미 다른 명령이 쓰는 조합은 충돌로 알린다", () => {
+    expect(findShortcutCommandConflict(DEFAULT_SHORTCUT_BINDINGS, "taskDetailDock1", "Mod+N"))
+      .toBe("createTask");
+    expect(findShortcutCommandConflict(DEFAULT_SHORTCUT_BINDINGS, "createTask", "Mod+N"))
+      .toBeNull();
+    expect(findShortcutCommandConflict(DEFAULT_SHORTCUT_BINDINGS, "taskDetailDock1", "Mod+Shift+K"))
+      .toBeNull();
+  });
+});

--- a/src/desktop/shared/__tests__/shortcutBindings.test.ts
+++ b/src/desktop/shared/__tests__/shortcutBindings.test.ts
@@ -224,27 +224,76 @@ describe("단축키 재배정", () => {
       taskDetailDock1: "Mod+Shift+K",
       unknownCommand: "Mod+J",
       taskDetailUsage: 7,
-    }))).toEqual({ taskDetailDock1: "Mod+Shift+K" });
+    }), "linux")).toEqual({ taskDetailDock1: "Mod+Shift+K" });
   });
 
   it("저장 형식이 깨져 있으면 재배정 없이 기본값을 쓴다", () => {
-    expect(parseShortcutOverrides("{not json")).toEqual({});
-    expect(resolveShortcutBindings(parseShortcutOverrides(null))).toEqual(DEFAULT_SHORTCUT_BINDINGS);
+    expect(parseShortcutOverrides("{not json", "linux")).toEqual({});
+    expect(resolveShortcutBindings(parseShortcutOverrides(null, "linux"))).toEqual(DEFAULT_SHORTCUT_BINDINGS);
   });
 
   it("기본값과 같아진 항목은 저장하지 않는다", () => {
     expect(collectShortcutOverrides({
       ...DEFAULT_SHORTCUT_BINDINGS,
       taskDetailDock1: "Mod+Shift+K",
-    })).toEqual({ taskDetailDock1: "Mod+Shift+K" });
+    }, "linux")).toEqual({ taskDetailDock1: "Mod+Shift+K" });
   });
 
   it("이미 다른 명령이 쓰는 조합은 충돌로 알린다", () => {
-    expect(findShortcutCommandConflict(DEFAULT_SHORTCUT_BINDINGS, "taskDetailDock1", "Mod+N"))
+    expect(findShortcutCommandConflict(DEFAULT_SHORTCUT_BINDINGS, "taskDetailDock1", "Mod+N", "linux"))
       .toBe("createTask");
-    expect(findShortcutCommandConflict(DEFAULT_SHORTCUT_BINDINGS, "createTask", "Mod+N"))
+    expect(findShortcutCommandConflict(DEFAULT_SHORTCUT_BINDINGS, "createTask", "Mod+N", "linux"))
       .toBeNull();
-    expect(findShortcutCommandConflict(DEFAULT_SHORTCUT_BINDINGS, "taskDetailDock1", "Mod+Shift+K"))
+    expect(findShortcutCommandConflict(DEFAULT_SHORTCUT_BINDINGS, "taskDetailDock1", "Mod+Shift+K", "linux"))
       .toBeNull();
+  });
+
+  /**
+   * 옛 버전은 Mod 없이 플랫폼 표기(`Meta+…`/`Ctrl+…`)로 저장했다.
+   * 그 표기를 접지 않으면 실행 시에는 같은 조합인데 중복 판정만 다른 조합으로 봐서,
+   * 경고 없이 겹치는 배정이 저장되고 정의 순서상 뒤인 명령이 도달 불가능해진다.
+   */
+  it("옛 플랫폼 표기로 저장된 조합도 같은 조합으로 보고 충돌을 알린다", () => {
+    const macBindings = resolveShortcutBindings(
+      parseShortcutOverrides(JSON.stringify({ taskSearch: "Meta+Shift+O" }), "mac"),
+    );
+    expect(macBindings.taskSearch).toBe("Mod+Shift+O");
+    expect(findShortcutCommandConflict(macBindings, "boardProjectFilter", "Mod+Shift+O", "mac"))
+      .toBe("taskSearch");
+
+    const linuxBindings = resolveShortcutBindings(
+      parseShortcutOverrides(JSON.stringify({ taskSearch: "Ctrl+Shift+O" }), "linux"),
+    );
+    expect(linuxBindings.taskSearch).toBe("Mod+Shift+O");
+    expect(findShortcutCommandConflict(linuxBindings, "boardProjectFilter", "Mod+Shift+O", "linux"))
+      .toBe("taskSearch");
+  });
+
+  /** mac의 Ctrl과 linux의 Meta는 Mod와 별개 키라 접으면 안 된다 */
+  it("그 플랫폼에서 Mod가 아닌 수식키는 접지 않는다", () => {
+    expect(findShortcutCommandConflict(
+      resolveShortcutBindings(parseShortcutOverrides(JSON.stringify({ taskSearch: "Ctrl+Shift+O" }), "mac")),
+      "boardProjectFilter",
+      "Mod+Shift+O",
+      "mac",
+    )).toBeNull();
+    expect(findShortcutCommandConflict(
+      resolveShortcutBindings(parseShortcutOverrides(JSON.stringify({ taskSearch: "Meta+Shift+O" }), "linux")),
+      "boardProjectFilter",
+      "Mod+Shift+O",
+      "linux",
+    )).toBeNull();
+  });
+
+  /** 실질적으로 기본값인 옛 표기를 override로 남기면 그 사용자만 향후 기본값 변경을 못 받는다 */
+  it("플랫폼 표기만 다른 기본값은 재배정으로 저장하지 않는다", () => {
+    expect(collectShortcutOverrides({
+      ...DEFAULT_SHORTCUT_BINDINGS,
+      taskSearch: "Meta+Shift+O",
+    }, "mac")).toEqual({});
+    expect(collectShortcutOverrides({
+      ...DEFAULT_SHORTCUT_BINDINGS,
+      taskSearch: "Ctrl+Shift+O",
+    }, "linux")).toEqual({});
   });
 });

--- a/src/desktop/shared/keyboardShortcut.ts
+++ b/src/desktop/shared/keyboardShortcut.ts
@@ -1,3 +1,5 @@
+import { TASK_DETAIL_DOCK_ITEM_IDS } from "@/desktop/shared/taskDetailDock";
+
 export type ShortcutPlatform = "mac" | "linux";
 export type ShortcutPlatformInput = ShortcutPlatform | boolean;
 export type ShortcutDefinition = string | Record<ShortcutPlatform, string>;
@@ -47,7 +49,13 @@ export const BLOCKED_DESKTOP_SHORTCUTS = {
 } as const;
 
 export const DEFAULT_TASK_SEARCH_SHORTCUT = SHORTCUTS.taskSearchDefault;
-export const TASK_DETAIL_DOCK_SHORTCUT_INDEXES = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
+/**
+ * 도크에 실제로 있는 자리만큼만 번호를 준다. 비어 있는 번호를 노출하면 설정 화면이
+ * 아무것도 실행하지 않는 단축키를 보여 준다. `satisfies`가 도크 항목 수와의 어긋남을 컴파일에서 잡는다.
+ */
+export const TASK_DETAIL_DOCK_SHORTCUT_INDEXES = [1, 2, 3, 4, 5, 6] as const satisfies {
+  length: typeof TASK_DETAIL_DOCK_ITEM_IDS["length"];
+};
 export const TERMINAL_TAB_SHORTCUT_INDEXES = [1, 2, 3, 4, 5] as const;
 
 export type TaskDetailDockShortcutIndex = typeof TASK_DETAIL_DOCK_SHORTCUT_INDEXES[number];

--- a/src/desktop/shared/keyboardShortcut.ts
+++ b/src/desktop/shared/keyboardShortcut.ts
@@ -197,14 +197,28 @@ function getNormalizedModifierState(event: ShortcutInput) {
   };
 }
 
-/** 표기 흔들림을 걷어낸 정규 단축키 문자열. 재배정 값 비교와 중복 판정이 같은 기준을 쓰게 한다 */
-export function normalizeShortcut(shortcut: string): string {
+/**
+ * 플랫폼에서 Mod가 가리키는 수식키(mac은 Meta, linux는 Ctrl)를 Mod 표기로 접는다.
+ * matchShortcutEvent는 두 표기를 같은 입력으로 보므로 저장과 중복 판정도 같은 기준을 써야 한다.
+ * 그러지 않으면 실제로 겹치는 조합이 서로 다른 명령에 조용히 배정되고, 정의 순서상 뒤인 명령은 도달할 방법이 없어진다.
+ * mac의 Ctrl과 linux의 Meta는 Mod와 별개 키이므로 접지 않는다.
+ */
+export function canonicalizeShortcutForPlatform(
+  shortcut: string,
+  platform: ShortcutPlatformInput,
+): string {
+  const shortcutPlatform = normalizeShortcutPlatform(platform);
   const { modifiers, key } = normalizeShortcutParts(shortcut);
   if (!key) {
     return "";
   }
 
-  return [...modifiers, key].join("+");
+  const platformModifier = shortcutPlatform === "mac" ? "Meta" : "Ctrl";
+  const canonicalModifiers = new Set(
+    modifiers.map((modifier) => (modifier === platformModifier ? "Mod" : modifier)),
+  );
+
+  return [...MODIFIER_ORDER.filter((modifier) => canonicalModifiers.has(modifier)), key].join("+");
 }
 
 export function formatShortcutForDisplay(shortcut: ShortcutDefinition, platform: ShortcutPlatformInput): string {
@@ -321,6 +335,15 @@ export function isBlockedElectronShortcutInput(
   ));
 }
 
+/**
+ * 수식키 단독 입력은 아직 조합이 완성되지 않은 상태다.
+ * captureShortcutFromEvent가 이 경우와 "수식키가 하나도 없는 조합"에 똑같이 null을 돌려주므로,
+ * 녹화 화면이 둘을 구분하려면 이 판별을 밖에서 쓸 수 있어야 한다.
+ */
+export function isShortcutModifierKey(key: string): boolean {
+  return MODIFIER_KEYS.has(key);
+}
+
 export function captureShortcutFromEvent(
   event: ShortcutInput,
   platform?: ShortcutPlatformInput,
@@ -372,6 +395,14 @@ export function captureShortcutFromEvent(
   }
 
   const shortcut = [...MODIFIER_ORDER.filter((modifier) => modifiers.has(modifier)), key].join("+");
+  /**
+   * `+`는 토큰 구분자라 키 자리에 담기지 못한다. 그대로 돌려주면 다시 파싱할 때 키가 통째로 사라져
+   * 저장·매칭·표시가 전부 조용히 실패하고, 녹화 화면에는 배정된 것처럼 보인다.
+   */
+  if (normalizeShortcutParts(shortcut).key !== key) {
+    return null;
+  }
+
   if (platform !== undefined && Object.values(BLOCKED_DESKTOP_SHORTCUTS).some((blockedShortcut) => (
     normalizeShortcutParts(blockedShortcut).key === key
     && matchShortcutEvent(event, blockedShortcut, platform)

--- a/src/desktop/shared/keyboardShortcut.ts
+++ b/src/desktop/shared/keyboardShortcut.ts
@@ -1,5 +1,3 @@
-import type { TerminalTabShortcutCommand } from "@/desktop/shared/terminalTabs";
-
 export type ShortcutPlatform = "mac" | "linux";
 export type ShortcutPlatformInput = ShortcutPlatform | boolean;
 export type ShortcutDefinition = string | Record<ShortcutPlatform, string>;
@@ -42,12 +40,6 @@ export const SHORTCUTS = {
   terminalTabPrevious: "Mod+Shift+[",
   terminalTabNext: "Mod+Shift+]",
   taskDetailUsage: "Mod+0",
-} as const;
-
-export const DESKTOP_SHORTCUTS = {
-  notificationCenter: SHORTCUTS.boardNotification,
-  createTask: SHORTCUTS.createTask,
-  newWindow: SHORTCUTS.newWindow,
 } as const;
 
 export const BLOCKED_DESKTOP_SHORTCUTS = {
@@ -205,6 +197,16 @@ function getNormalizedModifierState(event: ShortcutInput) {
   };
 }
 
+/** 표기 흔들림을 걷어낸 정규 단축키 문자열. 재배정 값 비교와 중복 판정이 같은 기준을 쓰게 한다 */
+export function normalizeShortcut(shortcut: string): string {
+  const { modifiers, key } = normalizeShortcutParts(shortcut);
+  if (!key) {
+    return "";
+  }
+
+  return [...modifiers, key].join("+");
+}
+
 export function formatShortcutForDisplay(shortcut: ShortcutDefinition, platform: ShortcutPlatformInput): string {
   const shortcutPlatform = normalizeShortcutPlatform(platform);
   const resolvedShortcut = resolveShortcutForPlatform(shortcut, shortcutPlatform);
@@ -280,98 +282,17 @@ export function matchElectronShortcutInput(
   }, shortcut, platform);
 }
 
-/** dock 항목 n번을 여는 단축키 */
-export function createTaskDetailDockShortcut(index: TaskDetailDockShortcutIndex): ShortcutDefinition {
+/** dock 항목 n번을 여는 기본 단축키 */
+export function createTaskDetailDockShortcut(index: TaskDetailDockShortcutIndex): string {
   return `Mod+${index}`;
 }
 
-export function matchTaskDetailDockShortcutEvent(
-  event: ShortcutInput,
-  platform: ShortcutPlatformInput,
-): TaskDetailDockShortcutIndex | null {
-  for (const shortcutIndex of TASK_DETAIL_DOCK_SHORTCUT_INDEXES) {
-    if (matchShortcutEvent(event, createTaskDetailDockShortcut(shortcutIndex), platform)) {
-      return shortcutIndex;
-    }
-  }
-
-  return null;
-}
-
-export function matchTaskDetailDockShortcutInput(
-  input: ElectronShortcutInput,
-  platform: ShortcutPlatformInput,
-): TaskDetailDockShortcutIndex | null {
-  for (const shortcutIndex of TASK_DETAIL_DOCK_SHORTCUT_INDEXES) {
-    if (matchElectronShortcutInput(input, createTaskDetailDockShortcut(shortcutIndex), platform)) {
-      return shortcutIndex;
-    }
-  }
-
-  return null;
-}
-
 /**
- * AI 사용량 패널 단축키. dock 항목이 아니라 dock 최하단의 독립 슬롯이므로
- * dock 번호를 파생시키는 `TASK_DETAIL_DOCK_SHORTCUT_INDEXES`에 넣지 않는다.
- * 0을 그 배열에 넣으면 `dockItems[-1]`을 집게 되고 dock 번호 규칙도 깨진다.
- */
-export function matchTaskDetailUsageShortcutEvent(
-  event: ShortcutInput,
-  platform: ShortcutPlatformInput,
-): boolean {
-  return matchShortcutEvent(event, SHORTCUTS.taskDetailUsage, platform);
-}
-
-/**
- * Electron `before-input-event` 입력이 사용량 패널 토글인지 판정한다.
- * 이 키는 태스크 상세에서만 의미가 있으므로 화면 판정까지 여기서 함께 한다.
- * 터미널 탭 명령과 같은 구조로 두어야 main과 렌더러가 같은 규칙을 공유한다.
- */
-export function resolveTaskDetailUsageShortcutInput(
-  input: ElectronShortcutInput,
-  platform: ShortcutPlatformInput,
-  isTaskDetailRoute: boolean,
-): boolean {
-  if (!isTaskDetailRoute) {
-    return false;
-  }
-
-  return matchElectronShortcutInput(input, SHORTCUTS.taskDetailUsage, platform);
-}
-
-/**
- * 터미널 탭 n번으로 바로 이동하는 단축키. `Mod+숫자`는 dock 항목이 쓰므로 Alt를 더해 비켜 간다.
+ * 터미널 탭 n번으로 바로 이동하는 기본 단축키. `Mod+숫자`는 dock 항목이 쓰므로 Alt를 더해 비켜 간다.
  * macOS의 `Cmd+Shift+3~5`는 OS 스크린샷이 먼저 가져가 앱에 도달하지 않으므로 Shift로는 비켜 갈 수 없다.
  */
-export function createTerminalTabShortcut(index: TerminalTabShortcutIndex): ShortcutDefinition {
+export function createTerminalTabShortcut(index: TerminalTabShortcutIndex): string {
   return `Mod+Alt+${index}`;
-}
-
-export function matchTerminalTabShortcutEvent(
-  event: ShortcutInput,
-  platform: ShortcutPlatformInput,
-): TerminalTabShortcutIndex | null {
-  for (const shortcutIndex of TERMINAL_TAB_SHORTCUT_INDEXES) {
-    if (matchShortcutEvent(event, createTerminalTabShortcut(shortcutIndex), platform)) {
-      return shortcutIndex;
-    }
-  }
-
-  return null;
-}
-
-export function matchTerminalTabShortcutInput(
-  input: ElectronShortcutInput,
-  platform: ShortcutPlatformInput,
-): TerminalTabShortcutIndex | null {
-  for (const shortcutIndex of TERMINAL_TAB_SHORTCUT_INDEXES) {
-    if (matchElectronShortcutInput(input, createTerminalTabShortcut(shortcutIndex), platform)) {
-      return shortcutIndex;
-    }
-  }
-
-  return null;
 }
 
 /**
@@ -380,76 +301,6 @@ export function matchTerminalTabShortcutInput(
  */
 export function isTaskDetailRouteUrl(url: string | null | undefined): boolean {
   return /#\/[^/]+\/task\/[^/?#]+(?:[?#]|$)/.test(url || "");
-}
-
-/**
- * 키 입력을 터미널 탭 명령으로 바꾼다. 해당 없으면 null.
- * 창 닫기는 어느 화면에서나 동작하고, 나머지는 터미널이 있는 태스크 상세에서만 의미가 있다.
- * 탭 닫기는 터미널 밖에서는 일반 앱처럼 창 닫기로 동작한다.
- *
- * 렌더러 이벤트와 Electron 입력이 같은 판정을 쓰도록 매칭 방법만 인자로 받는다.
- */
-function resolveTerminalTabCommand(
-  matchesShortcut: (shortcut: ShortcutDefinition) => boolean,
-  matchTabPosition: () => TerminalTabShortcutIndex | null,
-  isTaskDetailRoute: boolean,
-): TerminalTabShortcutCommand | null {
-  if (matchesShortcut(SHORTCUTS.terminalWindowClose)) {
-    return { type: "close-window" };
-  }
-
-  if (matchesShortcut(SHORTCUTS.terminalTabClose)) {
-    return isTaskDetailRoute ? { type: "close-tab" } : { type: "close-window" };
-  }
-
-  if (!isTaskDetailRoute) {
-    return null;
-  }
-
-  if (matchesShortcut(SHORTCUTS.terminalTabNew)) {
-    return { type: "new-tab" };
-  }
-
-  if (matchesShortcut(SHORTCUTS.terminalTabPrevious)) {
-    return { type: "previous-tab" };
-  }
-
-  if (matchesShortcut(SHORTCUTS.terminalTabNext)) {
-    return { type: "next-tab" };
-  }
-
-  const tabPosition = matchTabPosition();
-  return tabPosition === null ? null : { type: "go-to-tab", position: tabPosition };
-}
-
-/** Electron `before-input-event` 입력을 터미널 탭 명령으로 바꾼다. 터미널이 입력을 먹기 전에 가로채는 경로다 */
-export function resolveTerminalTabShortcutCommand(
-  input: ElectronShortcutInput,
-  platform: ShortcutPlatformInput,
-  isTaskDetailRoute: boolean,
-): TerminalTabShortcutCommand | null {
-  return resolveTerminalTabCommand(
-    (shortcut) => matchElectronShortcutInput(input, shortcut, platform),
-    () => matchTerminalTabShortcutInput(input, platform),
-    isTaskDetailRoute,
-  );
-}
-
-/**
- * 렌더러 keydown을 터미널 탭 명령으로 바꾼다.
- * main이 가로채지 못한 입력을 렌더러가 받아 처리하는 두 번째 경로이며,
- * 다른 단축키들과 같은 이중 경로 구조를 따른다.
- */
-export function resolveTerminalTabShortcutEvent(
-  event: ShortcutInput,
-  platform: ShortcutPlatformInput,
-  isTaskDetailRoute: boolean,
-): TerminalTabShortcutCommand | null {
-  return resolveTerminalTabCommand(
-    (shortcut) => matchShortcutEvent(event, shortcut, platform),
-    () => matchTerminalTabShortcutEvent(event, platform),
-    isTaskDetailRoute,
-  );
 }
 
 export function isBlockedShortcutEvent(

--- a/src/desktop/shared/shortcutBindings.ts
+++ b/src/desktop/shared/shortcutBindings.ts
@@ -12,6 +12,7 @@ import {
   type TaskDetailDockShortcutIndex,
   type TerminalTabShortcutIndex,
 } from "@/desktop/shared/keyboardShortcut";
+import { TASK_DETAIL_DOCK_ITEM_IDS, type TaskDetailDockItemId } from "@/desktop/shared/taskDetailDock";
 import type { TerminalTabShortcutCommand } from "@/desktop/shared/terminalTabs";
 
 /**
@@ -50,6 +51,8 @@ export interface ShortcutCommandDefinition {
   labelKey: string;
   /** 번호로만 구분되는 명령이 라벨에 끼워 넣을 숫자 */
   labelIndex?: number;
+  /** 도크 명령이 가리키는 항목. 설정 화면이 번호 대신 항목 이름을 보여 주는 근거다 */
+  dockItemId?: TaskDetailDockItemId;
 }
 
 export function createTaskDetailDockCommandId(index: TaskDetailDockShortcutIndex): TaskDetailDockCommandId {
@@ -82,6 +85,7 @@ export const SHORTCUT_COMMAND_DEFINITIONS: readonly ShortcutCommandDefinition[] 
     defaultShortcut: createTaskDetailDockShortcut(dockIndex),
     labelKey: "taskDetailDock",
     labelIndex: dockIndex,
+    dockItemId: TASK_DETAIL_DOCK_ITEM_IDS[dockIndex - 1],
   })),
   { id: "taskDetailUsage", group: "taskDetail", defaultShortcut: SHORTCUTS.taskDetailUsage, labelKey: "taskDetailUsage" },
   { id: "taskSearch", group: "board", defaultShortcut: SHORTCUTS.taskSearchDefault, labelKey: "taskSearch" },

--- a/src/desktop/shared/shortcutBindings.ts
+++ b/src/desktop/shared/shortcutBindings.ts
@@ -1,0 +1,261 @@
+import {
+  SHORTCUTS,
+  TASK_DETAIL_DOCK_SHORTCUT_INDEXES,
+  TERMINAL_TAB_SHORTCUT_INDEXES,
+  createTaskDetailDockShortcut,
+  createTerminalTabShortcut,
+  matchElectronShortcutInput,
+  matchShortcutEvent,
+  normalizeShortcut,
+  type ElectronShortcutInput,
+  type ShortcutPlatformInput,
+  type TaskDetailDockShortcutIndex,
+  type TerminalTabShortcutIndex,
+} from "@/desktop/shared/keyboardShortcut";
+import type { TerminalTabShortcutCommand } from "@/desktop/shared/terminalTabs";
+
+/**
+ * 사용자가 다시 배정할 수 있는 단축키 명령의 식별자.
+ * dock과 터미널 탭은 번호로만 구분되므로 번호 배열에서 식별자를 파생시킨다.
+ */
+export type TaskDetailDockCommandId = `taskDetailDock${TaskDetailDockShortcutIndex}`;
+export type TerminalTabCommandId = `terminalTab${TerminalTabShortcutIndex}`;
+
+export type ShortcutCommandId =
+  | TaskDetailDockCommandId
+  | TerminalTabCommandId
+  | "taskDetailUsage"
+  | "taskSearch"
+  | "boardNotification"
+  | "boardProjectFilter"
+  | "boardPageFind"
+  | "createTask"
+  | "newWindow"
+  | "pageBack"
+  | "pageForward"
+  | "terminalTabNew"
+  | "terminalTabClose"
+  | "terminalWindowClose"
+  | "terminalTabPrevious"
+  | "terminalTabNext";
+
+/** 설정 화면에서 명령을 묶어 보여 주는 단위 */
+export type ShortcutCommandGroup = "taskDetailDock" | "taskDetail" | "board" | "terminal";
+
+export interface ShortcutCommandDefinition {
+  id: ShortcutCommandId;
+  group: ShortcutCommandGroup;
+  defaultShortcut: string;
+  /** messages의 `settings.shortcuts.commands` 아래 라벨 키 */
+  labelKey: string;
+  /** 번호로만 구분되는 명령이 라벨에 끼워 넣을 숫자 */
+  labelIndex?: number;
+}
+
+export function createTaskDetailDockCommandId(index: TaskDetailDockShortcutIndex): TaskDetailDockCommandId {
+  return `taskDetailDock${index}`;
+}
+
+export function createTerminalTabCommandId(index: TerminalTabShortcutIndex): TerminalTabCommandId {
+  return `terminalTab${index}`;
+}
+
+const TASK_DETAIL_DOCK_COMMAND_PATTERN = /^taskDetailDock([1-9])$/;
+const TERMINAL_TAB_COMMAND_PATTERN = /^terminalTab([1-9])$/;
+
+/** dock 명령이면 그 dock 자리 번호를, 아니면 null을 준다 */
+export function getTaskDetailDockIndexForCommand(commandId: ShortcutCommandId | null): number | null {
+  const matchedCommand = commandId ? TASK_DETAIL_DOCK_COMMAND_PATTERN.exec(commandId) : null;
+  return matchedCommand ? Number(matchedCommand[1]) : null;
+}
+
+/** 터미널 탭 이동 명령이면 그 탭 자리 번호를, 아니면 null을 준다 */
+export function getTerminalTabPositionForCommand(commandId: ShortcutCommandId | null): number | null {
+  const matchedCommand = commandId ? TERMINAL_TAB_COMMAND_PATTERN.exec(commandId) : null;
+  return matchedCommand ? Number(matchedCommand[1]) : null;
+}
+
+export const SHORTCUT_COMMAND_DEFINITIONS: readonly ShortcutCommandDefinition[] = [
+  ...TASK_DETAIL_DOCK_SHORTCUT_INDEXES.map<ShortcutCommandDefinition>((dockIndex) => ({
+    id: createTaskDetailDockCommandId(dockIndex),
+    group: "taskDetailDock",
+    defaultShortcut: createTaskDetailDockShortcut(dockIndex),
+    labelKey: "taskDetailDock",
+    labelIndex: dockIndex,
+  })),
+  { id: "taskDetailUsage", group: "taskDetail", defaultShortcut: SHORTCUTS.taskDetailUsage, labelKey: "taskDetailUsage" },
+  { id: "taskSearch", group: "board", defaultShortcut: SHORTCUTS.taskSearchDefault, labelKey: "taskSearch" },
+  { id: "boardNotification", group: "board", defaultShortcut: SHORTCUTS.boardNotification, labelKey: "boardNotification" },
+  { id: "boardProjectFilter", group: "board", defaultShortcut: SHORTCUTS.boardProjectFilter, labelKey: "boardProjectFilter" },
+  { id: "boardPageFind", group: "board", defaultShortcut: SHORTCUTS.boardPageFind, labelKey: "boardPageFind" },
+  { id: "createTask", group: "board", defaultShortcut: SHORTCUTS.createTask, labelKey: "createTask" },
+  { id: "newWindow", group: "board", defaultShortcut: SHORTCUTS.newWindow, labelKey: "newWindow" },
+  { id: "pageBack", group: "board", defaultShortcut: SHORTCUTS.pageBack, labelKey: "pageBack" },
+  { id: "pageForward", group: "board", defaultShortcut: SHORTCUTS.pageForward, labelKey: "pageForward" },
+  { id: "terminalTabNew", group: "terminal", defaultShortcut: SHORTCUTS.terminalTabNew, labelKey: "terminalTabNew" },
+  { id: "terminalTabClose", group: "terminal", defaultShortcut: SHORTCUTS.terminalTabClose, labelKey: "terminalTabClose" },
+  { id: "terminalWindowClose", group: "terminal", defaultShortcut: SHORTCUTS.terminalWindowClose, labelKey: "terminalWindowClose" },
+  { id: "terminalTabPrevious", group: "terminal", defaultShortcut: SHORTCUTS.terminalTabPrevious, labelKey: "terminalTabPrevious" },
+  { id: "terminalTabNext", group: "terminal", defaultShortcut: SHORTCUTS.terminalTabNext, labelKey: "terminalTabNext" },
+  ...TERMINAL_TAB_SHORTCUT_INDEXES.map<ShortcutCommandDefinition>((tabIndex) => ({
+    id: createTerminalTabCommandId(tabIndex),
+    group: "terminal",
+    defaultShortcut: createTerminalTabShortcut(tabIndex),
+    labelKey: "terminalTab",
+    labelIndex: tabIndex,
+  })),
+];
+
+export type ShortcutBindings = Record<ShortcutCommandId, string>;
+
+const SHORTCUT_COMMAND_IDS = new Set<string>(SHORTCUT_COMMAND_DEFINITIONS.map((definition) => definition.id));
+
+export const DEFAULT_SHORTCUT_BINDINGS: ShortcutBindings = Object.freeze(
+  Object.fromEntries(SHORTCUT_COMMAND_DEFINITIONS.map((definition) => [definition.id, definition.defaultShortcut])),
+) as ShortcutBindings;
+
+function isShortcutCommandId(candidateId: string): candidateId is ShortcutCommandId {
+  return SHORTCUT_COMMAND_IDS.has(candidateId);
+}
+
+/**
+ * 저장된 재배정 값을 읽는다. 모르는 명령과 빈 값은 버려서 기본값이 그대로 남게 한다.
+ * 저장 형식이 깨져 있어도 앱이 단축키를 통째로 잃지 않아야 하므로 파싱 실패는 빈 재배정으로 본다.
+ */
+export function parseShortcutOverrides(rawValue: string | null | undefined): Partial<ShortcutBindings> {
+  if (!rawValue) {
+    return {};
+  }
+
+  let parsedValue: unknown;
+  try {
+    parsedValue = JSON.parse(rawValue);
+  } catch {
+    return {};
+  }
+
+  if (!parsedValue || typeof parsedValue !== "object" || Array.isArray(parsedValue)) {
+    return {};
+  }
+
+  const overrides: Partial<ShortcutBindings> = {};
+  for (const [commandId, shortcut] of Object.entries(parsedValue as Record<string, unknown>)) {
+    if (typeof shortcut !== "string" || !isShortcutCommandId(commandId)) {
+      continue;
+    }
+
+    const normalizedShortcut = normalizeShortcut(shortcut);
+    if (normalizedShortcut) {
+      overrides[commandId] = normalizedShortcut;
+    }
+  }
+
+  return overrides;
+}
+
+/** 기본값 위에 재배정을 얹은 최종 단축키 표 */
+export function resolveShortcutBindings(overrides: Partial<ShortcutBindings>): ShortcutBindings {
+  return { ...DEFAULT_SHORTCUT_BINDINGS, ...overrides };
+}
+
+/** 기본값과 같아진 재배정은 저장하지 않는다. 나중에 기본값을 바꿔도 옛 값이 발목을 잡지 않게 한다 */
+export function collectShortcutOverrides(bindings: ShortcutBindings): Partial<ShortcutBindings> {
+  const overrides: Partial<ShortcutBindings> = {};
+  for (const definition of SHORTCUT_COMMAND_DEFINITIONS) {
+    const shortcut = bindings[definition.id];
+    if (shortcut && shortcut !== definition.defaultShortcut) {
+      overrides[definition.id] = shortcut;
+    }
+  }
+
+  return overrides;
+}
+
+/** 이미 같은 조합을 쓰고 있는 다른 명령. 없으면 null */
+export function findShortcutCommandConflict(
+  bindings: ShortcutBindings,
+  commandId: ShortcutCommandId,
+  shortcut: string,
+): ShortcutCommandId | null {
+  const normalizedShortcut = normalizeShortcut(shortcut);
+
+  for (const definition of SHORTCUT_COMMAND_DEFINITIONS) {
+    if (definition.id === commandId) {
+      continue;
+    }
+
+    if (normalizeShortcut(bindings[definition.id]) === normalizedShortcut) {
+      return definition.id;
+    }
+  }
+
+  return null;
+}
+
+function findShortcutCommand(
+  bindings: ShortcutBindings,
+  matchesShortcut: (shortcut: string) => boolean,
+): ShortcutCommandId | null {
+  for (const definition of SHORTCUT_COMMAND_DEFINITIONS) {
+    if (matchesShortcut(bindings[definition.id])) {
+      return definition.id;
+    }
+  }
+
+  return null;
+}
+
+/** 렌더러 keydown이 어떤 명령인지 판정한다 */
+export function findShortcutCommandForEvent(
+  bindings: ShortcutBindings,
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey">,
+  platform: ShortcutPlatformInput,
+): ShortcutCommandId | null {
+  return findShortcutCommand(bindings, (shortcut) => matchShortcutEvent(event, shortcut, platform));
+}
+
+/** Electron `before-input-event` 입력이 어떤 명령인지 판정한다 */
+export function findShortcutCommandForElectronInput(
+  bindings: ShortcutBindings,
+  input: ElectronShortcutInput,
+  platform: ShortcutPlatformInput,
+): ShortcutCommandId | null {
+  return findShortcutCommand(bindings, (shortcut) => matchElectronShortcutInput(input, shortcut, platform));
+}
+
+/**
+ * 단축키 명령을 터미널 탭 명령으로 바꾼다. 해당 없으면 null.
+ * 창 닫기는 어느 화면에서나 동작하고, 나머지는 터미널이 있는 태스크 상세에서만 의미가 있다.
+ * 탭 닫기는 터미널 밖에서는 일반 앱처럼 창 닫기로 동작한다.
+ */
+export function resolveTerminalTabCommand(
+  commandId: ShortcutCommandId | null,
+  isTaskDetailRoute: boolean,
+): TerminalTabShortcutCommand | null {
+  if (commandId === "terminalWindowClose") {
+    return { type: "close-window" };
+  }
+
+  if (commandId === "terminalTabClose") {
+    return isTaskDetailRoute ? { type: "close-tab" } : { type: "close-window" };
+  }
+
+  if (!isTaskDetailRoute) {
+    return null;
+  }
+
+  if (commandId === "terminalTabNew") {
+    return { type: "new-tab" };
+  }
+
+  if (commandId === "terminalTabPrevious") {
+    return { type: "previous-tab" };
+  }
+
+  if (commandId === "terminalTabNext") {
+    return { type: "next-tab" };
+  }
+
+  const tabPosition = getTerminalTabPositionForCommand(commandId);
+  return tabPosition === null ? null : { type: "go-to-tab", position: tabPosition };
+}

--- a/src/desktop/shared/shortcutBindings.ts
+++ b/src/desktop/shared/shortcutBindings.ts
@@ -2,11 +2,11 @@ import {
   SHORTCUTS,
   TASK_DETAIL_DOCK_SHORTCUT_INDEXES,
   TERMINAL_TAB_SHORTCUT_INDEXES,
+  canonicalizeShortcutForPlatform,
   createTaskDetailDockShortcut,
   createTerminalTabShortcut,
   matchElectronShortcutInput,
   matchShortcutEvent,
-  normalizeShortcut,
   type ElectronShortcutInput,
   type ShortcutPlatformInput,
   type TaskDetailDockShortcutIndex,
@@ -121,8 +121,12 @@ function isShortcutCommandId(candidateId: string): candidateId is ShortcutComman
 /**
  * 저장된 재배정 값을 읽는다. 모르는 명령과 빈 값은 버려서 기본값이 그대로 남게 한다.
  * 저장 형식이 깨져 있어도 앱이 단축키를 통째로 잃지 않아야 하므로 파싱 실패는 빈 재배정으로 본다.
+ * 옛 버전이 남긴 `Meta+…`/`Ctrl+…` 표기는 읽는 순간 canonical 형태로 접어, 이후 비교가 전부 한 기준을 쓰게 한다.
  */
-export function parseShortcutOverrides(rawValue: string | null | undefined): Partial<ShortcutBindings> {
+export function parseShortcutOverrides(
+  rawValue: string | null | undefined,
+  platform: ShortcutPlatformInput,
+): Partial<ShortcutBindings> {
   if (!rawValue) {
     return {};
   }
@@ -144,9 +148,9 @@ export function parseShortcutOverrides(rawValue: string | null | undefined): Par
       continue;
     }
 
-    const normalizedShortcut = normalizeShortcut(shortcut);
-    if (normalizedShortcut) {
-      overrides[commandId] = normalizedShortcut;
+    const canonicalShortcut = canonicalizeShortcutForPlatform(shortcut, platform);
+    if (canonicalShortcut) {
+      overrides[commandId] = canonicalShortcut;
     }
   }
 
@@ -159,12 +163,16 @@ export function resolveShortcutBindings(overrides: Partial<ShortcutBindings>): S
 }
 
 /** 기본값과 같아진 재배정은 저장하지 않는다. 나중에 기본값을 바꿔도 옛 값이 발목을 잡지 않게 한다 */
-export function collectShortcutOverrides(bindings: ShortcutBindings): Partial<ShortcutBindings> {
+export function collectShortcutOverrides(
+  bindings: ShortcutBindings,
+  platform: ShortcutPlatformInput,
+): Partial<ShortcutBindings> {
   const overrides: Partial<ShortcutBindings> = {};
   for (const definition of SHORTCUT_COMMAND_DEFINITIONS) {
-    const shortcut = bindings[definition.id];
-    if (shortcut && shortcut !== definition.defaultShortcut) {
-      overrides[definition.id] = shortcut;
+    const canonicalShortcut = canonicalizeShortcutForPlatform(bindings[definition.id] ?? "", platform);
+    const canonicalDefault = canonicalizeShortcutForPlatform(definition.defaultShortcut, platform);
+    if (canonicalShortcut && canonicalShortcut !== canonicalDefault) {
+      overrides[definition.id] = canonicalShortcut;
     }
   }
 
@@ -176,15 +184,16 @@ export function findShortcutCommandConflict(
   bindings: ShortcutBindings,
   commandId: ShortcutCommandId,
   shortcut: string,
+  platform: ShortcutPlatformInput,
 ): ShortcutCommandId | null {
-  const normalizedShortcut = normalizeShortcut(shortcut);
+  const canonicalShortcut = canonicalizeShortcutForPlatform(shortcut, platform);
 
   for (const definition of SHORTCUT_COMMAND_DEFINITIONS) {
     if (definition.id === commandId) {
       continue;
     }
 
-    if (normalizeShortcut(bindings[definition.id]) === normalizedShortcut) {
+    if (canonicalizeShortcutForPlatform(bindings[definition.id] ?? "", platform) === canonicalShortcut) {
       return definition.id;
     }
   }

--- a/src/desktop/shared/taskDetailDock.ts
+++ b/src/desktop/shared/taskDetailDock.ts
@@ -1,0 +1,44 @@
+/**
+ * 작업 상세 도크에 놓인 항목의 순서. `Mod+{n}` 단축키 번호와 단축키 설정 화면의 라벨이 모두 여기서 나온다.
+ * 항목을 넣거나 빼면 뒤 항목의 단축키 번호가 함께 움직인다.
+ * PR 항목은 링크가 아직 없어도 자리를 지킨다. 자리가 사라지면 뒤 항목의 번호가 통째로 밀려 근육기억이 깨진다.
+ * 보드 복귀 버튼과 사용량 버튼은 이 목록 밖이라 번호를 받지 않는다.
+ */
+export const TASK_DETAIL_DOCK_ITEM_IDS = [
+  "overview",
+  "status",
+  "chat",
+  "pull-request",
+  "live-sessions",
+  "vscode",
+] as const;
+
+export type TaskDetailDockItemId = typeof TASK_DETAIL_DOCK_ITEM_IDS[number];
+
+/** `taskDetail` 메시지 번역기. 도크와 설정 화면이 라벨 정의를 공유하기 위한 최소 계약 */
+export type TaskDetailMessageTranslator = (key: string) => string;
+
+/**
+ * 도크 항목의 사람이 읽는 이름.
+ * 도크 툴팁과 단축키 설정 화면이 이 한 함수를 함께 써야, 설정 화면이 "도크 4번 항목"처럼
+ * 정체를 감추거나 도크의 이름이 바뀐 뒤 둘이 갈라지는 일이 생기지 않는다.
+ */
+export function resolveTaskDetailDockLabel(
+  t: TaskDetailMessageTranslator,
+  itemId: TaskDetailDockItemId,
+): string {
+  switch (itemId) {
+    case "overview":
+      return t("info");
+    case "status":
+      return `${t("actions")} · ${t("hooksStatus")}`;
+    case "chat":
+      return t("aiSessions.inlineChat");
+    case "pull-request":
+      return "PR";
+    case "live-sessions":
+      return t("liveSessions.dock");
+    case "vscode":
+      return t("openInVsCode");
+  }
+}

--- a/src/types/kanvibeDesktop.d.ts
+++ b/src/types/kanvibeDesktop.d.ts
@@ -16,6 +16,8 @@ interface KanvibeDesktopApi {
   onTaskDetailDockShortcut?: (listener: (shortcutIndex: number) => void) => () => void;
   onTaskDetailUsageShortcut?: (listener: () => void) => () => void;
   notifyShortcutBindingsChanged?: () => void;
+  onShortcutBindingsChanged?: (listener: () => void) => () => void;
+  notifyShortcutCaptureChanged?: (isCapturing: boolean) => void;
   focusExistingInternalRoute?: (route: string) => Promise<boolean>;
   [key: string]: unknown;
 }

--- a/src/types/kanvibeDesktop.d.ts
+++ b/src/types/kanvibeDesktop.d.ts
@@ -15,6 +15,7 @@ interface KanvibeDesktopApi {
   onCreateTaskShortcut?: (listener: () => void) => () => void;
   onTaskDetailDockShortcut?: (listener: (shortcutIndex: number) => void) => () => void;
   onTaskDetailUsageShortcut?: (listener: () => void) => () => void;
+  notifyShortcutBindingsChanged?: () => void;
   focusExistingInternalRoute?: (route: string) => Promise<boolean>;
   [key: string]: unknown;
 }


### PR DESCRIPTION
## 관련 자료
- 이슈 : 없음

## 어떤 작업인가요?
태스크 상세 도크의 `Mod+4`를 PR로 고정하고 `Mod+6`에 VS Code 열기를 붙였습니다. 그 김에 도크를 포함한 앱 단축키 25개를 설정 화면에서 녹화해 바꿀 수 있게 하고, direnv로 GitHub 인증을 잡아 둔 저장소에서 PR 링크 조회가 실패하던 문제를 함께 고쳤습니다.

## 어떻게 해결했나요?
**PR 도크 자리 고정**
- PR 링크가 붙기 전까지 `Mod+4`를 쓸 수 없고, 링크가 생기는 순간 뒤 항목의 도크 번호가 통째로 밀려 근육기억이 깨졌습니다.
- 링크 유무와 무관하게 PR 자리를 항상 두고, 링크가 아직 없으면 그 자리에서 조회해 엽니다.

**VS Code 열기**
- 원격 작업 폴더를 에디터로 여는 수단이 없었습니다.
- 도크 끝에 VS Code 열기를 더해 `Mod+6`을 기본값으로 잡고, 원격 작업은 로컬 VS Code를 Remote-SSH로 붙여서 엽니다.

**단축키 재배정**
- 단축키가 모두 코드에 하드코딩돼 있어 사용자가 바꿀 수 없었습니다.
- 명령 28개를 설정 화면에서 녹화해 재배정할 수 있게 하고, 중복 조합은 어떤 명령과 겹치는지 알리고 막습니다.

**PR 링크 조회 실패 수정**
- 등록된 프로젝트 경로가 저장소를 감싼 상위 폴더면 `gh`가 저장소를 찾지 못했고, `.envrc`에 GitHub 인증을 심어 둔 경우 direnv가 로드되지 않아 권한 없이 실패했습니다.
- 저장소를 한 단계 아래까지 찾고 direnv 환경을 태워 `gh`를 실행합니다.

## 중요한 변경 사항은 무엇인가요?
### PR 도크 자리 고정과 VS Code 열기

**PR 항목을 조건부에서 상시 표시로 바꿈**
- **변경 이유**: 도크 번호는 배열 순서에서 파생되므로, 항목 하나가 조건부로 사라지면 뒤 항목의 번호가 전부 밀립니다. 최종 순서는 `1 정보 · 2 상태 · 3 채팅 · 4 PR · 5 라이브세션 · 6 VS Code`로 고정됩니다.
- **수정 파일**: `src/desktop/renderer/routes/TaskDetailRoute.tsx`

**VS Code 실행을 로컬/원격으로 분기**
- **변경 이유**: 원격 셸에서 `code`를 부르면 그 머신에서 GUI를 띄우려 해 사용자 화면에는 아무것도 뜨지 않습니다. Remote-SSH의 `code` 셔틀은 이미 Remote-SSH로 붙은 통합 터미널 안에서만 로컬로 넘어옵니다. 그래서 명령은 항상 로컬에서 돌리고, 원격은 `--remote ssh-remote+<host>`로 붙을 곳을 알려 주는 방향으로 뒤집었습니다. 여는 경로는 worktree를 우선하고 없으면 프로젝트 저장소를 씁니다.
- **수정 파일**: `src/desktop/main/services/editorService.ts`, `src/desktop/renderer/actions/editor.ts`, `src/desktop/main/serviceRegistry.ts`

### 단축키 재배정

**명령 단위 단축키 표 도입**
- **변경 이유**: 단축키를 조합 문자열이 아니라 명령 id로 다루어야 사용자가 조합을 바꿔도 처리 경로가 그대로 동작합니다. 기존 `SHORTCUTS` 테이블을 기본값의 단일 출처로 삼아 도크 6 + 사용량 1 + 보드 8 + 터미널 10, 총 25개 명령을 정의했습니다.
- **수정 파일**: `src/desktop/shared/shortcutBindings.ts`, `src/desktop/shared/keyboardShortcut.ts`

**저장은 기본값과의 차이만**
- **변경 이유**: 표를 통째로 저장해 두면 나중에 기본값을 바꿔도 옛 값이 남아 새 기본값이 적용되지 않습니다. `AppSettings`의 `shortcut_bindings`에 재배정된 항목만 남깁니다.
- **수정 파일**: `src/desktop/main/services/appSettingsService.ts`, `src/desktop/renderer/actions/appSettings.ts`

**Electron main의 단축키 캐시**
- **변경 이유**: `before-input-event`는 동기라 그 자리에서 DB를 읽을 수 없습니다. 시작할 때 한 번 읽어 두고, 설정 화면이 저장할 때마다 IPC로 알려 다시 읽습니다. 기존의 명령별 매처 6종을 명령 판정 한 번 + 분기로 정리했습니다.
- **수정 파일**: `electron/main.js`, `electron/preload.js`, `src/types/kanvibeDesktop.d.ts`

**단축키 설정 페이지 신설**
- **변경 이유**: 녹화 중에 누른 조합이 원래 명령으로 실행되면 안 되므로, 녹화하는 동안 shortcut blocker를 걸고 컨테이너에 `data-shortcut-capture`를 붙였습니다. 창 닫기 단축키만 blocker를 보지 않아 녹화 중 창이 닫히던 경로도 함께 막았습니다.
- **수정 파일**: `src/desktop/renderer/routes/ShortcutSettingsRoute.tsx`, `src/desktop/renderer/utils/shortcutBindings.ts`, `src/desktop/renderer/App.tsx`, `src/components/ProjectSettings.tsx`, `messages/{ko,en,zh}.json`

**호출부를 명령 판정으로 교체**
- **변경 이유**: 조합 상수를 직접 비교하던 자리를 명령 판정으로 바꿔야 재배정이 실제로 먹습니다. 이 과정에서 쓰이지 않게 된 `DESKTOP_SHORTCUTS`와 매처 8종, 호출자가 없던 `setTaskSearchShortcut`을 함께 지웠습니다.
- **수정 파일**: `src/desktop/renderer/components/BoardCommandProvider.tsx`, `src/desktop/renderer/components/TaskQuickSearchDialog.tsx`, `src/components/BoardPageFindBar.tsx`, `src/desktop/renderer/routes/TaskDetailRoute.tsx`

### PR 링크 조회

**로컬/원격 조회를 한 셸 명령으로 통합**
- **변경 이유**: 로컬은 `execFile`, 원격은 `execGit`으로 갈라져 있어 direnv를 태울 지점이 두 곳이었습니다. 하나로 합치면서 `.git`이 없으면 바로 아래에서 저장소를 한 번 더 찾고, `direnv`가 있으면 그 경로의 환경을 태워 `gh`를 실행합니다. 제한 시간은 로컬 명령에만 걸어 원격이 쓰던 SSH 계층 제한 시간을 그대로 뒀습니다.
- **수정 파일**: `src/desktop/main/services/kanbanService.ts`

### 도크 단축키 설정이 가리키는 항목

**도크 항목 순서를 shared 정본으로 옮김**
- **변경 이유**: 설정 화면은 도크 명령을 번호 1~9에서 기계적으로 찍어 냈고 도크 항목은 `TaskDetailRoute`가 따로 만들었습니다. 두 곳이 서로를 모르니 개수(9 대 6)와 이름("도크 4번 항목" 대 "PR")이 둘 다 어긋났습니다. 항목 순서를 `TASK_DETAIL_DOCK_ITEM_IDS` 하나로 모으고 단축키 번호를 거기서 파생시켜, 도크에 없는 `Mod+7`~`Mod+9`는 아예 명령으로 만들어지지 않습니다. 항목 수와 번호 수가 어긋나면 `satisfies`가 컴파일에서 잡습니다.
- **수정 파일**: `src/desktop/shared/taskDetailDock.ts`(신설), `src/desktop/shared/keyboardShortcut.ts`, `src/desktop/shared/shortcutBindings.ts`

**도크 툴팁과 설정 라벨을 한 리졸버로 묶음**
- **변경 이유**: 설정 화면이 번호만 보여 주면 그 화면에서는 무엇을 여는 키인지 알 방법이 없습니다. `resolveTaskDetailDockLabel()`을 도크와 설정 화면이 함께 쓰게 해서 라벨이 `도크 4 · PR`처럼 실제 이름을 담고, 도크 항목 이름이 바뀌어도 두 화면이 갈라지지 않습니다. 항목 이름은 `taskDetail` 네임스페이스를 재사용하므로 새 번역문은 없습니다.
- **수정 파일**: `src/desktop/renderer/routes/ShortcutSettingsRoute.tsx`, `src/desktop/renderer/routes/TaskDetailRoute.tsx`, `messages/{ko,en,zh}.json`

### 리뷰 루프에서 해소한 결함

로컬 리뷰-리졸브 루프를 9회 반복해 나온 지적 19건을 모두 해소했습니다. 마지막 리뷰 패스는 actionable finding 0건으로 끝났습니다.

**저장이 다른 명령의 재배정을 지우던 문제 (P1)**
- **변경 이유**: 단축키 조회에 실패한 창은 캐시가 기본값에 갇히는데, 저장은 표를 통째로 치환하므로 그 창에서 한 번만 저장해도 DB에 있던 다른 명령의 재배정이 전부 지워졌습니다. 재조회 트리거가 "저장 성공"뿐이라 스스로 회복되지도 않았습니다.
- **수정 파일**: `src/desktop/renderer/utils/shortcutBindings.ts`

**녹화 중 main이 조합을 가로채던 문제 (P1)**
- **변경 이유**: `before-input-event`가 렌더러의 녹화 상태를 모른 채 `preventDefault()`를 걸어, 녹화하려는 조합이 원래 명령으로 실행됐습니다. 가드를 명령 조회보다 앞에 두고 그 순서를 테스트로 고정했습니다.
- **수정 파일**: `electron/main.js`, `src/desktop/renderer/routes/ShortcutSettingsRoute.tsx`

**재로드된 창에 녹화 표시가 남던 문제**
- **변경 이유**: 표시를 지우는 경로가 렌더러 알림과 창 `closed` 둘뿐이라, 재로드·크래시 복구로 문서가 다시 커밋되면 표시가 영구히 남아 그 창의 도크·터미널·보드 단축키가 통째로 죽었습니다. 해시 라우팅 때문에 `did-start-navigation` 대신 `did-navigate`를 씁니다.
- **수정 파일**: `electron/main.js`

**그 밖의 수정**
- 옛 `task_search_shortcut` 값을 `shortcut_bindings`로 한 번 승계합니다 (`appSettingsService.ts`).
- 기본값 복원도 녹화와 같은 충돌 검사 관문을 지나게 했습니다 (`ShortcutSettingsRoute.tsx`).
- 녹화에서 `+` 키를 받으면 단축키가 말없이 사라지던 파싱 결함을 고쳤습니다 (`keyboardShortcut.ts`).
- VS Code 도크 실행이 예외를 던져도 기존 실패 알림에 합류시킵니다 (`TaskDetailRoute.tsx`).
- 태스크 검색 단축키를 창 이벤트 대신 공유 스토어에서 읽습니다 (`TaskQuickSearchDialog.tsx`).
- `gh` 셸 명령 조합을 정리했습니다 (`kanbanService.ts`).

## 알아두실 점
- **동작이 바뀌는 지점**: PR이 없는 태스크에서 라이브 세션 패널이 `Mod+4` → `Mod+5`로 이동합니다.
- direnv 바이너리가 없는 환경에서 작업해 `.envrc`가 blocked인 경우의 direnv 동작은 실기기 확인을 하지 못했습니다. 셸 스니펫 자체는 direnv 유무 양쪽을 스텁으로 검증했습니다.

- 아래 두 가지는 아직 정하지 않은 열린 질문입니다.
  - `CLAUDE.md:51`의 도크 번호 규약이 아직 "PR은 조건부 슬롯"으로 남아 있어 이번 고정과 어긋납니다. 문서 갱신은 별도로 처리할 예정입니다.
  - main의 단축키 캐시가 시작 시 조회에 실패하면 그 세션 내내 기본 단축키로 입력을 가로채고, 재조회 트리거가 렌더러의 저장 성공뿐입니다. 재조회 지점을 더 붙일지 판단이 남았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoQDE45cJb5eTd2c91Jtaj
