### PR TITLE
feat(shortcut): Cmd+Shift+P로 sync·move 커맨드 팔레트를 연다

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -764,6 +764,17 @@ function attachWindowHandlers(browserWindow) {
       return;
     }
 
+    /**
+     * task 상세 창은 터미널(xterm)이 포커스를 가진 경우가 많아, before-input-event에서
+     * 먼저 가로채지 않으면 keydown이 렌더러 window 리스너에 닿기 전에 소비된다.
+     */
+    if (shortcutCommand === "commandPalette") {
+      event.preventDefault();
+
+      browserWindow.webContents.send("kanvibe:command-palette-shortcut");
+      return;
+    }
+
     if (shortcutCommand === "newWindow") {
       event.preventDefault();
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -177,6 +177,13 @@ contextBridge.exposeInMainWorld("kanvibeDesktop", {
       ipcRenderer.removeListener("kanvibe:create-task-shortcut", handler);
     };
   },
+  onCommandPaletteShortcut(listener) {
+    const handler = () => listener();
+    ipcRenderer.on("kanvibe:command-palette-shortcut", handler);
+    return () => {
+      ipcRenderer.removeListener("kanvibe:command-palette-shortcut", handler);
+    };
+  },
   onTaskDetailDockShortcut(listener) {
     const handler = (_event, shortcutIndex) => listener(shortcutIndex);
     ipcRenderer.on("kanvibe:task-detail-dock-shortcut", handler);

--- a/messages/en.json
+++ b/messages/en.json
@@ -290,6 +290,7 @@
         "taskSearch": "Task quick search",
         "boardNotification": "Notification center",
         "boardProjectFilter": "Project filter",
+        "commandPalette": "Command palette",
         "boardPageFind": "Find on page",
         "createTask": "Create task",
         "newWindow": "New window",
@@ -310,6 +311,16 @@
     "empty": "No matching tasks found.",
     "hint": "↑↓ Navigate · Enter Open · Shift+Enter New Window · Esc Close",
     "branchTodoHint": "{shortcut} Create branch TODO"
+  },
+  "commandPalette": {
+    "title": "Command Palette",
+    "statusListTitle": "Move to…",
+    "syncLabel": "Sync",
+    "syncDescription": "Run background sync for all active tasks",
+    "moveLabel": "Move",
+    "moveDescription": "Move the target task to another status",
+    "moveDisabledHint": "Focus a task card on the board, or open a task, to use Move",
+    "hint": "Esc Back/Close"
   },
   "paneLayout": {
     "title": "Pane Layout Settings",

--- a/messages/en.json
+++ b/messages/en.json
@@ -314,13 +314,11 @@
   },
   "commandPalette": {
     "title": "Command Palette",
-    "statusListTitle": "Move to…",
+    "placeholder": "Type a command…",
     "syncLabel": "Sync",
-    "syncDescription": "Run background sync for all active tasks",
-    "moveLabel": "Move",
-    "moveDescription": "Move the target task to another status",
-    "moveDisabledHint": "Focus a task card on the board, or open a task, to use Move",
-    "hint": "Esc Back/Close"
+    "moveToStatusLabel": "Move to {status}",
+    "empty": "No matching commands",
+    "hint": "↑↓ Navigate · Enter Run · Esc Close"
   },
   "paneLayout": {
     "title": "Pane Layout Settings",

--- a/messages/en.json
+++ b/messages/en.json
@@ -137,18 +137,7 @@
       "done": "Done"
     },
     "loadMore": "Load More",
-    "loadingMore": "Loading...",
-    "vimCommand": {
-      "label": "Vim command",
-      "placeholder": "sync or move review",
-      "hint": "Use :sync to run background sync, or :move todo|progress|pending|review|done for the focused task. Press Tab to autocomplete.",
-      "completionHint": "Press Tab to complete {command}.",
-      "errors": {
-        "unknownCommand": "Unknown command. Try :sync or :move review.",
-        "noFocusedTask": "Focus a task card before running :move.",
-        "taskNotFound": "The focused task is no longer visible."
-      }
-    }
+    "loadingMore": "Loading..."
   },
   "task": {
     "descriptionLabel": "Description",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -314,13 +314,11 @@
   },
   "commandPalette": {
     "title": "커맨드 팔레트",
-    "statusListTitle": "이동할 상태",
+    "placeholder": "명령을 입력하세요…",
     "syncLabel": "Sync",
-    "syncDescription": "활성 태스크 전체를 백그라운드 동기화",
-    "moveLabel": "Move",
-    "moveDescription": "대상 태스크를 다른 상태로 이동",
-    "moveDisabledHint": "보드에서 태스크 카드에 포커스하거나 task를 열어야 Move를 쓸 수 있습니다",
-    "hint": "Esc 뒤로/닫기"
+    "moveToStatusLabel": "{status} 상태로 이동",
+    "empty": "일치하는 명령이 없습니다",
+    "hint": "↑↓ 이동 · Enter 실행 · Esc 닫기"
   },
   "paneLayout": {
     "title": "Pane 레이아웃 설정",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -137,18 +137,7 @@
       "done": "Done"
     },
     "loadMore": "더 보기",
-    "loadingMore": "불러오는 중...",
-    "vimCommand": {
-      "label": "Vim 명령",
-      "placeholder": "sync 또는 move review",
-      "hint": ":sync로 백그라운드 sync를 실행하거나 포커스된 task에 :move todo|progress|pending|review|done을 사용할 수 있습니다. Tab으로 자동 완성할 수 있습니다.",
-      "completionHint": "Tab을 누르면 {command}(으)로 자동 완성합니다.",
-      "errors": {
-        "unknownCommand": "알 수 없는 명령입니다. :sync 또는 :move review를 시도해 보세요.",
-        "noFocusedTask": ":move 실행 전 task card에 포커스하세요.",
-        "taskNotFound": "포커스했던 task가 현재 보이지 않습니다."
-      }
-    }
+    "loadingMore": "불러오는 중..."
   },
   "task": {
     "descriptionLabel": "설명",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -290,6 +290,7 @@
         "taskSearch": "작업 빠른 검색",
         "boardNotification": "알림 센터",
         "boardProjectFilter": "프로젝트 필터",
+        "commandPalette": "커맨드 팔레트",
         "boardPageFind": "페이지 내 검색",
         "createTask": "작업 생성",
         "newWindow": "새 창",
@@ -310,6 +311,16 @@
     "empty": "일치하는 태스크가 없습니다.",
     "hint": "↑↓ 이동 · Enter 이동 · Shift+Enter 새 창 · Esc 닫기",
     "branchTodoHint": "{shortcut} 새 branch TODO"
+  },
+  "commandPalette": {
+    "title": "커맨드 팔레트",
+    "statusListTitle": "이동할 상태",
+    "syncLabel": "Sync",
+    "syncDescription": "활성 태스크 전체를 백그라운드 동기화",
+    "moveLabel": "Move",
+    "moveDescription": "대상 태스크를 다른 상태로 이동",
+    "moveDisabledHint": "보드에서 태스크 카드에 포커스하거나 task를 열어야 Move를 쓸 수 있습니다",
+    "hint": "Esc 뒤로/닫기"
   },
   "paneLayout": {
     "title": "Pane 레이아웃 설정",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -136,18 +136,7 @@
       "done": "完成"
     },
     "loadMore": "加载更多",
