### PR TITLE
chore(release): publish KanVibe 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanvibe",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanvibe",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "hasInstallScript": true,
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanvibe",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "AI agent task management Kanban board with embedded SQLite desktop packaging.",
   "author": "rookedsysc",


### PR DESCRIPTION
## Summary

Publish KanVibe 1.4.0. This PR carries only the version bump; the shipped changes are the command palette work (#385) and remote-terminal image paste (#386) already merged into `dev`.

## Release Artifacts

- GitHub release: https://github.com/rookedsysc/kanvibe/releases/tag/1.4.0
- DMG asset: `dist/KanVibe-1.4.0.dmg` (171,170,128 bytes)
- SHA-256: `4821d845c461cee58faba8b694fe86c9b4a0df6856caab2b8b0fd15b66c72e01`
- Homebrew cask: rookedsysc/homebrew-kanvibe@3734deb — `brew fetch --cask rookedsysc/kanvibe/kanvibe` reports `✔︎ Cask kanvibe (1.4.0)`

## Test Plan

| Gate | Result |
| --- | --- |
| Dependency collector | `pm=npm` |
| Packaging guard | `packaged node_modules verified: 278 packages` |
| Notarization | `status: Accepted`, `stapler validate` worked |
| Gatekeeper | `accepted`, `source=Notarized Developer ID` |
| Smoke test (isolated data dir) | process alive, module errors `0`, `invoke-succeeded` `19` |
| Served checksum | GitHub-served DMG hash equals the local build hash |

The smoke run used `KANVIBE_APP_DATA_DIR` pointed at a throwaway directory, so the installed instance and its data were untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
