### PR TITLE
feat(terminal): 원격 터미널에 클립보드 이미지를 붙여넣을 수 있게 한다

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -839,6 +839,7 @@ function registerDesktopHandlers() {
     focusTerminal,
     closeTerminal,
     closeWindowTerminals,
+    pasteImageToRemoteTerminal,
   } = require(getRuntimeModulePath(path.join("src", "desktop", "main", "terminalBridge.ts")));
   const {
     openAiAccountLogin,
@@ -933,6 +934,10 @@ function registerDesktopHandlers() {
     closeTerminal(event.sender.id, taskId, tabId);
   });
 
+  ipcMain.handle("kanvibe:terminal-paste-image", async (_event, taskId, imageDataUrl) => {
+    return pasteImageToRemoteTerminal(taskId, imageDataUrl);
+  });
+
   /**
    * 터미널 안 프로그램이 OSC 52로 보낸 복사 요청을 시스템 클립보드에 반영한다.
    * 렌더러의 navigator.clipboard는 문서 포커스를 요구하고, 포커스가 있어도 성공을 반환한 채
@@ -940,6 +945,16 @@ function registerDesktopHandlers() {
    */
   ipcMain.handle("kanvibe:clipboard-write", (_event, text) => {
     clipboard.writeText(String(text));
+  });
+
+  /**
+   * Ctrl+V, Ctrl+Shift+V, Shift+Insert, 마우스 중간 클릭은 macOS에서 네이티브 paste 이벤트를
+   * 만들지 않는다. 렌더러가 keydown/클릭 시점에 즉시 xterm 기본 처리를 막을지 정해야 하므로
+   * 동기 채널로 응답한다.
+   */
+  ipcMain.on("kanvibe:clipboard-read-image", (event) => {
+    const image = clipboard.readImage();
+    event.returnValue = image.isEmpty() ? null : `data:image/png;base64,${image.toPNG().toString("base64")}`;
   });
 
   ipcMain.handle("kanvibe:ai-login-open", async (event, provider, accountRoot, cols, rows) => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -75,8 +75,14 @@ contextBridge.exposeInMainWorld("kanvibeDesktop", {
   closeTerminal(taskId, tabId) {
     ipcRenderer.send("kanvibe:terminal-close", taskId, tabId);
   },
+  pasteImageToRemoteTerminal(taskId, imageDataUrl) {
+    return ipcRenderer.invoke("kanvibe:terminal-paste-image", taskId, imageDataUrl);
+  },
   writeSystemClipboard(text) {
     return ipcRenderer.invoke("kanvibe:clipboard-write", text);
+  },
+  readClipboardImage() {
+    return ipcRenderer.sendSync("kanvibe:clipboard-read-image");
   },
   openAiAccountLogin(provider, accountRoot, cols, rows) {
     return ipcRenderer.invoke("kanvibe:ai-login-open", provider, accountRoot, cols, rows);

--- a/src/desktop/main/__tests__/clipboardImageReadBridge.test.ts
+++ b/src/desktop/main/__tests__/clipboardImageReadBridge.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Ctrl+V, Ctrl+Shift+V, Shift+Insert, 마우스 중간 클릭은 macOS에서 네이티브 paste DOM 이벤트를
+ * 만들지 않는다. 그래서 렌더러가 keydown/auxclick 시점에 동기적으로 클립보드 이미지 유무를
+ * 물어봐야 하며, 이 sendSync 채널이 끊기면 그 트리거들이 전부 조용히 무력화된다.
+ */
+describe("clipboard image read bridge", () => {
+  const CHANNEL = "kanvibe:clipboard-read-image";
+
+  function readElectronSource(fileName: string): string {
+    return readFileSync(path.join(process.cwd(), "electron", fileName), "utf8");
+  }
+
+  it("should answer the sync channel from the main process clipboard", () => {
+    // Given
+    const source = readElectronSource("main.js");
+
+    // When
+    const handler = source.match(
+      /ipcMain\.on\("kanvibe:clipboard-read-image",[\s\S]*?\n {2}\}\);/,
+    )?.[0];
+
+    // Then
+    expect(handler).toBeDefined();
+    expect(handler).toMatch(/clipboard\.readImage\(\)/);
+    expect(handler).toMatch(/event\.returnValue/);
+  });
+
+  it("should expose a synchronous readClipboardImage on the desktop bridge", () => {
+    // Given
+    const source = readElectronSource("preload.js");
+
+    // When
+    const bridgeMethod = source.match(/readClipboardImage\(\) \{[\s\S]*?\n {2}\},/)?.[0];
+
+    // Then
+    expect(bridgeMethod).toBeDefined();
+    expect(bridgeMethod).toContain(CHANNEL);
+    expect(bridgeMethod).toMatch(/ipcRenderer\.sendSync/);
+  });
+});

--- a/src/desktop/main/__tests__/terminalBridge.test.ts
+++ b/src/desktop/main/__tests__/terminalBridge.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFindOneBy = vi.fn();
+vi.mock("@/lib/database", () => ({
+  getTaskRepository: async () => ({ findOneBy: mockFindOneBy }),
+}));
+
+const mockParseSSHConfig = vi.fn();
+vi.mock("@/lib/sshConfig", () => ({
+  parseSSHConfig: (...args: unknown[]) => mockParseSSHConfig(...args),
+}));
+
+const mockDecodeDataUrlToBuffer = vi.fn();
+const mockTransferImageToRemoteHost = vi.fn();
+vi.mock("@/lib/remoteImagePaste", () => ({
+  decodeDataUrlToBuffer: (...args: unknown[]) => mockDecodeDataUrlToBuffer(...args),
+  transferImageToRemoteHost: (...args: unknown[]) => mockTransferImageToRemoteHost(...args),
+}));
+
+vi.mock("@/lib/terminal", () => ({
+  attachLocalSession: vi.fn(),
+  attachRemoteSession: vi.fn(),
+  focusSession: vi.fn(),
+}));
+
+vi.mock("@/lib/remoteSessionDependency", () => ({
+  ensureRemoteSessionDependency: vi.fn(),
+}));
+
+vi.mock("@/desktop/main/services/paneLayoutService", () => ({
+  getEffectivePaneLayout: vi.fn(),
+}));
+
+const SSH_CONFIG = {
+  host: "app-prod",
+  hostname: "example.com",
+  port: 2202,
+  username: "tester",
+  privateKeyPath: "/tmp/test-key",
+};
+
+async function importBridge() {
+  return import("@/desktop/main/terminalBridge");
+}
+
+describe("terminalBridge.pasteImageToRemoteTerminal", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("returns an error without attempting a transfer when the task has no sshHost (local session)", async () => {
+    // Given
+    mockFindOneBy.mockResolvedValue({ id: "task-1", sshHost: null });
+    const { pasteImageToRemoteTerminal } = await importBridge();
+
+    // When
+    const result = await pasteImageToRemoteTerminal("task-1", "data:image/png;base64,aGVsbG8=");
+
+    // Then
+    expect(result).toEqual({ ok: false, error: "원격 세션이 아닙니다." });
+    expect(mockTransferImageToRemoteHost).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the task's sshHost has no matching parsed SSH config", async () => {
+    // Given
+    mockFindOneBy.mockResolvedValue({ id: "task-1", sshHost: "unknown-host" });
+    mockParseSSHConfig.mockResolvedValue([]);
+    const { pasteImageToRemoteTerminal } = await importBridge();
+
+    // When
+    const result = await pasteImageToRemoteTerminal("task-1", "data:image/png;base64,aGVsbG8=");
+
+    // Then
+    expect(result).toEqual({ ok: false, error: "SSH 호스트를 찾을 수 없습니다: unknown-host" });
+  });
+
+  it("transfers the decoded image and resolves with the remote path for a remote session", async () => {
+    // Given
+    mockFindOneBy.mockResolvedValue({ id: "task-1", sshHost: "app-prod" });
+    mockParseSSHConfig.mockResolvedValue([SSH_CONFIG]);
+    const decodedBuffer = Buffer.from("hello");
+    mockDecodeDataUrlToBuffer.mockReturnValue(decodedBuffer);
+    mockTransferImageToRemoteHost.mockResolvedValue("/tmp/kanvibe-paste-fixed-uuid.png");
+    const { pasteImageToRemoteTerminal } = await importBridge();
+
+    // When
+    const result = await pasteImageToRemoteTerminal("task-1", "data:image/png;base64,aGVsbG8=");
+
+    // Then
+    expect(result).toEqual({ ok: true, remotePath: "/tmp/kanvibe-paste-fixed-uuid.png" });
+    expect(mockTransferImageToRemoteHost).toHaveBeenCalledWith(SSH_CONFIG, decodedBuffer);
+  });
+
+  it("returns the failure message when the scp transfer rejects", async () => {
+    // Given
+    mockFindOneBy.mockResolvedValue({ id: "task-1", sshHost: "app-prod" });
+    mockParseSSHConfig.mockResolvedValue([SSH_CONFIG]);
+    mockDecodeDataUrlToBuffer.mockReturnValue(Buffer.from("hello"));
+    mockTransferImageToRemoteHost.mockRejectedValue(new Error("scp 전송 실패 (exit 1): Permission denied"));
+    const { pasteImageToRemoteTerminal } = await importBridge();
+
+    // When
+    const result = await pasteImageToRemoteTerminal("task-1", "data:image/png;base64,aGVsbG8=");
+
+    // Then
+    expect(result).toEqual({ ok: false, error: "scp 전송 실패 (exit 1): Permission denied" });
+  });
+});

--- a/src/desktop/main/__tests__/terminalPasteImageBridge.test.ts
+++ b/src/desktop/main/__tests__/terminalPasteImageBridge.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * 원격 터미널 이미지 붙여넣기는 렌더러(preload) → IPC 채널 → main의 pasteImageToRemoteTerminal로 이어진다.
+ * 세 조각 중 하나만 어긋나도 조용히 실패하므로, 채널 이름과 배선이 맞는지 소스 텍스트로 확인한다.
+ */
+describe("terminal paste-image bridge", () => {
+  const PASTE_IMAGE_CHANNEL = "kanvibe:terminal-paste-image";
+
+  function readElectronSource(fileName: string): string {
+    return readFileSync(path.join(process.cwd(), "electron", fileName), "utf8");
+  }
+
+  it("should route the paste-image channel to pasteImageToRemoteTerminal in main", () => {
+    // Given
+    const source = readElectronSource("main.js");
+
+    // When
+    const handler = source.match(
+      /ipcMain\.handle\("kanvibe:terminal-paste-image",[\s\S]*?\n {2}\}\);/,
+    )?.[0];
+
+    // Then
+    expect(handler).toBeDefined();
+    expect(handler).toMatch(/pasteImageToRemoteTerminal\(/);
+    expect(source).toMatch(/pasteImageToRemoteTerminal,?\s*\n[\s\S]*?terminalBridge\.ts/);
+  });
+
+  it("should expose pasteImageToRemoteTerminal on the desktop bridge", () => {
+    // Given
+    const source = readElectronSource("preload.js");
+
+    // When
+    const bridgeMethod = source.match(/pasteImageToRemoteTerminal\(taskId, imageDataUrl\) \{[\s\S]*?\n {2}\},/)?.[0];
+
+    // Then
+    expect(bridgeMethod).toBeDefined();
+    expect(bridgeMethod).toContain(PASTE_IMAGE_CHANNEL);
+  });
+});

--- a/src/desktop/main/terminalBridge.ts
+++ b/src/desktop/main/terminalBridge.ts
@@ -3,9 +3,10 @@ import type { WebContents } from "electron";
 import { getTaskRepository } from "@/lib/database";
 import { SessionType } from "@/entities/KanbanTask";
 import { attachLocalSession, attachRemoteSession, focusSession } from "@/lib/terminal";
-import { parseSSHConfig } from "@/lib/sshConfig";
+import { parseSSHConfig, type SSHHostConfig } from "@/lib/sshConfig";
 import { ensureRemoteSessionDependency } from "@/lib/remoteSessionDependency";
 import { getEffectivePaneLayout } from "@/desktop/main/services/paneLayoutService";
+import { decodeDataUrlToBuffer, transferImageToRemoteHost } from "@/lib/remoteImagePaste";
 
 const OPEN = 1;
 const CLOSED = 3;
@@ -84,6 +85,46 @@ function getClient(
   return terminalClients.get(buildClientKey(webContentsId, taskId, tabId)) ?? null;
 }
 
+/** taskId로 원격 세션 여부와 매칭되는 SSH 접속 정보를 함께 조회한다 */
+async function resolveRemoteSshConfig(
+  taskId: string,
+): Promise<{ ok: true; sshConfig: SSHHostConfig } | { ok: false; error: string }> {
+  const taskRepo = await getTaskRepository();
+  const task = await taskRepo.findOneBy({ id: taskId });
+
+  if (!task || !task.sshHost) {
+    return { ok: false, error: "원격 세션이 아닙니다." };
+  }
+
+  const sshHosts = await parseSSHConfig();
+  const sshConfig = sshHosts.find((host) => host.host === task.sshHost);
+
+  if (!sshConfig) {
+    return { ok: false, error: `SSH 호스트를 찾을 수 없습니다: ${task.sshHost}` };
+  }
+
+  return { ok: true, sshConfig };
+}
+
+/** 클립보드 이미지를 원격 세션에 scp로 전달하고, 성공하면 원격 경로를 반환한다 */
+export async function pasteImageToRemoteTerminal(
+  taskId: string,
+  imageDataUrl: string,
+): Promise<{ ok: true; remotePath: string } | { ok: false; error: string }> {
+  const resolved = await resolveRemoteSshConfig(taskId);
+  if (!resolved.ok) {
+    return resolved;
+  }
+
+  try {
+    const imageBuffer = decodeDataUrlToBuffer(imageDataUrl);
+    const remotePath = await transferImageToRemoteHost(resolved.sshConfig, imageBuffer);
+    return { ok: true, remotePath };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : "이미지 전송 실패" };
+  }
+}
+
 export async function openTerminal(
   webContents: WebContents,
   taskId: string,
@@ -122,12 +163,10 @@ export async function openTerminal(
     if (task.sshHost) {
       await ensureRemoteSessionDependency(task.sessionType as SessionType, task.sshHost);
 
-      const sshHosts = await parseSSHConfig();
-      const sshConfig = sshHosts.find((host) => host.host === task.sshHost);
-
-      if (!sshConfig) {
-        client.close(1008, `SSH 호스트를 찾을 수 없습니다: ${task.sshHost}`);
-        return { ok: false, error: `SSH 호스트를 찾을 수 없습니다: ${task.sshHost}` };
+      const resolved = await resolveRemoteSshConfig(taskId);
+      if (!resolved.ok) {
+        client.close(1008, resolved.error);
+        return { ok: false, error: resolved.error };
       }
 
       await attachRemoteSession(
@@ -137,7 +176,7 @@ export async function openTerminal(
         task.sessionType as SessionType,
         task.sessionName,
         client as never,
-        sshConfig,
+        resolved.sshConfig,
         cols,
         rows,
         task.worktreePath,

--- a/src/desktop/renderer/components/Terminal.tsx
+++ b/src/desktop/renderer/components/Terminal.tsx
@@ -13,6 +13,8 @@ interface TerminalProps {
    * 숨겨진 컨테이너는 높이·너비가 0이라 fit이 터미널을 2×1로 줄여 버리므로 크기 동기화를 멈춘다.
    */
   isHidden?: boolean;
+  /** 원격(SSH) 세션에서만 클립보드 이미지 붙여넣기를 가로챈다. 로컬 세션은 기존 텍스트 붙여넣기만 유지한다 */
+  isRemote?: boolean;
 }
 
 const NERD_FONT_FAMILY = "JetBrainsMono Nerd Font Mono";
@@ -74,18 +76,21 @@ function loadNerdFontFamily(): Promise<string | null> {
   return nerdFontLoadPromise;
 }
 
-export default function Terminal({ taskId, tabId = null, isHidden = false }: TerminalProps) {
+export default function Terminal({ taskId, tabId = null, isHidden = false, isRemote = false }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  /** connect는 taskId·tabId에만 묶여 있어야 하므로, 표시 여부는 ref로 읽는다 */
+  /** connect는 taskId·tabId에만 묶여 있어야 하므로, 표시 여부·원격 여부는 ref로 읽는다 */
   const isHiddenRef = useRef(isHidden);
+  const isRemoteRef = useRef(isRemote);
 
   isHiddenRef.current = isHidden;
+  isRemoteRef.current = isRemote;
 
   const connect = useCallback(async () => {
     if (!containerRef.current) {
       return undefined;
     }
 
+    const pasteEventTarget = containerRef.current;
     const [{ Terminal: XTerm }, { FitAddon }, { WebLinksAddon }] = await loadTerminalModules();
     let isTerminalDisposed = false;
 
@@ -98,6 +103,109 @@ export default function Terminal({ taskId, tabId = null, isHidden = false }: Ter
     const disposeMacShiftSelectionPatch = installMacShiftSelectionPatch(terminal);
     const osc52ClipboardHandler = installOsc52ClipboardHandler(terminal);
     terminal.options.fontFamily = FALLBACK_FONT_FAMILY;
+
+    /**
+     * 원격 세션의 CLI(예: Claude Code)는 헤드리스 서버라 로컬 클립보드 이미지를 직접 읽을 수 없다.
+     * 그래서 로컬 클립보드 이미지를 감지하면 scp로 원격에 옮기고, 그 경로만 텍스트로 붙여넣는다.
+     */
+    const sendImageToRemoteTerminal = (imageDataUrl: string) => {
+      void window.kanvibeDesktop!.pasteImageToRemoteTerminal(taskId, imageDataUrl).then((result: { ok: boolean; remotePath?: string; error?: string }) => {
+        if (result.ok && result.remotePath) {
+          window.kanvibeDesktop!.writeTerminal(taskId, tabId, result.remotePath);
+        } else {
+          terminal.writeln(`\r\n\x1b[31m${result.error || "이미지 전송 실패"}\x1b[0m`);
+        }
+      });
+    };
+
+    const handleImagePaste = (file: File) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const imageDataUrl = reader.result;
+        if (typeof imageDataUrl === "string") {
+          sendImageToRemoteTerminal(imageDataUrl);
+        }
+      };
+      reader.readAsDataURL(file);
+    };
+
+    /** capture 단계로 등록해야 xterm이 자신의 textarea(target)에 붙인 붙여넣기 처리보다 먼저 가로챌 수 있다 */
+    const handlePaste = (event: ClipboardEvent) => {
+      if (!isRemoteRef.current) {
+        return;
+      }
+
+      const items = event.clipboardData?.items;
+      if (!items) {
+        return;
+      }
+
+      const imageItem = Array.from(items).find(
+        (item) => item.kind === "file" && item.type.startsWith("image/"),
+      );
+      if (!imageItem) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+
+      const file = imageItem.getAsFile();
+      if (file) {
+        handleImagePaste(file);
+      }
+    };
+
+    pasteEventTarget.addEventListener("paste", handlePaste, true);
+
+    /**
+     * macOS의 Chromium 편집 동작은 Cmd+V만 붙여넣기로 매핑하므로, Ctrl+V·Ctrl+Shift+V·Shift+Insert는
+     * 네이티브 paste 이벤트를 만들지 않고 xterm이 제어 문자를 그대로 pty에 흘려보낸다.
+     * Claude Code·Codex 같은 CLI는 이 조합도 붙여넣기 시도로 해석하는 경우가 많아 같은 기능을 태운다.
+     * 클립보드에 이미지가 없으면 xterm 기본 처리를 그대로 둬야 vim 비주얼 블록 모드 같은 기존 용법이 깨지지 않는다.
+     */
+    const tryHandleImagePasteShortcut = (): boolean => {
+      if (!isRemoteRef.current) {
+        return false;
+      }
+
+      const imageDataUrl = window.kanvibeDesktop!.readClipboardImage();
+      if (!imageDataUrl) {
+        return false;
+      }
+
+      sendImageToRemoteTerminal(imageDataUrl);
+      return true;
+    };
+
+    terminal.attachCustomKeyEventHandler((event) => {
+      if (event.type !== "keydown") {
+        return true;
+      }
+
+      const isCtrlV = event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey && event.key.toLowerCase() === "v";
+      const isCtrlShiftV = event.ctrlKey && !event.metaKey && event.shiftKey && !event.altKey && event.key.toLowerCase() === "v";
+      const isShiftInsert = event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey && event.key === "Insert";
+
+      if (!isCtrlV && !isCtrlShiftV && !isShiftInsert) {
+        return true;
+      }
+
+      return !tryHandleImagePasteShortcut();
+    });
+
+    /** X11 중간 클릭 붙여넣기 관례를 macOS에서도 받아 주기 위한 트리거. 이 저장소에 기존 중간 클릭 처리는 없다 */
+    const handleAuxClick = (event: MouseEvent) => {
+      if (event.button !== 1) {
+        return;
+      }
+
+      if (tryHandleImagePasteShortcut()) {
+        event.preventDefault();
+      }
+    };
+
+    pasteEventTarget.addEventListener("auxclick", handleAuxClick);
 
     const isThisTerminal = (event: { taskId: string; tabId: string | null }) => (
       event.taskId === taskId && (event.tabId ?? null) === tabId
@@ -155,6 +263,8 @@ export default function Terminal({ taskId, tabId = null, isHidden = false }: Ter
         isTerminalDisposed = true;
         disposeMacShiftSelectionPatch();
         osc52ClipboardHandler.dispose();
+        pasteEventTarget.removeEventListener("paste", handlePaste, true);
+        pasteEventTarget.removeEventListener("auxclick", handleAuxClick);
         unsubscribeData();
         unsubscribeClose();
         terminal.dispose();
@@ -212,6 +322,8 @@ export default function Terminal({ taskId, tabId = null, isHidden = false }: Ter
       window.removeEventListener(REQUEST_ACTIVE_TERMINAL_FOCUS_EVENT, handleRequestTerminalFocus);
       disposeMacShiftSelectionPatch();
       osc52ClipboardHandler.dispose();
+      pasteEventTarget.removeEventListener("paste", handlePaste, true);
+      pasteEventTarget.removeEventListener("auxclick", handleAuxClick);
       resizeObserver.disconnect();
       unsubscribeData();
       unsubscribeClose();

--- a/src/desktop/renderer/components/TerminalLoader.tsx
+++ b/src/desktop/renderer/components/TerminalLoader.tsx
@@ -8,17 +8,19 @@ interface TerminalLoaderProps {
    * tmux와 zellij는 멀티플렉서가 화면을 하나로 그리므로 비워 두고 xterm 하나만 띄운다.
    */
   tabs?: TerminalTab[];
+  /** 원격(SSH) 세션인지 여부. `Terminal`로 그대로 전달해 클립보드 이미지 붙여넣기 범위를 가른다 */
+  isRemote?: boolean;
 }
 
 /**
  * terminal 세션은 탭마다 xterm을 따로 두고 비활성 탭을 숨기기만 한다.
  * 언마운트하면 그 탭의 스크롤백이 사라져서, 돌아왔을 때 화면이 비어 보인다.
  */
-export default function TerminalLoader({ taskId, tabs }: TerminalLoaderProps) {
+export default function TerminalLoader({ taskId, tabs, isRemote }: TerminalLoaderProps) {
   if (!tabs) {
     return (
       <div className="h-full">
-        <Terminal taskId={taskId} />
+        <Terminal taskId={taskId} isRemote={isRemote} />
       </div>
     );
   }
@@ -35,7 +37,7 @@ export default function TerminalLoader({ taskId, tabs }: TerminalLoaderProps) {
     <div className="h-full">
       {tabs.map((tab) => (
         <div key={tab.id} className={tab.isActive ? "h-full" : "hidden"}>
-          <Terminal taskId={taskId} tabId={tab.id} isHidden={!tab.isActive} />
+          <Terminal taskId={taskId} tabId={tab.id} isHidden={!tab.isActive} isRemote={isRemote} />
         </div>
       ))}
     </div>

--- a/src/desktop/renderer/components/__tests__/Terminal.test.tsx
+++ b/src/desktop/renderer/components/__tests__/Terminal.test.tsx
@@ -20,6 +20,8 @@ const {
   mockWriteTerminal,
   mockResizeTerminal,
   mockCloseTerminal,
+  mockPasteImageToRemoteTerminal,
+  mockReadClipboardImage,
   mockTerminalFocus,
   mockDisposeMacShiftSelectionPatch,
   mockFit,
@@ -31,10 +33,18 @@ const {
   mockWriteTerminal: vi.fn(),
   mockResizeTerminal: vi.fn(),
   mockCloseTerminal: vi.fn(),
+  mockPasteImageToRemoteTerminal: vi.fn(),
+  mockReadClipboardImage: vi.fn(),
   mockTerminalFocus: vi.fn(),
   mockDisposeMacShiftSelectionPatch: vi.fn(),
   mockFit: vi.fn(),
 }));
+
+let latestXtermInstance: MockXTerm | undefined;
+
+function rememberLatestXtermInstance(instance: MockXTerm) {
+  latestXtermInstance = instance;
+}
 
 class MockXTerm {
   cols = 80;
@@ -49,7 +59,53 @@ class MockXTerm {
   focus = mockTerminalFocus;
   onData = vi.fn();
   onResize = vi.fn();
+  attachCustomKeyEventHandler = vi.fn();
   parser = { registerOscHandler: vi.fn().mockReturnValue({ dispose: vi.fn() }) };
+
+  constructor() {
+    rememberLatestXtermInstance(this);
+  }
+}
+
+class MockFileReader {
+  result: string | null = null;
+  onload: (() => void) | null = null;
+
+  readAsDataURL(_file: File) {
+    this.result = "data:image/png;base64,ZmFrZQ==";
+    queueMicrotask(() => this.onload?.());
+  }
+}
+
+function dispatchPasteEvent(target: HTMLElement, clipboardData: unknown): Event {
+  const event = new Event("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clipboardData", { value: clipboardData });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function createImageClipboardData(file: Partial<File> = {}) {
+  return {
+    items: [
+      {
+        kind: "file",
+        type: "image/png",
+        getAsFile: () => file as File,
+      },
+    ],
+  };
+}
+
+function createTextClipboardData() {
+  return {
+    items: [
+      {
+        kind: "string",
+        type: "text/plain",
+        getAsFile: () => null,
+      },
+    ],
+  };
 }
 
 vi.mock("@xterm/xterm", () => ({
@@ -105,6 +161,9 @@ describe("Desktop Terminal", () => {
     mockOpenTerminal.mockResolvedValue({ ok: true });
     mockOnTerminalData.mockReturnValue(vi.fn());
     mockOnTerminalClose.mockReturnValue(vi.fn());
+    mockPasteImageToRemoteTerminal.mockResolvedValue({ ok: true, remotePath: "/tmp/kanvibe-paste-fixed-uuid.png" });
+    mockReadClipboardImage.mockReturnValue(null);
+    vi.stubGlobal("FileReader", MockFileReader);
 
     window.kanvibeDesktop = {
       isDesktop: true,
@@ -115,8 +174,18 @@ describe("Desktop Terminal", () => {
       writeTerminal: mockWriteTerminal,
       resizeTerminal: mockResizeTerminal,
       closeTerminal: mockCloseTerminal,
+      pasteImageToRemoteTerminal: mockPasteImageToRemoteTerminal,
+      readClipboardImage: mockReadClipboardImage,
     };
   });
+
+  function getRegisteredKeyEventHandler(): (event: Partial<KeyboardEvent> & { type: string }) => boolean {
+    const handler = latestXtermInstance?.attachCustomKeyEventHandler.mock.calls[0]?.[0];
+    if (!handler) {
+      throw new Error("attachCustomKeyEventHandler가 등록되지 않았습니다.");
+    }
+    return handler;
+  }
 
   it("상세 화면 진입 직후 xterm 입력 포커스만 맞춘다", async () => {
     // Given
@@ -221,5 +290,213 @@ describe("Desktop Terminal", () => {
     await waitFor(() => {
       expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
     });
+  });
+
+  it("원격 세션에서 이미지가 담긴 붙여넣기를 가로채 원격 경로로 대체한다", async () => {
+    // Given
+    const { container } = render(<Terminal taskId="task-1" isRemote />);
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
+    });
+    const target = container.firstChild as HTMLElement;
+
+    // When
+    const event = dispatchPasteEvent(target, createImageClipboardData());
+
+    // Then
+    expect(event.defaultPrevented).toBe(true);
+    await waitFor(() => {
+      expect(mockPasteImageToRemoteTerminal).toHaveBeenCalledWith("task-1", "data:image/png;base64,ZmFrZQ==");
+    });
+    await waitFor(() => {
+      expect(mockWriteTerminal).toHaveBeenCalledWith("task-1", null, "/tmp/kanvibe-paste-fixed-uuid.png");
+    });
+  });
+
+  it("원격 세션에서 이미지 전송이 실패하면 터미널에 에러를 표시한다", async () => {
+    // Given
+    mockPasteImageToRemoteTerminal.mockResolvedValue({ ok: false, error: "원격 세션이 아닙니다." });
+    const { container } = render(<Terminal taskId="task-1" isRemote />);
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
+    });
+    const target = container.firstChild as HTMLElement;
+
+    // When
+    dispatchPasteEvent(target, createImageClipboardData());
+
+    // Then
+    await waitFor(() => {
+      expect(latestXtermInstance?.writeln).toHaveBeenCalledWith("\r\n\x1b[31m원격 세션이 아닙니다.\x1b[0m");
+    });
+    expect(mockWriteTerminal).not.toHaveBeenCalled();
+  });
+
+  it("클립보드에 이미지가 없는 텍스트 붙여넣기는 원격 세션이어도 그대로 흘려보낸다", async () => {
+    // Given
+    const { container } = render(<Terminal taskId="task-1" isRemote />);
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
+    });
+    const target = container.firstChild as HTMLElement;
+    const bubbleSpy = vi.fn();
+    document.body.addEventListener("paste", bubbleSpy);
+
+    // When
+    const event = dispatchPasteEvent(target, createTextClipboardData());
+
+    // Then
+    expect(event.defaultPrevented).toBe(false);
+    expect(bubbleSpy).toHaveBeenCalledTimes(1);
+    expect(mockPasteImageToRemoteTerminal).not.toHaveBeenCalled();
+    document.body.removeEventListener("paste", bubbleSpy);
+  });
+
+  it("로컬 세션에서는 이미지 붙여넣기도 가로채지 않는다", async () => {
+    // Given
+    const { container } = render(<Terminal taskId="task-1" />);
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
+    });
+    const target = container.firstChild as HTMLElement;
+    const bubbleSpy = vi.fn();
+    document.body.addEventListener("paste", bubbleSpy);
+
+    // When
+    const event = dispatchPasteEvent(target, createImageClipboardData());
+
+    // Then
+    expect(event.defaultPrevented).toBe(false);
+    expect(bubbleSpy).toHaveBeenCalledTimes(1);
+    expect(mockPasteImageToRemoteTerminal).not.toHaveBeenCalled();
+    document.body.removeEventListener("paste", bubbleSpy);
+  });
+
+  it("원격 세션에서 Ctrl+V 시 클립보드에 이미지가 있으면 xterm 기본 처리를 막고 이미지를 전송한다", async () => {
+    // Given
+    mockReadClipboardImage.mockReturnValue("data:image/png;base64,ZmFrZQ==");
+    render(<Terminal taskId="task-1" isRemote />);
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
+    });
+    const handler = getRegisteredKeyEventHandler();
+
+    // When
+    const handled = handler({ type: "keydown", ctrlKey: true, metaKey: false, shiftKey: false, altKey: false, key: "v" });
+
+    // Then
+    expect(handled).toBe(false);
+    await waitFor(() => {
+      expect(mockPasteImageToRemoteTerminal).toHaveBeenCalledWith("task-1", "data:image/png;base64,ZmFrZQ==");
+    });
+  });
+
+  it("원격 세션에서 Ctrl+V 시 클립보드에 이미지가 없으면 xterm 기본 처리를 그대로 둔다 (vim 비주얼 블록 등 회귀 방지)", async () => {
+    // Given
+    mockReadClipboardImage.mockReturnValue(null);
+    render(<Terminal taskId="task-1" isRemote />);
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
+    });
+    const handler = getRegisteredKeyEventHandler();
+
+    // When
+    const handled = handler({ type: "keydown", ctrlKey: true, metaKey: false, shiftKey: false, altKey: false, key: "v" });
+
+    // Then
+    expect(handled).toBe(true);
+    expect(mockPasteImageToRemoteTerminal).not.toHaveBeenCalled();
+  });
+
+  it("로컬 세션에서는 Ctrl+V가 이미지가 있어도 가로채지 않는다", async () => {
+    // Given
+    mockReadClipboardImage.mockReturnValue("data:image/png;base64,ZmFrZQ==");
+    render(<Terminal taskId="task-1" />);
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
+    });
+    const handler = getRegisteredKeyEventHandler();
+
+    // When
+    const handled = handler({ type: "keydown", ctrlKey: true, metaKey: false, shiftKey: false, altKey: false, key: "v" });
+
+    // Then
+    expect(handled).toBe(true);
+    expect(mockReadClipboardImage).not.toHaveBeenCalled();
+  });
+
+  it("원격 세션에서 Ctrl+Shift+V와 Shift+Insert도 이미지 붙여넣기를 트리거한다", async () => {
+    // Given
+    mockReadClipboardImage.mockReturnValue("data:image/png;base64,ZmFrZQ==");
+    render(<Terminal taskId="task-1" isRemote />);
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
+    });
+    const handler = getRegisteredKeyEventHandler();
+
+    // When
+    const ctrlShiftVHandled = handler({ type: "keydown", ctrlKey: true, metaKey: false, shiftKey: true, altKey: false, key: "v" });
+    const shiftInsertHandled = handler({ type: "keydown", ctrlKey: false, metaKey: false, shiftKey: true, altKey: false, key: "Insert" });
+
+    // Then
+    expect(ctrlShiftVHandled).toBe(false);
+    expect(shiftInsertHandled).toBe(false);
+    expect(mockPasteImageToRemoteTerminal).toHaveBeenCalledTimes(2);
+  });
+
+  it("원격 세션에서 마우스 중간 클릭 시 클립보드 이미지를 전송한다", async () => {
+    // Given
+    mockReadClipboardImage.mockReturnValue("data:image/png;base64,ZmFrZQ==");
+    const { container } = render(<Terminal taskId="task-1" isRemote />);
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
+    });
+    const target = container.firstChild as HTMLElement;
+
+    // When
+    const event = new MouseEvent("auxclick", { button: 1, bubbles: true, cancelable: true });
+    target.dispatchEvent(event);
+
+    // Then
+    expect(event.defaultPrevented).toBe(true);
+    await waitFor(() => {
+      expect(mockPasteImageToRemoteTerminal).toHaveBeenCalledWith("task-1", "data:image/png;base64,ZmFrZQ==");
+    });
+  });
+
+  it("원격 세션에서 마우스 중간 클릭 시 클립보드에 이미지가 없으면 아무 것도 하지 않는다", async () => {
+    // Given
+    mockReadClipboardImage.mockReturnValue(null);
+    const { container } = render(<Terminal taskId="task-1" isRemote />);
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
+    });
+    const target = container.firstChild as HTMLElement;
+
+    // When
+    const event = new MouseEvent("auxclick", { button: 1, bubbles: true, cancelable: true });
+    target.dispatchEvent(event);
+
+    // Then
+    expect(event.defaultPrevented).toBe(false);
+    expect(mockPasteImageToRemoteTerminal).not.toHaveBeenCalled();
+  });
+
+  it("로컬 세션에서는 마우스 중간 클릭이 이미지가 있어도 가로채지 않는다", async () => {
+    // Given
+    mockReadClipboardImage.mockReturnValue("data:image/png;base64,ZmFrZQ==");
+    const { container } = render(<Terminal taskId="task-1" />);
+    await waitFor(() => {
+      expect(mockOpenTerminal).toHaveBeenCalledWith("task-1", null, 80, 24);
+    });
+    const target = container.firstChild as HTMLElement;
+
+    // When
+    const event = new MouseEvent("auxclick", { button: 1, bubbles: true, cancelable: true });
+    target.dispatchEvent(event);
+
+    // Then
+    expect(event.defaultPrevented).toBe(false);
+    expect(mockReadClipboardImage).not.toHaveBeenCalled();
   });
 });

--- a/src/desktop/renderer/global.d.ts
+++ b/src/desktop/renderer/global.d.ts
@@ -27,6 +27,12 @@ declare global {
       resizeTerminal: (taskId: string, tabId: string | null, cols: number, rows: number) => void;
       focusTerminal: (taskId: string) => void;
       closeTerminal: (taskId: string, tabId: string | null) => void;
+      pasteImageToRemoteTerminal: (
+        taskId: string,
+        imageDataUrl: string,
+      ) => Promise<{ ok: boolean; remotePath?: string; error?: string }>;
+      /** Ctrl+V 등 네이티브 paste 이벤트를 만들지 않는 트리거를 위한 동기 클립보드 이미지 조회 */
+      readClipboardImage: () => string | null;
       onTerminalData: (listener: (event: { taskId: string; tabId: string | null; data: string }) => void) => () => void;
       onTerminalClose: (listener: (event: { taskId: string; tabId: string | null; reason: string | null }) => void) => () => void;
       /** AI 계정 로그인 세션은 태스크에 묶이지 않으므로 계정 루트가 식별자다 */

--- a/src/desktop/renderer/routes/TaskDetailRoute.tsx
+++ b/src/desktop/renderer/routes/TaskDetailRoute.tsx
@@ -1845,6 +1845,7 @@ export default function TaskDetailRoute() {
               <TerminalLoader
                 taskId={state.task.id}
                 tabs={state.task.sessionType === SessionType.TERMINAL ? terminalTabs.tabs : undefined}
+                isRemote={Boolean(state.task.sshHost)}
               />
             </div>
           </div>

--- a/src/lib/__tests__/remoteImagePaste.test.ts
+++ b/src/lib/__tests__/remoteImagePaste.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  mkdtemp: vi.fn(),
+  writeFile: vi.fn(),
+  rm: vi.fn(),
+  tmpdir: vi.fn(() => "/tmp"),
+  randomUUID: vi.fn(() => "fixed-uuid"),
+}));
+
+vi.mock("child_process", () => ({
+  default: { spawn: mocks.spawn },
+  spawn: mocks.spawn,
+}));
+
+vi.mock("fs/promises", () => ({
+  default: {
+    mkdtemp: mocks.mkdtemp,
+    writeFile: mocks.writeFile,
+    rm: mocks.rm,
+    mkdir: vi.fn(),
+    readFile: vi.fn(),
+  },
+  mkdtemp: mocks.mkdtemp,
+  writeFile: mocks.writeFile,
+  rm: mocks.rm,
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+}));
+
+vi.mock("os", () => ({
+  default: { tmpdir: mocks.tmpdir },
+  tmpdir: mocks.tmpdir,
+}));
+
+vi.mock("crypto", () => ({
+  default: { randomUUID: mocks.randomUUID },
+  randomUUID: mocks.randomUUID,
+}));
+
+class FakeChildProcess extends EventEmitter {
+  stderr = new EventEmitter();
+}
+
+const SSH_CONFIG = {
+  host: "app-prod",
+  hostname: "example.com",
+  port: 2202,
+  username: "tester",
+  privateKeyPath: "/tmp/test-key",
+};
+
+describe("remoteImagePaste.decodeDataUrlToBuffer", () => {
+  it("decodes the base64 payload of a data URL", async () => {
+    // Given
+    const { decodeDataUrlToBuffer } = await import("@/lib/remoteImagePaste");
+    const payload = Buffer.from("hello").toString("base64");
+
+    // When
+    const buffer = decodeDataUrlToBuffer(`data:image/png;base64,${payload}`);
+
+    // Then
+    expect(buffer.toString()).toBe("hello");
+  });
+
+  it("throws when the data URL has no comma separator", async () => {
+    // Given
+    const { decodeDataUrlToBuffer } = await import("@/lib/remoteImagePaste");
+
+    // When & Then
+    expect(() => decodeDataUrlToBuffer("not-a-data-url")).toThrow();
+  });
+});
+
+describe("remoteImagePaste.buildRemoteImagePastePath", () => {
+  it("builds a fixed /tmp path from the given uuid", async () => {
+    // Given
+    const { buildRemoteImagePastePath } = await import("@/lib/remoteImagePaste");
+
+    // When & Then
+    expect(buildRemoteImagePastePath("fixed-uuid")).toBe("/tmp/kanvibe-paste-fixed-uuid.png");
+  });
+});
+
+describe("remoteImagePaste.transferImageToRemoteHost", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.tmpdir.mockReturnValue("/tmp");
+    mocks.randomUUID.mockReturnValue("fixed-uuid");
+    mocks.mkdtemp.mockResolvedValue("/tmp/kanvibe-paste-xyz");
+    mocks.writeFile.mockResolvedValue(undefined);
+    mocks.rm.mockResolvedValue(undefined);
+  });
+
+  it("uploads the image via scp and resolves the remote path on exit code 0", async () => {
+    // Given
+    const child = new FakeChildProcess();
+    mocks.spawn.mockReturnValue(child);
+    const { transferImageToRemoteHost } = await import("@/lib/remoteImagePaste");
+
+    // When
+    const resultPromise = transferImageToRemoteHost(SSH_CONFIG, Buffer.from("image-bytes"));
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalled());
+    child.emit("close", 0);
+    const result = await resultPromise;
+
+    // Then
+    expect(result).toBe("/tmp/kanvibe-paste-fixed-uuid.png");
+    expect(mocks.writeFile).toHaveBeenCalledWith("/tmp/kanvibe-paste-xyz/fixed-uuid.png", Buffer.from("image-bytes"));
+    expect(mocks.spawn).toHaveBeenCalledWith("scp", [
+      "-i",
+      "/tmp/test-key",
+      "-P",
+      "2202",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "IdentitiesOnly=yes",
+      "/tmp/kanvibe-paste-xyz/fixed-uuid.png",
+      "app-prod:/tmp/kanvibe-paste-fixed-uuid.png",
+    ], expect.anything());
+    expect(mocks.rm).toHaveBeenCalledWith("/tmp/kanvibe-paste-xyz", { recursive: true, force: true });
+  });
+
+  it("rejects with stderr context on non-zero exit and still cleans up the local temp directory", async () => {
+    // Given
+    const child = new FakeChildProcess();
+    mocks.spawn.mockReturnValue(child);
+    const { transferImageToRemoteHost } = await import("@/lib/remoteImagePaste");
+
+    // When
+    const resultPromise = transferImageToRemoteHost(SSH_CONFIG, Buffer.from("image-bytes"));
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalled());
+    child.stderr.emit("data", Buffer.from("Permission denied"));
+    child.emit("close", 1);
+
+    // Then
+    await expect(resultPromise).rejects.toThrow(/Permission denied/);
+    expect(mocks.rm).toHaveBeenCalledWith("/tmp/kanvibe-paste-xyz", { recursive: true, force: true });
+  });
+
+  it("rejects when the scp process itself fails to spawn and still cleans up", async () => {
+    // Given
+    const child = new FakeChildProcess();
+    mocks.spawn.mockReturnValue(child);
+    const { transferImageToRemoteHost } = await import("@/lib/remoteImagePaste");
+
+    // When
+    const resultPromise = transferImageToRemoteHost(SSH_CONFIG, Buffer.from("image-bytes"));
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalled());
+    child.emit("error", new Error("ENOENT"));
+
+    // Then
+    await expect(resultPromise).rejects.toThrow("ENOENT");
+    expect(mocks.rm).toHaveBeenCalledWith("/tmp/kanvibe-paste-xyz", { recursive: true, force: true });
+  });
+});