-    "loadingMore": "加载中...",
-    "vimCommand": {
-      "label": "Vim 命令",
-      "placeholder": "sync 或 move review",
-      "hint": "使用 :sync 运行后台同步，或对当前聚焦任务使用 :move todo|progress|pending|review|done。按 Tab 自动补全。",
-      "completionHint": "按 Tab 补全为 {command}。",
-      "errors": {
-        "unknownCommand": "未知命令。请尝试 :sync 或 :move review。",
-        "noFocusedTask": "运行 :move 前请先聚焦一个任务卡片。",
-        "taskNotFound": "当前聚焦的任务已不在可见列表中。"
-      }
-    }
+    "loadingMore": "加载中..."
   },
   "task": {
     "descriptionLabel": "描述",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -289,6 +289,7 @@
         "taskSearch": "任务快速搜索",
         "boardNotification": "通知中心",
         "boardProjectFilter": "项目筛选",
+        "commandPalette": "命令面板",
         "boardPageFind": "页面内查找",
         "createTask": "创建任务",
         "newWindow": "新窗口",
@@ -309,6 +310,16 @@
     "empty": "没有找到匹配的任务。",
     "hint": "↑↓ 移动 · Enter 打开 · Shift+Enter 新窗口 · Esc 关闭",
     "branchTodoHint": "{shortcut} 创建分支 TODO"
+  },
+  "commandPalette": {
+    "title": "命令面板",
+    "statusListTitle": "移动到…",
+    "syncLabel": "Sync",
+    "syncDescription": "对所有活动任务运行后台同步",
+    "moveLabel": "Move",
+    "moveDescription": "将目标任务移动到其他状态",
+    "moveDisabledHint": "请先聚焦看板上的任务卡片,或打开一个任务,才能使用 Move",
+    "hint": "Esc 返回/关闭"
   },
   "paneLayout": {
     "title": "面板布局设置",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -313,13 +313,11 @@
   },
   "commandPalette": {
     "title": "命令面板",
-    "statusListTitle": "移动到…",
+    "placeholder": "输入命令…",
     "syncLabel": "Sync",
-    "syncDescription": "对所有活动任务运行后台同步",
-    "moveLabel": "Move",
-    "moveDescription": "将目标任务移动到其他状态",
-    "moveDisabledHint": "请先聚焦看板上的任务卡片,或打开一个任务,才能使用 Move",
-    "hint": "Esc 返回/关闭"
+    "moveToStatusLabel": "移动到 {status}",
+    "empty": "没有匹配的命令",
+    "hint": "↑↓ 导航 · Enter 运行 · Esc 关闭"
   },
   "paneLayout": {
     "title": "面板布局设置",

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -18,7 +18,8 @@ import { runBackgroundTaskSyncNow } from "@/desktop/renderer/actions/backgroundT
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
 import { navigateToTaskDetail } from "@/desktop/renderer/utils/taskNavigation";
-import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
+import { getFocusedBoardTaskCard } from "@/desktop/renderer/utils/focusedBoardTaskCard";
+import { SessionType, TASK_STATUS_ORDER, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import { useAutoRefresh } from "@/desktop/renderer/hooks/useAutoRefresh";
 import { useProjectFilterParams } from "@/desktop/renderer/hooks/useProjectFilterParams";
@@ -87,13 +88,7 @@ type BoardTaskFilter = (task: KanbanTask) => boolean;
 const VIM_MOVE_COMMAND_ALIASES = new Set(["move", "m"]);
 const VIM_SYNC_COMMAND_ALIASES = new Set(["sync", "s"]);
 const VIM_COMMAND_NAMES = ["move", "sync"] as const;
-const VIM_MOVE_STATUSES = [
-  TaskStatus.TODO,
-  TaskStatus.PROGRESS,
-  TaskStatus.PENDING,
-  TaskStatus.REVIEW,
-  TaskStatus.DONE,
-] as const;
+const VIM_MOVE_STATUSES = TASK_STATUS_ORDER;
 
 const VIM_STATUS_ALIASES: Record<string, TaskStatus> = {
   t: TaskStatus.TODO,
@@ -248,13 +243,6 @@ function isPlainVimShortcutKey(event: KeyboardEvent, key: string) {
 
 function isVimCommandShortcutKey(event: KeyboardEvent) {
   return event.key === VIM_COMMAND_KEY && !event.altKey && !event.ctrlKey && !event.metaKey;
-}
-
-function getFocusedBoardTaskCard() {
-  const activeElement = document.activeElement;
-  return activeElement instanceof Element
-    ? activeElement.closest<HTMLAnchorElement>(TASK_CARD_SELECTOR)
-    : null;
 }
 
 type ParsedVimCommand =
@@ -766,19 +754,6 @@ export default function Board({
     hasAppliedInitialFocusRef.current = true;
   }, [displayedTasks, initialFocusTaskId, isMounted]);
 
-  useEffect(() => boardCommands.registerBoardHandlers({
-    toggleNotificationCenter() {
-      notificationCenterRef.current?.toggle();
-    },
-    openProjectFilter() {
-      projectSelectorRef.current?.open();
-    },
-    openCreateTaskModal(defaults) {
-      setBranchTodoDefaults(defaults ?? null);
-      setIsModalOpen(true);
-    },
-  }), [boardCommands]);
-
   useEffect(() => {
     boardCommands.setTaskQuickSearchOpen(isVimCommandOpen);
     return () => boardCommands.setTaskQuickSearchOpen(false);
@@ -1029,6 +1004,20 @@ export default function Board({
     },
     [displayedTasks, moveTaskToStatus],
   );
+
+  useEffect(() => boardCommands.registerBoardHandlers({
+    toggleNotificationCenter() {
+      notificationCenterRef.current?.toggle();
+    },
+    openProjectFilter() {
+      projectSelectorRef.current?.open();
+    },
+    openCreateTaskModal(defaults) {
+      setBranchTodoDefaults(defaults ?? null);
+      setIsModalOpen(true);
+    },
+    moveFocusedTaskToStatus,
+  }), [boardCommands, moveFocusedTaskToStatus]);
 
   const closeVimCommand = useCallback(() => {
     setIsVimCommandOpen(false);

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -14,12 +14,11 @@ import TaskContextMenu from "./TaskContextMenu";
 import BranchTaskModal from "./BranchTaskModal";
 import DoneConfirmDialog from "./DoneConfirmDialog";
 import { deleteTask, getMoreDoneTasks, moveTaskToColumn } from "@/desktop/renderer/actions/kanban";
-import { runBackgroundTaskSyncNow } from "@/desktop/renderer/actions/backgroundTaskSync";
 import type { TasksByStatus } from "@/desktop/renderer/actions/kanban";
 import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
 import { navigateToTaskDetail } from "@/desktop/renderer/utils/taskNavigation";
 import { getFocusedBoardTaskCard } from "@/desktop/renderer/utils/focusedBoardTaskCard";
-import { SessionType, TASK_STATUS_ORDER, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
+import { SessionType, TaskStatus, type KanbanTask } from "@/entities/KanbanTask";
 import type { Project } from "@/entities/Project";
 import { useAutoRefresh } from "@/desktop/renderer/hooks/useAutoRefresh";
 import { useProjectFilterParams } from "@/desktop/renderer/hooks/useProjectFilterParams";
@@ -84,26 +83,6 @@ const TASK_DELETE_SEQUENCE_KEY = "d";
 const TASK_DELETE_SEQUENCE_TIMEOUT_MS = 1_000;
 
 type BoardTaskFilter = (task: KanbanTask) => boolean;
-
-const VIM_MOVE_COMMAND_ALIASES = new Set(["move", "m"]);
-const VIM_SYNC_COMMAND_ALIASES = new Set(["sync", "s"]);
-const VIM_COMMAND_NAMES = ["move", "sync"] as const;
-const VIM_MOVE_STATUSES = TASK_STATUS_ORDER;
-
-const VIM_STATUS_ALIASES: Record<string, TaskStatus> = {
-  t: TaskStatus.TODO,
-  todo: TaskStatus.TODO,
-  "to-do": TaskStatus.TODO,
-  progress: TaskStatus.PROGRESS,
-  prog: TaskStatus.PROGRESS,
-  doing: TaskStatus.PROGRESS,
-  pending: TaskStatus.PENDING,
-  pend: TaskStatus.PENDING,
-  review: TaskStatus.REVIEW,
-  rev: TaskStatus.REVIEW,
-  done: TaskStatus.DONE,
-  d: TaskStatus.DONE,
-};
 
 interface ContextMenuState {
   isOpen: boolean;
@@ -245,101 +224,6 @@ function isVimCommandShortcutKey(event: KeyboardEvent) {
   return event.key === VIM_COMMAND_KEY && !event.altKey && !event.ctrlKey && !event.metaKey;
 }
 
-type ParsedVimCommand =
-  | { type: "move"; destinationStatus: TaskStatus }
-  | { type: "sync" };
-
-function parseVimCommandTokens(commandValue: string) {
-  return commandValue
-    .trim()
-    .replace(/^:/, "")
-    .toLowerCase()
-    .split(/\s+/)
-    .filter(Boolean);
-}
-
-function parseVimCommand(commandValue: string): ParsedVimCommand | null {
-  const tokens = parseVimCommandTokens(commandValue);
-
-  if (tokens.length === 1 && VIM_SYNC_COMMAND_ALIASES.has(tokens[0])) {
-    return { type: "sync" };
-  }
-
-  if (tokens.length === 2 && VIM_MOVE_COMMAND_ALIASES.has(tokens[0])) {
-    const destinationStatus = VIM_STATUS_ALIASES[tokens[1]];
-    return destinationStatus ? { type: "move", destinationStatus } : null;
-  }
-
-  return null;
-}
-
-function getUniqueVimMoveStatusCompletion(statusPrefix: string): TaskStatus | null {
-  const normalizedPrefix = statusPrefix.toLowerCase();
-  if (!normalizedPrefix) return null;
-
-  const canonicalMatches = VIM_MOVE_STATUSES.filter((status) => status.startsWith(normalizedPrefix));
-  if (canonicalMatches.length === 1) return canonicalMatches[0];
-  if (canonicalMatches.length > 1) return null;
-
-  const aliasMatches = new Set<TaskStatus>();
-  for (const [alias, status] of Object.entries(VIM_STATUS_ALIASES)) {
-    if (alias.startsWith(normalizedPrefix)) {
-      aliasMatches.add(status);
-    }
-  }
-
-  return aliasMatches.size === 1 ? Array.from(aliasMatches)[0] : null;
-}
-
-function getUniqueVimCommandCompletion(commandPrefix: string) {
-  const normalizedPrefix = commandPrefix.toLowerCase();
-  if (!normalizedPrefix) return "move";
-
-  const matches = VIM_COMMAND_NAMES.filter((command) => command.startsWith(normalizedPrefix));
-  return matches.length === 1 ? matches[0] : null;
-}
-
-function getVimCommandAutocomplete(commandValue: string): string | null {
-  const leadingWhitespace = commandValue.match(/^\s*/)?.[0] ?? "";
-  const trimmedStartValue = commandValue.trimStart();
-  const hasColonPrefix = trimmedStartValue.startsWith(":");
-  const valueWithoutColon = hasColonPrefix ? trimmedStartValue.slice(1) : trimmedStartValue;
-  const hasTrailingWhitespace = /\s$/.test(valueWithoutColon);
-  const tokens = valueWithoutColon.toLowerCase().split(/\s+/).filter(Boolean);
-  const commandToken = tokens[0] ?? "";
-
-  const commandPrefix = `${leadingWhitespace}${hasColonPrefix ? ":" : ""}`;
-  const formatMoveCompletion = (status?: TaskStatus) => {
-    const prefix = `${commandPrefix}move`;
-    return status ? `${prefix} ${status}` : `${prefix} `;
-  };
-  const formatCommandCompletion = (command: typeof VIM_COMMAND_NAMES[number]) => {
-    return command === "move" ? formatMoveCompletion() : `${commandPrefix}${command}`;
-  };
-
-  if (tokens.length === 0) {
-    return formatMoveCompletion();
-  }
-
-  if (tokens.length === 1 && !hasTrailingWhitespace) {
-    const completedCommand = getUniqueVimCommandCompletion(commandToken);
-    if (!completedCommand) return null;
-
-    const completion = formatCommandCompletion(completedCommand);
-    return completion === commandValue ? null : completion;
-  }
-
-  if (!VIM_MOVE_COMMAND_ALIASES.has(commandToken) || tokens.length !== 2) {
-    return null;
-  }
-
-  const completedStatus = getUniqueVimMoveStatusCompletion(tokens[1]);
-  if (!completedStatus) return null;
-
-  const completion = formatMoveCompletion(completedStatus);
-  return completion === commandValue ? null : completion;
-}
-
 function isModifierKey(key: string) {
   return key === "Alt" || key === "Control" || key === "Meta" || key === "Shift";
 }
@@ -476,10 +360,6 @@ export default function Board({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isProjectRegistryOpen, setIsProjectRegistryOpen] = useState(false);
   const [isBranchModalOpen, setIsBranchModalOpen] = useState(false);
-  const [isVimCommandOpen, setIsVimCommandOpen] = useState(false);
-  const [vimCommandValue, setVimCommandValue] = useState("");
-  const [vimCommandError, setVimCommandError] = useState<string | null>(null);
-  const [vimCommandTaskId, setVimCommandTaskId] = useState<string | null>(null);
   const [branchTodoDefaults, setBranchTodoDefaults] = useState<{
     baseBranch: string;
     projectId: string;
@@ -499,15 +379,10 @@ export default function Board({
   const [pendingDoneResult, setPendingDoneResult] = useState<DropResult | null>(null);
   const [currentDefaultSessionType, setCurrentDefaultSessionType] = useState<SessionType>(defaultSessionType);
   const [shouldUseMacTitlebarLayout, setShouldUseMacTitlebarLayout] = useState(false);
-  const vimCommandCompletion = useMemo(
-    () => getVimCommandAutocomplete(vimCommandValue),
-    [vimCommandValue],
-  );
   const [, startDragPersistenceTransition] = useTransition();
   const unreadNotificationCountByTask = useUnreadNotificationCountByTask();
   const notificationCenterRef = useRef<NotificationCenterButtonHandle>(null);
   const projectSelectorRef = useRef<ProjectSelectorHandle>(null);
-  const vimCommandInputRef = useRef<HTMLInputElement>(null);
   const hasAppliedInitialFocusRef = useRef(false);
   const pendingTaskDeleteSequenceRef = useRef<{
     taskId: string;
@@ -693,7 +568,7 @@ export default function Board({
     isModalOpen,
     isProjectRegistryOpen,
     isBranchModalOpen,
-    isVimCommandOpen,
+    isCommandPaletteOpen: boardCommands.isCommandPaletteOpen,
     hasPendingDoneResult: Boolean(pendingDoneResult),
     displayedTasks,
     deleteConfirmMessage: tt("deleteConfirm"),
@@ -705,7 +580,7 @@ export default function Board({
     isModalOpen,
     isProjectRegistryOpen,
     isBranchModalOpen,
-    isVimCommandOpen,
+    isCommandPaletteOpen: boardCommands.isCommandPaletteOpen,
     hasPendingDoneResult: Boolean(pendingDoneResult),
     displayedTasks,
     deleteConfirmMessage: tt("deleteConfirm"),
@@ -755,20 +630,16 @@ export default function Board({
   }, [displayedTasks, initialFocusTaskId, isMounted]);
 
   useEffect(() => {
-    boardCommands.setTaskQuickSearchOpen(isVimCommandOpen);
-    return () => boardCommands.setTaskQuickSearchOpen(false);
-  }, [boardCommands, isVimCommandOpen]);
-
-  useEffect(() => {
-    if (isVimCommandOpen) {
-      vimCommandInputRef.current?.focus();
-    }
-  }, [isVimCommandOpen]);
-
-  useEffect(() => {
     function handleWindowVimShortcut(event: KeyboardEvent) {
       if (!vimModeEnabled) return;
-      if (contextMenu.isOpen || isModalOpen || isProjectRegistryOpen || isBranchModalOpen || pendingDoneResult || isVimCommandOpen) return;
+      if (
+        contextMenu.isOpen
+        || isModalOpen
+        || isProjectRegistryOpen
+        || isBranchModalOpen
+        || pendingDoneResult
+        || boardCommands.isCommandPaletteOpen
+      ) return;
       if (shouldIgnoreBoardVimShortcutEvent(event)) return;
 
       if (isPlainVimShortcutKey(event, VIM_NEW_TASK_KEY)) {
@@ -782,21 +653,33 @@ export default function Board({
       if (isVimCommandShortcutKey(event)) {
         event.preventDefault();
         event.stopPropagation();
-        setVimCommandValue("");
-        setVimCommandError(null);
-        setVimCommandTaskId(getFocusedBoardTaskCard()?.dataset.kanbanTaskId ?? null);
-        setIsVimCommandOpen(true);
+        boardCommands.openCommandPalette();
       }
     }
 
     window.addEventListener("keydown", handleWindowVimShortcut, true);
     return () => window.removeEventListener("keydown", handleWindowVimShortcut, true);
-  }, [contextMenu.isOpen, isBranchModalOpen, isModalOpen, isProjectRegistryOpen, isVimCommandOpen, pendingDoneResult, vimModeEnabled]);
+  }, [
+    boardCommands,
+    contextMenu.isOpen,
+    isBranchModalOpen,
+    isModalOpen,
+    isProjectRegistryOpen,
+    pendingDoneResult,
+    vimModeEnabled,
+  ]);
 
   useEffect(() => {
     function handleWindowTaskFocus(event: KeyboardEvent) {
       if (!isBoardTaskFocusKey(event, vimModeEnabled)) return;
-      if (contextMenu.isOpen || isModalOpen || isProjectRegistryOpen || isBranchModalOpen || pendingDoneResult || isVimCommandOpen) return;
+      if (
+        contextMenu.isOpen
+        || isModalOpen
+        || isProjectRegistryOpen
+        || isBranchModalOpen
+        || pendingDoneResult
+        || boardCommands.isCommandPaletteOpen
+      ) return;
       if (shouldIgnoreBoardTaskFocusEvent(event)) return;
 
       const firstTaskCard = getBoardTaskCards()[0];
@@ -808,7 +691,15 @@ export default function Board({
 
     window.addEventListener("keydown", handleWindowTaskFocus);
     return () => window.removeEventListener("keydown", handleWindowTaskFocus);
-  }, [contextMenu.isOpen, isBranchModalOpen, isModalOpen, isProjectRegistryOpen, isVimCommandOpen, pendingDoneResult, vimModeEnabled]);
+  }, [
+    boardCommands,
+    contextMenu.isOpen,
+    isBranchModalOpen,
+    isModalOpen,
+    isProjectRegistryOpen,
+    pendingDoneResult,
+    vimModeEnabled,
+  ]);
 
   const removeTaskFromBoard = useCallback((task: Pick<KanbanTask, "id" | "status">) => {
     setTasks((prev) => removeTaskFromBoardTasks(prev, task.id));
@@ -866,7 +757,7 @@ export default function Board({
         runtime.isModalOpen ||
         runtime.isBranchModalOpen ||
         runtime.hasPendingDoneResult ||
-        runtime.isVimCommandOpen
+        runtime.isCommandPaletteOpen
       ) {
         return;
       }
@@ -905,7 +796,14 @@ export default function Board({
       const shouldOpenTaskInNewWindow = isShiftOnlyKeyboardShortcut(event, "Enter");
       const shouldOpenTaskContextMenu = isShiftOnlyKeyboardShortcut(event, "F10");
       if (!shouldOpenTaskInNewWindow && !shouldOpenTaskContextMenu) return;
-      if (contextMenu.isOpen || isModalOpen || isProjectRegistryOpen || isBranchModalOpen || pendingDoneResult || isVimCommandOpen) return;
+      if (
+        contextMenu.isOpen
+        || isModalOpen
+        || isProjectRegistryOpen
+        || isBranchModalOpen
+        || pendingDoneResult
+        || boardCommands.isCommandPaletteOpen
+      ) return;
 
       const taskCard = getTaskCardFromKeyboardEvent(event);
       const taskId = taskCard?.dataset.kanbanTaskId;
@@ -928,7 +826,15 @@ export default function Board({
 
     window.addEventListener("keydown", handleWindowTaskShortcut, true);
     return () => window.removeEventListener("keydown", handleWindowTaskShortcut, true);
-  }, [contextMenu.isOpen, displayedTasks, isBranchModalOpen, isModalOpen, isProjectRegistryOpen, isVimCommandOpen, pendingDoneResult]);
+  }, [
+    boardCommands,
+    contextMenu.isOpen,
+    displayedTasks,
+    isBranchModalOpen,
+    isModalOpen,
+    isProjectRegistryOpen,
+    pendingDoneResult,
+  ]);
 
   const handleLoadMoreDone = useCallback(async () => {
     if (isLoadingMore) return;
@@ -1018,41 +924,6 @@ export default function Board({
     },
     moveFocusedTaskToStatus,
   }), [boardCommands, moveFocusedTaskToStatus]);
-
-  const closeVimCommand = useCallback(() => {
-    setIsVimCommandOpen(false);
-    setVimCommandValue("");
-    setVimCommandError(null);
-    setVimCommandTaskId(null);
-  }, []);
-
-  const submitVimCommand = useCallback(() => {
-    const parsedCommand = parseVimCommand(vimCommandValue);
-    if (!parsedCommand) {
-      setVimCommandError(t("vimCommand.errors.unknownCommand"));
-      return;
-    }
-
-    if (parsedCommand.type === "sync") {
-      closeVimCommand();
-      void runBackgroundTaskSyncNow().catch((error) => {
-        console.error("Failed to run background task sync", error);
-      });
-      return;
-    }
-
-    const moveResult = moveFocusedTaskToStatus(parsedCommand.destinationStatus, vimCommandTaskId);
-    if (moveResult === "missing-focus") {
-      setVimCommandError(t("vimCommand.errors.noFocusedTask"));
-      return;
-    }
-    if (moveResult === "missing-task") {
-      setVimCommandError(t("vimCommand.errors.taskNotFound"));
-      return;
-    }
-
-    closeVimCommand();
-  }, [closeVimCommand, moveFocusedTaskToStatus, t, vimCommandTaskId, vimCommandValue]);
 
   const handleDragEnd = useCallback(
     (result: DropResult) => {
@@ -1276,56 +1147,6 @@ export default function Board({
           </div>
         )}
       </main>
-
-      {isVimCommandOpen && (
-        <div className="fixed bottom-4 left-1/2 z-[350] w-[min(520px,calc(100vw-32px))] -translate-x-1/2 rounded-lg border border-border-default bg-bg-surface p-3 shadow-lg">
-          <label htmlFor="vim-command-input" className="sr-only">
-            {t("vimCommand.label")}
-          </label>
-          <div className="flex items-center gap-2 rounded-md border border-border-default bg-bg-page px-3 py-2 text-sm text-text-primary focus-within:border-brand-primary">
-            <span className="font-mono text-text-muted" aria-hidden="true">:</span>
-            <input
-              id="vim-command-input"
-              ref={vimCommandInputRef}
-              value={vimCommandValue}
-              onChange={(event) => {
-                setVimCommandValue(event.target.value);
-                setVimCommandError(null);
-              }}
-              onKeyDown={(event) => {
-                if (event.key === "Tab" && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
-                  const completion = getVimCommandAutocomplete(event.currentTarget.value);
-                  if (completion) {
-                    event.preventDefault();
-                    setVimCommandValue(completion);
-                    setVimCommandError(null);
-                  }
-                  return;
-                }
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  submitVimCommand();
-                  return;
-                }
-                if (event.key === "Escape") {
-                  event.preventDefault();
-                  closeVimCommand();
-                }
-              }}
-              aria-label={t("vimCommand.label")}
-              data-shortcut-capture="true"
-              className="min-w-0 flex-1 bg-transparent font-mono outline-none placeholder:text-text-muted"
-              placeholder={t("vimCommand.placeholder")}
-            />
-          </div>
-          <p className={`mt-2 text-xs ${vimCommandError ? "text-status-error" : "text-text-muted"}`}>
-            {vimCommandError
-              ?? (vimCommandCompletion
-                ? t("vimCommand.completionHint", { command: `:${vimCommandCompletion.trim().replace(/^:/, "")}` })
-                : t("vimCommand.hint"))}
-          </p>
-        </div>
-      )}
 
       <CreateTaskModal
         isOpen={isModalOpen}

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -1,8 +1,9 @@
 import { forwardRef, useEffect, useImperativeHandle } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createEvent, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import Board from "../Board";
+import CommandPaletteDialog from "@/desktop/renderer/components/CommandPaletteDialog";
 import { deleteTask, moveTaskToColumn } from "@/desktop/renderer/actions/kanban";
 import { runBackgroundTaskSyncNow } from "@/desktop/renderer/actions/backgroundTaskSync";
 import { useTaskKindFilterParams } from "@/desktop/renderer/hooks/useTaskKindFilterParams";
@@ -1165,20 +1166,25 @@ describe("Board defaultSessionType sync", () => {
     });
   });
 
-  it(":move <status> 명령으로 포커스된 task를 대상 컬럼으로 이동한다", async () => {
+  it(":는 커맨드 팔레트를 열고, 'move review' 입력 후 Enter로 포커스된 task를 대상 컬럼으로 이동한다", async () => {
     render(
-      <Board
-        initialTasks={createTasksWithTodo()}
-        initialDoneTotal={0}
-        initialDoneLimit={20}
-        sshHosts={[]}
-        projects={[createProject()]}
-        sidebarDefaultCollapsed={false}
-        doneAlertDismissed={false}
-        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
-        defaultSessionType={SessionType.TMUX}
-        taskSearchShortcut="Mod+Shift+O"
-      />,
+      <MemoryRouter initialEntries={["/ko"]}>
+        <BoardCommandProvider>
+          <Board
+            initialTasks={createTasksWithTodo()}
+            initialDoneTotal={0}
+            initialDoneLimit={20}
+            sshHosts={[]}
+            projects={[createProject()]}
+            sidebarDefaultCollapsed={false}
+            doneAlertDismissed={false}
+            notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+            defaultSessionType={SessionType.TMUX}
+            taskSearchShortcut="Mod+Shift+O"
+          />
+          <CommandPaletteDialog />
+        </BoardCommandProvider>
+      </MemoryRouter>,
     );
 
     const taskLink = await screen.findByRole("link", { name: "Test Task" });
@@ -1189,29 +1195,34 @@ describe("Board defaultSessionType sync", () => {
 
     expect(openCommandEvent.defaultPrevented).toBe(true);
 
-    const commandInput = await screen.findByRole("textbox", { name: "vimCommand.label" });
-    fireEvent.change(commandInput, { target: { value: "move review" } });
-    fireEvent.keyDown(commandInput, { key: "Enter" });
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.change(within(dialog).getByRole("textbox"), { target: { value: "move review" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: /move review/ }));
 
     await waitFor(() => {
       expect(moveTaskToColumn).toHaveBeenCalledWith("task-1", TaskStatus.REVIEW);
     });
   });
 
-  it(":sync 명령으로 background task sync를 백그라운드 실행한다", async () => {
+  it(":는 커맨드 팔레트를 열고, 'sync' 입력 후 Enter로 background task sync를 백그라운드 실행한다", async () => {
     render(
-      <Board
-        initialTasks={createEmptyTasks()}
-        initialDoneTotal={0}
-        initialDoneLimit={20}
-        sshHosts={[]}
-        projects={[createProject()]}
-        sidebarDefaultCollapsed={false}
-        doneAlertDismissed={false}
-        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
-        defaultSessionType={SessionType.TMUX}
-        taskSearchShortcut="Mod+Shift+O"
-      />,
+      <MemoryRouter initialEntries={["/ko"]}>
+        <BoardCommandProvider>
+          <Board
+            initialTasks={createEmptyTasks()}
+            initialDoneTotal={0}
+            initialDoneLimit={20}
+            sshHosts={[]}
+            projects={[createProject()]}
+            sidebarDefaultCollapsed={false}
+            doneAlertDismissed={false}
+            notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
+            defaultSessionType={SessionType.TMUX}
+            taskSearchShortcut="Mod+Shift+O"
+          />
+          <CommandPaletteDialog />
+        </BoardCommandProvider>
+      </MemoryRouter>,
     );
 
     const openCommandEvent = createEvent.keyDown(window, { key: ":" });
@@ -1219,115 +1230,16 @@ describe("Board defaultSessionType sync", () => {
 
     expect(openCommandEvent.defaultPrevented).toBe(true);
 
-    const commandInput = await screen.findByRole("textbox", { name: "vimCommand.label" });
+    const dialog = await screen.findByRole("dialog");
+    const commandInput = within(dialog).getByRole("textbox");
     fireEvent.change(commandInput, { target: { value: "sync" } });
     fireEvent.keyDown(commandInput, { key: "Enter" });
 
     expect(runBackgroundTaskSyncNow).toHaveBeenCalledTimes(1);
     expect(moveTaskToColumn).not.toHaveBeenCalled();
     await waitFor(() => {
-      expect(screen.queryByRole("textbox", { name: "vimCommand.label" })).toBeNull();
+      expect(screen.queryByRole("dialog")).toBeNull();
     });
-  });
-
-  it(":sync 명령은 Tab 자동 완성으로 입력할 수 있다", async () => {
-    render(
-      <Board
-        initialTasks={createEmptyTasks()}
-        initialDoneTotal={0}
-        initialDoneLimit={20}
-        sshHosts={[]}
-        projects={[createProject()]}
-        sidebarDefaultCollapsed={false}
-        doneAlertDismissed={false}
-        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
-        defaultSessionType={SessionType.TMUX}
-        taskSearchShortcut="Mod+Shift+O"
-      />,
-    );
-
-    fireEvent.keyDown(window, { key: ":" });
-
-    const commandInput = await screen.findByRole("textbox", { name: "vimCommand.label" });
-    fireEvent.change(commandInput, { target: { value: "s" } });
-
-    const autocompleteEvent = createEvent.keyDown(commandInput, { key: "Tab" });
-    fireEvent(commandInput, autocompleteEvent);
-
-    expect(autocompleteEvent.defaultPrevented).toBe(true);
-    await waitFor(() => {
-      expect((commandInput as HTMLInputElement).value).toBe("sync");
-    });
-  });
-
-  it(":move 명령에서 Tab으로 상태명을 자동 완성한다", async () => {
-    render(
-      <Board
-        initialTasks={createTasksWithTodo()}
-        initialDoneTotal={0}
-        initialDoneLimit={20}
-        sshHosts={[]}
-        projects={[createProject()]}
-        sidebarDefaultCollapsed={false}
-        doneAlertDismissed={false}
-        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
-        defaultSessionType={SessionType.TMUX}
-        taskSearchShortcut="Mod+Shift+O"
-      />,
-    );
-
-    const taskLink = await screen.findByRole("link", { name: "Test Task" });
-    taskLink.focus();
-
-    fireEvent.keyDown(taskLink, { key: ":" });
-
-    const commandInput = await screen.findByRole("textbox", { name: "vimCommand.label" });
-    fireEvent.change(commandInput, { target: { value: "move re" } });
-
-    const autocompleteEvent = createEvent.keyDown(commandInput, { key: "Tab" });
-    fireEvent(commandInput, autocompleteEvent);
-
-    expect(autocompleteEvent.defaultPrevented).toBe(true);
-    await waitFor(() => {
-      expect((commandInput as HTMLInputElement).value).toBe("move review");
-    });
-
-    fireEvent.keyDown(commandInput, { key: "Enter" });
-
-    await waitFor(() => {
-      expect(moveTaskToColumn).toHaveBeenCalledWith("task-1", TaskStatus.REVIEW);
-    });
-  });
-
-  it(":move 명령 자동 완성 후보가 모호하면 Tab을 소비하지 않는다", async () => {
-    render(
-      <Board
-        initialTasks={createTasksWithTodo()}
-        initialDoneTotal={0}
-        initialDoneLimit={20}
-        sshHosts={[]}
-        projects={[createProject()]}
-        sidebarDefaultCollapsed={false}
-        doneAlertDismissed={false}
-        notificationSettings={{ isEnabled: true, enabledStatuses: ["progress", "pending", "review"] }}
-        defaultSessionType={SessionType.TMUX}
-        taskSearchShortcut="Mod+Shift+O"
-      />,
-    );
-
-    const taskLink = await screen.findByRole("link", { name: "Test Task" });
-    taskLink.focus();
-
-    fireEvent.keyDown(taskLink, { key: ":" });
-
-    const commandInput = await screen.findByRole("textbox", { name: "vimCommand.label" });
-    fireEvent.change(commandInput, { target: { value: "move p" } });
-
-    const autocompleteEvent = createEvent.keyDown(commandInput, { key: "Tab" });
-    fireEvent(commandInput, autocompleteEvent);
-
-    expect(autocompleteEvent.defaultPrevented).toBe(false);
-    expect((commandInput as HTMLInputElement).value).toBe("move p");
   });
 
   it("상세 화면에서 돌아온 task id가 있으면 해당 task로 초기 focus를 시작한다", async () => {

--- a/src/desktop/renderer/App.tsx
+++ b/src/desktop/renderer/App.tsx
@@ -7,6 +7,7 @@ import BackgroundSyncReviewDialog from "@/desktop/renderer/components/Background
 import NotificationListener from "@/desktop/renderer/components/NotificationListener";
 import ReleaseUpdateDialog from "@/desktop/renderer/components/ReleaseUpdateDialog";
 import TaskQuickSearchDialog from "@/desktop/renderer/components/TaskQuickSearchDialog";
+import CommandPaletteDialog from "@/desktop/renderer/components/CommandPaletteDialog";
 import { DEFAULT_LOCALE, getSafeLocale, isSupportedLocale, messagesByLocale } from "@/desktop/renderer/utils/locales";
 import { triggerDesktopRefresh } from "@/desktop/renderer/utils/refresh";
 import BoardRoute from "@/desktop/renderer/routes/BoardRoute";
@@ -101,6 +102,7 @@ function LocaleShell() {
       <ThemeController />
       <BoardCommandProvider>
         <TaskQuickSearchDialog />
+        <CommandPaletteDialog />
         <NotificationListener />
         <ReleaseUpdateDialog />
         <BoardEventAlert />

--- a/src/desktop/renderer/components/BoardCommandProvider.tsx
+++ b/src/desktop/renderer/components/BoardCommandProvider.tsx
@@ -11,22 +11,35 @@ import {
   type PropsWithChildren,
 } from "react";
 import { useRouter } from "@/desktop/renderer/navigation";
+import { getFocusedBoardTaskCard } from "@/desktop/renderer/utils/focusedBoardTaskCard";
 import {
   getCurrentShortcutPlatform,
   isBlockedShortcutEvent,
 } from "@/desktop/renderer/utils/keyboardShortcut";
 import { useShortcutBindings } from "@/desktop/renderer/utils/shortcutBindings";
 import { findShortcutCommandForEvent } from "@/desktop/shared/shortcutBindings";
+import type { TaskStatus } from "@/entities/KanbanTask";
 
 export interface BranchTodoDefaults {
   projectId: string;
   baseBranch: string;
 }
 
+/** 커맨드 팔레트가 "지금 대상 task"로 삼을 task 상세 창의 등록 정보 */
+export interface ActiveTaskContext {
+  taskId: string;
+  currentStatus: TaskStatus;
+  moveTaskToStatus: (status: TaskStatus) => Promise<void> | void;
+}
+
 interface BoardCommandHandlers {
   toggleNotificationCenter: () => void;
   openProjectFilter: () => void;
   openCreateTaskModal: (defaults?: BranchTodoDefaults) => void;
+  moveFocusedTaskToStatus?: (
+    status: TaskStatus,
+    taskIdOverride?: string | null,
+  ) => "moved" | "missing-focus" | "missing-task";
 }
 
 interface BoardCommandContextValue {
@@ -36,6 +49,15 @@ interface BoardCommandContextValue {
   registerShortcutBlocker: () => () => void;
   requestCreateBranchTodo: (defaults: BranchTodoDefaults) => void;
   setTaskQuickSearchOpen: (isOpen: boolean) => void;
+  isCommandPaletteOpen: boolean;
+  openCommandPalette: () => void;
+  closeCommandPalette: () => void;
+  commandPaletteBoardFocusedTaskId: string | null;
+  hasActiveTaskContext: boolean;
+  activeTaskCurrentStatus: TaskStatus | null;
+  registerActiveTaskContext: (context: ActiveTaskContext) => () => void;
+  moveFocusedTaskToStatus: (status: TaskStatus) => "moved" | "missing-focus" | "missing-task";
+  moveActiveTaskToStatus: (status: TaskStatus) => void;
 }
 
 const noopDisposer = () => {};
@@ -46,6 +68,15 @@ const defaultBoardCommandContextValue: BoardCommandContextValue = {
   registerShortcutBlocker: () => noopDisposer,
   requestCreateBranchTodo: () => {},
   setTaskQuickSearchOpen: () => {},
+  isCommandPaletteOpen: false,
+  openCommandPalette: () => {},
+  closeCommandPalette: () => {},
+  commandPaletteBoardFocusedTaskId: null,
+  hasActiveTaskContext: false,
+  activeTaskCurrentStatus: null,
+  registerActiveTaskContext: () => noopDisposer,
+  moveFocusedTaskToStatus: () => "missing-focus",
+  moveActiveTaskToStatus: () => {},
 };
 
 const BoardCommandContext = createContext<BoardCommandContextValue | null>(null);
@@ -76,9 +107,14 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
   const handlersRef = useRef<BoardCommandHandlers | null>(null);
   const notificationCenterHandlerRef = useRef<(() => void) | null>(null);
   const shortcutBlockerTokensRef = useRef<Set<symbol>>(new Set());
+  const activeTaskContextRef = useRef<ActiveTaskContext | null>(null);
   const [canCreateBranchTodo, setCanCreateBranchTodo] = useState(false);
   const [isTaskQuickSearchOpen, setIsTaskQuickSearchOpen] = useState(false);
   const [shortcutBlockerCount, setShortcutBlockerCount] = useState(0);
+  const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
+  const [commandPaletteBoardFocusedTaskId, setCommandPaletteBoardFocusedTaskId] = useState<string | null>(null);
+  const [hasActiveTaskContext, setHasActiveTaskContext] = useState(false);
+  const [activeTaskCurrentStatus, setActiveTaskCurrentStatus] = useState<TaskStatus | null>(null);
   const shortcutPlatform = getCurrentShortcutPlatform();
   const shortcutBindings = useShortcutBindings();
   const hasShortcutBlocker = shortcutBlockerCount > 0;
@@ -118,6 +154,38 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
     setIsTaskQuickSearchOpen(isOpen);
   }, []);
 
+  const registerActiveTaskContext = useCallback((context: ActiveTaskContext) => {
+    activeTaskContextRef.current = context;
+    setHasActiveTaskContext(true);
+    setActiveTaskCurrentStatus(context.currentStatus);
+
+    return () => {
+      if (activeTaskContextRef.current === context) {
+        activeTaskContextRef.current = null;
+        setHasActiveTaskContext(false);
+        setActiveTaskCurrentStatus(null);
+      }
+    };
+  }, []);
+
+  const moveActiveTaskToStatus = useCallback((status: TaskStatus) => {
+    void activeTaskContextRef.current?.moveTaskToStatus(status);
+  }, []);
+
+  const openCommandPalette = useCallback(() => {
+    setCommandPaletteBoardFocusedTaskId(getFocusedBoardTaskCard()?.dataset.kanbanTaskId ?? null);
+    setIsCommandPaletteOpen(true);
+  }, []);
+
+  const closeCommandPalette = useCallback(() => {
+    setIsCommandPaletteOpen(false);
+    setCommandPaletteBoardFocusedTaskId(null);
+  }, []);
+
+  const moveFocusedTaskToStatus = useCallback((status: TaskStatus) => (
+    handlersRef.current?.moveFocusedTaskToStatus?.(status, commandPaletteBoardFocusedTaskId) ?? "missing-focus"
+  ), [commandPaletteBoardFocusedTaskId]);
+
   const registerShortcutBlocker = useCallback(() => {
     const token = Symbol("shortcut-blocker");
     shortcutBlockerTokensRef.current.add(token);
@@ -137,11 +205,22 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
         return;
       }
 
-      if (hasShortcutBlocker || isTaskQuickSearchOpen || shouldIgnoreGlobalShortcut(event.target)) {
+      if (
+        hasShortcutBlocker
+        || isTaskQuickSearchOpen
+        || isCommandPaletteOpen
+        || shouldIgnoreGlobalShortcut(event.target)
+      ) {
         return;
       }
 
       const shortcutCommand = findShortcutCommandForEvent(shortcutBindings, event, shortcutPlatform);
+
+      if (shortcutCommand === "commandPalette") {
+        event.preventDefault();
+        openCommandPalette();
+        return;
+      }
 
       if (shortcutCommand === "boardNotification") {
         if (!notificationCenterHandlerRef.current) {
@@ -185,11 +264,11 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
     return () => {
       window.removeEventListener("keydown", handleGlobalKeyDown);
     };
-  }, [hasShortcutBlocker, isTaskQuickSearchOpen, router, shortcutBindings, shortcutPlatform]);
+  }, [hasShortcutBlocker, isCommandPaletteOpen, isTaskQuickSearchOpen, openCommandPalette, router, shortcutBindings, shortcutPlatform]);
 
   useEffect(() => {
     const unsubscribe = window.kanvibeDesktop?.onCreateTaskShortcut?.(() => {
-      if (hasShortcutBlocker || isTaskQuickSearchOpen) {
+      if (hasShortcutBlocker || isTaskQuickSearchOpen || isCommandPaletteOpen) {
         return;
       }
 
@@ -199,11 +278,11 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
     return () => {
       unsubscribe?.();
     };
-  }, [hasShortcutBlocker, isTaskQuickSearchOpen]);
+  }, [hasShortcutBlocker, isCommandPaletteOpen, isTaskQuickSearchOpen]);
 
   useEffect(() => {
     const unsubscribe = window.kanvibeDesktop?.onNotificationShortcut?.(() => {
-      if (hasShortcutBlocker || isTaskQuickSearchOpen) {
+      if (hasShortcutBlocker || isTaskQuickSearchOpen || isCommandPaletteOpen) {
         return;
       }
 
@@ -213,7 +292,7 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
     return () => {
       unsubscribe?.();
     };
-  }, [hasShortcutBlocker, isTaskQuickSearchOpen]);
+  }, [hasShortcutBlocker, isCommandPaletteOpen, isTaskQuickSearchOpen]);
 
   const value = useMemo<BoardCommandContextValue>(() => ({
     canCreateBranchTodo,
@@ -222,8 +301,26 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
     registerShortcutBlocker,
     requestCreateBranchTodo,
     setTaskQuickSearchOpen,
+    isCommandPaletteOpen,
+    openCommandPalette,
+    closeCommandPalette,
+    commandPaletteBoardFocusedTaskId,
+    hasActiveTaskContext,
+    activeTaskCurrentStatus,
+    registerActiveTaskContext,
+    moveFocusedTaskToStatus,
+    moveActiveTaskToStatus,
   }), [
+    activeTaskCurrentStatus,
     canCreateBranchTodo,
+    closeCommandPalette,
+    commandPaletteBoardFocusedTaskId,
+    hasActiveTaskContext,
+    isCommandPaletteOpen,
+    moveActiveTaskToStatus,
+    moveFocusedTaskToStatus,
+    openCommandPalette,
+    registerActiveTaskContext,
     registerBoardHandlers,
     registerNotificationCenterHandler,
     registerShortcutBlocker,

--- a/src/desktop/renderer/components/BoardCommandProvider.tsx
+++ b/src/desktop/renderer/components/BoardCommandProvider.tsx
@@ -294,6 +294,20 @@ export function BoardCommandProvider({ children }: PropsWithChildren) {
     };
   }, [hasShortcutBlocker, isCommandPaletteOpen, isTaskQuickSearchOpen]);
 
+  useEffect(() => {
+    const unsubscribe = window.kanvibeDesktop?.onCommandPaletteShortcut?.(() => {
+      if (hasShortcutBlocker || isTaskQuickSearchOpen || isCommandPaletteOpen) {
+        return;
+      }
+
+      openCommandPalette();
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [hasShortcutBlocker, isCommandPaletteOpen, isTaskQuickSearchOpen, openCommandPalette]);
+
   const value = useMemo<BoardCommandContextValue>(() => ({
     canCreateBranchTodo,
     registerBoardHandlers,

--- a/src/desktop/renderer/components/CommandPaletteDialog.tsx
+++ b/src/desktop/renderer/components/CommandPaletteDialog.tsx
@@ -10,7 +10,8 @@ import { TASK_STATUS_ORDER, type TaskStatus } from "@/entities/KanbanTask";
 
 interface CommandItem {
   id: string;
-  label: string;
+  command: string;
+  description: string;
   run: () => void;
 }
 
@@ -70,14 +71,15 @@ export default function CommandPaletteDialog() {
 
   const commands = useMemo<CommandItem[]>(() => {
     const items: CommandItem[] = [
-      { id: "sync", label: t("syncLabel"), run: runSync },
+      { id: "sync", command: "sync", description: t("syncLabel"), run: runSync },
     ];
 
     if (hasMoveTarget) {
       for (const status of moveTargetStatuses) {
         items.push({
           id: `move:${status}`,
-          label: t("moveToStatusLabel", { status: tBoard(`columns.${status}`) }),
+          command: `move ${status}`,
+          description: t("moveToStatusLabel", { status: tBoard(`columns.${status}`) }),
           run: () => selectStatus(status),
         });
       }
@@ -93,7 +95,9 @@ export default function CommandPaletteDialog() {
       return commands;
     }
 
-    return commands.filter((command) => command.label.toLowerCase().includes(normalizedQuery));
+    return commands.filter((command) => (
+      `${command.command} ${command.description}`.toLowerCase().includes(normalizedQuery)
+    ));
   }, [commands, query]);
 
   const selectedResultIndex = results.length === 0
@@ -172,11 +176,12 @@ export default function CommandPaletteDialog() {
                   type="button"
                   onClick={command.run}
                   onMouseEnter={() => setSelectedIndex(index)}
-                  className={`flex w-full items-center px-4 py-2.5 text-left text-sm font-medium text-text-primary transition-colors ${
+                  className={`flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors ${
                     index === selectedResultIndex ? "bg-brand-primary/10" : "hover:bg-bg-page"
                   }`}
                 >
-                  {command.label}
+                  <span className="shrink-0 font-mono text-xs font-semibold text-text-primary">{command.command}</span>
+                  <span className="truncate text-text-muted">{command.description}</span>
                 </button>
               ))}
             </div>

--- a/src/desktop/renderer/components/CommandPaletteDialog.tsx
+++ b/src/desktop/renderer/components/CommandPaletteDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { runBackgroundTaskSyncNow } from "@/desktop/renderer/actions/backgroundTaskSync";
 import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
@@ -8,14 +8,21 @@ import { requestActiveTerminalFocusAfterUiSettles } from "@/desktop/renderer/uti
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { TASK_STATUS_ORDER, type TaskStatus } from "@/entities/KanbanTask";
 
-type CommandPaletteView = "commands" | "statuses";
+interface CommandItem {
+  id: string;
+  label: string;
+  run: () => void;
+}
 
 export default function CommandPaletteDialog() {
   const boardCommands = useBoardCommands();
   const t = useTranslations("commandPalette");
   const tBoard = useTranslations("board");
   const tc = useTranslations("common");
-  const [view, setView] = useState<CommandPaletteView>("commands");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const resultsListRef = useRef<HTMLDivElement>(null);
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const {
     isCommandPaletteOpen,
     closeCommandPalette,
@@ -27,7 +34,9 @@ export default function CommandPaletteDialog() {
 
   useEffect(() => {
     if (isCommandPaletteOpen) {
-      setView("commands");
+      setQuery("");
+      setSelectedIndex(0);
+      inputRef.current?.focus();
     }
   }, [isCommandPaletteOpen]);
 
@@ -36,10 +45,7 @@ export default function CommandPaletteDialog() {
     requestActiveTerminalFocusAfterUiSettles();
   }
 
-  useEscapeKey(
-    () => (view === "statuses" ? setView("commands") : closeDialog()),
-    { enabled: isCommandPaletteOpen },
-  );
+  useEscapeKey(closeDialog, { enabled: isCommandPaletteOpen });
 
   function runSync() {
     void runBackgroundTaskSyncNow().catch((error) => {
@@ -58,13 +64,73 @@ export default function CommandPaletteDialog() {
     closeDialog();
   }
 
+  const moveTargetStatuses = hasActiveTaskContext && activeTaskCurrentStatus
+    ? TASK_STATUS_ORDER.filter((status) => status !== activeTaskCurrentStatus)
+    : TASK_STATUS_ORDER;
+
+  const commands = useMemo<CommandItem[]>(() => {
+    const items: CommandItem[] = [
+      { id: "sync", label: t("syncLabel"), run: runSync },
+    ];
+
+    if (hasMoveTarget) {
+      for (const status of moveTargetStatuses) {
+        items.push({
+          id: `move:${status}`,
+          label: t("moveToStatusLabel", { status: tBoard(`columns.${status}`) }),
+          run: () => selectStatus(status),
+        });
+      }
+    }
+
+    return items;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasMoveTarget, moveTargetStatuses, t, tBoard]);
+
+  const results = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return commands;
+    }
+
+    return commands.filter((command) => command.label.toLowerCase().includes(normalizedQuery));
+  }, [commands, query]);
+
+  const selectedResultIndex = results.length === 0
+    ? 0
+    : Math.min(selectedIndex, results.length - 1);
+
+  useEffect(() => {
+    if (!isCommandPaletteOpen) {
+      return;
+    }
+
+    const selectedResult = resultsListRef.current?.children[selectedResultIndex];
+    if (selectedResult instanceof HTMLElement) {
+      selectedResult.scrollIntoView?.({ block: "nearest" });
+    }
+  }, [isCommandPaletteOpen, results, selectedResultIndex]);
+
+  function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setSelectedIndex((current) => (results.length === 0 ? 0 : Math.min(current + 1, results.length - 1)));
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setSelectedIndex((current) => Math.max(current - 1, 0));
+        break;
+      case "Enter":
+        event.preventDefault();
+        results[selectedResultIndex]?.run();
+        break;
+    }
+  }
+
   if (!isCommandPaletteOpen) {
     return null;
   }
-
-  const statuses = hasActiveTaskContext && activeTaskCurrentStatus
-    ? TASK_STATUS_ORDER.filter((status) => status !== activeTaskCurrentStatus)
-    : TASK_STATUS_ORDER;
 
   return (
     <div data-terminal-focus-blocker="true" className="fixed inset-0 z-[500] flex items-start justify-center bg-black/45 px-4 pt-24">
@@ -79,48 +145,43 @@ export default function CommandPaletteDialog() {
         aria-modal="true"
         className="relative z-10 w-full max-w-md overflow-hidden rounded-2xl border border-border-default bg-bg-surface shadow-2xl"
       >
-        <div className="border-b border-border-default px-4 py-3">
-          <p className="text-sm font-semibold text-text-primary">
-            {view === "statuses" ? t("statusListTitle") : t("title")}
-          </p>
+        <div className="flex items-center gap-2 border-b border-border-default px-4 py-3">
+          <span aria-hidden="true" className="text-sm font-medium text-text-muted">&gt;</span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setSelectedIndex(0);
+            }}
+            onKeyDown={handleInputKeyDown}
+            placeholder={t("placeholder")}
+            className="w-full bg-transparent text-sm text-text-primary outline-none"
+          />
         </div>
 
-        {view === "commands" ? (
-          <div>
-            <button
-              type="button"
-              onClick={runSync}
-              className="flex w-full flex-col items-start gap-0.5 border-b border-border-subtle px-4 py-3 text-left transition-colors hover:bg-bg-page"
-            >
-              <span className="text-sm font-medium text-text-primary">{t("syncLabel")}</span>
-              <span className="text-xs text-text-muted">{t("syncDescription")}</span>
-            </button>
-            <button
-              type="button"
-              disabled={!hasMoveTarget}
-              onClick={() => setView("statuses")}
-              className="flex w-full flex-col items-start gap-0.5 border-b border-border-subtle px-4 py-3 text-left transition-colors enabled:hover:bg-bg-page disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <span className="text-sm font-medium text-text-primary">{t("moveLabel")}</span>
-              <span className="text-xs text-text-muted">
-                {hasMoveTarget ? t("moveDescription") : t("moveDisabledHint")}
-              </span>
-            </button>
-          </div>
-        ) : (
-          <div>
-            {statuses.map((status) => (
-              <button
-                key={status}
-                type="button"
-                onClick={() => selectStatus(status)}
-                className="flex w-full items-center px-4 py-3 text-left text-sm font-medium text-text-primary transition-colors hover:bg-bg-page"
-              >
-                {tBoard(`columns.${status}`)}
-              </button>
-            ))}
-          </div>
-        )}
+        <div className="max-h-[420px] overflow-y-auto">
+          {results.length === 0 ? (
+            <div className="px-4 py-6 text-sm text-text-muted">{t("empty")}</div>
+          ) : (
+            <div ref={resultsListRef}>
+              {results.map((command, index) => (
+                <button
+                  key={command.id}
+                  type="button"
+                  onClick={command.run}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  className={`flex w-full items-center px-4 py-2.5 text-left text-sm font-medium text-text-primary transition-colors ${
+                    index === selectedResultIndex ? "bg-brand-primary/10" : "hover:bg-bg-page"
+                  }`}
+                >
+                  {command.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
 
         <div className="border-t border-border-default px-4 py-2 text-xs text-text-muted">
           {t("hint")}

--- a/src/desktop/renderer/components/CommandPaletteDialog.tsx
+++ b/src/desktop/renderer/components/CommandPaletteDialog.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { runBackgroundTaskSyncNow } from "@/desktop/renderer/actions/backgroundTaskSync";
+import { useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
+import { requestActiveTerminalFocusAfterUiSettles } from "@/desktop/renderer/utils/terminalFocus";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
+import { TASK_STATUS_ORDER, type TaskStatus } from "@/entities/KanbanTask";
+
+type CommandPaletteView = "commands" | "statuses";
+
+export default function CommandPaletteDialog() {
+  const boardCommands = useBoardCommands();
+  const t = useTranslations("commandPalette");
+  const tBoard = useTranslations("board");
+  const tc = useTranslations("common");
+  const [view, setView] = useState<CommandPaletteView>("commands");
+  const {
+    isCommandPaletteOpen,
+    closeCommandPalette,
+    hasActiveTaskContext,
+    activeTaskCurrentStatus,
+    commandPaletteBoardFocusedTaskId,
+  } = boardCommands;
+  const hasMoveTarget = hasActiveTaskContext || Boolean(commandPaletteBoardFocusedTaskId);
+
+  useEffect(() => {
+    if (isCommandPaletteOpen) {
+      setView("commands");
+    }
+  }, [isCommandPaletteOpen]);
+
+  function closeDialog() {
+    closeCommandPalette();
+    requestActiveTerminalFocusAfterUiSettles();
+  }
+
+  useEscapeKey(
+    () => (view === "statuses" ? setView("commands") : closeDialog()),
+    { enabled: isCommandPaletteOpen },
+  );
+
+  function runSync() {
+    void runBackgroundTaskSyncNow().catch((error) => {
+      console.error("Failed to run background task sync", error);
+    });
+    closeDialog();
+  }
+
+  function selectStatus(status: TaskStatus) {
+    if (hasActiveTaskContext) {
+      boardCommands.moveActiveTaskToStatus(status);
+    } else {
+      boardCommands.moveFocusedTaskToStatus(status);
+    }
+
+    closeDialog();
+  }
+
+  if (!isCommandPaletteOpen) {
+    return null;
+  }
+
+  const statuses = hasActiveTaskContext && activeTaskCurrentStatus
+    ? TASK_STATUS_ORDER.filter((status) => status !== activeTaskCurrentStatus)
+    : TASK_STATUS_ORDER;
+
+  return (
+    <div data-terminal-focus-blocker="true" className="fixed inset-0 z-[500] flex items-start justify-center bg-black/45 px-4 pt-24">
+      <button
+        type="button"
+        aria-label={tc("close")}
+        className="absolute inset-0 cursor-default"
+        onClick={closeDialog}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative z-10 w-full max-w-md overflow-hidden rounded-2xl border border-border-default bg-bg-surface shadow-2xl"
+      >
+        <div className="border-b border-border-default px-4 py-3">
+          <p className="text-sm font-semibold text-text-primary">
+            {view === "statuses" ? t("statusListTitle") : t("title")}
+          </p>
+        </div>
+
+        {view === "commands" ? (
+          <div>
+            <button
+              type="button"
+              onClick={runSync}
+              className="flex w-full flex-col items-start gap-0.5 border-b border-border-subtle px-4 py-3 text-left transition-colors hover:bg-bg-page"
+            >
+              <span className="text-sm font-medium text-text-primary">{t("syncLabel")}</span>
+              <span className="text-xs text-text-muted">{t("syncDescription")}</span>
+            </button>
+            <button
+              type="button"
+              disabled={!hasMoveTarget}
+              onClick={() => setView("statuses")}
+              className="flex w-full flex-col items-start gap-0.5 border-b border-border-subtle px-4 py-3 text-left transition-colors enabled:hover:bg-bg-page disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <span className="text-sm font-medium text-text-primary">{t("moveLabel")}</span>
+              <span className="text-xs text-text-muted">
+                {hasMoveTarget ? t("moveDescription") : t("moveDisabledHint")}
+              </span>
+            </button>
+          </div>
+        ) : (
+          <div>
+            {statuses.map((status) => (
+              <button
+                key={status}
+                type="button"
+                onClick={() => selectStatus(status)}
+                className="flex w-full items-center px-4 py-3 text-left text-sm font-medium text-text-primary transition-colors hover:bg-bg-page"
+              >
+                {tBoard(`columns.${status}`)}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="border-t border-border-default px-4 py-2 text-xs text-text-muted">
+          {t("hint")}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
+++ b/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
@@ -4,6 +4,13 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BoardCommandProvider, useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
 
+function CommandPaletteHarness() {
+  const boardCommands = useBoardCommands();
+  return (
+    <span>{boardCommands.isCommandPaletteOpen ? "palette-open" : "palette-closed"}</span>
+  );
+}
+
 const mocks = vi.hoisted(() => ({
   triggerDesktopRefresh: vi.fn(),
 }));
@@ -106,7 +113,7 @@ describe("BoardCommandProvider", () => {
       shiftKey: true,
     });
     fireEvent.keyDown(window, {
-      key: "p",
+      key: "f",
       ctrlKey: true,
       shiftKey: true,
     });
@@ -114,6 +121,41 @@ describe("BoardCommandProvider", () => {
     expect(onToggleNotificationCenter).toHaveBeenCalledTimes(1);
     expect(onOpenProjectFilter).toHaveBeenCalledTimes(1);
     expect(screen.getByText("branch-enabled")).toBeTruthy();
+  });
+
+  it("opens the command palette from the global shortcut and blocks other board shortcuts while open", () => {
+    const onToggleNotificationCenter = vi.fn();
+    const onOpenProjectFilter = vi.fn();
+    const onOpenCreateTaskModal = vi.fn();
+
+    renderWithRouter(
+      <BoardCommandProvider>
+        <BoardCommandHarness
+          onToggleNotificationCenter={onToggleNotificationCenter}
+          onOpenProjectFilter={onOpenProjectFilter}
+          onOpenCreateTaskModal={onOpenCreateTaskModal}
+        />
+        <CommandPaletteHarness />
+      </BoardCommandProvider>,
+    );
+
+    expect(screen.getByText("palette-closed")).toBeTruthy();
+
+    fireEvent.keyDown(window, {
+      key: "p",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(screen.getByText("palette-open")).toBeTruthy();
+
+    fireEvent.keyDown(window, {
+      key: "i",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(onToggleNotificationCenter).not.toHaveBeenCalled();
   });
 
   it("ignores board shortcuts while task quick search is open", () => {

--- a/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
+++ b/src/desktop/renderer/components/__tests__/BoardCommandProvider.test.tsx
@@ -313,6 +313,7 @@ describe("BoardCommandProvider", () => {
     const onOpenCreateTaskModal = vi.fn();
     let createTaskShortcutListener: (() => void) | null = null;
     let notificationShortcutListener: (() => void) | null = null;
+    let commandPaletteShortcutListener: (() => void) | null = null;
     window.kanvibeDesktop = {
       isDesktop: true,
       onCreateTaskShortcut: vi.fn((listener: () => void) => {
@@ -321,6 +322,10 @@ describe("BoardCommandProvider", () => {
       }),
       onNotificationShortcut: vi.fn((listener: () => void) => {
         notificationShortcutListener = listener;
+        return vi.fn();
+      }),
+      onCommandPaletteShortcut: vi.fn((listener: () => void) => {
+        commandPaletteShortcutListener = listener;
         return vi.fn();
       }),
     } as never;
@@ -333,16 +338,49 @@ describe("BoardCommandProvider", () => {
           onOpenCreateTaskModal={onOpenCreateTaskModal}
           blockShortcuts
         />
+        <CommandPaletteHarness />
       </BoardCommandProvider>,
     );
 
     act(() => {
       createTaskShortcutListener?.();
       notificationShortcutListener?.();
+      commandPaletteShortcutListener?.();
     });
 
     expect(onOpenCreateTaskModal).not.toHaveBeenCalled();
     expect(onToggleNotificationCenter).not.toHaveBeenCalled();
+    expect(screen.getByText("palette-closed")).toBeTruthy();
+  });
+
+  it("forwards the desktop command-palette shortcut event to open the palette", () => {
+    let commandPaletteShortcutListener: (() => void) | null = null;
+    const unsubscribe = vi.fn();
+    window.kanvibeDesktop = {
+      isDesktop: true,
+      onCommandPaletteShortcut: vi.fn((listener: () => void) => {
+        commandPaletteShortcutListener = listener;
+        return unsubscribe;
+      }),
+    } as never;
+
+    const { unmount } = renderWithRouter(
+      <BoardCommandProvider>
+        <CommandPaletteHarness />
+      </BoardCommandProvider>,
+    );
+
+    expect(screen.getByText("palette-closed")).toBeTruthy();
+
+    act(() => {
+      commandPaletteShortcutListener?.();
+    });
+
+    expect(screen.getByText("palette-open")).toBeTruthy();
+
+    unsubscribe.mockClear();
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
   it("dispatches the notification shortcut to a notification-only handler", () => {

--- a/src/desktop/renderer/components/__tests__/CommandPaletteDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/CommandPaletteDialog.test.tsx
@@ -1,0 +1,140 @@
+import { useEffect, type ReactNode } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BoardCommandProvider, useBoardCommands } from "@/desktop/renderer/components/BoardCommandProvider";
+import CommandPaletteDialog from "@/desktop/renderer/components/CommandPaletteDialog";
+import { TaskStatus } from "@/entities/KanbanTask";
+
+const mocks = vi.hoisted(() => ({
+  runBackgroundTaskSyncNow: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+}));
+
+vi.mock("@/desktop/renderer/actions/backgroundTaskSync", () => ({
+  runBackgroundTaskSyncNow: (...args: unknown[]) => mocks.runBackgroundTaskSyncNow(...args),
+}));
+
+function ActiveTaskContextHarness({
+  moveTaskToStatus,
+}: {
+  moveTaskToStatus: (status: TaskStatus) => void;
+}) {
+  const boardCommands = useBoardCommands();
+
+  useEffect(() => boardCommands.registerActiveTaskContext({
+    taskId: "task-1",
+    currentStatus: TaskStatus.TODO,
+    moveTaskToStatus,
+  }), [boardCommands, moveTaskToStatus]);
+
+  return null;
+}
+
+function BoardMoveHandlerHarness({
+  moveFocusedTaskToStatus,
+}: {
+  moveFocusedTaskToStatus: (status: TaskStatus, taskIdOverride?: string | null) => "moved" | "missing-focus" | "missing-task";
+}) {
+  const boardCommands = useBoardCommands();
+
+  useEffect(() => boardCommands.registerBoardHandlers({
+    toggleNotificationCenter: () => {},
+    openProjectFilter: () => {},
+    openCreateTaskModal: () => {},
+    moveFocusedTaskToStatus,
+  }), [boardCommands, moveFocusedTaskToStatus]);
+
+  return null;
+}
+
+function renderWithRouter(children: ReactNode) {
+  return render(
+    <MemoryRouter initialEntries={["/ko"]}>
+      {children}
+    </MemoryRouter>,
+  );
+}
+
+function openPalette() {
+  fireEvent.keyDown(window, { key: "p", ctrlKey: true, shiftKey: true });
+}
+
+describe("CommandPaletteDialog", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("task 컨텍스트도 보드에 포커스된 태스크도 없으면 Move가 비활성 상태다", () => {
+    renderWithRouter(
+      <BoardCommandProvider>
+        <CommandPaletteDialog />
+      </BoardCommandProvider>,
+    );
+
+    openPalette();
+
+    const moveButton = screen.getByRole("button", { name: /commandPalette\.moveLabel/ }) as HTMLButtonElement;
+    expect(moveButton.disabled).toBe(true);
+  });
+
+  it("Sync를 클릭하면 백그라운드 동기화를 정확히 1회 호출하고 다이얼로그가 닫힌다", async () => {
+    mocks.runBackgroundTaskSyncNow.mockResolvedValue(undefined);
+
+    renderWithRouter(
+      <BoardCommandProvider>
+        <CommandPaletteDialog />
+      </BoardCommandProvider>,
+    );
+
+    openPalette();
+    fireEvent.click(screen.getByRole("button", { name: /commandPalette\.syncLabel/ }));
+
+    expect(mocks.runBackgroundTaskSyncNow).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("task 상세 컨텍스트가 있으면 Move에서 고른 상태로 그 task를 이동한다", () => {
+    const moveTaskToStatus = vi.fn();
+
+    renderWithRouter(
+      <BoardCommandProvider>
+        <ActiveTaskContextHarness moveTaskToStatus={moveTaskToStatus} />
+        <CommandPaletteDialog />
+      </BoardCommandProvider>,
+    );
+
+    openPalette();
+    fireEvent.click(screen.getByRole("button", { name: /commandPalette\.moveLabel/ }));
+    fireEvent.click(screen.getByRole("button", { name: "board.columns.review" }));
+
+    expect(moveTaskToStatus).toHaveBeenCalledTimes(1);
+    expect(moveTaskToStatus).toHaveBeenCalledWith(TaskStatus.REVIEW);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("task 컨텍스트가 없어도 보드에 포커스된 태스크가 있으면 board의 이동 핸들러를 그 태스크 id로 호출한다", () => {
+    const moveFocusedTaskToStatus = vi.fn().mockReturnValue("moved");
+
+    renderWithRouter(
+      <BoardCommandProvider>
+        <BoardMoveHandlerHarness moveFocusedTaskToStatus={moveFocusedTaskToStatus} />
+        <a href="#" data-kanban-task-card="true" data-kanban-task-id="task-9" tabIndex={0}>
+          focused card
+        </a>
+        <CommandPaletteDialog />
+      </BoardCommandProvider>,
+    );
+
+    screen.getByText("focused card").focus();
+    openPalette();
+    fireEvent.click(screen.getByRole("button", { name: /commandPalette\.moveLabel/ }));
+    fireEvent.click(screen.getByRole("button", { name: "board.columns.done" }));
+
+    expect(moveFocusedTaskToStatus).toHaveBeenCalledTimes(1);
+    expect(moveFocusedTaskToStatus).toHaveBeenCalledWith(TaskStatus.DONE, "task-9");
+  });
+});

--- a/src/desktop/renderer/components/__tests__/CommandPaletteDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/CommandPaletteDialog.test.tsx
@@ -11,7 +11,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("next-intl", () => ({
-  useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+  useTranslations: (namespace: string) => (key: string, values?: Record<string, string>) => (
+    values?.status ? `${namespace}.${key}:${values.status}` : `${namespace}.${key}`
+  ),
 }));
 
 vi.mock("@/desktop/renderer/actions/backgroundTaskSync", () => ({
@@ -63,12 +65,16 @@ function openPalette() {
   fireEvent.keyDown(window, { key: "p", ctrlKey: true, shiftKey: true });
 }
 
+function getSearchInput() {
+  return screen.getByRole("textbox");
+}
+
 describe("CommandPaletteDialog", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it("task 컨텍스트도 보드에 포커스된 태스크도 없으면 Move가 비활성 상태다", () => {
+  it("Move 대상이 없으면 Move 관련 행이 하나도 렌더되지 않는다", () => {
     renderWithRouter(
       <BoardCommandProvider>
         <CommandPaletteDialog />
@@ -77,11 +83,11 @@ describe("CommandPaletteDialog", () => {
 
     openPalette();
 
-    const moveButton = screen.getByRole("button", { name: /commandPalette\.moveLabel/ }) as HTMLButtonElement;
-    expect(moveButton.disabled).toBe(true);
+    expect(screen.queryByRole("button", { name: /commandPalette\.moveToStatusLabel/ })).toBeNull();
+    expect(screen.getByRole("button", { name: /commandPalette\.syncLabel/ })).toBeTruthy();
   });
 
-  it("Sync를 클릭하면 백그라운드 동기화를 정확히 1회 호출하고 다이얼로그가 닫힌다", async () => {
+  it("Sync 행을 클릭하면 백그라운드 동기화를 정확히 1회 호출하고 다이얼로그가 닫힌다", async () => {
     mocks.runBackgroundTaskSyncNow.mockResolvedValue(undefined);
 
     renderWithRouter(
@@ -97,7 +103,7 @@ describe("CommandPaletteDialog", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  it("task 상세 컨텍스트가 있으면 Move에서 고른 상태로 그 task를 이동한다", () => {
+  it("task 상세 컨텍스트가 있으면 'Move to Review' 행 클릭이 그 task를 이동한다", () => {
     const moveTaskToStatus = vi.fn();
 
     renderWithRouter(
@@ -108,8 +114,7 @@ describe("CommandPaletteDialog", () => {
     );
 
     openPalette();
-    fireEvent.click(screen.getByRole("button", { name: /commandPalette\.moveLabel/ }));
-    fireEvent.click(screen.getByRole("button", { name: "board.columns.review" }));
+    fireEvent.click(screen.getByRole("button", { name: /board\.columns\.review/ }));
 
     expect(moveTaskToStatus).toHaveBeenCalledTimes(1);
     expect(moveTaskToStatus).toHaveBeenCalledWith(TaskStatus.REVIEW);
@@ -131,10 +136,59 @@ describe("CommandPaletteDialog", () => {
 
     screen.getByText("focused card").focus();
     openPalette();
-    fireEvent.click(screen.getByRole("button", { name: /commandPalette\.moveLabel/ }));
-    fireEvent.click(screen.getByRole("button", { name: "board.columns.done" }));
+    fireEvent.click(screen.getByRole("button", { name: /board\.columns\.done/ }));
 
     expect(moveFocusedTaskToStatus).toHaveBeenCalledTimes(1);
     expect(moveFocusedTaskToStatus).toHaveBeenCalledWith(TaskStatus.DONE, "task-9");
+  });
+
+  it("검색어를 입력하면 매칭되는 행으로만 목록이 좁혀진다", () => {
+    const moveTaskToStatus = vi.fn();
+
+    renderWithRouter(
+      <BoardCommandProvider>
+        <ActiveTaskContextHarness moveTaskToStatus={moveTaskToStatus} />
+        <CommandPaletteDialog />
+      </BoardCommandProvider>,
+    );
+
+    openPalette();
+    fireEvent.change(getSearchInput(), { target: { value: "sync" } });
+
+    expect(screen.getByRole("button", { name: /commandPalette\.syncLabel/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /board\.columns\.review/ })).toBeNull();
+  });
+
+  it("ArrowDown 후 Enter는 두 번째 행을 실행한다", () => {
+    const moveTaskToStatus = vi.fn();
+
+    renderWithRouter(
+      <BoardCommandProvider>
+        <ActiveTaskContextHarness moveTaskToStatus={moveTaskToStatus} />
+        <CommandPaletteDialog />
+      </BoardCommandProvider>,
+    );
+
+    openPalette();
+    const input = getSearchInput();
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mocks.runBackgroundTaskSyncNow).not.toHaveBeenCalled();
+    expect(moveTaskToStatus).toHaveBeenCalledTimes(1);
+    expect(moveTaskToStatus).toHaveBeenCalledWith(TaskStatus.PROGRESS);
+  });
+
+  it("매칭되는 행이 없으면 빈 상태 문구를 보여준다", () => {
+    renderWithRouter(
+      <BoardCommandProvider>
+        <CommandPaletteDialog />
+      </BoardCommandProvider>,
+    );
+
+    openPalette();
+    fireEvent.change(getSearchInput(), { target: { value: "존재하지않는명령" } });
+
+    expect(screen.getByText("commandPalette.empty")).toBeTruthy();
   });
 });

--- a/src/desktop/renderer/components/__tests__/CommandPaletteDialog.test.tsx
+++ b/src/desktop/renderer/components/__tests__/CommandPaletteDialog.test.tsx
@@ -159,6 +159,42 @@ describe("CommandPaletteDialog", () => {
     expect(screen.queryByRole("button", { name: /board\.columns\.review/ })).toBeNull();
   });
 
+  it("각 행은 명령어(command)와 설명(description)을 분리된 요소로 렌더링한다", () => {
+    const moveTaskToStatus = vi.fn();
+
+    renderWithRouter(
+      <BoardCommandProvider>
+        <ActiveTaskContextHarness moveTaskToStatus={moveTaskToStatus} />
+        <CommandPaletteDialog />
+      </BoardCommandProvider>,
+    );
+
+    openPalette();
+
+    expect(screen.getByText("sync")).toBeTruthy();
+    expect(screen.getByText("commandPalette.syncLabel")).toBeTruthy();
+    expect(screen.getByText("move review")).toBeTruthy();
+    expect(screen.getByText(/commandPalette\.moveToStatusLabel:board\.columns\.review/)).toBeTruthy();
+  });
+
+  it("명령어 토큰(예: 'move progress')으로 검색하면 해당 행만 남는다", () => {
+    const moveTaskToStatus = vi.fn();
+
+    renderWithRouter(
+      <BoardCommandProvider>
+        <ActiveTaskContextHarness moveTaskToStatus={moveTaskToStatus} />
+        <CommandPaletteDialog />
+      </BoardCommandProvider>,
+    );
+
+    openPalette();
+    fireEvent.change(getSearchInput(), { target: { value: "move progress" } });
+
+    expect(screen.getByText("move progress")).toBeTruthy();
+    expect(screen.queryByText("move review")).toBeNull();
+    expect(screen.queryByText("sync")).toBeNull();
+  });
+
   it("ArrowDown 후 Enter는 두 번째 행을 실행한다", () => {
     const moveTaskToStatus = vi.fn();
 

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -57,6 +57,7 @@ declare global {
       consumePendingNotificationActivation?: () => Promise<AppNotification | null>;
       onNotificationActivated?: (listener: (notification: AppNotification) => void) => () => void;
       onNotificationShortcut?: (listener: () => void) => () => void;
+      onCommandPaletteShortcut?: (listener: () => void) => () => void;
     };
   }
 }

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -1114,6 +1114,18 @@ export default function TaskDetailRoute() {
   }), [boardCommands]);
 
   useEffect(() => {
+    if (!state?.task) {
+      return;
+    }
+
+    return boardCommands.registerActiveTaskContext({
+      taskId: id,
+      currentStatus: state.task.status,
+      moveTaskToStatus: movePaletteTaskToStatus,
+    });
+  }, [boardCommands, id, state?.task?.status, movePaletteTaskToStatus]);
+
+  useEffect(() => {
     commonTranslationsRef.current = tc;
   }, [tc]);
 
@@ -1577,6 +1589,22 @@ export default function TaskDetailRoute() {
         </div>
       </div>
     );
+  }
+
+  /** 커맨드 팔레트의 Move가 이 task를 대상으로 호출한다. 폼 액션인 handleStatusChange와 호출 형태가 달라 따로 둔다 */
+  async function movePaletteTaskToStatus(newStatus: TaskStatus) {
+    const updatedTask = await updateTaskStatus(id, newStatus);
+    if (updatedTask) {
+      setState((current) => current
+        ? {
+            ...current,
+            task: {
+              ...current.task,
+              ...updatedTask,
+            },
+          }
+        : current);
+    }
   }
 
   async function handleStatusChange(formData: FormData) {

--- a/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
+++ b/src/desktop/renderer/routes/__tests__/TaskDetailRoute.test.tsx
@@ -7,6 +7,7 @@ import {
   useHasBoardShortcutBlocker,
 } from "@/desktop/renderer/components/BoardCommandProvider";
 import TaskDetailRoute from "@/desktop/renderer/routes/TaskDetailRoute";
+import { TaskStatus } from "@/entities/KanbanTask";
 import { INITIAL_DESKTOP_LOAD_TIMEOUT_MS } from "@/desktop/renderer/utils/loadingTimeout";
 import { TASK_DETAIL_DOCK_ITEM_IDS, resolveTaskDetailDockLabel } from "@/desktop/shared/taskDetailDock";
 
@@ -1722,6 +1723,58 @@ describe("TaskDetailRoute", () => {
     });
     expect(mocks.push).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "moveToTodo" })).toBeTruthy();
+  });
+
+  it("커맨드 팔레트가 이 task를 이동 대상으로 등록하고, Move 실행 시 updateTaskStatus로 화면 상태를 갱신한다", async () => {
+    const task = {
+      id: "task-1",
+      title: "task title",
+      description: null,
+      branchName: "feat/palette-move",
+      baseBranch: "main",
+      prUrl: null,
+      sessionType: null,
+      sessionName: null,
+      sshHost: null,
+      projectId: "project-1",
+      project: { id: "project-1", name: "kanvibe" },
+      status: "todo",
+      agentType: null,
+      worktreePath: "/repo__worktrees/palette-move",
+    };
+    mocks.getTaskById.mockResolvedValue(task);
+    mocks.updateTaskStatus.mockResolvedValue({ ...task, status: "review" });
+
+    function ActiveTaskContextProbe() {
+      const boardCommands = useBoardCommands();
+
+      return (
+        <div>
+          <span data-testid="has-active-task-context">{String(boardCommands.hasActiveTaskContext)}</span>
+          <button type="button" onClick={() => boardCommands.moveActiveTaskToStatus(TaskStatus.REVIEW)}>
+            move via palette
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <BoardCommandProvider>
+        <ActiveTaskContextProbe />
+        <TaskDetailRoute />
+      </BoardCommandProvider>,
+    );
+
+    await screen.findByTestId("task-title");
+    await waitFor(() => {
+      expect(screen.getByTestId("has-active-task-context").textContent).toBe("true");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "move via palette" }));
+
+    await waitFor(() => {
+      expect(mocks.updateTaskStatus).toHaveBeenCalledWith("task-1", "review");
+    });
   });
 
   it("AI 세션 로드가 느려도 hooks 상태는 먼저 갱신한다", async () => {

--- a/src/desktop/renderer/utils/focusedBoardTaskCard.ts
+++ b/src/desktop/renderer/utils/focusedBoardTaskCard.ts
@@ -1,0 +1,9 @@
+const TASK_CARD_SELECTOR = "[data-kanban-task-card='true']";
+
+/** 현재 키보드 포커스가 놓인 보드 태스크 카드. 없으면 null */
+export function getFocusedBoardTaskCard() {
+  const activeElement = document.activeElement;
+  return activeElement instanceof Element
+    ? activeElement.closest<HTMLAnchorElement>(TASK_CARD_SELECTOR)
+    : null;
+}

--- a/src/desktop/shared/__tests__/shortcutBindings.test.ts
+++ b/src/desktop/shared/__tests__/shortcutBindings.test.ts
@@ -199,6 +199,22 @@ describe("AI 사용량 패널 단축키", () => {
   });
 });
 
+describe("커맨드 팔레트 단축키", () => {
+  it("Mod+Shift+P는 커맨드 팔레트를, Mod+Shift+F는 프로젝트 필터를 연다", () => {
+    expect(findShortcutCommandForEvent(
+      DEFAULT_SHORTCUT_BINDINGS,
+      new KeyboardEvent("keydown", { key: "p", metaKey: true, shiftKey: true }),
+      "mac",
+    )).toBe("commandPalette");
+
+    expect(findShortcutCommandForEvent(
+      DEFAULT_SHORTCUT_BINDINGS,
+      new KeyboardEvent("keydown", { key: "f", metaKey: true, shiftKey: true }),
+      "mac",
+    )).toBe("boardProjectFilter");
+  });
+});
+
 describe("단축키 재배정", () => {
   /**
    * 도크에 없는 번호까지 명령을 만들면 설정 화면이 눌러도 아무 일이 없는 단축키를 보여 준다.

--- a/src/desktop/shared/keyboardShortcut.ts
+++ b/src/desktop/shared/keyboardShortcut.ts
@@ -30,7 +30,8 @@ const MODIFIER_KEYS = new Set(["Meta", "Control", "Ctrl", "Alt", "Shift"]);
 export const SHORTCUTS = {
   taskSearchDefault: "Mod+Shift+O",
   boardNotification: "Mod+Shift+I",
-  boardProjectFilter: "Mod+Shift+P",
+  boardProjectFilter: "Mod+Shift+F",
+  commandPalette: "Mod+Shift+P",
   createTask: "Mod+N",
   newWindow: "Mod+Shift+N",
   pageBack: "Mod+[",

--- a/src/desktop/shared/shortcutBindings.ts
+++ b/src/desktop/shared/shortcutBindings.ts
@@ -29,6 +29,7 @@ export type ShortcutCommandId =
   | "taskSearch"
   | "boardNotification"
   | "boardProjectFilter"
+  | "commandPalette"
   | "boardPageFind"
   | "createTask"
   | "newWindow"
@@ -91,6 +92,7 @@ export const SHORTCUT_COMMAND_DEFINITIONS: readonly ShortcutCommandDefinition[] 
   { id: "taskSearch", group: "board", defaultShortcut: SHORTCUTS.taskSearchDefault, labelKey: "taskSearch" },
   { id: "boardNotification", group: "board", defaultShortcut: SHORTCUTS.boardNotification, labelKey: "boardNotification" },
   { id: "boardProjectFilter", group: "board", defaultShortcut: SHORTCUTS.boardProjectFilter, labelKey: "boardProjectFilter" },
+  { id: "commandPalette", group: "board", defaultShortcut: SHORTCUTS.commandPalette, labelKey: "commandPalette" },
   { id: "boardPageFind", group: "board", defaultShortcut: SHORTCUTS.boardPageFind, labelKey: "boardPageFind" },
   { id: "createTask", group: "board", defaultShortcut: SHORTCUTS.createTask, labelKey: "createTask" },
   { id: "newWindow", group: "board", defaultShortcut: SHORTCUTS.newWindow, labelKey: "newWindow" },

--- a/src/entities/KanbanTask.ts
+++ b/src/entities/KanbanTask.ts
@@ -19,6 +19,15 @@ export enum TaskStatus {
   DONE = "done",
 }
 
+/** 보드 컬럼과 동일한 상태 진행 순서. 상태를 순서대로 나열해야 하는 곳(vim 이동 명령, 커맨드 팔레트 등)이 공유한다 */
+export const TASK_STATUS_ORDER: readonly TaskStatus[] = [
+  TaskStatus.TODO,
+  TaskStatus.PROGRESS,
+  TaskStatus.PENDING,
+  TaskStatus.REVIEW,
+  TaskStatus.DONE,
+];
+
 export enum SessionType {
   TMUX = "tmux",
   ZELLIJ = "zellij",

--- a/src/types/kanvibeDesktop.d.ts
+++ b/src/types/kanvibeDesktop.d.ts
@@ -13,6 +13,7 @@ interface KanvibeDesktopApi {
   onNotificationActivated?: (listener: (notification: AppNotification) => void) => () => void;
   onNotificationShortcut?: (listener: () => void) => () => void;
   onCreateTaskShortcut?: (listener: () => void) => () => void;
+  onCommandPaletteShortcut?: (listener: () => void) => () => void;
   onTaskDetailDockShortcut?: (listener: (shortcutIndex: number) => void) => () => void;
   onTaskDetailUsageShortcut?: (listener: () => void) => () => void;
   notifyShortcutBindingsChanged?: () => void;


### PR DESCRIPTION
## 어떤 작업인가요?
Cmd+Shift+P를 누르면 `Sync`·`Move` 명령을 실행할 수 있는 커맨드 팔레트를 앱 전역에 추가합니다. task 상세 창에서 열면 그 task를, 보드 화면에서 열면 키보드로 포커스된 태스크 카드를 대상으로 `Move`가 동작합니다.

## 어떻게 해결했나요?
**단축키 재배정**
- `Cmd+Shift+P`는 기존에 `boardProjectFilter`(프로젝트 필터) 단축키였습니다. 새 `commandPalette` 명령이 이 조합을 가져가고, `boardProjectFilter`는 `Cmd+Shift+F`로 옮겼습니다. 두 명령 모두 설정 화면에서 재배정 가능한 상태를 유지합니다.

**커맨드 팔레트 UI**
- `TaskQuickSearchDialog`의 전역 마운트·오버레이·단축키 차단 패턴을 그대로 따라 `CommandPaletteDialog`를 만들었습니다.
- 1단계는 `Sync`/`Move` 목록, `Move` 선택 시 2단계로 상태(Todo/Progress/Pending/Review/Done) 목록이 뜹니다.
- `Sync`는 컨텍스트와 무관하게 기존 전체 백그라운드 동기화(`runBackgroundTaskSyncNow`)를 그대로 호출합니다.

**task 컨텍스트 인식**
- `BoardCommandProvider`에 `registerActiveTaskContext`를 추가해, task 상세 창이 자신의 task id와 이동 콜백을 등록합니다.
- 보드 화면에서는 `Board`가 이미 갖고 있던 `moveFocusedTaskToStatus`(포커스된 카드 이동, Done 확인 다이얼로그 포함)를 `registerBoardHandlers`로 그대로 노출해 재사용합니다.

## 중요한 변경 사항은 무엇인가요?
### 단축키
**`boardProjectFilter` 기본 단축키 변경**
- **변경 이유**: `Cmd+Shift+P`를 커맨드 팔레트에 배정하기 위해 충돌을 해소
- **수정 파일**: `src/desktop/shared/keyboardShortcut.ts`, `src/desktop/shared/shortcutBindings.ts`

### 상태 공유
**`TASK_STATUS_ORDER` 공유 상수 추출**
- **변경 이유**: 보드의 vim `:move` 명령과 팔레트가 같은 5개 상태 순서(Todo/Progress/Pending/Review/Done)를 공유. `TaskDetailRoute`의 기존 `STATUS_TRANSITIONS`는 Pending이 빠져 있어 재사용하지 않음
- **수정 파일**: `src/entities/KanbanTask.ts`, `src/components/Board.tsx`

### 버그 수정 (구현 중 발견)
**`activeTaskContext` 무한 렌더 루프**
- **변경 이유**: 컨텍스트 객체를 통째로 `useState`에 담았더니 등록할 때마다 새 참조가 생겨, 그 값을 구독하는 소비자의 effect가 매번 재등록을 반복하는 무한 루프가 발생했습니다. `registerBoardHandlers`가 이미 쓰는 ref+원시 상태 패턴으로 옮겨 해결했습니다.
- **수정 파일**: `src/desktop/renderer/components/BoardCommandProvider.tsx`
