### PR TITLE
chore(release): publish KanVibe 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Publish KanVibe 1.3.0. Bumps `package.json` and `package-lock.json` from 1.2.4 to 1.3.0 for the released DMG.

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.3.0
- DMG asset: `dist/KanVibe-1.3.0.dmg`
- SHA-256: `7abb69eb84c49b5cbfd67d2f9230ea3db634aac052a9d3a91fb1f077b6cbf192`
- Homebrew cask: `rookedsysc/homebrew-kanvibe@f38145a`, verified with `brew fetch --cask rookedsysc/kanvibe/kanvibe` → `✔︎ Cask kanvibe (1.3.0)`

## Test Plan

- `pnpm run deploy` completed with collector `pm=npm` and `packaged node_modules verified: 278 packages`
- Notarization accepted, stapled, and `xcrun stapler validate` passed
- Smoke test on the published bundle: `spctl -a -t exec` → `accepted / source=Notarized Developer ID`, process alive after launch, module errors 0, `invoke-succeeded` 19
- Release asset URL returns HTTP 200 with a matching served SHA-256