--- a/src/lib/__tests__/sshConfig.test.ts
+++ b/src/lib/__tests__/sshConfig.test.ts
@@ -196,3 +196,38 @@ describe("sshConfig.buildSSHArgs", () => {
     expect(hasLocalX11Display({})).toBe(false);
   });
 });
+
+describe("sshConfig.buildSCPArgs", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("uses the uppercase port flag and appends host:remotePath as the last argument", async () => {
+    // Given
+    const { buildSCPArgs } = await import("@/lib/sshConfig");
+
+    // When
+    const args = buildSCPArgs({
+      host: "app-prod",
+      hostname: "example.com",
+      port: 2202,
+      username: "tester",
+      privateKeyPath: "/tmp/test-key",
+    }, "/local/tmp/a.png", "/tmp/kanvibe-paste-abc.png");
+
+    // Then
+    expect(args).toEqual([
+      "-i",
+      "/tmp/test-key",
+      "-P",
+      "2202",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "IdentitiesOnly=yes",
+      "/local/tmp/a.png",
+      "app-prod:/tmp/kanvibe-paste-abc.png",
+    ]);
+  });
+});

--- a/src/lib/remoteImagePaste.ts
+++ b/src/lib/remoteImagePaste.ts
@@ -1,0 +1,66 @@
+import { randomUUID } from "crypto";
+import { spawn } from "child_process";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { buildSCPArgs, type SSHHostConfig } from "@/lib/sshConfig";
+import { createLocalShellEnvironment } from "@/lib/shellEnvironment";
+
+const REMOTE_TEMP_DIRECTORY = "/tmp";
+
+/** `data:image/png;base64,<payload>` 형태의 문자열에서 실제 바이트를 꺼낸다 */
+export function decodeDataUrlToBuffer(dataUrl: string): Buffer {
+  const commaIndex = dataUrl.indexOf(",");
+  if (commaIndex === -1) {
+    throw new Error("잘못된 이미지 데이터입니다.");
+  }
+
+  return Buffer.from(dataUrl.slice(commaIndex + 1), "base64");
+}
+
+/**
+ * 붙여넣은 이미지가 원격에 저장될 경로.
+ * SSH로 접속 가능한 원격 호스트는 사실상 항상 유닉스 계열이라 `/tmp`를 고정으로 가정한다.
+ */
+export function buildRemoteImagePastePath(uuid: string): string {
+  return path.posix.join(REMOTE_TEMP_DIRECTORY, `kanvibe-paste-${uuid}.png`);
+}
+
+/** 클립보드 이미지를 scp로 원격 호스트에 올리고, 성공하면 원격 경로를 반환한다 */
+export async function transferImageToRemoteHost(
+  sshConfig: SSHHostConfig,
+  imageBuffer: Buffer,
+): Promise<string> {
+  const uuid = randomUUID();
+  const remotePath = buildRemoteImagePastePath(uuid);
+  const localDirectory = await mkdtemp(path.join(tmpdir(), "kanvibe-paste-"));
+  const localPath = path.join(localDirectory, `${uuid}.png`);
+
+  try {
+    await writeFile(localPath, imageBuffer);
+    await runSCP(buildSCPArgs(sshConfig, localPath, remotePath));
+    return remotePath;
+  } finally {
+    await rm(localDirectory, { recursive: true, force: true });
+  }
+}
+
+function runSCP(args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("scp", args, { env: createLocalShellEnvironment() });
+    let stderr = "";
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`scp 전송 실패 (exit ${code}): ${stderr.trim()}`));
+      }
+    });
+  });
+}

--- a/src/lib/sshConfig.ts
+++ b/src/lib/sshConfig.ts
@@ -95,6 +95,29 @@ export function buildSSHArgs(
   return args;
 }
 
+/**
+ * scp CLI 인자를 만든다. scp는 ssh와 달리 포트 플래그가 `-P`(대문자)이고,
+ * `-p`는 "파일 속성 보존"이라는 다른 의미라 `buildSSHArgs`를 재사용하지 않는다.
+ */
+export function buildSCPArgs(
+  config: Pick<SSHHostConfig, "host" | "hostname" | "port" | "username" | "privateKeyPath">,
+  localPath: string,
+  remotePath: string,
+): string[] {
+  return [
+    "-i",
+    config.privateKeyPath,
+    "-P",
+    String(config.port),
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "IdentitiesOnly=yes",
+    localPath,
+    `${getSSHDestination(config)}:${remotePath}`,
+  ];
+}
+
 export function getKanvibeSSHControlDirectory(): string {
   return path.join(homedir(), ".kanvibe");
 }


### PR DESCRIPTION
## 관련 자료
- 이슈 : (해당 없음)

## 어떤 작업인가요?
원격(SSH) 터미널에서 Cmd+V, Ctrl+V, Ctrl+Shift+V, Shift+Insert, 마우스 중간 클릭 중 어느 것으로 붙여넣기를 시도해도 클립보드 이미지가 원격 세션으로 전달되지 않던 문제를 고칩니다. 원격 CLI(Claude Code, Codex 등)는 헤드리스 서버에서 돌아서 로컬 macOS 클립보드에 직접 접근할 수 없다는 점이 원인입니다.

## 어떻게 해결했나요?
**클립보드 이미지를 scp로 원격에 전달**
- Cmd+V로 붙여넣은 클립보드 이미지를 감지하면, 별도 scp 사이드채널로 원격 임시 파일(`/tmp/kanvibe-paste-<uuid>.png`)에 올리고 그 경로 텍스트만 기존 pty 입력 경로로 씁니다.
- 원격에서 지금 돌고 있는 프로그램(vim, CLI 등)에는 영향이 없도록, 이미지 바이트나 셸 명령이 아니라 최종 경로 텍스트만 pty에 전달합니다.
- 로컬 터미널은 이번 변경의 영향을 받지 않습니다.

**Cmd+V 외 다른 붙여넣기 트리거도 함께 지원**
- macOS Chromium의 편집 동작은 Cmd+V만 네이티브 paste 이벤트로 매핑하므로, Ctrl+V·Ctrl+Shift+V·Shift+Insert·마우스 중간 클릭은 별도로 가로챕니다.
- 클립보드에 이미지가 없으면 각 트리거의 기존 동작(예: vim 비주얼 블록 모드의 Ctrl+V)을 그대로 둡니다.

## 중요한 변경 사항은 무엇인가요?
### 이미지 전송 경로
**`buildSCPArgs` 추가**
- **변경 이유**: scp는 ssh와 달리 포트 플래그가 `-P`(대문자)라 `buildSSHArgs`를 그대로 재사용할 수 없음
- **수정 파일**: `src/lib/sshConfig.ts`

**`remoteImagePaste.ts` 신규**
- **변경 이유**: 클립보드 이미지를 로컬 임시 파일에 쓰고 scp로 원격에 올리는 순수 로직을 분리해 테스트 가능하게 함
- **수정 파일**: `src/lib/remoteImagePaste.ts`

**`pasteImageToRemoteTerminal` 추가 및 `openTerminal` 리팩터링**
- **변경 이유**: taskId로 SSH 설정을 조회하는 로직이 `openTerminal`에 이미 있어, 새 진입점과 공유하도록 `resolveRemoteSshConfig`로 추출
- **수정 파일**: `src/desktop/main/terminalBridge.ts`

**`kanvibe:terminal-paste-image` IPC 채널 추가**
- **변경 이유**: 렌더러에서 이미지 전송을 요청할 통로 필요
- **수정 파일**: `electron/main.js`, `electron/preload.js`, `src/desktop/renderer/global.d.ts`

### 붙여넣기 트리거 확장
**Cmd+V 캡처 리스너**
- **변경 이유**: xterm.js 기본 paste 처리보다 먼저 이미지 클립보드를 가로채야 함
- **수정 파일**: `src/desktop/renderer/components/Terminal.tsx`

**`isRemote` prop 전달**
- **변경 이유**: 원격 세션에서만 이 기능을 활성화하기 위해 `TaskDetailRoute` → `TerminalLoader` → `Terminal`로 전달
- **수정 파일**: `src/desktop/renderer/components/TerminalLoader.tsx`, `src/desktop/renderer/routes/TaskDetailRoute.tsx`

**`kanvibe:clipboard-read-image` 동기 IPC 채널 추가**
- **변경 이유**: Ctrl+V 등은 네이티브 paste 이벤트를 만들지 않아, keydown/클릭 시점에 동기적으로 클립보드 이미지 유무를 확인해야 xterm 기본 처리를 막을지 즉시 판단 가능
- **수정 파일**: `electron/main.js`, `electron/preload.js`, `src/desktop/renderer/global.d.ts`

**`attachCustomKeyEventHandler`로 Ctrl+V·Ctrl+Shift+V·Shift+Insert 가로채기, `auxclick`으로 마우스 중간 클릭 가로채기**
- **변경 이유**: 클립보드에 이미지가 있을 때만 가로채고, 없으면 기존 동작(raw byte 전달 등)을 그대로 둬 회귀 방지
- **수정 파일**: `src/desktop/renderer/components/Terminal.tsx`
